### PR TITLE
ENH: Lodcm

### DIFF
--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -1,6 +1,6 @@
 import math
 
-from ophyd.status import NullStatus
+from ophyd.sim import NullStatus
 
 from .state import StatePositioner, StateRecordPositioner, PVStatePositioner
 

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -1,5 +1,7 @@
 import math
 
+from ophyd.status import NullStatus
+
 from .state import StatePositioner, StateRecordPositioner, PVStatePositioner
 
 
@@ -52,7 +54,10 @@ class InOutPositioner(StatePositioner):
     def remove(self, moved_cb=None, timeout=None, wait=False):
         """
         Macro to move this device to the first state on the out_states list.
+        If we're already at some other out state, do nothing instead.
         """
+        if self.removed:
+            return NullStatus()
         return self.move(self.out_states[0], moved_cb=moved_cb,
                          timeout=timeout, wait=wait)
 

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -3,7 +3,7 @@ from threading import RLock
 from ophyd import Device, Component
 from ophyd.status import DeviceStatus, wait as status_wait
 
-from ..inout import InOutRecordPositioner
+from .inout import InOutRecordPositioner
 
 
 class H1NStates(InOutRecordPositioner):

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -1,3 +1,11 @@
+"""
+LODCM: Large offset dual-crystal monochrometer.
+
+The scope of this module is to identify where the beam is intended to go after
+passing through the monochrometer, and to manipulate the diagnostics.
+
+This will not assist in the alignment procedure.
+"""
 from threading import RLock
 
 from ophyd import Device, Component
@@ -25,8 +33,16 @@ class DectrisStates(InOutRecordPositioner):
 class FoilStates(InOutRecordPositioner):
     states_list = ['OUT']
     in_states = []
-    # This class needs rethinking because the foils are different between the
-    # two lodcm instances
+
+
+class XPPFoil(FoilStates):
+    states_list = ['OUT', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
+    in_states = ['Mo', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
+
+
+class XCSFoil(FoilStates):
+    states_list = ['OUT', 'Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
+    in_states = ['Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
 
 
 class LODCM(Device):

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -12,7 +12,8 @@ import functools
 
 from ophyd import Component as Cmp
 from ophyd.signal import EpicsSignal
-from ophyd.status import NullStatus, wait as status_wait
+from ophyd.sim import NullStatus
+from ophyd.status import wait as status_wait
 
 from .inout import InOutRecordPositioner
 

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -39,16 +39,6 @@ class Foil(InOutRecordPositioner):
     in_states = []
 
 
-class FoilXPP(Foil):
-    states_list = ['OUT', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
-    in_states = ['Mo', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
-
-
-class FoilXCS(Foil):
-    states_list = ['OUT', 'Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
-    in_states = ['Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
-
-
 class LODCM(InOutRecordPositioner):
     """
     Large Offset Dual Crystal Monochromator
@@ -148,11 +138,3 @@ class LODCM(InOutRecordPositioner):
             status_wait(status)
 
         return status
-
-
-class LODCMXPP(LODCM):
-    foil = Cmp(FoilXPP, ":FOIL")
-
-
-class LODCMXCS(LODCM):
-    foil = Cmp(FoilXCS, ":FOIL")

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -8,6 +8,7 @@ downstream hutches.
 It will not be possible to align the device with the class, and there will be
 no readback into the device's alignment. This is intended for a future update.
 """
+import logging
 import functools
 
 from ophyd import Component as Cmp
@@ -17,16 +18,20 @@ from ophyd.status import wait as status_wait
 
 from .inout import InOutRecordPositioner
 
+logger = logging.getLogger(__name__)
+
 
 class YagLom(InOutRecordPositioner):
     states_list = ['OUT', 'YAG', 'SLIT1', 'SLIT2', 'SLIT3']
     in_states = ['YAG', 'SLIT1', 'SLIT2', 'SLIT3']
+    _states_alias = {'YAG': 'IN'}
 
 
 class Dectris(InOutRecordPositioner):
     states_list = ['OUT', 'DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3', 'OUTLOW']
     in_states = ['DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3']
     out_states = ['OUT', 'OUTLOW']
+    _states_alias = {'DECTRIS': 'IN'}
 
 
 class Foil(InOutRecordPositioner):
@@ -131,6 +136,7 @@ class LODCM(InOutRecordPositioner):
         """
         Remove all diagnostic components.
         """
+        logger.debug('Removing %s diagnostics', self.name)
         status = NullStatus()
         for dia in (self.yag, self.dectris, self.diode, self.foil):
             status = status & dia.remove(timeout=timeout, wait=False)

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -14,33 +14,33 @@ from ophyd.status import DeviceStatus, wait as status_wait
 from .inout import InOutRecordPositioner
 
 
-class H1NStates(InOutRecordPositioner):
+class H1N(InOutRecordPositioner):
     states_list = ['OUT', 'C', 'Si']
     in_states = ['C', 'Si']
 
 
-class YagLomStates(InOutRecordPositioner):
+class YagLom(InOutRecordPositioner):
     states_list = ['OUT', 'YAG', 'SLIT1', 'SLIT2', 'SLIT3']
     in_states = ['YAG', 'SLIT1', 'SLIT2', 'SLIT3']
 
 
-class DectrisStates(InOutRecordPositioner):
+class Dectris(InOutRecordPositioner):
     states_list = ['OUT', 'DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3', 'OUTLOW']
     in_states = ['DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3']
     out_states = ['OUT', 'OUTLOW']
 
 
-class FoilStates(InOutRecordPositioner):
+class Foil(InOutRecordPositioner):
     states_list = ['OUT']
     in_states = []
 
 
-class XPPFoil(FoilStates):
+class FoilXPP(Foil):
     states_list = ['OUT', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
     in_states = ['Mo', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
 
 
-class XCSFoil(FoilStates):
+class FoilXCS(Foil):
     states_list = ['OUT', 'Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
     in_states = ['Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
 
@@ -54,11 +54,11 @@ class LODCM(Device):
     diagnostic devices between them. Beam can continue onto the main line, onto
     the mono line, onto both, or onto neither.
     """
-    h1n = Component(H1NStates, ":H1N")
-    yag = Component(YagLomStates, ":DV")
-    dectris = Component(DectrisStates, ":DH")
+    h1n = Component(H1N, ":H1N")
+    yag = Component(YagLom, ":DV")
+    dectris = Component(Dectris, ":DH")
     diode = Component(InOutRecordPositioner, ":DIODE")
-    foil = Component(FoilStates, ":FOIL")
+    foil = Component(Foil, ":FOIL")
 
     SUB_STATE = 'sub_state_changed'
     _default_sub = SUB_STATE
@@ -277,3 +277,11 @@ class LODCM(Device):
             and_status = and_status & stat
 
         return and_status
+
+
+class LODCMXPP(LODCM):
+    foil = Component(FoilXPP, ":FOIL")
+
+
+class LODCMXCS(LODCM):
+    foil = Component(FoilXCS, ":FOIL")

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -45,6 +45,9 @@ def test_inout_motion():
     inout = fake_inout()
     inout.remove()
     assert inout.position == 'OUT'
+    # Remove twice for branch coverage
+    inout.remove()
+    assert inout.position == 'OUT'
     inout.insert()
     assert inout.position == 'IN'
 

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from pcdsdevices.sim.pv import using_fake_epics_pv
-from pcdsdevices.epics.lodcm import LODCM
+from pcdsdevices.lodcm import LODCM
 
 from .conftest import attr_wait_true
 

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -51,6 +51,10 @@ def test_lodcm_destination():
     lodcm.yag.state.put('OUT')
     assert len(lodcm.destination) == 1
 
+    # Unknown state
+    lodcm.state._read_pv.put('Unknown')
+    assert len(lodcm.destination) == 0
+
 
 @using_fake_epics_pv
 def test_lodcm_branches():

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -1,12 +1,13 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+import logging
+
 from unittest.mock import Mock
-import pytest
 
 from pcdsdevices.sim.pv import using_fake_epics_pv
 from pcdsdevices.lodcm import LODCM
 
 from .conftest import attr_wait_true
+
+logger = logging.getLogger(__name__)
 
 
 def fake_lodcm():
@@ -14,19 +15,12 @@ def fake_lodcm():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    lom = LODCM('FAKE:LOM', name='fake_lom', main_line='MAIN')
-    lom.h1n.state._read_pv.put('OUT')
-    lom.h1n.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
+    lom = LODCM('FAKE:LOM', name='fake_lom')
+    lom.state._read_pv.put('OUT')
     lom.yag.state._read_pv.put('OUT')
-    lom.yag.state._read_pv.enum_strs = ['OUT', 'YAG', 'SLIT1', 'SLIT2',
-                                        'SLIT3']
     lom.dectris.state._read_pv.put('OUT')
-    lom.dectris.state._read_pv.enum_strs = ['OUT', 'DECTRIS', 'SLIT1',
-                                            'SLIT2', 'SLIT3', 'OUTLOW']
     lom.diode.state._read_pv.put('OUT')
-    lom.diode.state._read_pv.enum_strs = ['OUT', 'IN']
     lom.foil.state._read_pv.put('OUT')
-    lom.foil.state._read_pv.enum_strs = ['OUT']
     lom.wait_for_connection()
     return lom
 
@@ -77,6 +71,6 @@ def test_subscribe():
     lodcm.subscribe(cb, event_type=lodcm.SUB_STATE, run=False)
     assert not cb.called
     # Change destination from main to mono and main
-    lodcm.h1n.state._read_pv.put('C')
+    lodcm.state._read_pv.put('C')
     attr_wait_true(cb, 'called')
     assert cb.called

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from pcdsdevices.sim.pv import using_fake_epics_pv
 from pcdsdevices.lodcm import LODCM
 
-from .conftest import attr_wait_true
+from .conftest import attr_wait_true, connect_rw_pvs
 
 logger = logging.getLogger(__name__)
 
@@ -15,28 +15,46 @@ def fake_lodcm():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    lom = LODCM('FAKE:LOM', name='fake_lom')
-    lom.state._read_pv.put('OUT')
-    lom.yag.state._read_pv.put('OUT')
-    lom.dectris.state._read_pv.put('OUT')
-    lom.diode.state._read_pv.put('OUT')
-    lom.foil.state._read_pv.put('OUT')
-    lom.wait_for_connection()
-    return lom
+    lodcm = LODCM('FAKE:LOM', name='fake_lom')
+    connect_rw_pvs(lodcm.state)
+    connect_rw_pvs(lodcm.yag.state)
+    connect_rw_pvs(lodcm.dectris.state)
+    connect_rw_pvs(lodcm.diode.state)
+    connect_rw_pvs(lodcm.foil.state)
+    lodcm.state.put('OUT')
+    lodcm.yag.state.put('OUT')
+    lodcm.dectris.state.put('OUT')
+    lodcm.diode.state.put('OUT')
+    lodcm.foil.state.put('OUT')
+    lodcm.wait_for_connection()
+    return lodcm
 
 
-# Call all light interface items and hope for the best
 @using_fake_epics_pv
-def test_destination():
+def test_lodcm_destination():
+    logger.debug('test_lodcm_destination')
     lodcm = fake_lodcm()
     dest = lodcm.destination
     assert isinstance(dest, list)
     for d in dest:
         assert isinstance(d, str)
 
+    lodcm.state.put('OUT')
+    assert len(lodcm.destination) == 1
+    lodcm.state.put('C')
+    assert len(lodcm.destination) == 2
+    # Block the mono line
+    lodcm.yag.state.put('IN')
+    assert len(lodcm.destination) == 1
+    lodcm.state.put('Si')
+    assert len(lodcm.destination) == 0
+    lodcm.yag.state.put('OUT')
+    assert len(lodcm.destination) == 1
+
 
 @using_fake_epics_pv
-def test_branches():
+def test_lodcm_branches():
+    logger.debug('test_lodcm_branches')
     lodcm = fake_lodcm()
     branches = lodcm.branches
     assert isinstance(branches, list)
@@ -45,32 +63,12 @@ def test_branches():
 
 
 @using_fake_epics_pv
-def test_inserted():
+def test_lodcm_remove_dia():
+    logger.debug('test_lodcm_remove_dia')
     lodcm = fake_lodcm()
-    inserted = lodcm.inserted
-    assert isinstance(inserted, bool)
-
-
-@using_fake_epics_pv
-def test_removed():
-    lodcm = fake_lodcm()
-    removed = lodcm.removed
-    assert isinstance(removed, bool)
-
-
-@using_fake_epics_pv
-def test_remove():
-    lodcm = fake_lodcm()
-    lodcm.remove()
-
-
-@using_fake_epics_pv
-def test_subscribe():
-    lodcm = fake_lodcm()
+    lodcm.yag.insert(wait=True)
     cb = Mock()
-    lodcm.subscribe(cb, event_type=lodcm.SUB_STATE, run=False)
-    assert not cb.called
-    # Change destination from main to mono and main
-    lodcm.state._read_pv.put('C')
+    lodcm.remove_dia(moved_cb=cb, wait=True)
     attr_wait_true(cb, 'called')
     assert cb.called
+    assert lodcm.yag.position == 'OUT'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Clean up all the clutter. Simplify down to a states record with just the H1N (first crystal) state, plus some utilities for clearing the diagnostic path. Minor change to `inout` to cause no action on `remove` if already removed. This is because of the `OUTLOW` state in the diagnostics here.

closes #122 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
90% of the time you use the lodcm you just want to get it out of the way. This handles that in a simple, concise way without repeating code. I'd like to defer the rest for later, but it probably just needs some raw motors for alignment tweaking. I expect that an alignment expert just wants the motors, and everyone else just wants to know where H1N is and if the beam passes through the diagnostic stand. If there are no objections, I'll probably just hardcode the motors for the XPP and XCS LODCMS, since there are a ton of them with arbitrary prefixes and they are fixed installations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings