### PR TITLE
FIX: Wait a second for file lock

### DIFF
--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -77,6 +77,11 @@ class FltMvInterface(MvInterface):
     Extension of `MvInterface` for when the position is a ``float``.
 
     This lets us do more with the interface, such as relative moves.
+
+    Attributes
+    ----------
+    presets: `Presets`
+        Manager for preset positions.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Wait for the file lock with a timeout instead of immediately giving up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The file lock error prevents presets from loading, so if it's a manner of a short wait we shouldn't go straight to throwing an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests still pass, they just take a little longer because we're waiting more in the file lock test.