### PR TITLE
FIX: Misc areadetector fixes

### DIFF
--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -7,7 +7,6 @@ functions needed by all instances of a detector are added here.
 import logging
 
 from ophyd.areadetector import cam
-from ophyd.areadetector.base import ADComponent
 from ophyd.areadetector.detectors import DetectorBase
 from ophyd.device import Component as Cpt
 
@@ -24,7 +23,7 @@ class PCDSDetectorBase(DetectorBase):
     """
     Standard area detector with no plugins.
     """
-    cam = ADComponent(cam.CamBase, ":")
+    cam = Cpt(cam.CamBase, ":")
 
 
 class PCDSDetector(PCDSDetectorBase):
@@ -36,7 +35,7 @@ class PCDSDetector(PCDSDetectorBase):
     IMAGE2: reduced rate image
     Stats2: reduced rate stats
     """
-    image = Cpt(ImagePlugin, ':IMAGE1:', read_attrs=['array_data'])
+    image = Cpt(ImagePlugin, ':IMAGE2:', read_attrs=['array_data'])
     stats = Cpt(StatsPlugin, ':Stats2:', read_attrs=['centroid',
                                                      'mean_value',
                                                      'sigma_x',
@@ -44,7 +43,5 @@ class PCDSDetector(PCDSDetectorBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.image.stage_sigs[self.image.enable] = 1
-        self.stats.stage_sigs[self.stats.enable] = 1
-        self.stats.stage_sigs[self.stats.compute_statistics] = 'Yes'
-        self.stats.stage_sigs[self.stats.compute_centroid] = 'Yes'
+        self.stage_sigs['stats.compute_statistics'] = 'Yes'
+        self.stage_sigs['stats.compute_centroid'] = 'Yes'

--- a/pcdsdevices/areadetector/plugins.py
+++ b/pcdsdevices/areadetector/plugins.py
@@ -21,6 +21,14 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
     """
     enable = C(EpicsSignal, 'EnableCallbacks_RBV.RVAL', write_pv="EnableCallbacks", string=False)
 
+    def __init__(self, *args, **kwargs):
+        # Avoid ophyd PluginBase's init
+        ADBase.__init__(self, *args, **kwargs)
+        self.enable_on_stage()
+        self.ensure_blocking()
+        if self.parent is not None and 'cam' in self.parent.component_names:
+            self.stage_sigs.update([('parent.cam.array_callbacks', 1)])
+
     @property
     def source_plugin(self):
         # The PluginBase object that is the asyn source for this plugin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- switch off of ADComponent because lazy=True
- fix typo in IMAGE2
- remove stage_sigs covered in base classes
- express remaining stage_sigs as strings to avoid signal getattrs at init
- patch around signal gets in ophyd's plugin base initialization

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- lazy=True is bad
- redundancy is bad
- Our AD classes blow up if certain PVs are missing, which means they access PVs at init... unless we do these things, or some equivalent