### PR TITLE
FIX: call setup_ophyd at init

### DIFF
--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,3 +1,7 @@
+from ophyd import setup_ophyd
 from ._version import get_versions
+
+setup_ophyd()
+del setup_ophyd
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`setup_ophyd` installs the `MonitorDispatcher` which makes `pyepics` run more reliably.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We learned about `setup_ophyd` today. We can put it here so that all users of `pcdsdevices` at lcls don't have to worry about setting it up.