### PR TITLE
DOC: Clean up the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ script:
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_PCDSDEVICES" && $BUILD_DOCS ]]; then
       conda install --file docs-requirements.txt
       pushd docs
-      sphinx-autogen -o source/generated source/*.rst
       make html
       popd
       #Publish docs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 script:
   - coverage run run_tests.py
   - coverage report -m
+  - flake8 pcdsdevices/*.py
   - set -e
   #Build docs
   - |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-timeout
 codecov
+flake8

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTO    = sphinx-autogen
 SPHINXPROJ    = PCDSDevices
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -17,4 +18,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	$(SPHINXAUTO) -o $(SOURCEDIR)/generated $(SOURCEDIR)/*.rst
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,6 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXAUTO    = sphinx-autogen
 SPHINXPROJ    = PCDSDevices
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -15,8 +14,11 @@ help:
 
 .PHONY: help Makefile
 
+clean:
+	-rm -rf $(BUILDDIR)
+	-rm -rf $(SOURCEDIR)/generated
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	$(SPHINXAUTO) -o $(SOURCEDIR)/generated $(SOURCEDIR)/*.rst
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/_templates/autosummary/base.rst
+++ b/docs/source/_templates/autosummary/base.rst
@@ -1,0 +1,5 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,28 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: generated
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -1,0 +1,36 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: Functions
+
+   .. autosummary::
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: Classes
+
+   .. autosummary::
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -7,6 +7,7 @@
    .. rubric:: Functions
 
    .. autosummary::
+      :toctree: generated
    {% for item in functions %}
       {{ item }}
    {%- endfor %}
@@ -18,6 +19,7 @@
    .. rubric:: Classes
 
    .. autosummary::
+      :toctree: generated
    {% for item in classes %}
       {{ item }}
    {%- endfor %}
@@ -29,6 +31,7 @@
    .. rubric:: Exceptions
 
    .. autosummary::
+      :toctree: generated
    {% for item in exceptions %}
       {{ item }}
    {%- endfor %}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,22 @@
+API
+###
+
+.. autosummary::
+   :toctree: generated
+
+   ~pcdsdevices.attenuator
+   ~pcdsdevices.epics_motor
+   ~pcdsdevices.inout
+   ~pcdsdevices.ipm
+   ~pcdsdevices.lens
+   ~pcdsdevices.lodcm
+   ~pcdsdevices.mirror
+   ~pcdsdevices.movablestand
+   ~pcdsdevices.mps
+   ~pcdsdevices.mv_interface
+   ~pcdsdevices.pim
+   ~pcdsdevices.pulsepicker
+   ~pcdsdevices.signal
+   ~pcdsdevices.slits
+   ~pcdsdevices.state
+   ~pcdsdevices.valve

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,8 @@ extensions = ['sphinx.ext.autodoc',
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+autosummary_generate = True
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
@@ -83,6 +85,9 @@ language = None
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
+
+# The reST default role (used for this markup: `text`)
+default_role = 'any'
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -7,14 +7,16 @@ Common EPICS Devices
     :toctree: generated
     
     Attenuator
-    IMS
-    Newport
-    PMC100
+    EpicsMotor
+    LODCM
     GateValve
+    IMS
     IPM
-    OffsetMirror
+    Newport
     PIM
-    PulsePicker
+    PMC100
+    OffsetMirror
+    PointingMirror
     Slits
     Stopper
     XFLS

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -7,7 +7,9 @@ Common EPICS Devices
     :toctree: generated
     
     Attenuator
-    EpicsMotor
+    IMS
+    Newport
+    PMC100
     GateValve
     IPM
     OffsetMirror

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -16,6 +16,7 @@ Common EPICS Devices
     PIM
     PMC100
     OffsetMirror
+    PulsePicker
     PointingMirror
     Slits
     Stopper

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,5 +19,4 @@ custom devices for specific applications.
    :caption: Developer Documentation 
    :hidden:
     
-   state.rst
-   inout.rst
+   api.rst

--- a/docs/source/inout.rst
+++ b/docs/source/inout.rst
@@ -1,5 +1,0 @@
-InOut Devices
-#############
-
-.. automodule:: pcdsdevices.inout
-   :members:

--- a/docs/source/state.rst
+++ b/docs/source/state.rst
@@ -1,5 +1,0 @@
-State Classes
-#############
-
-.. automodule:: pcdsdevices.state
-   :members:

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1,3 +1,6 @@
+"""
+Module for `Attenuator` and related classes.
+"""
 import logging
 import time
 
@@ -23,7 +26,7 @@ class Filter(InOutPositioner):
     can work around mechanical problems.
 
     This is not intended to be instantiated by a user, but instead included as
-    a ``Component`` in a subclass of ``AttBase``. You can instantiate these
+    a ``Component`` in a subclass of `AttBase`. You can instantiate these
     classes via the `Attenuator` factory function.
     """
     state = Cmp(EpicsSignal, ':STATE', write_pv=':GO')

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -1,5 +1,6 @@
+# flake8: NOQA
 from .attenuator import Attenuator
-from .epics_motor import IMS, Newport, PMC100
+from .epics_motor import IMS, Newport, PMC100, EpicsMotor
 from .ipm import IPM
 from .lens import XFLS
 from .lodcm import LODCM

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -1,5 +1,5 @@
 from .attenuator import Attenuator
-from .epics_motor import EpicsMotor
+from .epics_motor import IMS, Newport, PMC100
 from .ipm import IPM
 from .lens import XFLS
 from .lodcm import LODCM

--- a/pcdsdevices/doc_stubs.py
+++ b/pcdsdevices/doc_stubs.py
@@ -1,0 +1,40 @@
+basic_positioner_init = """
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The EPICS PV prefix for this motor.
+
+    name: ``str``, required keyword
+        An identifying name for this motor.
+
+    settle_time: ``float``, optional
+        The amount of extra time to wait before interpreting a move as done
+
+    timeout ``float``, optional
+        The amount of time to wait before automatically marking a long
+        in-progress move as failed.
+
+"""
+
+insert_remove = """
+
+        Parameters
+        ----------
+        moved_cb: ``callable``, optional
+            Call this callback when movement is finished. This callback must
+            accept one keyword argument, ``obj``, which will be set to this
+            instance.
+
+        timeout: ``float``, optional
+            Maximum time to wait for the motion.
+
+        wait: ``bool``, optional
+            If ``True``, do not continue until the move is complete.
+
+        Returns
+        -------
+        moved_status: ``Status``
+            ``Status`` that will be marked as done when the motion is complete.
+
+"""

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1,3 +1,6 @@
+"""
+Module for LCLS's special motor records.
+"""
 import logging
 
 from ophyd.utils import LimitError

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -3,6 +3,7 @@ import logging
 from ophyd.utils import LimitError
 from ophyd import EpicsMotor, Component, EpicsSignal, Signal
 
+from .doc_stubs import basic_positioner_init
 from .mv_interface import FltMvInterface
 
 
@@ -151,32 +152,13 @@ class PCDSMotorBase(EpicsMotor, FltMvInterface):
                              value=value, **kwargs)
 
 
-basic_motor_doc = """
-
-    Parameters
-    ----------
-    prefix: ``str``
-        The EPICS PV prefix for this motor.
-
-    name: ``str``, required keyword
-        An identifying name for this motor.
-
-    settle_time: ``float``, optional
-        The amount of extra time to wait before interpreting a move as done
-
-    timeout ``float``, optional
-        The amount of time to wait before automatically marking a long
-        in-progress move as failed.
-"""
-
-
 class IMS(PCDSMotorBase):
     """
     PCDS implementation of the Motor Record for IMS motors.
 
     This is a subclass of `PCDSMotorBase`
     """
-    __doc__ += basic_motor_doc
+    __doc__ += basic_positioner_init
 
 
 class Newport(PCDSMotorBase):
@@ -187,7 +169,7 @@ class Newport(PCDSMotorBase):
     disables the ``home`` method, because it will not work the same way for
     Newport motors.
     """
-    __doc__ += basic_motor_doc
+    __doc__ += basic_positioner_init
 
     offset_freeze_switch = Component(Signal)
     home_forward = Component(Signal)
@@ -208,7 +190,7 @@ class PMC100(PCDSMotorBase):
     disables the ``home`` method, because it will not work the same way for
     Newport motors.
     """
-    __doc__ += basic_motor_doc
+    __doc__ += basic_positioner_init
 
     home_forward = Component(Signal)
     home_reverse = Component(Signal)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -151,14 +151,44 @@ class PCDSMotorBase(EpicsMotor, FltMvInterface):
                              value=value, **kwargs)
 
 
-# This is a place holder until we have IMS specific records and methods
-IMS = PCDSMotorBase
+basic_motor_doc = """
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The EPICS PV prefix for this motor.
+
+    name: ``str``, required keyword
+        An identifying name for this motor.
+
+    settle_time: ``float``, optional
+        The amount of extra time to wait before interpreting a move as done
+
+    timeout ``float``, optional
+        The amount of time to wait before automatically marking a long
+        in-progress move as failed.
+"""
+
+
+class IMS(PCDSMotorBase):
+    """
+    PCDS implementation of the Motor Record for IMS motors.
+
+    This is a subclass of `PCDSMotorBase`
+    """
+    __doc__ += basic_motor_doc
 
 
 class Newport(PCDSMotorBase):
     """
     PCDS implementation of the Motor Record for Newport motors
+
+    This is a subclass of `PCDSMotorBase` that overwrites missings signals and
+    disables the ``home`` method, because it will not work the same way for
+    Newport motors.
     """
+    __doc__ += basic_motor_doc
+
     offset_freeze_switch = Component(Signal)
     home_forward = Component(Signal)
     home_reverse = Component(Signal)
@@ -173,7 +203,13 @@ class Newport(PCDSMotorBase):
 class PMC100(PCDSMotorBase):
     """
     PCDS implementation of the Motor Record PMC100 motors
+
+    This is a subclass of `PCDSMotorBase` that overwrites missing signals and
+    disables the ``home`` method, because it will not work the same way for
+    Newport motors.
     """
+    __doc__ += basic_motor_doc
+
     home_forward = Component(Signal)
     home_reverse = Component(Signal)
 

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -2,29 +2,32 @@ import math
 
 from ophyd.sim import NullStatus
 
+from .doc_stubs import basic_positioner_init, insert_remove
 from .state import StatePositioner, StateRecordPositioner, PVStatePositioner
 
 
 class InOutPositioner(StatePositioner):
     """
-    Basic InOut StatePositioner. It can be inserted and removed and queried for
-    insertion and removal. It can also define transmission values for the
+    Basic in/out `StatePositioner`. It can be inserted, removed and queried for
+    insertion and removal state. It can also define transmission values for the
     various states.
-
+%s
     Attributes
     ----------
-    in_states: list of strings
-        State values that should be considered 'in'.
+    in_states: ``list` of ``str``
+        State values that should be considered ``IN``.
 
-    out_states: list of strings
-        State values that should be considered 'out'.
+    out_states: ``list`` of ``str``
+        State values that should be considered ``OUT``.
 
-    _transmission: dict{str: number}
+    _transmission: ``dict{str: float}``
         Mapping from each state to the transmission ratio. This should be a
         number from 0 to 1. Default values will be 1 (full transmission) for
-        out_states, 0 (full block) for in_states, and nan (no idea!) for
-        unaccounted states.
+        ``out_states``, 0 (full block) for ``in_states``, and nan (no idea!)
+        for unaccounted states.
     """
+    __doc__ = __doc__ % basic_positioner_init
+
     states_list = ['IN', 'OUT']
     in_states = ['IN']
     out_states = ['OUT']
@@ -38,15 +41,23 @@ class InOutPositioner(StatePositioner):
 
     @property
     def inserted(self):
+        """
+        True if the device is inserted
+        """
         return self._pos_in_list(self.in_states)
 
     @property
     def removed(self):
+        """
+        True if the device is removed
+        """
         return self._pos_in_list(self.out_states)
 
     def insert(self, moved_cb=None, timeout=None, wait=False):
         """
-        Macro to move this device to the first state on the in_states list.
+        Insert this device.
+
+        Moves this device to the first state on the `in_states` list.
         """
         return self.move(self.in_states[0], moved_cb=moved_cb,
                          timeout=timeout, wait=wait)
@@ -60,6 +71,9 @@ class InOutPositioner(StatePositioner):
             return NullStatus()
         return self.move(self.out_states[0], moved_cb=moved_cb,
                          timeout=timeout, wait=wait)
+
+    insert.__doc__ += insert_remove
+    remove.__doc__ += insert_remove
 
     @property
     def transmission(self):
@@ -81,26 +95,32 @@ class InOutPositioner(StatePositioner):
 
 class InOutRecordPositioner(StateRecordPositioner, InOutPositioner):
     """
-    Positioner for a motor that moves to states IN and OUT using a standard
-    states record. This can be subclassed for other states records that involve
-    inserting and removing something into the beam.
+    `InOutPositioner` for a standard states record.
+
+    Positioner for a motor that moves to states ``IN`` and ``OUT`` using a
+    standard states record. This can be subclassed for other states records
+    that involve inserting and removing something into the beam.
     """
-    pass
+    __doc__ += basic_positioner_init
 
 
 class TTReflaser(InOutRecordPositioner):
     """
     Motor stack that includes both a timetool and a reflaser.
     """
+    __doc__ += basic_positioner_init
+
     states_list = ['TT', 'REFL', 'OUT']
     in_states = ['TT', 'REFL']
 
 
 class InOutPVStatePositioner(PVStatePositioner, InOutPositioner):
     """
+    `InOutPositioner` on top of a `PVStatePositioner`
+
     Positioner for a set of PVs that result in aggregate IN and OUT states for
     a single device. This must be subclassed and provided a _state_logic
-    attribute to be used. Consult the PVStatePositioner documentation for more
-    information.
+    attribute to be used. Consult the `PVStatePositioner` documentation for
+    more information.
     """
-    pass
+    __doc__ += basic_positioner_init

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -1,3 +1,10 @@
+"""
+Module to centralize code related to devices that can be ``IN`` or ``OUT``.
+
+The classes that are defined here can be used to create other devices that need
+methods such as ``insert`` or ``remove`` and the ability to mark discrete
+states as in the beam or out of the beam.
+"""
 import math
 
 from ophyd.sim import NullStatus

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -1,19 +1,24 @@
 from ophyd import Component as Cmp
 from ophyd.signal import EpicsSignal
 
+from .doc_stubs import basic_positioner_init
 from .inout import InOutRecordPositioner
 
 
 class IPM(InOutRecordPositioner):
     """
-    Standard intensity position monitor motion. This is a positioner that moves
+    Standard intensity position monitor.
+
+    This is an `InOutRecordPositioner` that moves
     the target position to any of the four set positions, or out. Valid states
     are (1, 2, 3, 4, 5) or the equivalent (T1, T2, T3, T4, OUT).
 
     IPMs each also have a diode, which is implemented as the diode attribute of
-    this class. This can easily be controlled using ipm.diode.insert() or
-    ipm.diode.remove().
+    this class. This can easily be controlled using ``ipm.diode.insert()`` or
+    ``ipm.diode.remove()``.
     """
+    __doc__ += basic_positioner_init
+
     state = Cmp(EpicsSignal, ':TARGET', write_pv=':TARGET:GO')
     diode = Cmp(InOutRecordPositioner, ":DIODE")
 

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -1,3 +1,6 @@
+"""
+Module for the `IPM` intensity position monitor class
+"""
 from ophyd import Component as Cmp
 from ophyd.signal import EpicsSignal
 

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -4,6 +4,7 @@ Basic Beryllium Lens XFLS
 The scope of this module is picking a lens, not focusing or aligning the
 lenses. This will be expanded in the future.
 """
+from .doc_stubs import basic_positioner_init
 from .inout import InOutRecordPositioner
 
 
@@ -13,6 +14,8 @@ class XFLS(InOutRecordPositioner):
 
     This is the simple version where the lens positions are named by number.
     """
+    __doc__ += basic_positioner_init
+
     states_list = ['LENS1', 'LENS2', 'LENS3', 'OUT']
     in_states = ['LENS1', 'LENS2', 'LENS3']
     _lens_transmission = 0.8

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -16,6 +16,7 @@ from ophyd.signal import EpicsSignal
 from ophyd.sim import NullStatus
 from ophyd.status import wait as status_wait
 
+from .doc_stubs import basic_positioner_init, insert_remove
 from .inout import InOutRecordPositioner
 
 logger = logging.getLogger(__name__)
@@ -49,7 +50,15 @@ class LODCM(InOutRecordPositioner):
     the mono line, onto both, or onto neither.
 
     This positioner only considers the h1n and diagnostic motors.
+{}
+    main_line: ``str``, optional
+        Name of the main, no-bounce beamline.
+
+    mono_line: ``str``, optional
+        Name of the mono, double-bounce beamline.
     """
+    __doc__.format(basic_positioner_init)
+
     state = Cmp(EpicsSignal, ':H1N', write_pv=':H1N:GO')
 
     yag = Cmp(YagLom, ":DV")
@@ -76,7 +85,7 @@ class LODCM(InOutRecordPositioner):
         """
         Returns
         -------
-        branches: list of str
+        branches: ``list`` of ``str``
             A list of possible destinations.
         """
         return [self.main_line, self.mono_line]
@@ -84,14 +93,15 @@ class LODCM(InOutRecordPositioner):
     @property
     def destination(self):
         """
-        Return where the light is going at the current LODCM
-        state. Indeterminate states will show as blocked.
+        Which beamline the light is reaching.
+
+        Indeterminate states will show as blocked.
 
         Returns
         -------
-        destination: list of str
-            self.main_line if the light continues on the main line.
-            self.mono_line if the light continues on the mono line.
+        destination: ``list`` of ``str``
+            ``self.main_line`` if the light continues on the main line.
+            ``self.mono_line`` if the light continues on the mono line.
         """
         if self.position == 'OUT':
             dest = [self.main_line]
@@ -114,8 +124,8 @@ class LODCM(InOutRecordPositioner):
 
         Returns
         -------
-        diag_clear: bool
-            False if the diagnostics will prevent beam.
+        diag_clear: ``bool``
+            ``False`` if the diagnostics will prevent beam.
         """
         yag_clear = self.yag.removed
         dectris_clear = self.dectris.removed
@@ -138,3 +148,5 @@ class LODCM(InOutRecordPositioner):
             status_wait(status)
 
         return status
+
+    remove_dia.__doc__ += insert_remove

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -50,14 +50,14 @@ class LODCM(InOutRecordPositioner):
     the mono line, onto both, or onto neither.
 
     This positioner only considers the h1n and diagnostic motors.
-{}
+%s
     main_line: ``str``, optional
         Name of the main, no-bounce beamline.
 
     mono_line: ``str``, optional
         Name of the mono, double-bounce beamline.
     """
-    __doc__.format(basic_positioner_init)
+    __doc__ = __doc__ % basic_positioner_init
 
     state = Cmp(EpicsSignal, ':H1N', write_pv=':H1N:GO')
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -12,6 +12,7 @@ import numpy as np
 from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as C,
                    PVPositioner, FormattedComponent as FC)
 
+from .doc_stubs import basic_positioner_init
 from .inout import InOutRecordPositioner
 from .mv_interface import FltMvInterface
 
@@ -21,15 +22,9 @@ logger = logging.getLogger(__name__)
 class OMMotor(PVPositioner, FltMvInterface):
     """
     Base class for each motor in the LCLS offset mirror system.
-
-    Parameters
-    ----------
-    prefix : str
-        The EPICS base pv to use
-
-    name : str
-        The name of the motor
     """
+    __doc__ += basic_positioner_init
+
     # position
     readback = C(EpicsSignalRO, ':RBV', auto_monitor=True)
     setpoint = C(EpicsSignal, ':VAL', limits=True)
@@ -50,7 +45,7 @@ class OMMotor(PVPositioner, FltMvInterface):
 
         Returns
         -------
-        egu: str
+        egu: ``str``
         """
         return self.motor_egu.get()
 
@@ -61,15 +56,15 @@ class OMMotor(PVPositioner, FltMvInterface):
 
         Parameters
         ----------
-        position : float
+        position: ``float``
             Position to check for validity
 
         Raises
         ------
-        ValueError
-            If position is None, NaN or Inf
+        ``ValueError``
+            If position is ``None``, ``NaN`` or ``Inf``
 
-        LimitError
+        ``LimitError``
             If the position is outside the soft limits
         """
         # Check that we do not have a NaN or an Inf as those will
@@ -87,6 +82,8 @@ class Pitch(OMMotor):
     The axis is actually a piezo actuator and a stepper motor in series, and
     this is reflected in the PV naming
     """
+    __doc__ += basic_positioner_init
+
     piezo_volts = FC(EpicsSignalRO, "{self._piezo}:VRBV")
     stop_signal = FC(EpicsSignal, "{self._piezo}:STOP")
     # TODO: Limits will be added soon, but not present yet
@@ -148,7 +145,9 @@ class Gantry(OMMotor):
 
 class OffsetMirror(Device):
     """
-    X-Ray offset mirror class for each individual mirror system used in the FEE
+    X-Ray offset mirror class.
+
+    This is for each individual mirror system used in the FEE
     and XRT. Controls for the pitch, and primary gantry x and y motors are
     included.
 
@@ -212,20 +211,20 @@ class OffsetMirror(Device):
 
 class PointingMirror(InOutRecordPositioner, OffsetMirror):
     """
-    Retractable OffsetMirror
+    Retractable `OffsetMirror`
 
     Both XRT M1H and XRT M2H can be completely removed from the beam depending
     on the beam destination. In this case, the X gantry can be controlled via
     the standard PCDS states record. This class has all the functionality of
-    :class:`.OffsetMirror` with the addition of the records that control the
+    `OffsetMirror` with the addition of the records that control the
     overall state.
 
     Parameters
     ----------
-    in_lines : list, optional
+    in_lines: ``list``, optional
         List of beamlines that are delivered beam when the mirror is in
 
-    out_lines : list, optional
+    out_lines: ``list``, optional
         List of beamlines thate are delivered beam when the mirror is out
     """
     # Define default read and configuration attributes

--- a/pcdsdevices/movablestand.py
+++ b/pcdsdevices/movablestand.py
@@ -4,6 +4,15 @@ from .inout import InOutPVStatePositioner
 
 
 class MovableStand(InOutPVStatePositioner):
+    """
+    Stand that can be moved.
+
+    Parameters
+    ----------
+    prefix: ``str``
+
+    name: ``str``, required keyword
+    """
     in_limit = Cmp(EpicsSignalRO, ':IN_DI')
     out_limit = Cmp(EpicsSignalRO, ':OUT_DO')
 

--- a/pcdsdevices/movablestand.py
+++ b/pcdsdevices/movablestand.py
@@ -1,3 +1,6 @@
+"""
+Module for stands that can be moved
+"""
 from ophyd import Component as Cmp, EpicsSignalRO
 
 from .inout import InOutPVStatePositioner

--- a/pcdsdevices/mps.py
+++ b/pcdsdevices/mps.py
@@ -1,6 +1,8 @@
 """
-Devices that are integrated with the MPS system communicate with ACR via a
-single bit summary. The results of these are published over EPICS and
+Module for devices that are integrated with the MPS system.
+
+These communicate with ACR via a single bit summary.
+The results of these are published over EPICS and
 interpreted by :class:`.MPS`.
 """
 import logging

--- a/pcdsdevices/mps.py
+++ b/pcdsdevices/mps.py
@@ -16,10 +16,15 @@ class MPSBase(OphydObject):
     """
     Base MPS class
 
-    Used for shared methods between the individual :class;`.MPS` bit class and
-    the :class:`.MPSLimits` class. The class handles much of the bookkeeping
-    for both of these classes, but each subclass must reimplement: faulted,
-    bypassed and _sub_to_children
+    Used for shared methods between the individual `MPS` bit class and
+    the `MPSLimits` class. The class handles much of the bookkeeping
+    for both of these classes.
+
+    Each subclass must reimplement:
+
+    - ``faulted``
+    - ``bypassed``
+    - ``sub_to_children``
     """
     # Subscription information
     SUB_FAULT_CH = 'sub_mps_faulted'
@@ -82,13 +87,13 @@ class MPS(MPSBase, Device):
 
     Parameters
     ----------
-    prefix : str
+    prefix : ``str``
         PV prefix of MPS information
 
-    name : str
+    name : ``str``, required keyword
         Name of MPS bit
 
-    veto : bool, optional
+    veto : ``bool``, optional
         Whether or not the the device is capable of vetoing downstream faults
     """
     # Signals
@@ -126,21 +131,21 @@ def mps_factory(clsname, cls,  *args, mps_prefix, veto=False,  **kwargs):
     Create a new object of arbitrary class capable of storing MPS information
 
     A new class identical to the provided one is created, but with additional
-    attribute `mps` that relies upon the provided `mps_prefix`. All other
+    attribute ``mps`` that relies upon the provided ``mps_prefix``. All other
     information is passed through to the class constructor as args and kwargs
 
     Parameters
     ----------
-    clsname : str
+    clsname : ``str``
         Name of new class to create
 
-    cls :
-        Device class to add `mps`
+    cls : ``type``
+        Device class to add ``mps``
 
-    mps_prefix : str
+    mps_prefix : ``str``
         Prefix for MPS subcomponent
 
-    veto : bool, optional
+    veto : ``bool``, optional
         Whether the MPS bit is capable of veto
 
     args :
@@ -160,10 +165,10 @@ def must_be_out(in_limit, out_limit):
 
     Parameters
     ----------
-    in_limit : bool
+    in_limit : ``bool``
         Whether the in limit is active
 
-    out_limit: bool
+    out_limit: ``bool``
         Whether the out limit is active
 
     Returns
@@ -185,10 +190,10 @@ def must_be_known(in_limit, out_limit):
 
     Parameters
     ----------
-    in_limit : bool
+    in_limit : ``bool``
         Whether the in limit is active
 
-    out_limit: bool
+    out_limit: ``bool``
         Whether the out limit is active
 
     Returns
@@ -207,19 +212,19 @@ class MPSLimits(MPSBase, Device):
     For devices that are inserted and removed from the beam, the MPS system
 
     The MPSLimits class is to determine what action is to be taken based on the
-    MPS values of a devicepertaining to a single device. If a device has two
+    MPS values of a device pertaining to a single device. If a device has two
     MPS values, there is certain logic that needs to be followed to determine
     whether or not the beam is allowed through.
 
     Parameters
     ----------
-    prefix :
+    prefix : ``str``
         Base of the MPS PVs
 
-    name : str
+    name : ``str``
         Name of the MPS combination
 
-    logic: callable
+    logic: ``callable``
         Determine whether the MPS is faulted based on the state of each limit.
         The function signature should look like:
 

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -1,3 +1,6 @@
+"""
+Module for defining bell-and-whistles movement features
+"""
 from bluesky.utils import ProgressBar
 from ophyd.status import wait as status_wait
 

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -4,8 +4,10 @@ from ophyd.status import wait as status_wait
 
 class MvInterface:
     """
-    Define common shortcuts that the beamline scientists like for moving things
-    on the command line. There is no need for these in a scripting
+    Interface layer to attach to a positioner for motion shortcuts.
+
+    Defines common shortcuts that the beamline scientists like for moving
+    things on the command line. There is no need for these in a scripting
     environnment, but this is a safe space for implementing move features that
     would otherwise be disruptive to running scans and writing higher-level
     applications.
@@ -19,14 +21,14 @@ class MvInterface:
         position
             Desired end position
 
-        timeout: number, optional
+        timeout: ``float``, optional
             If provided, the mover will throw an error if motion takes longer
             than timeout to complete. If omitted, the mover's default timeout
             will be use.
 
-        wait: bool, optional
-            If True, wait for motion completion before returning. Defaults to
-            False.
+        wait: ``bool``, optional
+            If ``True``, wait for motion completion before returning.
+            Defaults to ``False``.
         """
         self.move(position, timeout=timeout, wait=wait)
 
@@ -45,7 +47,7 @@ class MvInterface:
         """
         Calling the object will either move the object or get the current
         position, depending on if the position argument is given. See the
-        docstrings for mv and wm.
+        docstrings for `mv` and `wm`.
         """
         if position is None:
             return self.wm()
@@ -55,8 +57,9 @@ class MvInterface:
 
 class FltMvInterface(MvInterface):
     """
-    Extension of MvInterface for when the position is a float. This lets us do
-    more with the interface.
+    Extension of MvInterface for when the position is a float.
+
+    This lets us do more with the interface, such as relative moves.
     """
     def mvr(self, delta, timeout=None, wait=False):
         """
@@ -76,7 +79,6 @@ class FltMvInterface(MvInterface):
             If True, wait for motion completion before returning. Defaults to
             False.
         """
-
         self.mv(delta + self.wm(), timeout=timeout, wait=wait)
 
     def umv(self, position, timeout=None):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -4,19 +4,6 @@ Profile Intensity Monitor Classes
 This module contains all the classes relating to the profile intensity monitor
 classes at the user level. A PIM will usually have at least a motor to control
 yag position and a camera to view the yag.
-
-Classes Implemented here are as follows:
-
-PIMPulnixDetector
-    Pulnix detector with only the plugins used by the PIMs.
-
-PIMMotor
-    Profile intensity monitor motor that moves the yag and diode into and out
-    of the beam.
-
-PIM
-    High level profile intensity monitor class that inherits from PIMMotor and
-    has a PIMPulnixDetector as a component.
 """
 import logging
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -31,8 +31,9 @@ logger = logging.getLogger(__name__)
 
 class PIMPulnixDetector(PulnixDetector):
     """
-    Pulnix detector that is used in the PIM. Plugins should be added on an as
-    needed basis here.
+    Pulnix detector that is used in the PIM.
+
+    Plugins should be added on an as needed basis here.
     """
     image1 = Cmp(ImagePlugin, ":IMAGE1:", read_attrs=['array_data'])
     image2 = Cmp(ImagePlugin, ":IMAGE2:", read_attrs=['array_data'])
@@ -56,21 +57,25 @@ class PIMPulnixDetector(PulnixDetector):
 
 class PIMMotor(InOutRecordPositioner):
     """
-    Standard position monitor motor that can move the stage to insert the yag
-    or diode, or retract it from the beam path.
+    Standard position monitor motor.
+
+    This can move the stage to insert the yag
+    or diode, or retract from the beam path.
     """
     states_list = ['DIODE', 'YAG', 'OUT']
     _states_alias = {'YAG': 'IN'}
 
     def stage(self):
+        """
+        Save the original position to be restored on `unstage`.
+        """
         self._original_vals[self.state] = self.state.value
         return super().stage()
 
 
 class PIM(PIMMotor):
     """
-    Full profile intensity monitor including the motor to move the yag, and the
-    detector to view it.
+    Profile intensity monitor, fully motorized and with a detector.
 
     Parameters
     ----------

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -4,6 +4,7 @@ from ophyd.device import Component as Cmp, FormattedComponent as FCmp
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.status import SubscriptionStatus, wait as status_wait
 
+from .doc_stubs import basic_positioner_init
 from .inout import InOutRecordPositioner, InOutPVStatePositioner
 
 logger = logging.getLogger(__name__)
@@ -11,9 +12,13 @@ logger = logging.getLogger(__name__)
 
 class PulsePicker(InOutPVStatePositioner):
     """
-    Device that can open/close in response to event codes to let certain pulses
+    Device that picks which pulses to let through.
+
+    This device opens/closes in response to event codes to let certain pulses
     through and block others.
     """
+    __doc__ += basic_positioner_init
+
     blade = Cmp(EpicsSignalRO, ':READ_DF')
     mode = Cmp(EpicsSignalRO, ':SD_SIMPLE')
 
@@ -61,6 +66,11 @@ class PulsePicker(InOutPVStatePositioner):
     def reset(self, wait=False):
         """
         Cancel the current mode.
+
+        Parameters
+        ----------
+        wait: ``bool``, optional
+            If ``True``, block until procedure is done.
         """
         self._log_request('RESET')
         if self.mode.get() not in (0, 'IDLE'):
@@ -71,6 +81,11 @@ class PulsePicker(InOutPVStatePositioner):
     def open(self, wait=False):
         """
         Cancel the current mode and leave the PulsePicker OPEN.
+
+        Parameters
+        ----------
+        wait: ``bool``, optional
+            If ``True``, block until procedure is done.
         """
         self.reset(wait=True)
         self._log_request('OPEN')
@@ -81,6 +96,11 @@ class PulsePicker(InOutPVStatePositioner):
     def close(self, wait=False):
         """
         Cancel the current mode and leave the PulsePicker CLOSED.
+
+        Parameters
+        ----------
+        wait: ``bool``, optional
+            If ``True``, block until procedure is done.
         """
         self.reset(wait=True)
         self._log_request('CLOSED')
@@ -91,6 +111,11 @@ class PulsePicker(InOutPVStatePositioner):
     def flipflop(self, wait=False):
         """
         Change the current mode to FLIP-FLOP.
+
+        Parameters
+        ----------
+        wait: ``bool``, optional
+            If ``True``, block until procedure is done.
         """
         self.reset(wait=True)
         self._log_request('FLIP-FLOP')
@@ -101,6 +126,11 @@ class PulsePicker(InOutPVStatePositioner):
     def burst(self, wait=False):
         """
         Change the current mode to BURST.
+
+        Parameters
+        ----------
+        wait: ``bool``, optional
+            If ``True``, block until procedure is done.
         """
         self.reset(wait=True)
         self._log_request('BURST')
@@ -111,6 +141,11 @@ class PulsePicker(InOutPVStatePositioner):
     def follower(self, wait=False):
         """
         Change the current mode to FOLLOWER.
+
+        Parameters
+        ----------
+        wait: ``bool``, optional
+            If ``True``, block until procedure is done.
         """
         self.reset(wait=True)
         self._log_request('FOLLOWER')
@@ -121,8 +156,9 @@ class PulsePicker(InOutPVStatePositioner):
 
 class PulsePickerInOut(PulsePicker):
     """
-    PulsePicker paired with a states record to control the Y position. This
-    allows us to insert and remove the entire device from the beam.
+    `PulsePicker` paired with a states record to control the Y position.
+
+    This allows us to insert and remove the entire device from the beam.
 
     The inout states record lives in a separate IOC from the main pulsepicker
     due to versioning issues. The parent IOC is called 'device_states'. We're
@@ -132,6 +168,8 @@ class PulsePickerInOut(PulsePicker):
     So therefore, if the picker is 'TST:DG1:MMS:03', the inout states should be
     'TST:DG1:PP:Y'.
     """
+    __doc__ += basic_positioner_init
+
     inout = FCmp(InOutRecordPositioner, '{self._inout}')
 
     states_list = ['OUT', 'OPEN', 'CLOSED']

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -1,3 +1,6 @@
+"""
+Module for the LCLS1 `PulsePicker`
+"""
 import logging
 
 from ophyd.device import Component as Cmp, FormattedComponent as FCmp

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -10,9 +10,10 @@ logger = logging.getLogger(__name__)
 
 class AggregateSignal(Signal):
     """
-    Signal that is composed of a number of other signals. This class exists to
-    handle the group subscriptions without repeatedly getting the values of all
-    the subsignals at all times.
+    Signal that is composed of a number of other signals.
+
+    This class exists to handle the group subscriptions without repeatedly
+    getting the values of all the subsignals at all times.
 
     Attributes
     ----------
@@ -73,6 +74,11 @@ class AggregateSignal(Signal):
         raise NotImplementedError('put should be overriden in the subclass')
 
     def subscribe(self, cb, event_type=None, run=True):
+        """
+        Set up a callback function to run at specific times.
+
+        See the ``ophyd`` documentation for details.
+        """
         cid = super().subscribe(cb, event_type=event_type, run=run)
         if event_type in (None, self.SUB_VALUE) and not self._has_subscribed:
             # We need to subscribe to ALL relevant signals!

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -34,24 +34,24 @@ class SlitPositioner(PVPositioner, Device, FltMvInterface):
 
     Parameters
     ----------
-    prefix : str
+    prefix : ``str``
         The prefix location of the slits, i.e MFX:DG2
 
-    slit_type : XWIDTH, YWIDTH, XCENTER, YCENTER
+    slit_type : ``'XWIDTH'``, ``'YWIDTH'``, ``'XCENTER'``, ``'YCENTER'``
         The aspect of the slit position you would like to control with this
         specific motor
 
-    name : str
+    name : ``str``
         Alias for the axis
 
-    limits : tuple, optional
+    limits : ``tuple``, optional
         Limits on the motion of the positioner. By default, the limits on the
         setpoint PV are used if None is given.
 
     See Also
     --------
-    ophyd.PVPositioner
-        SlitPositioner inherits directly from PVPositioner.
+    ``ophyd.PVPositioner``
+        ``SlitPositioner`` inherits directly from ``PVPositioner``.
     """
     setpoint = FC(EpicsSignal, "{self.prefix}:{self._dirshort}_REQ")
     readback = FC(EpicsSignalRO, "{self.prefix}:ACTUAL_{self._dirlong}")
@@ -86,13 +86,13 @@ class Slits(Device, MvInterface):
 
     Parameters
     ----------
-    prefix : str
+    prefix : ``str``
         The EPICS base of the motor
 
-    name : str, optional
+    name : ``str``, optional
         The name of the offset mirror
 
-    nominal_aperture : float, optional
+    nominal_aperture : ``float``, optional
         Nominal slit size that will encompass the beam without blocking
 
     Notes
@@ -140,26 +140,26 @@ class Slits(Device, MvInterface):
 
         Parameters
         ---------
-        size : float, tuple
+        size : ``float``, tuple
             Target size for slits in both x and y axis. Either specify as a
             tuple for a rectangular aperture (width, height) or set both with
             single floating point value to use set a square width
 
-        wait : bool
+        wait : ``bool``
             If true, block until move is completed
 
 
-        timeout: float, optional
+        timeout: ``float``, optional
             Maximum time for the motion. If None is given, the default value of
             `xwidth` and `ywidth` positioners is used.
 
-        moved_cb: callable, optional
+        moved_cb: ``callable``, optional
             Function to be run when the operation finishes. This callback
             should not expect any arguments or keywords
 
         Returns
         -------
-        status : AndStatus
+        status : ``AndStatus``
             Logical combination of the request to both horizontal and vertical
             motors
         """
@@ -229,21 +229,21 @@ class Slits(Device, MvInterface):
 
         Parameters
         ----------
-        size : float, optional
+        size : ``float``, optional
             Open the slits to a specific size otherwise
             `:attr:`.nominal_aperture is used
 
-        wait : bool, optional
+        wait : ``bool``, optional
             Wait for the status object to complete the move before returning
 
-        timeout : float, optional
+        timeout : ``float``, optional
             Maximum time to wait for the motion. If None, the default timeout
             for this positioner is used
 
         Returns
         -------
         MoveStatus:
-            Status object based on move completion
+            ``Status`` object based on move completion
 
         See Also
         --------
@@ -267,7 +267,7 @@ class Slits(Device, MvInterface):
 
     def open(self):
         """
-        Uses the built-in `OPEN` record to move open the aperture
+        Uses the built-in ``OPEN`` record to move open the aperture
         """
         self.open_cmd.put(1)
 
@@ -297,13 +297,13 @@ class Slits(Device, MvInterface):
 
         Parameters
         ----------
-        cb : callable
+        cb : ``callable``
             Callback to be run
 
-        event_type : str, optional
+        event_type : ``str``, optional
             Type of event to run callback on
 
-        run : bool, optional
+        run : ``bool``, optional
             Run the callback immediatelly
         """
         # Avoid making child subscriptions unless a client cares

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -1,13 +1,15 @@
 """
+Module to define `Slits` classes.
+
 The SLAC EPICS motor record contains an extra set of records to abstract four
 axes into a Slits object. This allows an operator to manipulate the center and
 width in two dimensions of a small aperture. The classes below allow both
 individual parameters of the aperture and the Slit as a whole to be controlled
-and scanned. The :class:`.Slits` instantiates four sub-devices `xwidth`,
-`xcenter`, `ycenter`, `ywidth`. These are each represented by
-:class:`.SlitPositioner`. The main :class:`.Slits` class assumes that most of
+and scanned. The :class:`.Slits` instantiates four sub-devices ``xwidth``,
+``xcenter``, ``ycenter``, ``ywidth``. These are each represented by
+`SlitPositioner`. The main `Slits` class assumes that most of
 the manipulation will be done on the size of the aperture not the position,
-however, if control of the center is desired the `center` sub-devices can be
+however, if control of the center is desired the ``center`` sub-devices can be
 used.
 """
 import logging

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -21,7 +21,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
     """
     Base class for a ``Positioner`` that moves between discrete states rather
     than along a continuout axis.
-{}
+%s
     Attributes
     ----------
     state: ``Signal``
@@ -50,7 +50,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         Mapping of state names to lists of acceptable aliases. This can
         optionally be overriden in a child class.
     """
-    __doc__.format(basic_positioner_init)
+    __doc__ = __doc__ % basic_positioner_init
 
     state = None  # Override with Signal that represents state readback
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -10,6 +10,7 @@ from ophyd.status import wait as status_wait, SubscriptionStatus
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.device import Device, Component, FormattedComponent
 
+from .doc_stubs import basic_positioner_init
 from .mv_interface import MvInterface
 from .signal import AggregateSignal
 
@@ -18,24 +19,39 @@ logger = logging.getLogger(__name__)
 
 class StatePositioner(Device, PositionerBase, MvInterface):
     """
-    Base class for a Positioner that moves between discrete states rather than
-    along a continuout axis.
-
+    Base class for a ``Positioner`` that moves between discrete states rather
+    than along a continuout axis.
+{}
     Attributes
     ----------
-    state: Signal
+    state: ``Signal``
         This signal is the final authority on what state the object is in.
 
-    states_list: list of str
+    states_list: ``list of str``
         An exhaustive list of all possible states. This should be overridden in
         a base class. Unknown must be omitted in the class definition and will
         be added dynamically in position 0 when the object is created.
 
-    states_enum: Enum
+    states_enum: ``Enum``
         An enum that represents all possible states. This will be constructed
         for the user based on the contents of `states_list` and
-        `_states_alias`, but it can also be overriden in the base class.
+        `_states_alias`, but it can also be overriden in a child class.
+
+    _invalid_states: ``list of str``
+        States that cannot be moved to. This can be optionally overriden to be
+        extended in a base class. The `_unknown` state will be included
+        automatically.
+
+    _unknown: ``str``
+        The name of the unknown state, defaulting to 'Unknown'. This can be set
+        to ``False`` if there is no unknown state.
+
+    _states_alias: ``dict``
+        Mapping of state names to lists of acceptable aliases. This can
+        optionally be overriden in a child class.
     """
+    __doc__.format(basic_positioner_init)
+
     state = None  # Override with Signal that represents state readback
 
     states_list = []  # Override with an exhaustive list of states
@@ -68,22 +84,22 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
         Parameters
         ----------
-        position: int or str
+        position: ``int`` or ``str``
             The enumerate state or the corresponding integer
 
-        moved_cb: function, optional
+        moved_cb: ``function``, optional
             moved_cb(obj=self) will be called at the end of motion
 
-        timeout: int or float, optional
+        timeout: ``int`` or ``float``, optional
             Move timeout in seconds
 
-        wait: bool, optional
+        wait: ``bool``, optional
             If True, do not return until the motion has completed.
 
         Returns
         -------
-        status: StateStatus
-            Status object that represents the move's progress.
+        status: ``StateStatus``
+            ``Status`` object that represents the move's progress.
         """
         status = self.set(position, moved_cb=moved_cb, timeout=timeout)
         if wait:
@@ -93,6 +109,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
     def set(self, position, moved_cb=None, timeout=None):
         """
         Move to the desired state and return completion information.
+
         This is the bare-bones implementation of the move with only motion,
         callbacks, and timeouts defined. Additional functional options are
         relegated to the `move` command and bells and whistles are relegated to
@@ -100,19 +117,19 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
         Parameters
         ----------
-        position: int or str
+        position: ``int`` or ``str``
             The enumerate state or the corresponding integer
 
-        moved_cb: function, optional
+        moved_cb: ``function``, optional
             moved_cb(obj=self) will be called at the end of motion
 
-        timeout: int or float, optional
+        timeout: ``int`` or ``float``, optional
             Move timeout in seconds
 
         Returns
         -------
-        status: StateStatus
-            Status object that represents the move's progress.
+        status: ``StateStatus``
+            ``Status`` object that represents the move's progress.
         """
         logger.debug('set %s to position %s', self.name, position)
         state = self.check_value(position)
@@ -131,6 +148,11 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         return status
 
     def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subcribe a callback to be run on specific events.
+
+        See the ``opyhd`` documentation for more information.
+        """
         cid = super().subscribe(cb, event_type=event_type, run=run)
         if event_type is None:
             event_type = self._default_sub
@@ -170,9 +192,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
         Returns
         -------
-        state: Enum entry
-            The corresponding Enum entry for this value. It has two meaningful
-            fields, `name` and `value`.
+        state: ``Enum``
+            The corresponding ``Enum`` entry for this value. It has two
+            meaningful fields, ``name`` and ``value``.
         """
         if not isinstance(value, (int, str)):
             raise TypeError('Valid states must be of type str or int')
@@ -187,9 +209,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
         Returns
         -------
-        state: Enum entry
-            The corresponding Enum entry for this value. It has two meaningful
-            fields, `name` and `value`.
+        state: ``Enum``
+            The corresponding ``Enum`` entry for this value. It has two
+            meaningful fields, ``name`` and ``value``.
         """
         try:
             return self.states_enum[value]
@@ -211,9 +233,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
         Parameters
         ----------
-        state: Enum entry
-            Object whose `name` attribute is the string enum name and whose
-            `value` attribute is the integer enum value.
+        state: ``Enum``
+            Object whose ``name`` attribute is the string enum name and whose
+            ``value`` attribute is the integer enum value.
         """
         self.state.put(state.name)
 
@@ -243,7 +265,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
 class PVStateSignal(AggregateSignal):
     """
-    Signal that implements the PVStatePositioner state logic.
+    Signal that implements the `PVStatePositioner` state logic.
+
+    See `AggregateSignal` for more information.
     """
     def __init__(self, *, name, **kwargs):
         super().__init__(name=name, **kwargs)
@@ -292,35 +316,41 @@ class PVStateSignal(AggregateSignal):
 
 class PVStatePositioner(StatePositioner):
     """
-    A StatePositioner that combines some number of arbitrary state PVs into a
-    single device state. The user can provide state logic and a move method if
-    desired.
+    A `StatePositioner` that combines a set of PVs into a single state.
 
+    The user can provide state logic and a move method if desired.
+%s
     Attributes
     ----------
-    _state_logic: dict
+    _state_logic: ``dict``
         Information dictionaries for each state of the following form:
-        {
-          "signal_name": {
-                           0: "OUT",
-                           1: "IN",
-                           2: "Unknown",
-                           3: "defer"
-                         }
-        }
+
+        .. code::
+
+            {
+              "signal_name": {
+                               0: "OUT",
+                               1: "IN",
+                               2: "Unknown",
+                               3: "defer"
+                             }
+            }
+
         The dictionary defines the relevant signal names and how to interpret
         each of the states. These states will be evaluated in the dict's order,
-        which may matter if _state_logic_mode == 'FIRST'.
+        which may matter if ``_state_logic_mode == 'FIRST'``.
 
         This is for cases where the logic is simple. If there are more complex
         requirements, replace the `state` component.
 
-    _state_logic_mode: string
-        This should be 'ALL' (default) if the pvs need to agree for a valid
+    _state_logic_mode: ``str``, ``'ALL'`` or ``'FIRST'``
+        This should be ``ALL`` (default) if the pvs need to agree for a valid
         state. You can set this to 'FIRST' to instead use the first state
         found while traversing the state_logic tree. This means an earlier
         state definition can mask a later state definition.
-        """
+    """
+    __doc__ = __doc__ % basic_positioner_init
+
     state = Component(PVStateSignal)
 
     _state_logic = {}
@@ -343,8 +373,9 @@ class PVStatePositioner(StatePositioner):
 
 class StateRecordPositioner(StatePositioner):
     """
-    A StatePositioner that relies on an EPICS States record to process the
-    device state. The `states_list` must match the order of the EPICS enum.
+    A `StatePositioner` for an EPICS states record.
+
+    The `states_list` must match the order of the EPICS enum.
     """
     state = Component(EpicsSignal, '', write_pv=':GO')
     readback = FormattedComponent(EpicsSignalRO, '{self._readback}')
@@ -358,6 +389,11 @@ class StateRecordPositioner(StatePositioner):
         self._has_subscribed_readback = False
 
     def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subcribe a callback to be run on specific events.
+
+        See the ``opyhd`` documentation for more information.
+        """
         cid = super().subscribe(cb, event_type=event_type, run=run)
         if (event_type == self.SUB_READBACK and not
                 self._has_subscribed_readback):
@@ -373,27 +409,27 @@ class StateRecordPositioner(StatePositioner):
 
 class StateStatus(SubscriptionStatus):
     """
-    Status produced by state request
+    ``Status`` produced by state request
 
     The status relies on two methods of the device, first the attribute
-    `.position` should reflect the current state. Second, the status will call
-    the built-in method `subscribe` with the `event_type` explicitly set to
-    "device.SUB_STATE". This will cause the StateStatus to process whenever the
-    device changes state to avoid unnecessary polling of the associated EPICS
-    variables
+    ``.position`` should reflect the current state. Second, the status will
+    call the built-in method ``subscribe`` with the ``event_type`` explicitly
+    set to ``device.SUB_STATE``. This will cause the ``StateStatus`` to
+    process whenever the device changes state to avoid unnecessary polling
+    of the associated EPICS variables
 
     Parameters
     ----------
-    device : obj
-        Device with `value` attribute that returns a state string
+    device : `StatePositioner`
+        The relevant states device
 
-    desired_state : str
+    desired_state : ``str``
         Requested state
 
-    timeout : float, optional
+    timeout : ``float``, optional
         The default timeout to wait to mark the request as a failure
 
-    settle_time : float, optional
+    settle_time : ``float``, optional
         Time to wait after completion until running callbacks
     """
     def __init__(self, device, desired_state,

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -31,21 +31,21 @@ class Stopper(InOutPVStatePositioner):
     Controls Stopper
 
     A base class for a device with two limits switches controlled via an
-    external command PV. This full encompasses the controls Stopper
-    installations as well as un-interlocked GateValves
+    external command PV. This fully encompasses the controls `Stopper`
+    installations as well as un-interlocked `GateValves`
 
     Parameters
     ----------
-    prefix : str
+    prefix : ``str``
         Full PPS Stopper PV
 
-    name : str
+    name : ``str``
         Alias for the stopper
 
     Attributes
     ----------
-    commands : Enum
-        An enum with integer values for open_valve, close_valve values
+    commands : ``Enum``
+        An enum with integer values for ``open_valve``, ``close_valve`` values
     """
     # Default attributes
     _default_read_attrs = ['open_limit', 'closed_limit']
@@ -129,16 +129,16 @@ class PPSStopper(InOutPositioner):
 
     Parameters
     ----------
-    prefix : str
+    prefix : ``str``
         Full PPS Stopper PV
 
-    name : str
+    name : ``str``
         Alias for the stopper
 
-    in_state : str, optional
+    in_state : ``str``, optional
         String associatted with in enum value
 
-    out_state : str, optional
+    out_state : ``str``, optional
         String associatted with out enum value
     """
     state = C(EpicsSignalRO, '', string=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Rework the docs
  - Make sure all top-level boxes have text in them
  - Make sure everything links together
  - Give everything a once-over
  - Full API docs
- Add flake8 check to the CI
- Add devices to `device_types`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Docs need to be in an ok state prior to thurs
- flake8 is good

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Docs build on my machine

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is docs

## Other
- I added a `doc_stubs` submodule because I found myself repeating a few bits way too many times. This isn't used everywhere but I think it's an ok inclusion.
- Note that I've done something sneaky here and I've overridden the autosummary templates to generate more layers of linked doc files. So this actually ends up making a `generated/generated/generated` directory, hilariously. I think the result looks nice because you can keep clicking down further and get all of the full docstrings.
- This generates 830 errors and takes longer to build than your average docs, but it looks great. Many of the errors appear to be issues with inherited docstrings.