### PR TITLE
FIX: Check for types before doing file ops

### DIFF
--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -4,6 +4,7 @@ Module for defining bell-and-whistles movement features
 import time
 import fcntl
 import logging
+import numbers
 import signal
 from contextlib import contextmanager
 from pathlib import Path
@@ -287,6 +288,12 @@ class Presets:
         logger.debug(('call %s presets._update(%s, %s, value=%s, comment=%s, '
                       'active=%s)'), self._device.name, preset_type, name,
                      value, comment, active)
+        if not isinstance(name, str):
+            raise TypeError(('name must be of type <str>, not type'
+                             '{}'.format(type(name))))
+        if value is not None and not isinstance(value, numbers.Real):
+            raise TypeError(('value must be a real numeric type, not type'
+                             '{}'.format(type(value))))
         try:
             path = self._path(preset_type)
             if not path.exists():

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -164,3 +164,12 @@ def test_presets(presets, motor):
 
     motor.presets.sync()
     assert hasattr(motor, 'mv_sample')
+
+def test_presets_type(presets, motor):
+    logger.debug('test_presets_type')
+    # Mess up the input types, fail before opening the file
+
+    with pytest.raises(TypeError):
+        motor.presets.add_here_user(123)
+    with pytest.raises(TypeError):
+        motor.presets.add_user(234234, 'cats')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Before updating the presets, check the types

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I ran into a bug while writing presets documentaiton. If the wrong type slips through here, the exception handling brings the open file into a bad state for the rest of the python session.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added two tests.

This is innocuous enough that I'll pull it in without review if the travis passes, because Teddy is on vacation.