### PR TITLE
ENH: Presets on FltMvInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ logs
 
 # Sphinx
 docs/source/generated/*
+
+#pytest
+.pytest_cache

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python {{PY_VER}}*,>=3
     - ophyd >=1.1.0
     - bluesky >=1.2.0
+    - pyyaml
 
 test:
   imports:

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -35,7 +35,7 @@ class Filter(InOutPositioner):
     stuck = Cmp(EpicsSignal, ':STUCK')
 
 
-class AttBase(PVPositioner, FltMvInterface):
+class AttBase(FltMvInterface, PVPositioner):
     """
     Base class for the attenuators.
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -13,7 +13,7 @@ from .mv_interface import FltMvInterface
 logger = logging.getLogger(__name__)
 
 
-class PCDSMotorBase(EpicsMotor, FltMvInterface):
+class PCDSMotorBase(FltMvInterface, EpicsMotor):
     """
     EpicsMotor for PCDS
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -19,7 +19,7 @@ from .mv_interface import FltMvInterface
 logger = logging.getLogger(__name__)
 
 
-class OMMotor(PVPositioner, FltMvInterface):
+class OMMotor(FltMvInterface, PVPositioner):
     """
     Base class for each motor in the LCLS offset mirror system.
     """

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -227,12 +227,15 @@ class Presets:
         Works like threading.Rlock in that you can acquire it multiple times
         safely.
 
-        Raises an OSError if we cannot acquire the file lock.
-
         Parameters
         ----------
         fd: ``file``
             The file descriptor to lock on.
+
+        Raises
+        ------
+        OSError:
+            If we cannot acquire the file lock.
         """
         if self._fd is None:
             path = self._path(preset_type)

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -305,7 +305,8 @@ class Presets:
         self._create_methods()
 
     def _log_flock_error(self):
-        logger.error('Cannot acquire file lock for %s', self.name)
+        logger.error(('Unable to acquire file lock for %s. '
+                      'File may be being edited by another user'), self.name)
         logger.debug('', exc_info=True)
 
     def _create_methods(self):

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -1,6 +1,8 @@
 """
 Module for defining bell-and-whistles movement features
 """
+from pathlib import Path
+
 from bluesky.utils import ProgressBar
 from ophyd.status import wait as status_wait
 
@@ -120,3 +122,39 @@ class FltMvInterface(MvInterface):
             will be use.
         """
         self.umv(delta + self.wm(), timeout=timeout)
+
+
+class Presets:
+    """
+    Manager for device preset positions.
+
+    Parameters
+    ----------
+    device: ``Device``
+        The device to manage saved preset positions for
+
+    paths: ``dict{str: str}``
+        A mapping from type of preset to destination path.
+    """
+    def __init__(self, device, paths):
+        self._device = device
+        self._paths = {}
+        for k, v in paths.items():
+            self._paths[k] = Path(v)
+        self._methods = []
+        self._load_all()
+
+    def _save(self, path, name, position):
+        pass
+
+    def _save_here(self, path, name):
+        pass
+
+    def _load(self, path):
+        pass
+
+    def _load_all(self):
+        pass
+
+    def _delete(self, path, name):
+        pass

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -57,6 +57,8 @@ class MvInterface:
 
     def __call__(self, position=None, timeout=None, wait=False):
         """
+        Dispatches to `mv` or `wm` based on the arguments.
+
         Calling the object will either move the object or get the current
         position, depending on if the position argument is given. See the
         docstrings for `mv` and `wm`.
@@ -69,7 +71,7 @@ class MvInterface:
 
 class FltMvInterface(MvInterface):
     """
-    Extension of MvInterface for when the position is a float.
+    Extension of `MvInterface` for when the position is a ``float``.
 
     This lets us do more with the interface, such as relative moves.
     """
@@ -84,17 +86,17 @@ class FltMvInterface(MvInterface):
 
         Parameters
         ----------
-        delta: float
+        delta: ``float``
             Desired change in position
 
-        timeout: number, optional
+        timeout: ``float``, optional
             If provided, the mover will throw an error if motion takes longer
             than timeout to complete. If omitted, the mover's default timeout
             will be use.
 
-        wait: bool, optional
-            If True, wait for motion completion before returning. Defaults to
-            False.
+        wait: ``bool``, optional
+            If ``True``, wait for motion completion before returning. Defaults
+            to ``False``.
         """
         self.mv(delta + self.wm(), timeout=timeout, wait=wait)
 
@@ -104,10 +106,10 @@ class FltMvInterface(MvInterface):
 
         Parameters
         ----------
-        position: float
+        position: ``float``
             Desired end position
 
-        timeout: number, optional
+        timeout: ``float``, optional
             If provided, the mover will throw an error if motion takes longer
             than timeout to complete. If omitted, the mover's default timeout
             will be use.
@@ -125,10 +127,10 @@ class FltMvInterface(MvInterface):
 
         Parameters
         ----------
-        delta: float
+        delta: ``float``
             Desired change in position
 
-        timeout: number, optional
+        timeout: ``float``, optional
             If provided, the mover will throw an error if motion takes longer
             than timeout to complete. If omitted, the mover's default timeout
             will be use.
@@ -138,8 +140,9 @@ class FltMvInterface(MvInterface):
 
 def setup_preset_paths(**paths):
     """
-    Prepare the `Presets` class with the correct paths for saving and loading
-    presets.
+    Prepare the `Presets` class.
+
+    Sets the paths for saving and loading presets.
 
     Parameters
     ----------
@@ -155,8 +158,10 @@ def setup_preset_paths(**paths):
 
 class Presets:
     """
-    Manager for device preset positions. This provides methods for adding new
-    presets, checking which presets are active, and related utilities.
+    Manager for device preset positions.
+
+    This provides methods for adding new presets, checking which presets are
+    active, and related utilities.
 
     It will install the ``mv_presetname`` and ``wm_presetname`` methods onto
     the associated device.
@@ -183,8 +188,7 @@ class Presets:
 
     def _path(self, preset_type):
         """
-        Utility function go get the proper ``Path`` object that points to the
-        presets file.
+        Utility function to get the preset file ``Path``.
         """
         path = self._paths[preset_type] / (self._device.name + '.yml')
         logger.debug('select presets path %s', path)
@@ -209,9 +213,11 @@ class Presets:
     def _update(self, preset_type, name, value=None, comment=None,
                 active=True):
         """
-        Utility function to read the existing preset's datum, update the value
-        the comment, and the active state, and then write the datum back to the
-        file, updating the last updated time and history accordingly.
+        Utility function to update a preset position.
+
+        Reads the existing preset's datum, updates the value the comment, and
+        the active state, and then writes the datum back to the file, updating
+        the history accordingly.
         """
         logger.debug(('call %s presets._update(%s, %s, value=%s, comment=%s, '
                       'active=%s)'), self._device.name, preset_type, name,
@@ -252,6 +258,8 @@ class Presets:
 
     def _create_methods(self):
         """
+        Create the dynamic methods based on the configured paths.
+
         Add methods to this object for adding presets of each type, add
         methods to the associated device to move and check each preset, and
         add `PresetPosition` instances to ``self.positions`` for each preset
@@ -275,8 +283,10 @@ class Presets:
 
     def _register_method(self, obj, method_name, method):
         """
-        Utility function to add a method to the ``_methods`` list and to bind
-        the method to an object.
+        Utility function for managing dynamic methods.
+
+        Adds a method to the ``_methods`` list and binds the method to an
+        object.
         """
         logger.debug('register method %s to %s', method_name, obj.name)
         self._methods.append((obj, method_name))
@@ -284,7 +294,9 @@ class Presets:
 
     def _make_add(self, preset_type):
         """
-        Create suitable versions of ``add`` and ``add_here`` for a particular
+        Create the functions that add preset positions.
+
+        Creates suitable versions of ``add`` and ``add_here`` for a particular
         preset type, e.g. ``add_preset_type`` and ``add_here_preset_type``.
         """
         def add(self, name, value, comment=None):
@@ -326,7 +338,9 @@ class Presets:
 
     def _make_mv_pre(self, preset_type, name):
         """
-        Create a suitable versions of ``mv`` and ``umv`` for a particular
+        Create the functions that move to preset positions.
+
+        Creates a suitable versions of ``mv`` and ``umv`` for a particular
         preset type and name e.g. ``mv_sample``.
         """
         def mv_pre(self, timeout=None, wait=False):
@@ -367,7 +381,9 @@ class Presets:
 
     def _make_wm_pre(self, preset_type, name):
         """
-        Create a suitable version of ``wm`` for a particular preset type and
+        Create a method to get the offset from a preset position.
+
+        Creates a suitable version of ``wm`` for a particular preset type and
         name e.g. ``wm_sample``.
         """
         def wm_pre(self):
@@ -447,8 +463,9 @@ class PresetPosition:
 
     def deactivate(self):
         """
-        Deactivate a preset from a device. This can be undone unless you edit
-        the underlying file.
+        Deactivate a preset from a device.
+
+        This can always be undone unless you edit the underlying file.
         """
         self._presets._update(self._preset_type, self._name, active=False)
         self._presets.sync()

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -76,8 +76,7 @@ class FltMvInterface(MvInterface):
     This lets us do more with the interface, such as relative moves.
     """
     def __init__(self, *args, **kwargs):
-        if Presets._paths:
-            self.presets = Presets(self)
+        self.presets = Presets(self)
         super().__init__(*args, **kwargs)
 
     def mvr(self, delta, timeout=None, wait=False):
@@ -154,6 +153,8 @@ def setup_preset_paths(**paths):
     Presets._paths = {}
     for k, v in paths.items():
         Presets._paths[k] = Path(v)
+    for preset in Presets._registry.values():
+        preset.sync()
 
 
 class Presets:
@@ -178,11 +179,13 @@ class Presets:
         A namespace that contains all of the active presets as `PresetPosition`
         objects.
     """
+    _registry = {}
     _paths = {}
 
     def __init__(self, device):
         self._device = device
         self._methods = []
+        self._registry[device.name] = self
         self.name = device.name + '_presets'
         self.sync()
 

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -1,8 +1,11 @@
 """
 Module for defining bell-and-whistles movement features
 """
+import time
 from pathlib import Path
-from types import SimpleNamespace
+from types import SimpleNamespace, MethodType
+
+import yaml
 
 from bluesky.utils import ProgressBar
 from ophyd.status import wait as status_wait
@@ -67,6 +70,11 @@ class FltMvInterface(MvInterface):
 
     This lets us do more with the interface, such as relative moves.
     """
+    def __init__(self, *args, **kwargs):
+        if Presets._paths:
+            self.presets = Presets(self)
+        super().__init__(*args, **kwargs)
+
     def mvr(self, delta, timeout=None, wait=False):
         """
         Relative move from this position.
@@ -125,10 +133,30 @@ class FltMvInterface(MvInterface):
         self.umv(delta + self.wm(), timeout=timeout)
 
 
+def setup_preset_paths(**paths):
+    """
+    Prepare the `Presets` class with the correct paths for saving and loading
+    presets.
+
+    Parameters
+    ----------
+    **paths: ``str`` keyword args
+        A mapping from type of preset to destination path. These will be
+        directories that contain the yaml files that define the preset
+        positions.
+    """
+    Presets._paths = {}
+    for k, v in paths.items():
+        Presets._paths[k] = Path(v)
+
+
 class Presets:
     """
     Manager for device preset positions. This provides methods for adding new
     presets, checking which presets are active, and related utilities.
+
+    It will install the ``mv_presetname`` and ``wm_presetname`` methods onto
+    the associated device.
 
     Parameters
     ----------
@@ -136,60 +164,207 @@ class Presets:
         The device to manage saved preset positions for. It must implement the
         `FltMvInterface`.
 
-    paths: ``dict{str: str}``
-        A mapping from type of preset to destination path. These will be
-        directories that contain the yaml files that define the preset
-        positions.
+    Attributes
+    ----------
+    positions: ``SimpleNamespace``
+        A namespace that contains all of the active presets as `PresetPosition`
+        objects.
     """
-    _MAX_HISTORY_LENGTH = 5
+    _paths = {}
 
-    def __init__(self, device, paths):
+    def __init__(self, device):
         self._device = device
-        self._paths = {}
-        for k, v in paths.items():
-            self._paths[k] = Path(v)
         self._methods = []
-        self.positions = SimpleNamespace()
         self.sync()
+
+    def _path(self, preset_type):
+        """
+        Utility function go get the proper ``Path`` object that points to the
+        presets file.
+        """
+        return self._paths[preset_type] / (self._device.name + '.yml')
+
+    def _read(self, preset_type):
+        """
+        Utility function to get a particular preset's datum dictionary.
+        """
+        with self._path(preset_type).open('r') as f:
+            return yaml.load(f)
+
+    def _write(self, preset_type, data):
+        """
+        Utility function to overwrite a particular preset's datum dictionary.
+        """
+        with self._path(preset_type).open('w') as f:
+            yaml.dump(data, f, default_flow_style=False)
+
+    def _update(self, preset_type, name, value=None, comment=None,
+                active=True):
+        """
+        Utility function to read the existing preset's datum, update the value
+        the comment, and the active state, and then write the datum back to the
+        file, updating the last updated time and history accordingly.
+        """
+        try:
+            data = self._read(preset_type)
+        except FileNotFoundError:
+            data = {name: {}}
+        if value is not None:
+            try:
+                old_value = data[name]['value']
+                old_ts = data[name]['last_updated']
+                history = data[name].get('history', [])
+                data[name]['history'] = history.append((old_value, old_ts))
+            except KeyError:
+                pass
+            data[name]['value'] = value
+            data[name]['last_updated'] = time.strftime('%d %b %Y %H:%M:%S')
+        if comment is not None:
+            data[name]['comment'] = comment
+        if active:
+            data[name]['active'] = True
+        else:
+            data[name]['active'] = False
+        self._write(preset_type, data)
 
     def sync(self):
         """
-        Read from the database and create methods and objects appropriately.
+        Synchronize the presets with the database.
         """
-        pass
+        self._remove_methods()
+        self._cache = {}
+        for preset_type in self._paths.keys():
+            try:
+                self._cache[preset_type] = self._read(preset_type)
+            except FileNotFoundError:
+                pass
+        self._create_methods()
 
-    def _save(self, path, name, position):
-        pass
-
-    def _save_here(self, path, name):
-        pass
-
-    def _load(self, path):
-        pass
-
-    def _clear_load(self, name):
-        pass
-
-    def _clear_load_all(self):
-        pass
-
-    def _delete(self, path, name, deactivate=True):
+    def _create_methods(self):
         """
-        Remove an entry from the database.
-
-        Parameters
-        ----------
-        path: ``Path``
-            Directory to use
-
-        name: ``str``
-            Name of the device, which informs the file name to find
-
-        deactivate: ``bool``, optional
-            If ``True``, we'll simply mark the preset as inactive. If
-            ``False``, we'll permenantly remove it.
+        Add methods to this object for adding presets of each type, add
+        methods to the associated device to move and check each preset, and
+        add `PresetPosition` instances to ``self.positions`` for each preset
+        name.
         """
-        pass
+        for preset_type in self._paths.keys():
+            add, add_here = self._make_add(preset_type)
+            self._register_method(self, 'add_' + preset_type, add)
+            self._register_method(self, 'add_here_' + preset_type, add_here)
+        for preset_type, data in self._cache.items():
+            for name in data.keys():
+                mv = self._make_mv_pre(preset_type, name)
+                wm = self._make_wm_pre(preset_type, name)
+                self._register_method(self._device, 'mv_' + name, mv)
+                self._register_method(self._device, 'wm_' + name, wm)
+                setattr(self.positions, name,
+                        PresetPosition(self, preset_type, name))
+
+    def _register_method(self, obj, method_name, method):
+        """
+        Utility function to add a method to the ``_methods`` list and to bind
+        the method to an object.
+        """
+        self._methods.append((obj, method_name))
+        setattr(obj, method_name, MethodType(method, obj))
+
+    def _make_add(self, preset_type):
+        """
+        Create suitable versions of ``add`` and ``add_here`` for a particular
+        preset type, e.g. ``add_preset_type`` and ``add_here_preset_type``.
+        """
+        def add(self, name, value, comment=None):
+            """
+            Add a preset position of type "{}".
+
+            Parameters
+            ----------
+            name: ``str``
+                The name of the new preset position.
+
+            value: ``float``
+                The value of the new preset_position.
+
+            comment: ``str``, optional
+                A comment to associate with the preset position.
+            """.format(preset_type)
+            self.presets._update(preset_type, name, value=value,
+                                 comment=comment)
+            self.presets.sync()
+
+        def add_here(self, name, comment=None):
+            """
+            Add a preset of the current position of type "{}".
+
+            Parameters
+            ----------
+            name: ``str``
+                The name of the new preset position.
+
+            comment: ``str``, optional
+                A comment to associate with the preset position.
+            """.format(preset_type)
+            add(name, self.wm(), comment=comment)
+        return add, add_here
+
+    def _make_mv_pre(self, preset_type, name):
+        """
+        Create a suitable version of ``mv`` for a particular preset type and
+        name e.g. ``mv_sample``.
+        """
+        def mv_pre(self, offset=0, timeout=None, wait=False):
+            """
+            Move to the {} preset position, or to a fixed offset from it.
+
+            Parameters
+            ----------
+            offset: ``float``, optional
+                Offset from the preset position. If omitted, we'll move
+                as close to the preset position as possible.
+
+            timeout: ``float``, optional
+                If provided, the mover will throw an error if motion takes
+                longer than timeout to complete. If omitted, the mover's
+                default timeout will be use.
+
+            wait: ``bool``, optional
+                If ``True``, wait for motion completion before returning.
+                Defaults to ``False``.
+            """.format(name)
+            pos = self.presets._cache[preset_type][name]['value']
+            self.mv(pos+offset, timeout=timeout, wait=wait)
+        return mv_pre
+
+    def _make_wm_pre(self, preset_type, name):
+        """
+        Create a suitable version of ``wm`` for a particular preset type and
+        name e.g. ``wm_sample``.
+        """
+        def wm_pre(self):
+            """
+            Check the offset from the {} preset position.
+
+            Returns
+            -------
+            offset: ``float``
+                How far we are from the preset position. If this is near zero,
+                we are at the position.
+            """.format(preset_type)
+            pos = self.presets._cache[preset_type][name]['value']
+            return self.wm() - pos
+        return wm_pre
+
+    def _remove_methods(self):
+        """
+        Remove all methods created in the last call to _create_methods.
+        """
+        for obj, method_name in self._methods:
+            try:
+                delattr(obj, method_name)
+            except AttributeError:
+                pass
+        self._methods = []
+        self.positions = SimpleNamespace()
 
 
 class PresetPosition:
@@ -204,11 +379,12 @@ class PresetPosition:
     name: ``str``
         The name of this preset position.
     """
-    def __init__(self, presets, name):
+    def __init__(self, presets, preset_type, name):
         self._presets = presets
+        self._preset_type = preset_type
         self._name = name
 
-    def update(self, pos=None):
+    def update_pos(self, pos=None):
         """
         Change this preset position and save it.
 
@@ -219,19 +395,50 @@ class PresetPosition:
             current position.
         """
         if pos is None:
-            self._presets._add_here(self._name)
-        else:
-            self._presets._add(self._name, pos)
+            pos = self._presets._device.wm()
+        self._presets._update(self._preset_type, self._name, value=pos)
+        self._presets.sync()
 
-    def delete(self, deactivate=True):
+    def update_comment(self, comment):
         """
-        Remove this preset from the device. By default, this will only
-        deactivate the name, not permenantly delete it.
+        Change the comment and save it.
 
         Parameters
         ----------
-        deactivate: ``bool``, optional
-            This can be changed to ``False`` to permenantly delete a preset
-            instead of just deactivating it.
+        comment: ``str``
+            The comment to save for this preset.
         """
-        self._presets.delete(self._name, deactivate=deactivate)
+        self._presets.update(self._preset_type, self._name, comment=comment)
+        self._presets.sync()
+
+    def deactivate(self):
+        """
+        Deactivate a preset from a device. This can be undone unless you edit
+        the underlying file.
+        """
+        self._presets._update(self._preset_type, self._name, active=False)
+        self._presets.sync()
+
+    @property
+    def pos(self):
+        """
+        The set position of this preset.
+        """
+        return self._presets._cache[self._preset_type][self._name]['value']
+
+    @property
+    def comment(self):
+        """
+        The comment associated with this preset.
+        """
+        return self._presets._cache[self._preset_type][self._name]['comment']
+
+    @property
+    def history(self):
+        """
+        This position history associated with this preset.
+        """
+        return self._presets._cache[self._preset_type][self._name]['history']
+
+    def __repr__(self):
+        return self.pos

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -256,7 +256,8 @@ class Presets:
             try:
                 self._cache[preset_type] = self._read(preset_type)
             except FileNotFoundError:
-                pass
+                logger.debug('No %s preset file for %s',
+                             preset_type, self._device.name)
         self._create_methods()
 
     def _create_methods(self):

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -76,8 +76,8 @@ class FltMvInterface(MvInterface):
     This lets us do more with the interface, such as relative moves.
     """
     def __init__(self, *args, **kwargs):
-        self.presets = Presets(self)
         super().__init__(*args, **kwargs)
+        self.presets = Presets(self)
 
     def mvr(self, delta, timeout=None, wait=False):
         """

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -274,7 +274,11 @@ class Presets:
                     ts = time.strftime('%d %b %Y %H:%M:%S')
                     data[name]['value'] = value
                     history = data[name].get('history', {})
-                    history[ts] = '{:8.4f} {}'.format(value, comment or '')
+                    if comment:
+                        comment = ' ' + comment
+                    else:
+                        comment = ''
+                    history[ts] = '{:10.4f}{}'.format(value, comment)
                     data[name]['history'] = history
                 if active:
                     data[name]['active'] = True

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -267,6 +267,7 @@ class Presets:
             path = self._path(preset_type)
             if not path.exists():
                 path.touch()
+                path.chmod(0o666)
             with self._file_open_rlock(preset_type):
                 data = self._read(preset_type)
                 if value is None and comment is not None:

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -301,7 +301,7 @@ class Presets:
 
             comment: ``str``, optional
                 A comment to associate with the preset position.
-            """.format(preset_type)
+            """
             self._update(preset_type, name, value=value,
                          comment=comment)
             self.sync()
@@ -317,8 +317,11 @@ class Presets:
 
             comment: ``str``, optional
                 A comment to associate with the preset position.
-            """.format(preset_type)
+            """
             add(self, name, self._device.wm(), comment=comment)
+
+        add.__doc__ = add.__doc__.format(preset_type)
+        add_here.__doc__ = add_here.__doc__.format(preset_type)
         return add, add_here
 
     def _make_mv_pre(self, preset_type, name):
@@ -340,7 +343,7 @@ class Presets:
             wait: ``bool``, optional
                 If ``True``, wait for motion completion before returning.
                 Defaults to ``False``.
-            """.format(name)
+            """
             pos = self.presets._cache[preset_type][name]['value']
             self.mv(pos, timeout=timeout, wait=wait)
 
@@ -357,6 +360,9 @@ class Presets:
             """
             pos = self.presets._cache[preset_type][name]['value']
             self.umv(pos, timeout=timeout)
+
+        mv_pre.__doc__ = mv_pre.__doc__.format(name)
+        umv_pre.__doc__ = umv_pre.__doc__.format(name)
         return mv_pre, umv_pre
 
     def _make_wm_pre(self, preset_type, name):
@@ -374,9 +380,11 @@ class Presets:
                 How far we are from the preset position. If this is near zero,
                 we are at the position. If this positive, the preset position
                 is in the positive direction from us.
-            """.format(preset_type)
+            """
             pos = self.presets._cache[preset_type][name]['value']
             return pos - self.wm()
+
+        wm_pre.__doc__ = wm_pre.__doc__.format(name)
         return wm_pre
 
     def _remove_methods(self):

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -156,5 +156,11 @@ class Presets:
     def _load_all(self):
         pass
 
+    def _clear_load(self, path):
+        pass
+
+    def _clear_load_all(self):
+        pass
+
     def _delete(self, path, name):
         pass

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -225,7 +225,6 @@ class Presets:
         if value is not None:
             ts = time.strftime('%d %b %Y %H:%M:%S')
             data[name]['value'] = value
-            data[name]['last_updated'] = ts
             history = data[name].get('history', {})
             history[ts] = value
             data[name]['history'] = history
@@ -472,7 +471,7 @@ class PresetPosition:
         """
         This position history associated with this preset.
         """
-        return self.info.get('history')
+        return self.info['history']
 
     def __repr__(self):
         return str(self.pos)

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -214,7 +214,7 @@ class Presets:
         file, updating the last updated time and history accordingly.
         """
         logger.debug(('call %s presets._update(%s, %s, value=%s, comment=%s, '
-                      'active=%s'), self._device.name, preset_type, name,
+                      'active=%s)'), self._device.name, preset_type, name,
                      value, comment, active)
         try:
             data = self._read(preset_type)

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -25,7 +25,7 @@ from .mv_interface import MvInterface, FltMvInterface
 logger = logging.getLogger(__name__)
 
 
-class SlitPositioner(PVPositioner, Device, FltMvInterface):
+class SlitPositioner(FltMvInterface, PVPositioner, Device):
     """
     Abstraction of Slit Axis
 

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -99,8 +99,8 @@ def test_presets(presets_motor):
     presets_motor.presets.positions.zero.update_comment('uno')
     assert presets_motor.presets.positions.zero.comment == 'uno'
     assert presets_motor.presets.positions.sample.comment is None
-    assert len(presets_motor.presets.positions.zero.history) == 1
-    assert presets_motor.presets.positions.sample.history is None
+    assert len(presets_motor.presets.positions.zero.history) == 2
+    assert len(presets_motor.presets.positions.sample.history) == 1
 
     repr(presets_motor.presets.positions.zero)
     presets_motor.presets.positions.zero.deactivate()

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -99,7 +99,7 @@ def test_presets(presets_motor):
     assert presets_motor.presets.positions.zero.comment == 'uno'
     assert presets_motor.presets.positions.sample.comment is None
     assert len(presets_motor.presets.positions.zero.history) == 1
-    assert len(presets_motor.presets.positions.sample.history) == 0
+    assert presets_motor.presets.positions.sample.history is None
 
     repr(presets_motor.presets.positions.zero)
     presets_motor.presets.positions.zero.deactivate()
@@ -110,5 +110,5 @@ def test_presets(presets_motor):
     with pytest.raises(AttributeError):
         presets_motor.presets.positions.zero
 
-    presets_motor.mv_sample(wait=True)
+    presets_motor.umv_sample()
     assert presets_motor.wm() == 3

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -57,7 +57,10 @@ def motor():
 
 @pytest.fixture(scope='function')
 def presets():
-    folder = str(Path(__file__).parent / 'test_presets')
+    folder_obj = Path(__file__).parent / 'test_presets'
+    folder = str(folder_obj)
+    if folder_obj.exists():
+        shutil.rmtree(folder)
     bl = folder + '/beamline'
     user = folder + '/user'
     os.makedirs(bl)
@@ -87,10 +90,12 @@ def test_umv(motor):
 
 def test_presets_device(presets):
     # Make sure init works with devices, not just toy positioners
+    logger.debug('test_presets_device')
     DeviceTest(name='test')
 
 
 def test_presets(presets, motor):
+    logger.debug('test_presets')
     motor.mv(3, wait=True)
     motor.presets.add_beamline('zero', 0, comment='center')
     motor.presets.add_here_user('sample')

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -3,6 +3,7 @@ import threading
 import os
 import shutil
 import logging
+from pathlib import Path
 
 import pytest
 from ophyd.positioner import SoftPositioner
@@ -51,7 +52,7 @@ def motor():
 
 @pytest.fixture(scope='function')
 def presets_motor():
-    folder = 'test_presets'
+    folder = str(Path(__file__).parent / 'test_presets')
     bl = folder + '/beamline'
     user = folder + '/user'
     os.makedirs(bl)
@@ -92,6 +93,8 @@ def test_presets(presets_motor):
     assert presets_motor.wm() == 1
     assert presets_motor.presets.positions.zero.comment == 'center'
 
+    # Sleep for one so we don't override old history
+    time.sleep(1)
     presets_motor.presets.positions.zero.update_pos()
     assert presets_motor.wm_zero() == 0
     assert presets_motor.presets.positions.zero.pos == 1

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -87,6 +87,14 @@ def test_presets(presets_motor):
     assert presets_motor.wm_zero() == -3
     assert presets_motor.wm_sample() == 0
 
+    # Clear paths, refresh, should still exist
+    old_paths = presets_motor.presets._paths
+    setup_preset_paths()
+    assert not hasattr(presets_motor, 'wm_zero')
+    setup_preset_paths(**old_paths)
+    assert presets_motor.wm_zero() == -3
+    assert presets_motor.wm_sample() == 0
+
     presets_motor.mv_zero(wait=True)
     presets_motor.mvr(1, wait=True)
     assert presets_motor.wm_zero() == -1

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -46,7 +46,7 @@ class Motor(SoftPositioner, FltMvInterface):
         self._stop = True
 
 
-class TestDevice(Device, FltMvInterface):
+class DeviceTest(FltMvInterface, Device):
     pass
 
 
@@ -87,7 +87,7 @@ def test_umv(motor):
 
 def test_presets_device(presets):
     # Make sure init works with devices, not just toy positioners
-    TestDevice(name='test')
+    DeviceTest(name='test')
 
 
 def test_presets(presets, motor):

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -81,13 +81,14 @@ def test_umv(motor):
 
 def test_presets(presets_motor):
     presets_motor.mv(3, wait=True)
-    presets_motor.add_beamline('zero', 0, comment='center')
-    presets_motor.add_here_user('sample')
+    presets_motor.presets.add_beamline('zero', 0, comment='center')
+    presets_motor.presets.add_here_user('sample')
     assert presets_motor.wm_zero() == -3
     assert presets_motor.wm_sample() == 0
 
-    presets_motor.mv_zero(1, wait=True)
-    assert presets_motor.wm_zero() == 1
+    presets_motor.mv_zero(wait=True)
+    presets_motor.mvr(1, wait=True)
+    assert presets_motor.wm_zero() == -1
     assert presets_motor.wm() == 1
     assert presets_motor.presets.positions.zero.comment == 'center'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Allow our special interface to save preset positions to yaml files. This is a port/rework of the old hutch python feature.

There will be one of these files per device that has presets, or multiple if we're running out of multiple paths. The file will be called `devicename.yml`.
```
pi:
  active: true
  comment: the constant
  history:
    26 Mar 2018 17:33:20: 3.1415926535
  last_updated: 26 Mar 2018 17:33:20
  value: 3.1415926535
uno:
  active: false
  history:
    26 Mar 2018 17:33:08: 1.023
    26 Mar 2018 17:33:11: 1
  last_updated: 26 Mar 2018 17:33:11
  value: 1
zero:
  active: true
  history:
    26 Mar 2018 17:32:42: 0
    26 Mar 2018 17:32:45: 0
    26 Mar 2018 17:32:46: 0
    26 Mar 2018 17:32:57: 0.0234
  last_updated: 26 Mar 2018 17:32:57
  value: 0.0234
```
If presets are configured using `setup_prefix_paths`, then there will be a `presets` object attached to the device. The intention is to call `setup_prefix_paths(xpp=<path>, lr13=<path>)` or some equivalent in the `hutch-python` setup, and then we call methods like:
```
motor.presets.add_xpp('my_position', 1.4, comment='hello there') 
motor.presets.add_here_lr13('sample')

motor.mv_sample()
```
And then by manipulating these paths we can specify which are permanent and which are temporary. I'm leaving this flexible because `pcdsdevices` needs to define the method calls but should not define where files are stored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is used every day in xpp. The usage for experiment-specific positions is clear, the usage for permanent positions is dubious (they should become an IOC). Either way, it's good to allow flexibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests up to high coverage, did a "feel" test with fake objects. Seems ok.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I have provided full docstrings and this should already be under the umbrella of the existing autodocs.

<!--
## Screenshots (if appropriate):
-->
