### PR TITLE
FIX: workaround for pyepics warnings

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1,7 +1,7 @@
 import logging
 
 from ophyd.utils import LimitError
-from ophyd import EpicsMotor, Component, EpicsSignal, Signal
+from ophyd import EpicsMotor, Component, EpicsSignal, EpicsSignalRO, Signal
 
 from .mv_interface import FltMvInterface
 
@@ -44,6 +44,11 @@ class EpicsMotor(EpicsMotor, FltMvInterface):
     # Additional soft limit configurations
     low_soft_limit = Component(EpicsSignal, ".LLM")
     high_soft_limit = Component(EpicsSignal, ".HLM")
+
+    # In our control system, these need to be monitored to avoid warnings
+    low_limit_switch = Component(EpicsSignalRO, ".LLS", auto_monitor=True)
+    high_limit_switch = Component(EpicsSignalRO, ".HLS",
+                                  auto_monitor=True)
     # Disable missing field that our EPICS motor record lacks
     # This attribute is tracked by the _pos_changed callback
     direction_of_travel = Component(Signal)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Something weird in the `EpicsMotor` class in conjunction with the rest of our system spits out pyepics warnings on every move, unless we monitor these values.