### PR TITLE
Fixes

### DIFF
--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -75,7 +75,7 @@ class AttBase(PVPositioner, FltMvInterface):
         goal = self.setpoint.get()
         ceil = self.trans_ceil.get()
         floor = self.trans_floor.get()
-        if abs(goal - ceil) < abs(goal - floor):
+        if abs(goal - ceil) > abs(goal - floor):
             return 2
         else:
             return 3

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -59,8 +59,8 @@ class AttBase(PVPositioner, FltMvInterface):
     @property
     def actuate_value(self):
         """
-        Sets the value we use in the GO command. This command will return 2 if
-        the setpoint is closer to the ceiling than the floor, or 3 otherwise.
+        Sets the value we use in the GO command. This command will return 3 if
+        the setpoint is closer to the ceiling than the floor, or 2 otherwise.
         In the unlikely event of a tie, we choose the floor.
 
         This will wait until a pending calculation completes before returning.

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -63,9 +63,10 @@ class PulsePicker(InOutPVStatePositioner):
         Cancel the current mode.
         """
         self._log_request('RESET')
-        self.cmd_reset.put(1)
-        if wait:
-            self._wait(self.mode, 0, 'IDLE')
+        if self.mode not in (0, 'IDLE'):
+            self.cmd_reset.put(1)
+            if wait:
+                self._wait(self.mode, 0, 'IDLE')
 
     def open(self, wait=False):
         """

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -63,7 +63,7 @@ class PulsePicker(InOutPVStatePositioner):
         Cancel the current mode.
         """
         self._log_request('RESET')
-        if self.mode not in (0, 'IDLE'):
+        if self.mode.get() not in (0, 'IDLE'):
             self.cmd_reset.put(1)
             if wait:
                 self._wait(self.mode, 0, 'IDLE')

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -219,6 +219,10 @@ class Slits(Device, MvInterface):
         """
         return (self.xwidth.position, self.ywidth.position)
 
+    @property
+    def position(self):
+        return self.current_aperture
+
     def remove(self, size=None, wait=False, timeout=None, **kwargs):
         """
         Open the slits to unblock the beam

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -55,8 +55,6 @@ def fake_move_transition(att, status, goal):
     Set to the PVs sort of like it would happen in the real world and check the
     status
     """
-    # Sanity check
-    assert not status.done
     # Set status to "MOVING"
     att.done._read_pv.put(1)
     attr_wait_true(att, '_moving')  # This transition is important

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -82,12 +82,12 @@ def test_attenuator_motion():
     status = att.move(0.8, wait=False)
     fake_move_transition(att, status, 0.8001)
     assert att.setpoint.value == 0.8
-    assert att.actuate_value == 2
+    assert att.actuate_value == 3
     # Move to floor
     status = att.move(0.5, wait=False)
     fake_move_transition(att, status, 0.5001)
     assert att.setpoint.value == 0.5
-    assert att.actuate_value == 3
+    assert att.actuate_value == 2
     # Call remove method
     status = att.remove(wait=False)
     fake_move_transition(att, status, 1)

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -92,11 +92,21 @@ def test_picker_motion():
     assert picker.position == 'OUT'
 
 
+def put_soon(sig, val):
+    def inner():
+        time.sleep(0.2)
+        sig._read_pv.put(val)
+    t = threading.Thread(target=inner, args=())
+    t.start()
+
+
 @pytest.mark.timeout(5)
 @using_fake_epics_pv
 def test_picker_mode():
     logger.debug('test_picker_mode')
     picker = fake_picker()
+    picker.mode._read_pv.put(1)
+    put_soon(picker.mode, 0)
     picker.reset(wait=True)
     assert picker.cmd_reset.get() == 1
     picker.open(wait=False)
@@ -116,13 +126,6 @@ def test_picker_mode():
 def test_picker_mode_wait():
     logger.debug('test_picker_mode_waits')
     picker = fake_picker()
-
-    def put_soon(sig, val):
-        def inner():
-            time.sleep(0.2)
-            sig._read_pv.put(val)
-        t = threading.Thread(target=inner, args=())
-        t.start()
 
     put_soon(picker.blade, 0)
     picker.open(wait=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- pulsepicker reset skips itself if not needed to solve race conditions
- att sets were backwards with respect to ceil/floor, so I flipped them
- slits have a position property now
- att moves to the same position should return quickly if waited on