### PR TITLE
EventSequencer

### DIFF
--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -8,6 +8,7 @@ Common EPICS Devices
     
     Attenuator
     EpicsMotor
+    EventSequencer
     LODCM
     GateValve
     IMS

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -10,3 +10,4 @@ from .pim import PIM
 from .pulsepicker import PulsePicker
 from .slits import Slits
 from .valve import Stopper, GateValve
+from .sequencer import EventSequencer

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -8,6 +8,6 @@ from .mirror import OffsetMirror, PointingMirror
 from .movablestand import MovableStand
 from .pim import PIM
 from .pulsepicker import PulsePicker
+from .sequencer import EventSequencer
 from .slits import Slits
 from .valve import Stopper, GateValve
-from .sequencer import EventSequencer

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -1,6 +1,4 @@
-import time
 import logging
-from functools import partial
 
 from ophyd import Device, EpicsSignal, EpicsSignalRO, Component as Cpt
 from ophyd.status import DeviceStatus, SubscriptionStatus
@@ -58,8 +56,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
     _default_read_attrs = ['play_status']
     _default_configuration_attrs = ['play_mode', 'sequence_length']
 
-    def __init__(self, prefix, *, name=None,
-                  monitor_attrs=None, **kwargs):
+    def __init__(self, prefix, *, name=None, monitor_attrs=None, **kwargs):
         monitor_attrs = monitor_attrs or ['current_step', 'play_count']
         # Device initialization
         super().__init__(prefix, name=name,

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -75,6 +75,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         self.start()
         # Start monitor signals
         super().kickoff()
+
         # Create our status
         def done(*args, value=None, old_value=None, **kwargs):
             return value == 2 and old_value == 0

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -60,9 +60,13 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
     play_count = Cpt(EpicsSignal, ':PLYCNT')
     play_status = Cpt(EpicsSignalRO, ':PLSTAT', auto_monitor=True)
     play_mode = Cpt(EpicsSignal, ':PLYMOD')
+    sync_marker = Cpt(EpicsSignal, ':SYNCMARKER')
+    next_sync = Cpt(EpicsSignal, ':SYNCNEXTTICK')
+    pulse_req = Cpt(EpicsSignal, ':BEAMPULSEREQ')
 
     _default_read_attrs = ['play_status']
-    _default_configuration_attrs = ['play_mode', 'sequence_length']
+    _default_configuration_attrs = ['play_mode', 'sequence_length',
+                                    'sync_marker']
 
     def __init__(self, prefix, *, name=None, monitor_attrs=None, **kwargs):
         monitor_attrs = monitor_attrs or ['current_step', 'play_count']

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -147,4 +147,5 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
 
     def stop(self):
         """Stop the EventSequencer"""
+        logger.debug("Stopping the EventSequencer")
         self.play_control.put(0)

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -35,8 +35,8 @@ class EventSequencer(Device):
 
         fly_during_wrapper(scan([det], motor, ...), [sequencer])
 
-    Run the EventSequencer at each step in my scan, after the completing the
-    motor move.
+    Run the EventSequencer at each step in my scan after completing the
+    motor move and detector reading:
 
     .. code::
 

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -63,6 +63,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
     sync_marker = Cpt(EpicsSignal, ':SYNCMARKER')
     next_sync = Cpt(EpicsSignal, ':SYNCNEXTTICK')
     pulse_req = Cpt(EpicsSignal, ':BEAMPULSEREQ')
+    sequence_owner = Cpt(EpicsSignalRO, ':HUTCH_NAME')
 
     _default_read_attrs = ['play_status']
     _default_configuration_attrs = ['play_mode', 'sequence_length',

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -1,0 +1,169 @@
+import time
+import logging
+from functools import partial
+
+from ophyd import Device, EpicsSignal, EpicsSignalRO, Component as Cpt
+from ophyd.status import DeviceStatus, SubscriptionStatus
+from ophyd.utils.epics_pvs import raise_if_disconnected
+
+
+logger = logging.getLogger(__name__)
+
+
+class EventSequencer(Device):
+    """
+    Event Sequencer
+
+    The LCLS Event Sequencer implemented as an Flyer; i.e it has the methods
+    :meth:`.kickoff`, :meth:`.complete` and :meth:`.collect`. This allows the
+    EventSequencer to be used succinctly with the `fly_during_wrapper` and
+    associated preprocessor.
+
+    Parameters
+    ----------
+    prefix: str
+        Base prefix of the EventSequencer
+
+    name : str
+        Name of Event Sequencer object
+
+    Examples
+    --------
+    Run the EventSequencer throughout my scan
+
+    .. code::
+
+        fly_during_wrapper(scan([det], motor, ...), [sequencer])
+
+    Run the EventSequencer at each step in my scan, after the completing the
+    motor move.
+
+    .. code::
+
+        def step_then_sequence(detectors, step, pos_cache)
+            yield from one_nd_step(detectors, step, pos_cache)
+            yield from kickoff(sequencer)
+            yield from complete(sequencer)  # Waits for sequence to complete if
+                                            # not in "Run Forever" mode
+
+        scan([det], motor, ..., per_step=step_then_sequence)
+    """
+    play_control = Cpt(EpicsSignal, ':PLYCTL')
+    sequence_length = Cpt(EpicsSignal, ':LEN')
+    current_step = Cpt(EpicsSignal, ':CURSTP')
+    play_count = Cpt(EpicsSignal, ':PLYCNT')
+    play_status = Cpt(EpicsSignalRO, ':PLSTAT', auto_monitor=True)
+    play_mode = Cpt(EpicsSignal, ':PLYMOD')
+
+    _default_read_attrs = ['play_status']
+    _default_configuration_attrs = ['play_mode', 'sequence_length']
+
+    def __init__(self, prefix, *, name=None,  **kwargs):
+        # Device initialization
+        super().__init__(prefix, name=name, **kwargs)
+        # Data caches
+        self._steps = list()
+        self._iterations = list()
+
+    @raise_if_disconnected
+    def kickoff(self):
+        """
+        Start the EventSequencer
+
+        Returns
+        -------
+        status : SubscriptionStatus
+            Status indicating whether or not the EventSequencer has started
+        """
+        # Clear cached data from prior runs
+        self._steps.clear()
+        self._iterations.clear()
+        # Start the sequencer
+        self.play_control.set(1)
+
+        # Subscribe to changes in the play step and iteration
+        def add_event(cache, timestamp=None, value=None, **kwargs):
+            cache.append((timestamp, value))
+
+        self.current_step.subscribe(partial(add_event, self._steps))
+        self.play_count.subscribe(partial(add_event, self._iterations))
+
+        # Create our status
+        def done(*args, value=None, old_value=None, **kwargs):
+            return value == 2 and old_value == 0
+        # Create our status object
+        return SubscriptionStatus(self.play_status, done, run=True)
+
+    def complete(self):
+        """
+        Complete the EventSequencer's current sequence
+
+        The result of this method varies on the mode that the EventSequencer is
+        configured. If the EventSequencer is either set to "Run Once" or "Run N
+        Times" this method allows the current sequence to complete and returns
+        a status object that indicates a successful completion. However, this
+        mode of operation does not make sense if the EventSequencer is in
+        "Run Forever" mode. In this case, the EventSequencer is stopped
+        immediately and a completed status object is returned.
+
+        Returns
+        -------
+        status: DeviceStatus or SubscriptionStatus
+            Status indicating completion of sequence
+
+        Note
+        ----
+        If you want to stop the sequence from running regardless of
+        configuration use the :meth:`.stop` command.
+
+        """
+        # Clear subscriptions
+        def clear_subs(**kwargs):
+            self.current_step.unsubscribe_all()
+            self.play_count.unsubscribe_all()
+
+        # If we are running forever we can stop whenever
+        if self.play_mode.get() == 2:
+            self.stop()
+            clear_subs()
+            return DeviceStatus(self, done=True, success=True)
+
+        # Otherwise we should wait for the sequencer to end
+        def done(*args, value=None, old_value=None, **kwargs):
+            return value == 0 and old_value == 2
+
+        # Create a SubscriptionStatus
+        st = SubscriptionStatus(self.play_status, done, run=True)
+        st.add_callback(clear_subs)
+        return st
+
+    def collect(self):
+        """
+        Gather information about the state of the Sequencer
+
+        During :meth:`.kickoff`, a monitor is started on the ``current_step``
+        and ``play_count`` signals. The timestamps and values of these signals
+        are stored internally and can be added back into the data stream
+        asynchronously by calling this method.
+        """
+        # Create partial event document
+        event = {'time': time.time(), 'timestamps': dict(), 'data': dict()}
+        for sig, cache in zip((self.current_step, self.play_count),
+                              (self._steps, self._iterations)):
+            event['timestamps'][sig.name] = [evt[0] for evt in cache]
+            event['data'][sig.name] = [evt[1] for evt in cache]
+        # Clear caches
+        self._steps.clear()
+        self._iterations.clear()
+        yield event
+
+    def describe_collect(self):
+        """Describe the collection information"""
+        dd = dict()
+        dd.update(self.play_count.describe())
+        dd.update(self.current_step.describe())
+        return {'sequence': dd}
+
+    def stop(self):
+        """Stop the EventSequencer"""
+        self.play_control.put(0)

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -72,18 +72,36 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         status : SubscriptionStatus
             Status indicating whether or not the EventSequencer has started
         """
-        # Start the sequencer
-        logger.debug("Starting EventSequencer ...")
-        self.play_control.set(1)
+        self.start()
         # Start monitor signals
         super().kickoff()
-
         # Create our status
         def done(*args, value=None, old_value=None, **kwargs):
             return value == 2 and old_value == 0
 
         # Create our status object
         return SubscriptionStatus(self.play_status, done, run=True)
+
+    @raise_if_disconnected
+    def start(self):
+        """
+        Start the EventSequencer
+        """
+        # Start the sequencer
+        logger.debug("Starting EventSequencer ...")
+        self.play_control.set(1)
+
+    def pause(self):
+        """Stop the event sequencer and stop monitoring events"""
+        # Order a stop
+        self.stop()
+        # Pause monitoring
+        super().pause
+
+    def resume(self):
+        """Resume the EventSequencer procedure"""
+        super().resume()
+        self.start()
 
     def complete(self):
         """

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -79,6 +79,7 @@ class EventSequencer(Device):
         self._steps.clear()
         self._iterations.clear()
         # Start the sequencer
+        logger.debug("Starting EventSequencer ...")
         self.play_control.set(1)
 
         # Subscribe to changes in the play step and iteration
@@ -124,6 +125,8 @@ class EventSequencer(Device):
 
         # If we are running forever we can stop whenever
         if self.play_mode.get() == 2:
+            logger.debug("EventSequencer is set to run forever, "
+                         "stopping immediately")
             self.stop()
             clear_subs()
             return DeviceStatus(self, done=True, success=True)
@@ -133,6 +136,8 @@ class EventSequencer(Device):
             return value == 0 and old_value == 2
 
         # Create a SubscriptionStatus
+        logger.debug("EventSequencer has a determined stopping point, "
+                     " waiting for sequence to complete")
         st = SubscriptionStatus(self.play_status, done, run=True)
         st.add_callback(clear_subs)
         return st
@@ -147,6 +152,7 @@ class EventSequencer(Device):
         asynchronously by calling this method.
         """
         # Create partial event document
+        logger.debug("Interpreting stored EventSequencer information")
         event = {'time': time.time(), 'timestamps': dict(), 'data': dict()}
         for sig, cache in zip((self.current_step, self.play_count),
                               (self._steps, self._iterations)):

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -45,6 +45,14 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
                                             # not in "Run Forever" mode
 
         scan([det], motor, ..., per_step=step_then_sequence)
+
+    Note
+    ----
+    It is ambiguous what the correct behavior for the EventSequencer is when we
+    pause and resume during a scan. The current implementation will stop the
+    EventSequencer and restart the sequence from the beginning. This may impact
+    applications which depend on a long single looped sequence running through
+    out the scan
     """
     play_control = Cpt(EpicsSignal, ':PLYCTL')
     sequence_length = Cpt(EpicsSignal, ':LEN')
@@ -97,7 +105,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         # Order a stop
         self.stop()
         # Pause monitoring
-        super().pause
+        super().pause()
 
     def resume(self):
         """Resume the EventSequencer procedure"""

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -102,6 +102,7 @@ def test_pause_and_resume():
 @using_fake_epics_pv
 def test_fly_scan_smoke():
     seq = SimSequencer('ECS:TST', name='seq')
+    seq.wait_for_connection()
     RE = RunEngine()
 
     # Create a plan where we fly for a second

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,0 +1,87 @@
+from ophyd.sim import NullStatus
+from bluesky import RunEngine
+from bluesky.preprocessors import fly_during_wrapper, run_wrapper
+from bluesky.plan_stubs import sleep
+
+from pcdsdevices.sequencer import EventSequencer
+from pcdsdevices.sim.pv import using_fake_epics_pv
+
+
+def sequence():
+    seq = EventSequencer('ECS:TST', name='seq')
+    seq.wait_for_connection()
+    # Running forever
+    seq.play_mode.put(2)
+    return seq
+
+
+# Simulated Sequencer for use in scans
+class SimSequencer(EventSequencer):
+    """Simulated Sequencer usable in bluesky plans"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Forces an immediate stop on complete
+        self.play_mode.put(2)
+
+    def kickoff(self):
+        super().kickoff()
+        return NullStatus()
+
+
+@using_fake_epics_pv
+def test_kickoff():
+    seq = sequence()
+    st = seq.kickoff()
+    # Not currently playing
+    seq.play_status._read_pv.put(0)
+    seq.play_status._read_pv.run_callbacks()
+    # Check we gave the command to start the sequencer
+    assert seq.play_control.value == 1
+    # Check that our monitors have started
+    assert len(seq.current_step._callbacks['value']) == 1
+    assert len(seq.play_count._callbacks['value']) == 1
+    # Our status should not be done until the sequencer starts
+    assert not st.done
+    seq.play_status._read_pv.put(2)
+    seq.play_status._read_pv.run_callbacks()
+    assert st.done
+    assert st.success
+
+
+@using_fake_epics_pv
+def test_complete_run_forever():
+    seq = sequence()
+    # Run Forever mode should tell this to stop
+    st = seq.complete()
+    assert seq.play_control.value == 0
+    assert st.done
+    assert st.success
+
+
+@using_fake_epics_pv
+def test_complete_run_once():
+    seq = sequence()
+    # Start the sequencer in run once mode
+    seq.play_mode.put(0)
+    seq.play_status._read_pv.put(2)
+    seq.play_status._read_pv.run_callbacks()
+    st = seq.complete()
+    # Our status should not be done until the sequence stops naturally
+    assert not st.done
+    seq.play_status._read_pv.put(0)
+    seq.play_status._read_pv.run_callbacks()
+    assert st.done
+    assert st.success
+
+
+@using_fake_epics_pv
+def test_fly_scan_smoke():
+    seq = SimSequencer('ECS:TST', name='seq')
+    RE = RunEngine()
+
+    # Create a plan where we fly for a second
+    def plan():
+        yield from fly_during_wrapper(run_wrapper(sleep(1)), [seq])
+
+    # Run the plan
+    RE(plan())

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -51,6 +51,7 @@ def test_kickoff():
 @using_fake_epics_pv
 def test_complete_run_forever():
     seq = sequence()
+    seq._acquiring = True
     # Run Forever mode should tell this to stop
     st = seq.complete()
     assert seq.play_control.value == 0
@@ -61,6 +62,7 @@ def test_complete_run_forever():
 @using_fake_epics_pv
 def test_complete_run_once():
     seq = sequence()
+    seq._acquiring = True
     # Start the sequencer in run once mode
     seq.play_mode.put(0)
     seq.play_status._read_pv.put(2)

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,7 +1,7 @@
-from ophyd.sim import NullStatus
 from bluesky import RunEngine
 from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from bluesky.plan_stubs import sleep
+from ophyd.sim import NullStatus
 
 from pcdsdevices.sequencer import EventSequencer
 from pcdsdevices.sim.pv import using_fake_epics_pv

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -77,6 +77,20 @@ def test_complete_run_once():
 
 
 @using_fake_epics_pv
+def test_pause_and_resume():
+    seq = sequence()
+    # Start the sequence
+    seq._acquiring = True
+    seq.play_control.put(1)
+    # Assert we stopped our sequencer
+    seq.pause()
+    assert seq.play_control.get() == 0
+    seq.resume()
+    # Assert we restarted our sequencer
+    assert seq.play_control.get() == 1
+
+
+@using_fake_epics_pv
 def test_fly_scan_smoke():
     seq = SimSequencer('ECS:TST', name='seq')
     RE = RunEngine()

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,3 +1,5 @@
+import time
+
 from bluesky import RunEngine
 from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from bluesky.plan_stubs import sleep
@@ -12,6 +14,7 @@ def sequence():
     seq.wait_for_connection()
     # Running forever
     seq.play_mode.put(2)
+    seq.play_control.put(0)
     return seq
 
 
@@ -35,6 +38,8 @@ def test_kickoff():
     # Not currently playing
     seq.play_status._read_pv.put(0)
     seq.play_status._read_pv.run_callbacks()
+    # Wait for set threads
+    time.sleep(0.5)
     # Check we gave the command to start the sequencer
     assert seq.play_control.value == 1
     # Check that our monitors have started
@@ -84,8 +89,12 @@ def test_pause_and_resume():
     seq.play_control.put(1)
     # Assert we stopped our sequencer
     seq.pause()
+    # Wait for set threads
+    time.sleep(0.5)
     assert seq.play_control.get() == 0
     seq.resume()
+    # Wait for set threads
+    time.sleep(0.5)
     # Assert we restarted our sequencer
     assert seq.play_control.get() == 1
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A basic `EventSequencer` object. 

This handles **only** starting and stopping the `EventSequencer` in the various modes of operation. Actually configuring what the sequence loaded is should be discussed outside of this PR. 

I suspect the main controversy will be the fact that this is a `bluesky` flyer. I decided to go this route because the `set` method does not make much sense. In reality most of the time you want to start and stop the Event Sequencer as two entirely separate actions.  This works especially nicely if you just want to run the sequencer the entire time you are scanning:

```python
fly_during_wrapper(my_scan, [sequencer])
```

I do agree that when you want to keep starting and stopping the sequencer during a scan it is a little more awkward, but I don't think the `set` and `wait` syntax really makes much more sense. I like the granularity of this. It is clear exactly when I want to start the sequence, and exactly when I want to wait for my sequence to complete.
```python
def step_then_sequence(detectors, step, pos_cache):
   yield from one_nd_step(detectors, step, pos_cache)
   yield from kickoff(sequencer)
   yield from complete(sequencer, wait=True)

scan([det], motor, ..., per_step=step_then_sequence)
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #195 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added to test suite a series of methods that run the `EventSequencer` in a `bluesky` plan as well as some more in-depth tests on specific methods
* Tested with the CXI EventSequencer `R3.8.0`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to `device_types` table. Included some sample use cases
