### PR TITLE
FIX: flock test on NFS

### DIFF
--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -142,7 +142,7 @@ def test_presets(presets, motor):
     assert len(motor.presets.positions.sample.history) == 2
 
     def block_file(path, lock):
-        with open(path, 'r') as f:
+        with open(path, 'r+') as f:
             fcntl.flock(f, fcntl.LOCK_EX)
             lock.acquire()
             fcntl.flock(f, fcntl.LOCK_UN)


### PR DESCRIPTION
closes #206 

Nearest I can tell, `flock` on NFS doesn't work unless the file is opened in write or append or some equivalent mode... We don't "need" to write to the file to run the test here, but empirically it seems like we do need it to avoid an exception on NFS.

The code bit here is simply starting a second process and locking the file, and checking that the presets behave as expected in this situation. The `mp.Lock` is used to tell the process to release the file lock.