### PR TITLE
TST: wait_for_connection in PCDS motor fixture

### DIFF
--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -10,6 +10,7 @@ def fake_motor():
     # Wait for threads to finish
     attr_wait_value(m, 'low_limit', -100)
     attr_wait_value(m, 'high_limit', 100)
+    m.wait_for_connection()
     return m
 
 @using_fake_epics_pv


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`wait_for_connection` in fixture to avoid race condition when calling `move`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In response to #189 
