### PR TITLE
ENH: calib_at_step

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,8 +17,8 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
-    - ophyd >=1.0.0
-    - bluesky >=1.0.0
+    - ophyd >=1.1.0
+    - bluesky >=1.2.0
 
 test:
   imports:

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -2,16 +2,17 @@ import time
 import logging
 import pytest
 
-from ophyd.sim import SynSignal
+from ophyd.sim import SynSignal, motor1
 from ophyd.status import wait as status_wait
 from bluesky import RunEngine
+from bluesky.plans import scan
 from bluesky.plan_stubs import (trigger_and_read,
                                 create, read, save, null)
 from bluesky.preprocessors import run_decorator, run_wrapper
 
 from pcdsdevices import daq as daq_module
 from pcdsdevices.daq import (Daq, daq_wrapper, daq_decorator, calib_cycle,
-                             BEGIN_TIMEOUT)
+                             calib_at_step, BEGIN_TIMEOUT)
 from pcdsdevices.sim import pydaq as sim_pydaq
 from pcdsdevices.sim.pydaq import SimNoDaq
 
@@ -42,6 +43,12 @@ def sig():
     sig = SynSignal(name='test')
     sig.put(0)
     return sig
+
+
+@pytest.fixture(scope='function')
+def mot():
+    motor1.set(0)
+    return motor1
 
 
 def test_connect(daq):
@@ -291,6 +298,28 @@ def test_scan_auto(daq, RE, sig):
     daq.configure(mode='auto', events=1)
     RE(plan(sig))
     assert daq.state == 'Configured'
+
+
+@pytest.mark.timeout(10)
+def test_scan_at_step(daq, RE, sig, mot):
+    """
+    We expect that calib_at_step works for the basic scan in manual mode
+    """
+    logger.debug(test_scan_at_step)
+
+    dt = 1
+    steps = 3
+    daq_dur = steps * dt
+    pos_end = 10
+    start = time.time()
+    RE(daq_wrapper(scan([sig], mot, 0, pos_end, steps,
+                        per_step=calib_at_step(duration=dt)),
+                   mode='manual'))
+    end = time.time()
+    duration = end - start
+    assert daq_dur < duration < daq_dur + 1
+    assert mot.position == pos_end
+    assert sig in daq.config['controls']
 
 
 @pytest.mark.timeout(10)

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -319,7 +319,6 @@ def test_scan_at_step(daq, RE, sig, mot):
     duration = end - start
     assert daq_dur < duration < daq_dur + 1
     assert mot.position == pos_end
-    assert sig in daq.config['controls']
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Add calib_at_step that can be safely passed as a `per_step` argument to plans such as `scan`
- Fix bug where under certain conditions the `calib_cycle` plan would have duration zero, instead of the desired duration
- Avoid race conditions where errors spew out at close if `daq.__del__` was called too late

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #161 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a test that makes sure we can use it as a `per_step` hook in `manual` mode and that the scan lasts for three calib cycles.