### PR TITLE
FIX: PPSStopper created state_list not states_list

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -147,7 +147,7 @@ class PPSStopper(InOutPositioner):
         # Store state information
         self.in_states = [in_state]
         self.out_states = [out_state]
-        self.state_list = self.in_states + self.out_states
+        self.states_list = self.in_states + self.out_states
         # Load InOutPositioner
         super().__init__(prefix, **kwargs)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Unhappy discovery while creating a `PPSStopper`. The class constructor overwrites `state_list` and not `states_list` as it should. This means that the `states_enum` is not created correctly which causes a multitude of problems.
