### PR TITLE
ENH: Clear flags, reinitialize, autosetup

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -304,12 +304,12 @@ class IMS(PCDSMotorBase):
         bit = flag_info['readback']
         mask = flag_info.get('mask', 1)
 
-        # Create a function to check the flag
-        def flag_is_present(msta):
-            return (int(msta) >> bit) & mask
+        # Create a callback function to check for bit 
+        def flag_is_cleared(value=None, **kwargs):
+            return not bool((int(value) >> bit) & mask)
 
         # Check that we need to actually set the flag
-        if not flag_is_present(self.bit_status.get()):
+        if flag_is_cleared(value=self.bit_status.get()):
             logger.debug("%s flag is not currently active", flag)
             return DeviceStatus(self, done=True, success=True)
 
@@ -317,9 +317,9 @@ class IMS(PCDSMotorBase):
         logger.info('Clearing %s flag ...', flag)
         self.seq_seln.put(flag_info['clear'])
         # Generate a status
-        st = SubscriptionStatus(self.msta, flag_is_present)
+        st = SubscriptionStatus(self.bit_status, flag_is_cleared)
         if wait:
-            status_wait(st)
+            status_wait(st, timeout=timeout)
         return st
 
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -223,11 +223,8 @@ class IMS(PCDSMotorBase):
         # Reinitialize if necessary
         if self.error_severity.get() == 3:
             self.reinitalize(wait=True)
-        # Issue flag commands and collect statuses
-        st = [func() for func in (self.clear_powerup,
-                                  self.clear_stall,
-                                  self.clear_error)]
-        status_wait(st[0] & st[1] & st[2])
+        # Clear all flags
+        self.clear_all_flags(wait=True)
 
     def reinitalize(self, wait=False):
         """Reinitialize the IMS motor"""
@@ -237,6 +234,25 @@ class IMS(PCDSMotorBase):
         # Generate a status
         st = SubscriptionStatus(self.error_severity,
                                 lambda x: x != 3)
+
+    def clear_all_flags(self, wait=False):
+        """
+        Clear all the flags from the IMS motor
+
+        Parameters
+        ----------
+        wait: bool
+
+        Returns
+        -------
+        AndStatus:
+            Combined status of clearing all flags
+        """
+        # Issue flag commands and collect statuses
+        st = [func() for func in (self.clear_powerup,
+                                  self.clear_stall,
+                                  self.clear_error)]
+        status_wait(st[0] & st[1] & st[2])
         if wait:
             status_wait(st)
         return st

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -208,7 +208,7 @@ class IMS(PCDSMotorBase):
                            'mask': 0x7f}}
     # Custom IMS bit fields
     reinit_command = Component(EpicsSignal, '.RINI')
-    status = Component(EpicsSignalRO, '.MSTA')
+    bit_status = Component(EpicsSignalRO, '.MSTA')
     seq_seln = Component(EpicsSignal, ':SEQ_SELN')
     error_severity = Component(EpicsSignal, '.SEVR')
 
@@ -290,7 +290,7 @@ class IMS(PCDSMotorBase):
             return (int(msta) >> bit) & mask
 
         # Check that we need to actually set the flag
-        if not flag_is_present(self.status.get()):
+        if not flag_is_present(self.bit_status.get()):
             logger.debug("%s flag is not currently active", flag)
             return DeviceStatus(self, done=True, success=True)
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -199,7 +199,7 @@ class IMS(PCDSMotorBase):
     """
     __doc__ += basic_positioner_init
     # Bit masks to clear errors and flags
-    bit_flags = {'powerup': {'clear': 36,
+    _bit_flags = {'powerup': {'clear': 36,
                              'readback':  24},
                  'stall': {'clear': 40,
                            'readback': 24},
@@ -279,9 +279,9 @@ class IMS(PCDSMotorBase):
         return self._clear_flag('error', wait=wait)
 
     def _clear_flag(self, flag, wait=False):
-        """Clear flag whose information is in ``.bit_flags``"""
+        """Clear flag whose information is in ``._bit_flags``"""
         # Gather our flag information
-        flag_info = self.bit_flags[flag]
+        flag_info = self._bit_flags[flag]
         bit = flag_info['readback']
         mask = flag_info.get('mask', 1)
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -221,7 +221,7 @@ class IMS(PCDSMotorBase):
         if we don't register a valid part number
         """
         # Check the part number to avoid crashing the IOC
-        if not self.part_number.get():
+        if not self.part_number.get() or self.error_severity.get() == 3:
             self.reinitialize(wait=True)
         # Clear any pre-existing flags
         self.clear_all_flags(wait=True)
@@ -237,7 +237,7 @@ class IMS(PCDSMotorBase):
             * Clear powerup, stall and error flags
         """
         # Reinitialize if necessary
-        if self.error_severity.get() == 3:
+        if not self.part_number.get() or self.error_severity.get() == 3:
             self.reinitialize(wait=True)
         # Clear all flags
         self.clear_all_flags()

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -5,7 +5,7 @@ import logging
 
 from ophyd.utils import LimitError
 from ophyd import EpicsMotor, Component, EpicsSignalRO, EpicsSignal, Signal
-from ophyd.status import SubscriptionStatus, wait as status_wait
+from ophyd.status import DeviceStatus, SubscriptionStatus, wait as status_wait
 
 from .doc_stubs import basic_positioner_init
 from .mv_interface import FltMvInterface
@@ -267,7 +267,8 @@ class IMS(PCDSMotorBase):
         # Check that we need to actually set the flag
         if not flag_is_present(self.status.get()):
             logger.debug("%s flag is not currently active", flag)
-            return
+            return DeviceStatus(self, done=True, success=True)
+
         # Issue our command
         logger.info('Clearing %s flag ...', flag)
         self.seq_seln.put(flag_info['clear'])

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -259,9 +259,14 @@ class IMS(PCDSMotorBase):
         logger.info('Reinitializing motor')
         # Issue command
         self.reinit_command.put(1)
+
+        # Check error
+        def initialize_complete(value=None, **kwargs):
+            return value != 3
+
         # Generate a status
         st = SubscriptionStatus(self.error_severity,
-                                lambda x: x != 3,
+                                initialize_complete,
                                 settle_time=0.5)
         # Wait on status if requested
         if wait:

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -232,6 +232,7 @@ class IMS(PCDSMotorBase):
         Automated setup of the IMS motor
 
         If necessarry this command will:
+
             * Reinitialize the motor
             * Clear powerup, stall and error flags
         """
@@ -242,7 +243,19 @@ class IMS(PCDSMotorBase):
         self.clear_all_flags(wait=True)
 
     def reinitalize(self, wait=False):
-        """Reinitialize the IMS motor"""
+        """
+        Reinitialize the IMS motor
+
+        Parameters
+        ----------
+        wait : bool
+            Wait for the motor to be fully intialized
+
+        Returns
+        -------
+        SubscriptionStatus:
+            Status object reporting the initialization state of the motor
+        """
         logger.info('Reinitalizing motor')
         # Issue command
         self.reinit_command.put(1)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -268,13 +268,9 @@ class IMS(PCDSMotorBase):
             status_wait(st)
         return st
 
-    def clear_all_flags(self, wait=False):
+    def clear_all_flags(self):
         """
         Clear all the flags from the IMS motor
-
-        Parameters
-        ----------
-        wait: bool
 
         Returns
         -------
@@ -282,15 +278,14 @@ class IMS(PCDSMotorBase):
             Combined status of clearing all flags
         """
         # Issue flag commands and collect statuses
-        st = [func() for func in (self.clear_powerup,
-                                  self.clear_stall,
-                                  self.clear_error)]
-        status_wait(st[0] & st[1] & st[2])
-        if wait:
-            status_wait(st)
-        return st
+        st = [func(wait=True) for func in (self.clear_powerup,
+                                           self.clear_stall,
+                                           self.clear_error)]
+        # Combine statuses and wait for result
+        and_st = st[0] & st[1] & st[2]
+        return and_st
 
-    def clear_powerup(self, wait=False):
+    def clear_powerup(self, wait=False, timeout=10):
         """Clear powerup flag"""
         return self._clear_flag('powerup', wait=wait, timeout=timeout)
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -212,6 +212,15 @@ class IMS(PCDSMotorBase):
     seq_seln = Component(EpicsSignal, ':SEQ_SELN')
     error_severity = Component(EpicsSignal, '.SEVR')
 
+    def stage(self):
+        """
+        State the IMS motor
+
+        This clears all present flags on the motor
+        """
+        self.clear_all_flags(wait=True)
+        self.stage()
+
     def auto_setup(self):
         """
         Automated setup of the IMS motor

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -225,7 +225,7 @@ class IMS(PCDSMotorBase):
             self.reinitialize(wait=True)
         # Clear any pre-existing flags
         self.clear_all_flags()
-        self.stage()
+        super().stage()
 
     def auto_setup(self):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -224,7 +224,7 @@ class IMS(PCDSMotorBase):
         if not self.part_number.get() or self.error_severity.get() == 3:
             self.reinitialize(wait=True)
         # Clear any pre-existing flags
-        self.clear_all_flags(wait=True)
+        self.clear_all_flags()
         self.stage()
 
     def auto_setup(self):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -242,7 +242,12 @@ class IMS(PCDSMotorBase):
         self.reinit_command.put(1)
         # Generate a status
         st = SubscriptionStatus(self.error_severity,
-                                lambda x: x != 3)
+                                lambda x: x != 3,
+                                settle_time=0.5)
+        # Wait on status if requested
+        if wait:
+            status_wait(st)
+        return st
 
     def clear_all_flags(self, wait=False):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -292,17 +292,17 @@ class IMS(PCDSMotorBase):
 
     def clear_powerup(self, wait=False):
         """Clear powerup flag"""
-        return self._clear_flag('powerup', wait=wait)
+        return self._clear_flag('powerup', wait=wait, timeout=timeout)
 
-    def clear_stall(self, wait=False):
+    def clear_stall(self, wait=False, timeout=5):
         """Clear stall flag"""
-        return self._clear_flag('stall', wait=wait)
+        return self._clear_flag('stall', wait=wait, timeout=timeout)
 
-    def clear_error(self, wait=False):
+    def clear_error(self, wait=False, timeout=10):
         """Clear error flag"""
-        return self._clear_flag('error', wait=wait)
+        return self._clear_flag('error', wait=wait, timeout=timeout)
 
-    def _clear_flag(self, flag, wait=False):
+    def _clear_flag(self, flag, wait=False, timeout=10):
         """Clear flag whose information is in ``._bit_flags``"""
         # Gather our flag information
         flag_info = self._bit_flags[flag]

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -225,7 +225,7 @@ class IMS(PCDSMotorBase):
             self.reinitialize(wait=True)
         # Clear any pre-existing flags
         self.clear_all_flags()
-        super().stage()
+        return super().stage()
 
     def auto_setup(self):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -211,13 +211,19 @@ class IMS(PCDSMotorBase):
     bit_status = Component(EpicsSignalRO, '.MSTA')
     seq_seln = Component(EpicsSignal, ':SEQ_SELN')
     error_severity = Component(EpicsSignal, '.SEVR')
+    part_number = Component(EpicsSignalRO, '.PN')
 
     def stage(self):
         """
         State the IMS motor
 
-        This clears all present flags on the motor
+        This clears all present flags on the motor and reinitializes the motor
+        if we don't register a valid part number
         """
+        # Check the part number to avoid crashing the IOC
+        if not self.part_number.get():
+            self.reinitialize(wait=True)
+        # Clear any pre-existing flags
         self.clear_all_flags(wait=True)
         self.stage()
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -238,11 +238,11 @@ class IMS(PCDSMotorBase):
         """
         # Reinitialize if necessary
         if self.error_severity.get() == 3:
-            self.reinitalize(wait=True)
+            self.reinitialize(wait=True)
         # Clear all flags
         self.clear_all_flags(wait=True)
 
-    def reinitalize(self, wait=False):
+    def reinitialize(self, wait=False):
         """
         Reinitialize the IMS motor
 
@@ -256,7 +256,7 @@ class IMS(PCDSMotorBase):
         SubscriptionStatus:
             Status object reporting the initialization state of the motor
         """
-        logger.info('Reinitalizing motor')
+        logger.info('Reinitializing motor')
         # Issue command
         self.reinit_command.put(1)
         # Generate a status

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -240,7 +240,7 @@ class IMS(PCDSMotorBase):
         if self.error_severity.get() == 3:
             self.reinitialize(wait=True)
         # Clear all flags
-        self.clear_all_flags(wait=True)
+        self.clear_all_flags()
 
     def reinitialize(self, wait=False):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -274,21 +274,10 @@ class IMS(PCDSMotorBase):
         return st
 
     def clear_all_flags(self):
-        """
-        Clear all the flags from the IMS motor
-
-        Returns
-        -------
-        AndStatus:
-            Combined status of clearing all flags
-        """
-        # Issue flag commands and collect statuses
-        st = [func(wait=True) for func in (self.clear_powerup,
-                                           self.clear_stall,
-                                           self.clear_error)]
-        # Combine statuses and wait for result
-        and_st = st[0] & st[1] & st[2]
-        return and_st
+        """Clear all the flags from the IMS motor"""
+        # Clear all flags
+        for func in (self.clear_powerup, self.clear_stall, self.clear_error):
+            func(wait=True)
 
     def clear_powerup(self, wait=False, timeout=10):
         """Clear powerup flag"""

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -309,7 +309,7 @@ class IMS(PCDSMotorBase):
         bit = flag_info['readback']
         mask = flag_info.get('mask', 1)
 
-        # Create a callback function to check for bit 
+        # Create a callback function to check for bit
         def flag_is_cleared(value=None, **kwargs):
             return not bool((int(value) >> bit) & mask)
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -200,12 +200,12 @@ class IMS(PCDSMotorBase):
     __doc__ += basic_positioner_init
     # Bit masks to clear errors and flags
     _bit_flags = {'powerup': {'clear': 36,
-                             'readback':  24},
-                 'stall': {'clear': 40,
-                           'readback': 24},
-                 'error': {'clear': 48,
-                           'readback': 22,
-                           'mask': 0x7f}}
+                              'readback':  24},
+                  'stall': {'clear': 40,
+                            'readback': 24},
+                  'error': {'clear': 48,
+                            'readback': 22,
+                            'mask': 0x7f}}
     # Custom IMS bit fields
     reinit_command = Component(EpicsSignal, '.RINI')
     bit_status = Component(EpicsSignalRO, '.MSTA')

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -202,9 +202,9 @@ class IMS(PCDSMotorBase):
     _bit_flags = {'powerup': {'clear': 36,
                               'readback':  24},
                   'stall': {'clear': 40,
-                            'readback': 24},
+                            'readback': 22},
                   'error': {'clear': 48,
-                            'readback': 22,
+                            'readback': 15,
                             'mask': 0x7f}}
     # Custom IMS bit fields
     reinit_command = Component(EpicsSignal, '.RINI')

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -83,3 +83,9 @@ def test_ims_reinitialize():
     time.sleep(1.0)
     assert st.done
     assert st.success
+
+@using_fake_epics_pv
+def test_ims_stage_smoke():
+    m = IMS('Tst:Mtr:1', name='motor')
+    m.wait_for_connection()
+    m.stage()

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -6,6 +6,7 @@ from pcdsdevices.epics_motor import PCDSMotorBase, IMS
 from pcdsdevices.sim.pv import using_fake_epics_pv
 from .conftest import attr_wait_value
 
+
 def fake_motor():
     m = PCDSMotorBase("Tst:MMS:02", name='Test Motor')
     m.limits = (-100, 100)
@@ -14,6 +15,7 @@ def fake_motor():
     attr_wait_value(m, 'high_limit', 100)
     m.wait_for_connection()
     return m
+
 
 @using_fake_epics_pv
 def test_epics_motor_soft_limits():
@@ -25,6 +27,7 @@ def test_epics_motor_soft_limits():
         m.move(-150)
     with pytest.raises(ValueError):
         m.move(None)
+
 
 @using_fake_epics_pv
 def test_epics_motor_tdir():
@@ -45,7 +48,7 @@ def test_ims_clear_flag():
     m.bit_status._read_pv.put(0)
     m.clear_all_flags()
     # Clear a specific flag
-    m.bit_status._read_pv.put(4194304) # 2*22
+    m.bit_status._read_pv.put(4194304)  # 2*22
     time.sleep(0.5)
     st = m.clear_stall(wait=False)
     assert m.seq_seln.get() == 40
@@ -67,7 +70,7 @@ def test_ims_reinitialize():
     m.error_severity._read_pv.put(0)
     m.auto_setup()
     assert m.reinit_command.get() == 0
-    # Check that we reinitialize 
+    # Check that we reinitialize
     m.error_severity._read_pv.put(3)
     st = m.reinitialize(wait=False)
     assert m.reinit_command.get() == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Posting this for discussion now, will add tests later if we decide this is the best way forward.
* Adds a general `_clear_flag` function used by `clear_powerup`, `clear_stall` and `clear_error`
* Add a `reinitialize` function
* Wraps these in a nice `auto_setup` method.

This is pretty much a straight port of the `auto_setup` functionality in the old `blbase.Motor` for setting up IMS motors with the notable exception of the `ParameterManager`. The minor improvements are that these methods all return status objects so they can be done asynchronously and they are pulled from a `bit_flags` dictionary instead of module variables.

Also, should `auto_setup` go in `stage`? Obviously not if we include the ParameterManager but as it is now it might make sense to run this at the start of scans.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #184 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not yet.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings