### PR TITLE
ENH: Mirror state

### DIFF
--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -227,6 +227,9 @@ class PointingMirror(InOutRecordPositioner, OffsetMirror):
     out_lines: ``list``, optional
         List of beamlines thate are delivered beam when the mirror is out
     """
+    # Reverse state order as PointingMirror is non-standard
+    states_list = ['OUT', 'IN']
+
     # Define default read and configuration attributes
     _default_read_attrs = ['pitch.readback', 'xgantry.readback',
                            'xgantry.gantry_difference']

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -75,12 +75,12 @@ def test_branching_mirror_destination():
     assert not branching_mirror.inserted
     assert branching_mirror.destination == []
     # Inserted
-    branching_mirror.state._read_pv.put(1)
+    branching_mirror.state._read_pv.put(2)
     assert branching_mirror.inserted
     assert not branching_mirror.removed
     assert branching_mirror.destination == ['MFX', 'MEC']
     # Removed
-    branching_mirror.state._read_pv.put(2)
+    branching_mirror.state._read_pv.put(1)
     assert branching_mirror.removed
     assert not branching_mirror.inserted
     assert branching_mirror.destination == ['CXI']
@@ -104,12 +104,12 @@ def test_branching_mirror_moves():
     assert branching_mirror.xgantry.setpoint._write_pv.get() == 0.2
     # Test removal
     branching_mirror.remove()
-    assert branching_mirror.state._write_pv.value == 2
+    assert branching_mirror.state._write_pv.value == 1
     # Finish simulated move manually
     branching_mirror.state._read_pv.put(2)
     # Insert
     branching_mirror.insert()
-    assert branching_mirror.state._write_pv.value == 1
+    assert branching_mirror.state._write_pv.value == 2
 
 
 @using_fake_epics_pv


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The mirrors in the XRT do not use the standard states records from the IMS record. There was a conversion error for the `enum_strs` and `IN` and `OUT` are reversed. After #205 we are no longer using the string to check states but instead use the integer, this uncovered this bug.

It is a little interesting how this bug manifested itself. It looks like the `states_enum` only added `Unknown` and `Inserted`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #214 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works on live devices. Updated tests to use proper `enum_strs`
