### PR TITLE
ENH: States Updates for IPM and XFLS

### DIFF
--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -84,13 +84,19 @@ class InOutPositioner(StatePositioner):
 
     @property
     def transmission(self):
-        state = self.get_state(self.position)
-        return self._trans_enum.get(state, math.nan)
+        """
+        The proportion of incoming beam that makes it through the device.
+
+        This will be a float between 0 and 1, where 0 is no beam and 1 is full
+        transmission.
+        """
+        state_index = self.get_state(self.position).value
+        return self._trans_enum.get(state_index, math.nan)
 
     def _extend_trans_enum(self, state_list, default):
         for state in state_list:
-            enumst = self.get_state(state)
-            self._trans_enum[enumst] = self._transmission.get(state, default)
+            index = self.states_list.index(state)
+            self._trans_enum[index] = self._transmission.get(state, default)
 
     def _pos_in_list(self, state_list):
         current_state = self.get_state(self.position)

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -1,8 +1,8 @@
 """
 Module for the `IPM` intensity position monitor class
 """
-from ophyd import Component as Cmp
-from ophyd.signal import EpicsSignal
+from ophyd import Component as Cpt, FormattedComponent as FCpt
+from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from .doc_stubs import basic_positioner_init
 from .inout import InOutRecordPositioner
@@ -14,7 +14,8 @@ class IPM(InOutRecordPositioner):
 
     This is an `InOutRecordPositioner` that moves
     the target position to any of the four set positions, or out. Valid states
-    are (1, 2, 3, 4, 5) or the equivalent (T1, T2, T3, T4, OUT).
+    are (1, 2, 3, 4, 5) or the equivalent
+    (TARGET1, TARGET2, TARGET3, TARGET4, OUT).
 
     IPMs each also have a diode, which is implemented as the diode attribute of
     this class. This can easily be controlled using ``ipm.diode.insert()`` or
@@ -22,16 +23,12 @@ class IPM(InOutRecordPositioner):
     """
     __doc__ += basic_positioner_init
 
-    state = Cmp(EpicsSignal, ':TARGET', write_pv=':TARGET:GO')
-    diode = Cmp(InOutRecordPositioner, ":DIODE")
+    state = Cpt(EpicsSignal, ':TARGET', write_pv=':TARGET:GO')
+    diode = Cpt(InOutRecordPositioner, ':DIODE')
+    readback = FCpt(EpicsSignalRO, '{self.prefix}:TARGET:{self._readback}')
 
-    states_list = ['T1', 'T2', 'T3', 'T4', 'OUT']
-    _states_alias = {'T1': ['T1', 'TARGET1', 't1', 'target1'],
-                     'T2': ['T2', 'TARGET2', 't2', 'target2'],
-                     'T3': ['T3', 'TARGET3', 't3', 'target3'],
-                     'T4': ['T4', 'TARGET4', 't4', 'target4']}
-
-    in_states = ['T1', 'T2', 'T3', 'T4']
+    in_states = ['TARGET1', 'TARGET2', 'TARGET3', 'TARGET4']
+    states_list = in_states + ['OUT']
 
     # Assume that having any target in gives transmission 0.8
-    _transmission = {'T' + str(n): 0.8 for n in range(1, 5)}
+    _transmission = {st: 0.8 for st in in_states}

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -35,6 +35,10 @@ class Dectris(InOutRecordPositioner):
     _states_alias = {'DECTRIS': 'IN'}
 
 
+class Diode(InOutRecordPositioner):
+    states_list = ['OUT', 'IN']
+
+
 class Foil(InOutRecordPositioner):
     states_list = ['OUT']
     in_states = []
@@ -63,7 +67,7 @@ class LODCM(InOutRecordPositioner):
 
     yag = Cmp(YagLom, ":DV")
     dectris = Cmp(Dectris, ":DH")
-    diode = Cmp(InOutRecordPositioner, ":DIODE")
+    diode = Cmp(Diode, ":DIODE")
     foil = Cmp(Foil, ":FOIL")
 
     states_list = ['OUT', 'C', 'Si']

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -50,6 +50,8 @@ class PIMMotor(InOutRecordPositioner):
     or diode, or retract from the beam path.
     """
     states_list = ['DIODE', 'YAG', 'OUT']
+    in_states = ['YAG', 'DIODE']
+
     _states_alias = {'YAG': 'IN'}
 
     def stage(self):

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -3,7 +3,7 @@ Module for the LCLS1 `PulsePicker`
 """
 import logging
 
-from ophyd.device import Component as Cmp, FormattedComponent as FCmp
+from ophyd.device import Component as Cpt, FormattedComponent as FCpt
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.status import SubscriptionStatus, wait as status_wait
 
@@ -22,15 +22,15 @@ class PulsePicker(InOutPVStatePositioner):
     """
     __doc__ += basic_positioner_init
 
-    blade = Cmp(EpicsSignalRO, ':READ_DF')
-    mode = Cmp(EpicsSignalRO, ':SD_SIMPLE')
+    blade = Cpt(EpicsSignalRO, ':READ_DF')
+    mode = Cpt(EpicsSignalRO, ':SD_SIMPLE')
 
-    cmd_reset = Cmp(EpicsSignal, ':RESET_PG')
-    cmd_open = Cmp(EpicsSignal, ':S_OPEN')
-    cmd_close = Cmp(EpicsSignal, ':S_CLOSE')
-    cmd_flipflop = Cmp(EpicsSignal, ':RUN_FLIPFLOP')
-    cmd_burst = Cmp(EpicsSignal, ':RUN_BURSTMODE')
-    cmd_follower = Cmp(EpicsSignal, ':RUN_FOLLOWERMODE')
+    cmd_reset = Cpt(EpicsSignal, ':RESET_PG')
+    cmd_open = Cpt(EpicsSignal, ':S_OPEN')
+    cmd_close = Cpt(EpicsSignal, ':S_CLOSE')
+    cmd_flipflop = Cpt(EpicsSignal, ':RUN_FLIPFLOP')
+    cmd_burst = Cpt(EpicsSignal, ':RUN_BURSTMODE')
+    cmd_follower = Cpt(EpicsSignal, ':RUN_FOLLOWERMODE')
 
     states_list = ['OPEN', 'CLOSED']
     in_states = ['CLOSED']
@@ -173,14 +173,14 @@ class PulsePickerInOut(PulsePicker):
     """
     __doc__ += basic_positioner_init
 
-    inout = FCmp(InOutRecordPositioner, '{self._inout}')
+    inout = FCpt(InOutRecordPositioner, '{self._inout}')
 
     states_list = ['OUT', 'OPEN', 'CLOSED']
     out_states = ['OUT', 'OPEN']
-    _state_logic = {'inout.state': {1: 'OUT',
-                                    2: 'defer',
-                                    'OUT': 'OUT',
-                                    'IN': 'defer'},
+    _state_logic = {'inout.state': {1: 'defer',
+                                    2: 'OUT',
+                                    'IN': 'defer',
+                                    'OUT': 'OUT'},
                     'blade': {0: 'OPEN',
                               1: 'CLOSED',
                               2: 'CLOSED'}}

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -13,6 +13,7 @@ def fake_inout():
     inout = InOutRecordPositioner('Test:Ref', name='test')
     connect_rw_pvs(inout.state)
     inout.state._write_pv.put('Unknown')
+    inout.state._read_pv.enum_strs = ('Unknown', 'IN', 'OUT')
     inout.wait_for_connection()
     return inout
 

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -2,8 +2,9 @@ import logging
 
 from unittest.mock import Mock
 
-from pcdsdevices.sim.pv import using_fake_epics_pv
+from pcdsdevices.inout import InOutRecordPositioner
 from pcdsdevices.ipm import IPM
+from pcdsdevices.sim.pv import using_fake_epics_pv
 
 from .conftest import connect_rw_pvs, attr_wait_true
 
@@ -19,7 +20,10 @@ def fake_ipm():
     connect_rw_pvs(ipm.diode.state)
     connect_rw_pvs(ipm.state)
     ipm.diode.state._write_pv.put('Unknown')
+    ipm.diode.state._read_pv.enum_strs = (['Unknown'] +
+                                          InOutRecordPositioner.states_list)
     ipm.state._write_pv.put('Unknown')
+    ipm.state._read_pv.enum_strs = ['Unknown'] + IPM.states_list
     ipm.wait_for_connection()
     return ipm
 
@@ -28,10 +32,10 @@ def fake_ipm():
 def test_ipm_states():
     logger.debug('test_ipm_states')
     ipm = fake_ipm()
-    ipm.state._read_pv.put('OUT')
+    ipm.state._read_pv.put(5)
     assert ipm.removed
     assert not ipm.inserted
-    ipm.state._read_pv.put('TARGET1')
+    ipm.state._read_pv.put(1)
     assert not ipm.removed
     assert ipm.inserted
 
@@ -42,16 +46,16 @@ def test_ipm_motion():
     ipm = fake_ipm()
     # Remove IPM Targets
     ipm.remove(wait=True, timeout=1.0)
-    assert ipm.state._write_pv.get() == 'OUT'
+    assert ipm.state._write_pv.get() == 5
     # Insert IPM Targets
     ipm.set(1)
-    assert ipm.state._write_pv.get() == 'T1'
+    assert ipm.state._write_pv.get() == 1
     # Move diodes in
     ipm.diode.insert()
-    assert ipm.diode.state._write_pv.get() == 'IN'
+    assert ipm.diode.state._write_pv.get() == 1
     ipm.diode.remove()
     # Move diodes out
-    assert ipm.diode.state._write_pv.get() == 'OUT'
+    assert ipm.diode.state._write_pv.get() == 2
 
 
 @using_fake_epics_pv
@@ -62,6 +66,6 @@ def test_ipm_subscriptions():
     cb = Mock()
     ipm.subscribe(cb, event_type=ipm.SUB_STATE, run=False)
     # Change the target state
-    ipm.state._read_pv.put('OUT')
+    ipm.state._read_pv.put(2)
     attr_wait_true(cb, 'called')
     assert cb.called

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -13,7 +13,9 @@ def fake_xfls():
     """
     xfls = XFLS('TST:XFLS', name='lens')
     connect_rw_pvs(xfls.state)
-    xfls.state.put('OUT')
+    xfls.state.put(4)
+    xfls.state._read_pv.enum_strs = ('Unknown', 'LENS1', 'LENS2', 'LENS3',
+                                     'OUT')
     xfls.wait_for_connection()
     return xfls
 
@@ -39,7 +41,7 @@ def test_xfls_states():
 def test_xfls_motion():
     xfls = fake_xfls()
     xfls.remove()
-    assert xfls.state._write_pv.get() == 'OUT'
+    assert xfls.state._write_pv.get() == 4
 
 
 @using_fake_epics_pv

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -2,8 +2,8 @@ import logging
 
 from unittest.mock import Mock
 
+from pcdsdevices.lodcm import LODCM, YagLom, Dectris, Diode, Foil
 from pcdsdevices.sim.pv import using_fake_epics_pv
-from pcdsdevices.lodcm import LODCM
 
 from .conftest import attr_wait_true, connect_rw_pvs
 
@@ -21,11 +21,16 @@ def fake_lodcm():
     connect_rw_pvs(lodcm.dectris.state)
     connect_rw_pvs(lodcm.diode.state)
     connect_rw_pvs(lodcm.foil.state)
-    lodcm.state.put('OUT')
-    lodcm.yag.state.put('OUT')
-    lodcm.dectris.state.put('OUT')
-    lodcm.diode.state.put('OUT')
-    lodcm.foil.state.put('OUT')
+    lodcm.state.put(1)
+    lodcm.state._read_pv.enum_strs = ['Unknown'] + LODCM.states_list
+    lodcm.yag.state.put(1)
+    lodcm.yag.state._read_pv.enum_strs = ['Unknown'] + YagLom.states_list
+    lodcm.dectris.state.put(1)
+    lodcm.dectris.state._read_pv.enum_strs = ['Unknown'] + Dectris.states_list
+    lodcm.diode.state.put(1)
+    lodcm.diode.state._read_pv.enum_strs = ['Unknown'] + Diode.states_list
+    lodcm.foil.state.put(1)
+    lodcm.foil.state._read_pv.enum_strs = ['Unknown'] + Foil.states_list
     lodcm.wait_for_connection()
     return lodcm
 

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -19,6 +19,7 @@ def fake_branching_mirror():
                        in_lines=['MFX', 'MEC'], out_lines=['CXI'])
     connect_rw_pvs(m.state)
     m.state._write_pv.put('Unknown')
+    m.state._read_pv.enum_strs = ['Unknown'] + PointingMirror.states_list
     m.wait_for_connection()
     # Couple the gantry
     m.xgantry.decoupled._read_pv.put(0)
@@ -103,12 +104,12 @@ def test_branching_mirror_moves():
     assert branching_mirror.xgantry.setpoint._write_pv.get() == 0.2
     # Test removal
     branching_mirror.remove()
-    assert branching_mirror.state._write_pv.value == 'OUT'
+    assert branching_mirror.state._write_pv.value == 2
     # Finish simulated move manually
-    branching_mirror.state._read_pv.put('OUT')
+    branching_mirror.state._read_pv.put(2)
     # Insert
     branching_mirror.insert()
-    assert branching_mirror.state._write_pv.value == 'IN'
+    assert branching_mirror.state._write_pv.value == 1
 
 
 @using_fake_epics_pv

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -29,7 +29,8 @@ def fake_pim():
     pim = PIMMotor('Test:Yag', name='test')
     connect_rw_pvs(pim.state)
     pim.wait_for_connection()
-    pim.state.put('OUT', wait=True)
+    pim.state.put(0, wait=True)
+    pim.state._read_pv.enum_strs = ['Unknown'] + PIMMotor.states_list
     return pim
 
 

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -6,8 +6,9 @@ import pytest
 from unittest.mock import Mock
 from ophyd.status import wait as status_wait
 
-from pcdsdevices.sim.pv import using_fake_epics_pv
+from pcdsdevices.inout import InOutRecordPositioner
 from pcdsdevices.pulsepicker import PulsePickerInOut
+from pcdsdevices.sim.pv import using_fake_epics_pv
 
 from .conftest import attr_wait_true, connect_rw_pvs
 
@@ -20,7 +21,9 @@ def fake_picker():
     """
     picker = PulsePickerInOut('TST:SB1:MMS:35', name='picker')
     connect_rw_pvs(picker.inout.state)
-    picker.inout.state.put('IN')
+    picker.inout.state.put(0)
+    picker.inout.state._read_pv.enum_strs = (['Unknown'] +
+                                             InOutRecordPositioner.states_list)
     picker.blade._read_pv.put(0)
     picker.mode._read_pv.put(0)
     picker.wait_for_connection()
@@ -32,7 +35,9 @@ def fake_picker():
 def test_picker_states():
     logger.debug('test_picker_states')
     picker = fake_picker()
-    # Starts OPEN
+    # Insert and OPEN
+    picker.inout.state.put('IN')
+    picker.blade._read_pv.put(0)
     assert not picker.inserted
     assert picker.removed
     assert picker.position == 'OPEN'

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -157,6 +157,6 @@ def test_picker_subs():
     cb = Mock()
     picker.subscribe(cb, event_type=picker.SUB_STATE, run=False)
     # Change the target state
-    picker.blade._read_pv.put(1)
+    picker.insert()
     attr_wait_true(cb, 'called')
     assert cb.called


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add EPICS enums as primary aliases
- Put integer instead of str for moves
- Map transmissions with integers
- Adjust IPMs to work with these changes
- Fix bug where readback was broken for all IPM
- Remove redundant docstrings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Force IOCs to have the same PVs for configuring the same devices. Take the EPICS enum so that users can create aliases in EPICS.
closes #203 
closes #150 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated tests and it works with the real IPM objects