### PR TITLE
WIP: Dynamic States

### DIFF
--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -25,13 +25,8 @@ class IPM(InOutRecordPositioner):
     state = Cmp(EpicsSignal, ':TARGET', write_pv=':TARGET:GO')
     diode = Cmp(InOutRecordPositioner, ":DIODE")
 
-    states_list = ['T1', 'T2', 'T3', 'T4', 'OUT']
-    _states_alias = {'T1': ['T1', 'TARGET1', 't1', 'target1'],
-                     'T2': ['T2', 'TARGET2', 't2', 'target2'],
-                     'T3': ['T3', 'TARGET3', 't3', 'target3'],
-                     'T4': ['T4', 'TARGET4', 't4', 'target4']}
-
-    in_states = ['T1', 'T2', 'T3', 'T4']
+    _default_settings = ['TARGET1', 'TARGET2', 'TARGET3', 'TARGET4', 'OUT']
+    in_states = [1, 2, 3, 4]
 
     # Assume that having any target in gives transmission 0.8
-    _transmission = {'T' + str(n): 0.8 for n in range(1, 5)}
+    _transmission = {n: 0.8 for n in in_states}

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -16,8 +16,9 @@ class XFLS(InOutRecordPositioner):
     """
     __doc__ += basic_positioner_init
 
-    states_list = ['LENS1', 'LENS2', 'LENS3', 'OUT']
-    in_states = ['LENS1', 'LENS2', 'LENS3']
+    _default_settings = ['LENS1', 'LENS2', 'LENS3', 'OUT']
+    in_states = [1, 2, 3]
+
     _lens_transmission = 0.8
 
     def __init__(self, prefix, *, name, **kwargs):

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -23,21 +23,24 @@ logger = logging.getLogger(__name__)
 
 
 class YagLom(InOutRecordPositioner):
-    states_list = ['OUT', 'YAG', 'SLIT1', 'SLIT2', 'SLIT3']
+    _states_list = ['OUT', 'YAG', 'SLIT1', 'SLIT2', 'SLIT3']
     in_states = ['YAG', 'SLIT1', 'SLIT2', 'SLIT3']
     _states_alias = {'YAG': 'IN'}
+    _dynamic_states = False
 
 
 class Dectris(InOutRecordPositioner):
-    states_list = ['OUT', 'DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3', 'OUTLOW']
+    _states_list = ['OUT', 'DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3', 'OUTLOW']
     in_states = ['DECTRIS', 'SLIT1', 'SLIT2', 'SLIT3']
     out_states = ['OUT', 'OUTLOW']
     _states_alias = {'DECTRIS': 'IN'}
+    _dynamic_states = False
 
 
 class Foil(InOutRecordPositioner):
-    states_list = ['OUT']
+    _states_list = ['OUT']
     in_states = []
+    _dynamic_states = False
 
 
 class LODCM(InOutRecordPositioner):
@@ -66,8 +69,9 @@ class LODCM(InOutRecordPositioner):
     diode = Cmp(InOutRecordPositioner, ":DIODE")
     foil = Cmp(Foil, ":FOIL")
 
-    states_list = ['OUT', 'C', 'Si']
+    _states_list = ['OUT', 'C', 'Si']
     in_states = ['C', 'Si']
+    _dynamic_states = False
 
     # TBH these are guessed. Please replace if you know better. These don't
     # need to be 100% accurate, but they should reflect a reasonable reduction

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -49,8 +49,9 @@ class PIMMotor(InOutRecordPositioner):
     This can move the stage to insert the yag
     or diode, or retract from the beam path.
     """
-    states_list = ['DIODE', 'YAG', 'OUT']
+    _states_list = ['DIODE', 'YAG', 'OUT']
     _states_alias = {'YAG': 'IN'}
+    _dynamic_states = False
 
     def stage(self):
         """

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -175,7 +175,7 @@ class PulsePickerInOut(PulsePicker):
 
     inout = FCmp(InOutRecordPositioner, '{self._inout}')
 
-    states_list = ['OUT', 'OPEN', 'CLOSED']
+    _states_list = ['OUT', 'OPEN', 'CLOSED']
     out_states = ['OUT', 'OPEN']
     _state_logic = {'inout.state': {1: 'OUT',
                                     2: 'defer',

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -147,7 +147,7 @@ class PPSStopper(InOutPositioner):
         # Store state information
         self.in_states = [in_state]
         self.out_states = [out_state]
-        self.states_list = self.in_states + self.out_states
+        self._states_list = self.in_states + self.out_states
         # Load InOutPositioner
         super().__init__(prefix, **kwargs)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Allow setting a `_dynamic_states` boolean to `True` to grab enum states information from the `states` signal. Everything else is a consequence of that change, while continuing to meet the design constraint of not using our signal connections during `__init__`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IPMS and XFLS have a varied array of states names. We can't cover them all with different classes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

<!--
## Screenshots (if appropriate):
-->

This is a work in progress, I haven't reviewed the code myself. I'm stopping here due to splitting headache. This needs to be thought over, completed, tested, documented, etc.