### PR TITLE
MNT: Newer ophyd will set itself up

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
-    - ophyd >=1.1.0
+    - ophyd >1.1.0
     - bluesky >=1.2.0
     - pyyaml
 

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,7 +1,4 @@
-from ophyd import setup_ophyd
 from ._version import get_versions
 
-setup_ophyd()
-del setup_ophyd
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove `setup_ophyd` call and bump required ophyd version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the next release, `ophyd` will set itself up and `setup_ophyd` will be deprecated.

Do not merge until the next ophyd release.