### PR TITLE
ENH: Add disable puts field (.DISP) to PCDSMotorBase

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -145,16 +145,15 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
     def check_value(self, value):
         """
         Check if the motor is disabled
-
-        Raises
-        ------
-        Exception
-
         Check if the value is within the soft limits of the motor.
 
         Raises
         ------
+        Exception
+            If the motor is passed any motion command when disabled
         ValueError
+            When the provided value is outside the range of the low
+            and high limits
         """
         # First check that the user has returned a valid EPICS value. It will
         # not consult the limits of the PV itself because limits=False

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -149,17 +149,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         Raises
         ------
         Exception
-        """
-        # First check that the user has returned a valid EPICS value.
-        super().check_value(value)
 
-        # Find the value for the disabled attribute
-        is_disabled = self.disabled.value
-        if is_disabled == 1:
-            raise Exception("Motor is not enabled. Motion requests "
-                            "ignored")
-
-        """
         Check if the value is within the soft limits of the motor.
 
         Raises
@@ -169,6 +159,12 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         # First check that the user has returned a valid EPICS value. It will
         # not consult the limits of the PV itself because limits=False
         super().check_value(value)
+
+        # Find the value for the disabled attribute
+        if self.disabled.value == 1:
+            raise Exception("Motor is not enabled. Motion requests "
+                            "ignored")
+
         # Find the soft limit values from EPICS records and check that this
         # command will be accepted by the motor
         low_limit, high_limit = self.limits

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -51,6 +51,8 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
     # Disable missing field that our EPICS motor record lacks
     # This attribute is tracked by the _pos_changed callback
     direction_of_travel = Component(Signal)
+    # This attribute will show the current status of motor
+    current_motor_status = Component(EpicsSignal, ".DISP")
 
     @property
     def low_limit(self):
@@ -124,6 +126,31 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         """
         self.low_limit = limits[0]
         self.high_limit = limits[1]
+
+    @property
+    def motor_status(self):
+        """
+        Returns the current state of motor.
+        
+        Returns
+        -------
+        motor_status: Int
+            Current state of motor.
+        0 is Enabled. 1 is Disabled
+        """
+        return self.motor_status.value
+
+    @motor_status.setter
+    def motor_status(self,value):
+        """
+        Sets the state for the motor.
+
+        Returns
+        -------
+        status: Status Object
+            Status object of the set.
+        """
+        return self.motor_status.put(value)
 
     def check_value(self, value):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -51,7 +51,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
     # Disable missing field that our EPICS motor record lacks
     # This attribute is tracked by the _pos_changed callback
     direction_of_travel = Component(Signal)
-    # This attribute will show the current status of motor
+    # This attribute will show if the motor is disabled or not
     disabled = Component(EpicsSignal, ".DISP")
 
     @property
@@ -127,20 +127,27 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         self.low_limit = limits[0]
         self.high_limit = limits[1]
 
-    def enable(self, enable):
+    def enable(self):
         """
-        Sets the state for the motor
-
-        Parameters
-        ----------
-        enable: Bool
+        Sets the motor to enabled.
 
         Returns
         -------
         status: Status Object
             Status object of the set
         """
-        return self.disabled.set(not enable)
+        return self.disabled.set(value=0)
+
+    def disable(self):
+        """
+        Sets the motor to disabled.
+
+        Returns
+        -------
+        status: Status Object
+            Status object of the set
+        """
+        return self.disabled.set(value=1)
 
     def check_value(self, value):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR adds the disabled attribute (.DISP) to the epics_motor class. This will allow users to enable/disable the motor when they see fit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was added to disable the motors if needed when changing the CXI beamline configuration (moving the stands). If one of the motors moves to the wrong position, all the motors will stop moving and be disabled. This is also a safety check prior to moving the motors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
