### PR TITLE
ENH: Add AvgSignal, add mj_avg to BeamStats

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,6 +5,7 @@ API
    :toctree: generated
 
    ~pcdsdevices.attenuator
+   ~pcdsdevices.beam_stats
    ~pcdsdevices.epics_motor
    ~pcdsdevices.inout
    ~pcdsdevices.ipm

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,5 +1,7 @@
 from ophyd.device import Device, Component as Cpt
-from ophyd.signal import EpicsSignalRO
+from ophyd.signal import EpicsSignalRO, AttributeSignal
+
+from .signal import AvgSignal
 
 
 class BeamStats(Device):
@@ -8,7 +10,11 @@ class BeamStats(Device):
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID')
 
-    _default_read_attrs = ['mj', 'ev', 'rate']
+    mj_avg = Cpt(AvgSignal, 'mj', averages=120)
+    mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages')
+
+    _default_read_attrs = ['mj', 'mj_avg', 'ev', 'rate']
+    _default_config_attrs = ['mj_buffersize']
 
     def __init__(self, prefix='', name='beam_stats', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -14,7 +14,7 @@ class BeamStats(Device):
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages')
 
     _default_read_attrs = ['mj', 'mj_avg', 'ev', 'rate']
-    _default_config_attrs = ['mj_buffersize']
+    _default_configuration_attrs = ['mj_buffersize']
 
     def __init__(self, prefix='', name='beam_stats', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -125,14 +125,14 @@ class AvgSignal(Signal):
 
     def get(self, *args, **kwargs):
         self._ensure_sub()
-        super().get(*args, **kwargs)
+        return super().get(*args, **kwargs)
 
     def put(self, *args, **kwargs):
         raise ReadOnlyError()
 
     def subscribe(self, *args, **kwargs):
         self._ensure_sub()
-        super().subsribe(*args, **kwargs)
+        return super().subsribe(*args, **kwargs)
 
     @property
     def averages(self):

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -4,6 +4,7 @@ Module to define ophyd Signal subclass utilities.
 import logging
 from threading import RLock
 
+import numpy as np
 from ophyd.signal import Signal
 from ophyd.utils.errors import ReadOnlyError
 
@@ -113,7 +114,7 @@ class AvgSignal(Signal):
         if isinstance(signal, str):
             signal = getattr(parent, signal)
         self.sig = signal
-        self.lock = threading.RLock()
+        self.lock = RLock()
         self._subscribed = False
         self._avg = averages
 
@@ -142,7 +143,7 @@ class AvgSignal(Signal):
         with self.lock:
             self._avg
             self.index = 0
-            self.values = np.ones(averages) * self.sig.get()
+            self.values = np.ones(avg) * self.sig.get()
 
     def _update_avg(self, *args, value, **kwargs):
         with self.lock:

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -108,6 +108,15 @@ class AvgSignal(Signal):
     """
     Signal that acts as a rolling average of another signal.
 
+    This will subscribe to a signal, and fill an internal buffer with values
+    from SUB_VALUE. It will update its own value to be the mean of the last n
+    accumulated values, up to the buffer size. If we haven't filled this
+    buffer, this will still report a mean value composed of all the values
+    we've receieved so far.
+
+    Warning: this means that if we only have recieved ONE value, the mean will
+    just be the mean of a single value!
+
     Parameters
     ----------
     signal: ``Signal``

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -13,3 +13,27 @@ def test_beam_stats():
     stats.wait_for_connection()
     stats.read()
     stats.hints
+
+
+@using_fake_epics_pv
+def test_beam_stats_avg():
+    logger.debug('test_beam_stats_avg')
+    stats = BeamStats()
+    stats.mj._read_pv.put(-1)
+    stats.wait_for_connection()
+
+    assert stats.mj_buffersize.value == 120
+
+    stats.mj_buffersize.put(10)
+
+    with stats.mj._read_pv._lock:
+        for i in range(10):
+            stats.mj._read_pv._value = i
+            stats.mj._read_pv.run_callbacks()
+
+        assert stats.mj_avg.value == sum(range(10))/10
+
+    stats.configure(dict(mj_buffersize=20))
+    cfg = stats.read_configuration()
+
+    assert cfg['beam_stats_mj_buffersize']['value'] == 20

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,0 +1,39 @@
+import logging
+from unittest.mock import Mock
+
+from ophyd.signal import Signal
+
+from pcdsdevices.signal import AvgSignal
+
+logger = logging.getLogger(__name__)
+
+
+def test_avg_signal():
+    logger.debug('test_avg_signal')
+    sig = Signal(name='raw')
+    avg = AvgSignal(sig, 2, name='avg')
+
+    assert sig.value is None
+    assert avg.value is None
+    assert avg.averages == 2
+
+    sig.put(1)
+    assert avg.value == 1
+    sig.put(3)
+    assert avg.value == 2
+    sig.put(2)
+    assert avg.value == 2.5
+
+    avg.averages = 3
+
+    sig.put(1)
+    assert avg.value == 1
+    sig.put(3)
+    assert avg.value == 2
+    sig.put(2)
+    assert avg.value == 2
+
+    cb = Mock()
+    avg.subscribe(cb)
+    sig.put(0)
+    assert cb.called


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Port and update `AvgSignal` from `pswalker`
- add `mj_avg` field to `BeamStats`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `AvgSignal` was useful for suspenders, and it will be useful in `nabs` for the suspend-and-drop construct I'm working on
- The beam mj level is a common thing to be averaged, since an individual reading going bad does not necessarily mean the beam is down.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added, and did "feel" tests on psbuild-rhel7

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- `AvgSignal` automatically included in API docs
- `BeamStats` added to API docs

<!--
## Screenshots (if appropriate):
-->
