### PR TITLE
Travis by Conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
 
 install:
   - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -22,18 +20,17 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
+  - conda config --append channels conda-forge
+  - conda config --append channels lightsource2-tag
   # Useful for debugging any issues with conda
   - conda info -a
+  # Test conda build
+  - conda build -q conda-recipe --output-folder bld-dir
+  - conda config --add channels "file://`pwd`/bld-dir"
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pip wheel happi=0.5.0 ophyd=1.0.0 bluesky=1.0.0 event-model=1.3.0 pytest pytest-timeout hypothesis=3.11.6 -c conda-forge -c lightsource2-tag -c skywalker-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
   #Launch Conda environment
   - source activate test-environment
-  #Install mongomock
-  - pip install mongomock
-  - pip install codecov
-  - pip install -r requirements.txt
-  #Install
-  - python setup.py install
 
 script:
   - coverage run run_tests.py
@@ -42,7 +39,7 @@ script:
   #Build docs
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD_DOCS ]]; then
-      pip install -r docs-requirements.txt
+      conda install --file docs-requirements.txt
       # Install doctr from a custom branch until
       # https://github.com/drdoctr/doctr/pull/190 is merged.
       pip uninstall -y doctr

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-timeout
+codecov
+bluesky


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Entire build is now done with Conda. This has the following advantages:

1) Checks the accuracy of our conda-recipe. This is more important than checking `pip` with `requirements.txt` as most users will install via Conda.
2) Checks that all the packages from our stack are properly in the Conda channel. Not so important for this package as there are no internal dependencies. In general however, it is nice to know that before we push our build to Anaconda that we have built and passed the tests with the latest `pcds-tag` versions
3) Building the package then makes it very quick to send to Anaconda. We also avoid those annoying errors were everything passes tests with a `pip` install then fails at the very end when trying to build the package for Anaconda.

### Transition to PCDS Conda channels
For packages that will be used widely throughout PCDS it does not make sense to stick these in a Skywalker channel. Therefore, after this is merged to master, **no more builds will be sent to the skywalker- conda channels**. This is not actually done in the Travis file itself but instead with env variables configured on the Travis site. However, since this refactors the Travis file it seems like an obvious point to make the switch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #124 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and on my Travis branch