### PR TITLE
ENH: fail in an obvious way if state is bad

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -161,3 +161,13 @@ def test_state_status():
     assert status.done and status.success
     # Check our callback was cleared
     assert status.check_value not in lim_obj._callbacks[lim_obj.SUB_STATE]
+
+
+class InconsistentState(StatePositioner):
+    states_list = ['Unknown', 'IN', 'OUT']
+    _states_alias = {'IN': 'OUT', 'OUT': 'IN'}
+
+
+def test_state_error():
+    with pytest.raises(ValueError):
+        InconsistentState('prefix', name='bad')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Raise a `ValueError` with a helpful string if something has gone wrong in creating the states enum

This is related to #214, to make it more obvious what has happened in these instances.

- Fix a bug where `None` could make it into the `_valid_states` list if used as a skip state
- Fix a bug where transmission would be malformed if `None` used as a skip state

In practice we aren't using this incidental `None` skip state feature, but I wanted to maintain it just in case. I noticed these bugs because other tests started failing after fixing the original bug.