### PR TITLE
FIX: Mirror prefixes

### DIFF
--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -177,7 +177,9 @@ class OffsetMirror(Device):
     xgantry = FC(Gantry, "{self._prefix_xy}:X",
                  gantry_prefix="{self._xgantry}",
                  add_prefix=['suffix', 'gantry_prefix'])
-    ygantry = FC(Gantry, "{self._prefix_xy}:Y")
+    ygantry = FC(Gantry, "{self._prefix_xy}:Y",
+                 gantry_prefix='GANTRY:{self.prefix}:Y',
+                 add_prefix=['suffix', 'gantry_prefix'])
     # Transmission for Lightpath Interface
     transmission = 1.0
 

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -47,7 +47,7 @@ def test_mirror_init():
     assert bm.xgantry.prefix == 'STEP:TST:M1H:X:P'
     assert bm.xgantry.gantry_prefix == 'GANTRY:M1H:X'
     assert bm.ygantry.prefix == 'STEP:TST:M1H:Y:P'
-    assert bm.ygantry.gantry_prefix == 'GANTRY:STEP:TST:M1H:Y'
+    assert bm.ygantry.gantry_prefix == 'GANTRY:TST:M1H:Y'
     m = OffsetMirror('TST:M1H', name="Test Mirror")
     assert m.pitch.prefix == 'MIRR:TST:M1H'
     assert m.xgantry.prefix == 'TST:M1H:X:P'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The tests did not accurately reflect the naming scheme for the `FEE` HOMS mirrors. This caused an issue with the way we load the `YGantry.gantry_prefix`. The tests have been updated to reflect reality and we are able to load the mirror information with:
```python
fee_m1 = OffsetMirror('FEE:M1H', name='fee_m1h', prefix_xy='STEP:M1H', xgantry_prefix='STEP:FEE1:611:MOTR')
xrt_m1 = OffsetMirror('XRT:M1H', name='xrt_m1h')
```
