### PR TITLE
ENH: CCM, Conventions for Combined Axes and Calc Motors

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,7 +6,9 @@ Full API
 
    ~pcdsdevices.attenuator
    ~pcdsdevices.beam_stats
+   ~pcdsdevices.ccm
    ~pcdsdevices.epics_motor
+   ~pcdsdevices.evr
    ~pcdsdevices.inout
    ~pcdsdevices.ipm
    ~pcdsdevices.lens
@@ -16,6 +18,7 @@ Full API
    ~pcdsdevices.mps
    ~pcdsdevices.mv_interface
    ~pcdsdevices.pim
+   ~pcdsdevices.pseudopos
    ~pcdsdevices.pulsepicker
    ~pcdsdevices.signal
    ~pcdsdevices.slits

--- a/docs/source/base_classes.rst
+++ b/docs/source/base_classes.rst
@@ -1,0 +1,25 @@
+============
+Base Classes
+============
+
+Synchronized Axes
+-----------------
+The `SyncAxesBase` class is provided as a shortcut for creating classes that
+need to move multiple positioners at the same time with the same scale. This
+is useful for things like stands that have multiple motors.
+
+You can create a class as:
+
+.. code-block:: python
+
+    class Parallel(SyncAxesBase):
+        left = Cpt(EpicsMotor, ':01')
+        right = Cpt(EpicsMotor, ':02')
+
+On the first move, these classes will save the offsets between the axes and
+maintain them for all moves. This allows you to do things like move a table
+with a constant tilt. You can manually save offsets using the ``save_offests``
+method. By default, the position of the combined axes will be the smallest of
+the composite positions, but this can be configured for other behavior.
+
+See the `full api <SyncAxesBase>` for more information.

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -8,6 +8,7 @@ Common EPICS Devices
     
     Attenuator
     BeckhoffAxis
+    CCM
     EpicsMotor
     EventSequencer
     LODCM

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@
    :caption: Device Types
 
    epics_types.rst
+   base_classes.rst
 
 .. toctree::
    :maxdepth: 1

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -224,6 +224,6 @@ class CCM(InOutPositioner):
     @_state.setter
     def _state(self, value):
         if value == 1:
-            self.x.move(self._inpos)
+            self.x.move(self._inpos, wait=False)
         elif value == 2:
-            self.x.move(self._outpos)
+            self.x.move(self._outpos, wait=False)

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 from ophyd.device import Component as Cpt, FormattedComponent as FCpt
 from ophyd.pseudopos import PseudoPositioner, PseudoSingle
@@ -30,8 +32,20 @@ def alio_to_theta(alio, gTheta0, gR, gD):
     """
     Converts alio position (mm) to theta angle (rad)
     """
-    theta = 2*np.arctan((np.sqrt(alio**2+gD**2+2*gR*alio)-gD)/(2*gR+alio))
-    return gTheta0 + theta
+    low = -1.0
+    high = 1.0
+    timeout = 1.0
+    start = time.time()
+    while time.time() - start < timeout:
+        theta_guess = (low+high)/2
+        alio_calc = theta_to_alio(theta_guess, gTheta0, gR, gD)
+        if np.isclose(alio, alio_calc):
+            break
+        elif alio_calc > alio:
+            high = theta_guess
+        else:
+            low = theta_guess
+    return theta_guess
 
 
 def wavelength_to_theta(wavelength, gdspacing):

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import numpy as np
@@ -10,6 +11,7 @@ from .epics_motor import IMS
 from .inout import InOutPositioner
 from .pseudopos import SyncAxesBase
 
+logger = logging.getLogger(__name__)
 
 # Constants
 si_111_dspacing = 3.1356011499587773
@@ -114,7 +116,7 @@ class CCMCalc(PseudoPositioner):
 
     def __init__(self, *args, theta0=default_theta0, dspacing=default_dspacing,
                  gr=default_gr, gd=default_gd, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, auto_target=False, **kwargs)
         self.theta0 = theta0
         self.dspacing = dspacing
         self.gr = gr
@@ -135,6 +137,7 @@ class CCMCalc(PseudoPositioner):
             theta = pseudo_pos.theta*np.pi/180
         else:
             alio = self.alio.position
+        logger.debug((energy, wavelength, theta))
         if energy is not None:
             wavelength = energy_to_wavelength(energy)
         if wavelength is not None:

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -32,7 +32,7 @@ class CCMMotor(PVPositionerPC):
     loading, and make the wait for done just compare the values.
     """
     setpoint = Cpt(EpicsSignal, ":POSITIONSET")
-    readback = Cpt(EpicsSignalRO, ":POSITIONGET")
+    readback = Cpt(EpicsSignalRO, ":POSITIONGET", kind='hinted')
 
     limits = None
 
@@ -137,13 +137,15 @@ class CCM(InOutPositioner):
     x = FCpt(CCMX,
              down_prefix='{self.x_down_prefix}',
              up_prefix='{self.x_up_prefix}',
-             add_prefix=('down_prefix', 'up_prefix'))
+             add_prefix=('down_prefix', 'up_prefix'),
+             kind='omitted')
     y = FCpt(CCMY,
              down_prefix='{self.y_down_prefix}',
              up_north_prefix='{self.y_up_north_prefix}',
              up_south_prefix='{self.y_up_south_prefix}',
-             add_prefix=('down_prefix', 'up_north_prefix', 'up_south_prefix'))
-    state = Cpt(AttributeSignal, '_state', kind='hinted', add_prefix=())
+             add_prefix=('down_prefix', 'up_north_prefix', 'up_south_prefix'),
+             kind='omitted')
+    state = Cpt(AttributeSignal, attr='_state', kind='omitted')
 
     # Placeholder value. This represents "not full transmission".
     _transmission = {'IN': 0.9}

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -125,7 +125,7 @@ class CCMCalc(PseudoPositioner):
             alio = theta_to_alio(theta, self.gTheta0, self.gR, self.gD)
         return self.RealPosition(alio=alio)
 
-    def reverse(self, real_pos):
+    def inverse(self, real_pos):
         """
         Take alio and map to energy, wavelength, and theta
         """

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1,7 +1,7 @@
 import numpy as np
 from ophyd.device import Component as Cpt, FormattedComponent as FCpt
 from ophyd.pseudopos import PseudoPositioner, PseudoSingle
-from ophyd.pv_positioner import PVPositioner
+from ophyd.pv_positioner import PVPositionerPC
 from ophyd.signal import EpicsSignal, EpicsSignalRO, AttributeSignal
 
 from .epics_motor import IMS
@@ -10,12 +10,12 @@ from .pseudopos import SyncAxes
 
 
 # Default constants copied verbatim from old python
-gTheta0 = 14.9792
+gTheta0 = 14.9792 * np.pi/180
 gSi111dspacing = 3.1356011499587773
 gSi511dspacing = 1.0452003833195924
 gdspacing = gSi111dspacing
 gR = 3.175
-gD = 321.303
+gD = 231.303
 
 
 # Calculations between alio position and energy, with all intermediates.
@@ -63,9 +63,12 @@ def wavelength_to_energy(wavelength):
 
 
 # Auxilliary classes
-class CCMMotor(PVPositioner):
+class CCMMotor(PVPositionerPC):
     """
     Goofy records used in the CCM.
+
+    TODO: switch to PVPositioner subclass and override code that prevents
+    loading, and make the wait for done just compare the values.
     """
     setpoint = Cpt(EpicsSignal, ":POSITIONSET")
     readback = Cpt(EpicsSignalRO, ":POSITIONGET")

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -127,7 +127,7 @@ class CCMCalc(PseudoPositioner):
         energy, wavelength, theta = None, None, None
         if pseudo_pos.energy != self.energy.position:
             energy = pseudo_pos.energy
-        elif pseudo_pos.wavelenth != self.wavelength.position:
+        elif pseudo_pos.wavelength != self.wavelength.position:
             wavelength = pseudo_pos.wavelength
         elif pseudo_pos.theta*np.pi/180 != self.theta.position:
             theta = pseudo_pos.theta*np.pi/180

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -129,21 +129,22 @@ class CCMCalc(PseudoPositioner):
         pseudo_pos = self.PseudoPosition(*pseudo_pos)
         # Figure out which one changed.
         energy, wavelength, theta = None, None, None
-        if pseudo_pos.energy != self.energy.position:
+        if not np.isclose(pseudo_pos.energy, self.energy.position):
             energy = pseudo_pos.energy
-        elif pseudo_pos.wavelength != self.wavelength.position:
+        elif not np.isclose(pseudo_pos.wavelength, self.wavelength.position):
             wavelength = pseudo_pos.wavelength
-        elif pseudo_pos.theta*np.pi/180 != self.theta.position:
-            theta = pseudo_pos.theta*np.pi/180
+        elif not np.isclose(pseudo_pos.theta, self.theta.position):
+            theta = pseudo_pos.theta
         else:
             alio = self.alio.position
         logger.debug((energy, wavelength, theta))
         if energy is not None:
             wavelength = energy_to_wavelength(energy)
         if wavelength is not None:
-            theta = wavelength_to_theta(wavelength, self.dspacing)
+            theta = wavelength_to_theta(wavelength, self.dspacing) * 180/np.pi
         if theta is not None:
-            alio = theta_to_alio(theta, self.theta0, self.gr, self.gd)
+            alio = theta_to_alio(theta * np.pi/180, self.theta0,
+                                 self.gr, self.gd)
         return self.RealPosition(alio=alio)
 
     def inverse(self, real_pos):

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -24,70 +24,6 @@ default_gr = 3.175
 default_gd = 231.303
 
 
-# Calculations between alio position and energy, with all intermediates.
-def theta_to_alio(theta, theta0, gr, gd):
-    """
-    Converts theta angle (rad) to alio position (mm)
-    """
-    return gr * (1/np.cos(theta)-1) + gd * np.tan(theta - theta0)
-
-
-def alio_to_theta(alio, theta0, gr, gd):
-    """
-    Converts alio position (mm) to theta angle (rad)
-
-    This is an empirical inversion via binary search. If you decide to spend
-    time trying to find the analytic solution here, please update this
-    docstring, either to indicate your success or to increment the hours
-    counter below.
-
-    total hours spent here: 2
-    """
-    low = -1.0
-    high = 1.0
-    timeout = 1.0
-    start = time.time()
-    while time.time() - start < timeout:
-        theta_guess = (low+high)/2
-        alio_calc = theta_to_alio(theta_guess, theta0, gr, gd)
-        if np.isclose(alio, alio_calc):
-            break
-        elif alio_calc > alio:
-            high = theta_guess
-        else:
-            low = theta_guess
-    return theta_guess
-
-
-def wavelength_to_theta(wavelength, dspacing):
-    """
-    Converts wavelength (A) to theta angle (rad)
-    """
-    return np.arcsin(wavelength/2/dspacing)
-
-
-def theta_to_wavelength(theta, dspacing):
-    """
-    Converts theta angle (rad) to wavelength (A)
-    """
-    return 2*dspacing*np.sin(theta)
-
-
-def energy_to_wavelength(energy):
-    """
-    Converts photon energy (keV) to wavelength (A)
-    """
-    return 12.39842/energy
-
-
-def wavelength_to_energy(wavelength):
-    """
-    Converts wavelength (A) to photon energy (keV)
-    """
-    return 12.39842/wavelength
-
-
-# Auxilliary classes
 class CCMMotor(PVPositionerPC):
     """
     Goofy records used in the CCM.
@@ -189,7 +125,6 @@ class CCMY(SyncAxesBase):
         super().__init__(down_prefix, *args, **kwargs)
 
 
-# Main Class
 class CCM(InOutPositioner):
     """
     The full CCM assembly.
@@ -242,3 +177,66 @@ class CCM(InOutPositioner):
             self.x.move(self._in_pos, wait=False)
         elif value == 2:
             self.x.move(self._out_pos, wait=False)
+
+
+# Calculations between alio position and energy, with all intermediates.
+def theta_to_alio(theta, theta0, gr, gd):
+    """
+    Converts theta angle (rad) to alio position (mm)
+    """
+    return gr * (1/np.cos(theta)-1) + gd * np.tan(theta - theta0)
+
+
+def alio_to_theta(alio, theta0, gr, gd):
+    """
+    Converts alio position (mm) to theta angle (rad)
+
+    This is an empirical inversion via binary search. If you decide to spend
+    time trying to find the analytic solution here, please update this
+    docstring, either to indicate your success or to increment the hours
+    counter below.
+
+    total hours spent here: 2
+    """
+    low = -1.0
+    high = 1.0
+    timeout = 1.0
+    start = time.time()
+    while time.time() - start < timeout:
+        theta_guess = (low+high)/2
+        alio_calc = theta_to_alio(theta_guess, theta0, gr, gd)
+        if np.isclose(alio, alio_calc):
+            break
+        elif alio_calc > alio:
+            high = theta_guess
+        else:
+            low = theta_guess
+    return theta_guess
+
+
+def wavelength_to_theta(wavelength, dspacing):
+    """
+    Converts wavelength (A) to theta angle (rad)
+    """
+    return np.arcsin(wavelength/2/dspacing)
+
+
+def theta_to_wavelength(theta, dspacing):
+    """
+    Converts theta angle (rad) to wavelength (A)
+    """
+    return 2*dspacing*np.sin(theta)
+
+
+def energy_to_wavelength(energy):
+    """
+    Converts photon energy (keV) to wavelength (A)
+    """
+    return 12.39842/energy
+
+
+def wavelength_to_energy(wavelength):
+    """
+    Converts wavelength (A) to photon energy (keV)
+    """
+    return 12.39842/wavelength

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -172,8 +172,8 @@ class CCMY(SyncAxesBase):
     Combined motion of the CCM Y motors
     """
     down = FCpt(IMS, '{self._down}')
-    up_north = FCpt(IMS, '{self._up_north')
-    up_south = FCpt(IMS, '{self._up_south')
+    up_north = FCpt(IMS, '{self._up_north}')
+    up_south = FCpt(IMS, '{self._up_south}')
 
     def __init__(self, *args, parent, **kwargs):
         self._down = parent._y_down_prefix

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -33,6 +33,13 @@ def theta_to_alio(theta, theta0, gr, gd):
 def alio_to_theta(alio, theta0, gr, gd):
     """
     Converts alio position (mm) to theta angle (rad)
+
+    This is an empirical inversion via binary search. If you decide to spend
+    time trying to find the analytic solution here, please update this
+    docstring, either to indicate your success or to increment the hours
+    counter below.
+
+    total hours spent here: 2
     """
     low = -1.0
     high = 1.0
@@ -93,6 +100,10 @@ class CCMMotor(PVPositionerPC):
 class CCMCalc(PseudoPositioner):
     """
     CCM calculation motors to move in terms of physics quantities
+
+    All new parameters are scientific constants, and the current docstring
+    writer is not familiar with all of them, so I will omit the full
+    description instead of giving a partial and possibly incorrect summary.
     """
     energy = Cpt(PseudoSingle, egu='keV', kind='hinted')
     wavelength = Cpt(PseudoSingle, egu='A')
@@ -173,6 +184,12 @@ class CCMY(SyncAxesBase):
 
 # Main Class
 class CCM(InOutPositioner):
+    """
+    The full CCM assembly.
+
+    This requires a huge number of motor pv prefixes to be passed in, and they
+    are all labelled accordingly.
+    """
     calc = FCpt(CCMCalc, "{self._alio_prefix}", kind='hinted')
     theta2fine = FCpt(CCMMotor, "{self._th2f_prefix}")
     x = Cpt(CCMX)

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -96,6 +96,8 @@ class CCMMotor(PVPositionerPC):
     setpoint = Cpt(EpicsSignal, ":POSITIONSET")
     readback = Cpt(EpicsSignalRO, ":POSITIONGET")
 
+    limits = None
+
 
 class CCMCalc(PseudoPositioner):
     """

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1,0 +1,168 @@
+import numpy as np
+from ophyd.device import Component as Cpt, FormattedComponent as FCpt
+from ophyd.psuedopos import PsuedoPositioner, PseudoSingle
+from ophyd.pv_positioner import PVPositioner
+from ophyd.signal import EpicsSignal, EpicsSignalRO, AttributeSignal
+
+from .epics_motor import IMS
+from .inout import InOutPositioner
+from .pseudopos import SyncAxes
+
+
+# Defaults copied verbatim from old python
+gTheta0 = 14.9792
+gSi111dspacing = 3.1356011499587773
+gSi511dspacing = 1.0452003833195924
+gdspacing = gSi111dspacing
+gR = 3.175
+gD = 321.303
+
+
+# Auxilliary classes
+class CCMMotor(PVPositioner):
+    """
+    Goofy records used in the CCM.
+    """
+    setpoint = Cpt(EpicsSignal, ":POSITIONSET")
+    readback = Cpt(EpicsSignalRO, ":POSITIONGET")
+
+
+class CCMCalc(PsuedoPositioner):
+    energy = Cpt(PseudoSingle, egu='keV')
+    wavelength = Cpt(PseudoSingle, egu='A')
+    theta = Cpt(PseudoSingle, egu='deg')
+    alio = Cpt(CCMMotor)
+
+    def __init__(self, *args, gTheta0=gTheta0, gdspacing=gdspacing,
+                 gR=gR, gD=gD, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.gTheta0 = gTheta0
+        self.gdspacing = gdspacing
+        self.gR = gR
+        self.gD = gD
+
+    def forward(self, pseudo_pos):
+        """
+        Take energy, wavelength, or theta and map to alio
+        """
+        pseudo_pos = self.PseudoPosition(*pseudo_pos)
+        # Figure out which one changed.
+        energy, wavelength, theta = None, None, None
+        if pseudo_pos.energy != self.energy.position:
+            energy = pseudo_pos.energy
+        elif pseudo_pos.wavelenth != self.wavelength.position:
+            wavelength = pseudo_pos.wavelength
+        elif pseudo_pos.theta*np.pi/180 != self.theta.position:
+            theta = pseudo_pos.theta*np.pi/180
+        else:
+            alio = self.alio.position
+        if energy is not None:
+            wavelength = energy_to_wavelength(energy)
+        if wavelength is not None:
+            theta = wavelength_to_theta(wavelength, self.gdspacing)
+        if theta is not None:
+            alio = theta_to_alio(theta, self.gTheta0, self.gR, self.gD)
+        return self.RealPosition(alio=alio)
+
+    def reverse(self, real_pos):
+        """
+        Take alio and map to energy, wavelength, and theta
+        """
+        real_pos = self.RealPosition(*real_pos)
+        theta = alio_to_theta(real_pos.alio, self.gTheta0, self.gR, self.gD)
+        wavelength = theta_to_wavelength(theta, self.gdspacing)
+        energy = wavelength_to_energy(wavelength)
+        return self.PseudoPosition(energy=energy,
+                                   wavelength=wavelength,
+                                   theta=theta*180/np.pi)
+
+
+# Calculations between alio position and energy, with all intermediates.
+def theta_to_alio(theta, gTheta0, gR, gD):
+    """
+    Converts theta angle (rad) to alio position (mm)
+    """
+    return gR * (1/np.cos(theta)-1) + gD * np.tan(theta - gTheta0)
+
+
+def alio_to_theta(alio, gTheta0, gR, gD):
+    """
+    Converts alio position (mm) to theta angle (rad)
+    """
+    theta = 2*np.arctan((np.sqrt(alio**2+gD**2+2*gR*alio)-gD)/(2*gR+alio))
+    return gTheta0 + theta
+
+
+def wavelength_to_theta(wavelength, gdspacing):
+    """
+    Converts wavelength (A) to theta angle (rad)
+    """
+    return np.arcsin(wavelength/2/gdspacing)
+
+
+def theta_to_wavelength(theta, gdspacing):
+    """
+    Converts theta angle (rad) to wavelength (A)
+    """
+    return 2*gdspacing*np.sin(theta)
+
+
+def wavelength_to_energy(wavelength):
+    """
+    Converts wavelength (A) to photon energy (keV)
+    """
+    return 12.39842/wavelength
+
+
+def energy_to_wavelength(energy):
+    """
+    Converts photon energy (keV) to wavelength (A)
+    """
+    return 12.39842/energy
+
+
+# Main Class
+class CCM(InOutPositioner):
+    x = Cpt(SyncAxes,
+            down=FCpt(IMS, '{self.parent._x_down_prefix}'),
+            up=FCpt(IMS, '{self.parent._x_up_prefix}'))
+    y = Cpt(SyncAxes,
+            down=FCpt(IMS, '{self.parent._y_down_prefix}'),
+            up_north=FCpt(IMS, '{self.parent._y_up_north_prefix}'),
+            up_south=FCpt(IMS, '{self.parent._y_up_south_prefix}'))
+    calc = FCpt(CCMCalc, "{self._alio_prefix}")
+    theta2fine = FCpt(CCMMotor, "{self._th2f_prefix}")
+
+    state = Cpt(AttributeSignal, '_state')
+
+    # Placeholder value. This represents "not full transmission".
+    _transmission = {'IN': 0.9}
+
+    def __init__(self, x_down, x_up, y_down, y_up_north, y_up_south, alio,
+                 theta2fine, inpos, outpos, **kwargs):
+        self._x_down_prefix = x_down
+        self._x_up_prefix = x_up
+        self._y_down_prefix = y_down
+        self._y_up_north_prefix = y_up_north
+        self._y_up_south_prefix = y_up_south
+        self._alio_prefix = alio
+        self._th2f_prefix = theta2fine
+        self._inpos = inpos
+        self._outpos = outpos
+        super().__init__(prefix='', **kwargs)
+
+    @property
+    def _state(self):
+        if np.isclose(self.x.position, self._inpos):
+            return 1
+        elif np.isclose(self.x.position, self._outpos):
+            return 2
+        else:
+            return 0
+
+    @_state.setter
+    def _state(self, value):
+        if value == 1:
+            self.x.move(self._inpos)
+        elif value == 2:
+            self.x.move(self._outpos)

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ophyd.device import Component as Cpt, FormattedComponent as FCpt
-from ophyd.pseudopos import PsuedoPositioner, PseudoSingle
+from ophyd.pseudopos import PseudoPositioner, PseudoSingle
 from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import EpicsSignal, EpicsSignalRO, AttributeSignal
 
@@ -71,7 +71,7 @@ class CCMMotor(PVPositioner):
     readback = Cpt(EpicsSignalRO, ":POSITIONGET")
 
 
-class CCMCalc(PsuedoPositioner):
+class CCMCalc(PseudoPositioner):
     energy = Cpt(PseudoSingle, egu='keV')
     wavelength = Cpt(PseudoSingle, egu='A')
     theta = Cpt(PseudoSingle, egu='deg')

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -1,5 +1,6 @@
 # flake8: NOQA
 from .attenuator import Attenuator
+from .ccm import CCM
 from .epics_motor import IMS, Newport, PMC100, BeckhoffAxis, EpicsMotor
 from .evr import Trigger
 from .ipm import IPM

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -1,4 +1,3 @@
-import numpy as np
 from ophyd.device import Component as Cpt
 from ophyd.pseudopos import PseudoPositioner, PseudoSingle
 
@@ -7,8 +6,20 @@ class SyncAxesBase(PseudoPositioner):
     """
     Synchronized Axes.
 
-    This will move all axes to the same position at the same time. And report
-    its position as the average value of all axes.
+    This will move all axes in a coordinated way, retaining offsets.
+
+    This can be configured to report its position as the min, max, mean, or any
+    custom function acting on a list of positions. Min is the default.
+
+    You should subclass this by adding real motors as components. The class
+    will pick them up and include them correctly into the coordinated move.
+
+    Parameters
+    ----------
+    position_mode: ``func``, optional
+        The function to apply to the list of current positions to determine
+        the combined position. By default, this is the minimum of all axis
+        positions.
 
     Attributes
     ----------
@@ -17,43 +28,65 @@ class SyncAxesBase(PseudoPositioner):
     """
     pseudo = Cpt(PseudoSingle)
 
+    _default_mode = min
+
+    def __init__(self, *args, position_mode=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mode = position_mode or self._default_mode
+        self._offsets = {}
+
+    def save_offsets(self, **offsets):
+        """
+        Save the current offsets for the synchronized assembly.
+
+        If not done earlier, this will be automatically run before it is first
+        needed (generally, right before the first move).
+
+        Note that this method does not protect you from getting your offsets
+        into an inconsistent state! Pass arguments into the `offsets` param at
+        your own risk.
+
+        Parameters
+        ----------
+        **offsets: ``int`` or ``float``, optional
+            Mapping of axis name to offset. If omitted, we'll use the current
+            positions. If a partial dictionary is provided, the omitted values
+            are assumed to be either 0 (if no value is available) or unchanged
+            (if previous saved values are available).
+        """
+        if not offsets:
+            pos = self.real_position
+            combo = self._mode(pos)
+            offsets = {fld: getattr(pos, fld) - combo for fld in pos._fields}
+        for fld in self.RealPosition._fields:
+            if fld not in offsets:
+                offsets[fld] = self._offsets.get(fld, 0)
+        self._offsets = offsets
+
     def forward(self, pseudo_pos):
         """
-        Composite axes all move to the combined axis position
+        Composite axes move to the combined axis position plus an offset
         """
+        if not self._offsets:
+            self.save_offsets()
         pseudo_pos = self.PseudoPosition(*pseudo_pos)
-        return self.RealPosition(**{axis: pseudo_pos.pseudo
-                                    for axis in self.axes})
+        real_pos = {}
+        for axis, offset in self._offsets.items():
+            real_pos[axis] = pseudo_pos.pseudo + offset
+        return self.RealPosition(**real_pos)
 
     def inverse(self, real_pos):
         """
         Combined axis readback is the mean of the composite axes
         """
         real_pos = self.RealPosition(*real_pos)
-        return self.PseudoPosition(pseudo=np.mean(real_pos))
+        return self.PseudoPosition(pseudo=self._mode(real_pos))
 
     @property
     def position(self):
+        """
+        Override the position to just show the number.
+
+        This would otherwise be a named tuple with one element, pseudo.
+        """
         return super().position.pseudo
-
-
-def SyncAxes(*args, **kwargs):
-    """
-    Create and instantiate a `SyncAxesBase` subclass with the desired
-    components.
-    """
-    if 'axes' in kwargs:
-        raise ValueError(('axes is a reserved name for SyncAxes and cannot be '
-                          'a component name or a kwarg'))
-    cpt = {}
-    kwd = {}
-
-    for key, value in kwargs.items():
-        if isinstance(value, Cpt):
-            cpt[key] = value
-        else:
-            kwd[key] = value
-    cpt['axes'] = list(cpt.keys())
-
-    cls = type('SyncAxes', (SyncAxesBase,), cpt)
-    return cls(*args, **kwd)

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ophyd.component import Component as Cpt
+from ophyd.device import Component as Cpt
 from ophyd.pseudopos import PseudoPositioner, PseudoSingle
 
 

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -49,7 +49,7 @@ def SyncAxes(*args, **kwargs):
     cpt = {}
     kwd = {}
 
-    for key, value in kwd.items():
+    for key, value in kwargs.items():
         if isinstance(value, Cpt):
             cpt[key] = value
         else:

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -81,12 +81,3 @@ class SyncAxesBase(PseudoPositioner):
         """
         real_pos = self.RealPosition(*real_pos)
         return self.PseudoPosition(pseudo=self._mode(real_pos))
-
-    @property
-    def position(self):
-        """
-        Override the position to just show the number.
-
-        This would otherwise be a named tuple with one element, pseudo.
-        """
-        return super().position.pseudo

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -14,17 +14,24 @@ class SyncAxesBase(PseudoPositioner):
     You should subclass this by adding real motors as components. The class
     will pick them up and include them correctly into the coordinated move.
 
+    An example:
+
+    .. code-block:: python
+
+       class Parallel(SyncAxesBase):
+           left = Cpt(EpicsMotor, ':01')
+           right = Cpt(EpicsMotor, ':02')
+
+    Like all ``PseudoPositioner`` classes, any subclass of ``PositionerBase``
+    will be included in the synchronized move.
+
+
     Parameters
     ----------
     position_mode: ``func``, optional
         The function to apply to the list of current positions to determine
         the combined position. By default, this is the minimum of all axis
         positions.
-
-    Attributes
-    ----------
-    axes: ``list of str``
-        Names of the components that correspond to the real axes.
     """
     pseudo = Cpt(PseudoSingle)
 

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -1,0 +1,60 @@
+import numpy as np
+from ophyd.component import Component as Cpt
+from ophyd.pseudopos import PseudoPositioner, PseudoSingle
+
+
+class SyncAxesBase(PseudoPositioner):
+    """
+    Synchronized Axes.
+
+    This will move all axes to the same position at the same time. And report
+    its position as the average value of all axes.
+
+    Attributes
+    ----------
+    axes: ``list of str``
+        Names of the components that correspond to the real axes.
+    """
+    pseudo = Cpt(PseudoSingle)
+
+    def forward(self, pseudo_pos):
+        """
+        Composite axes all move to the combined axis position
+        """
+        pseudo_pos = self.PseudoPosition(*pseudo_pos)
+        return self.RealPosition(**{axis: pseudo_pos.pseudo
+                                    for axis in self.axes})
+
+    def inverse(self, real_pos):
+        """
+        Combined axis readback is the mean of the composite axes
+        """
+        real_pos = self.RealPosition(*real_pos)
+        mean_pos = np.mean(getattr(real_pos, axis) for axis in self.axes)
+        return self.PseudoPosition(pseudo=mean_pos)
+
+    @property
+    def position(self):
+        return super().position.pseudo
+
+
+def SyncAxes(*args, **kwargs):
+    """
+    Create and instantiate a `SyncAxesBase` subclass with the desired
+    components.
+    """
+    if 'axes' in kwargs:
+        raise ValueError(('axes is a reserved name for SyncAxes and cannot be '
+                          'a component name or a kwarg'))
+    cpt = {}
+    kwd = {}
+
+    for key, value in kwd.items():
+        if isinstance(value, Cpt):
+            cpt[key] = value
+        else:
+            kwd[key] = value
+    cpt['axes'] = list(cpt.keys())
+
+    cls = type('SyncAxes', (SyncAxesBase,), cpt)
+    return cls(*args, **kwd)

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -35,29 +35,16 @@ class SyncAxesBase(PseudoPositioner):
         self._mode = position_mode or self._default_mode
         self._offsets = {}
 
-    def save_offsets(self, **offsets):
+    def save_offsets(self):
         """
         Save the current offsets for the synchronized assembly.
 
         If not done earlier, this will be automatically run before it is first
         needed (generally, right before the first move).
-
-        Note that this method does not protect you from getting your offsets
-        into an inconsistent state! Pass arguments into the `offsets` param at
-        your own risk.
-
-        Parameters
-        ----------
-        **offsets: ``int`` or ``float``, optional
-            Mapping of axis name to offset. If omitted, we'll use the current
-            positions. If a partial dictionary is provided, the omitted values
-            are assumed to be either 0 (if no value is available) or unchanged
-            (if previous saved values are available).
         """
-        if not offsets:
-            pos = self.real_position
-            combo = self._mode(pos)
-            offsets = {fld: getattr(pos, fld) - combo for fld in pos._fields}
+        pos = self.real_position
+        combo = self._mode(pos)
+        offsets = {fld: getattr(pos, fld) - combo for fld in pos._fields}
         for fld in self.RealPosition._fields:
             if fld not in offsets:
                 offsets[fld] = self._offsets.get(fld, 0)

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -52,9 +52,6 @@ class SyncAxesBase(PseudoPositioner):
         pos = self.real_position
         combo = self._mode(pos)
         offsets = {fld: getattr(pos, fld) - combo for fld in pos._fields}
-        for fld in self.RealPosition._fields:
-            if fld not in offsets:
-                offsets[fld] = self._offsets.get(fld, 0)
         self._offsets = offsets
 
     def forward(self, pseudo_pos):

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -30,8 +30,7 @@ class SyncAxesBase(PseudoPositioner):
         Combined axis readback is the mean of the composite axes
         """
         real_pos = self.RealPosition(*real_pos)
-        mean_pos = np.mean(getattr(real_pos, axis) for axis in self.axes)
-        return self.PseudoPosition(pseudo=mean_pos)
+        return self.PseudoPosition(pseudo=np.mean(real_pos))
 
     @property
     def position(self):

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -17,16 +17,18 @@ SAMPLE_WAVELENGTH = 10  # xray
 # Make sure the calcs are properly inverted
 def test_theta_alio_inversion():
     logger.debug('test_theta_alio_inversion')
-    theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.theta0, ccm.gr, ccm.gd)
-    alio_calc = ccm.theta_to_alio(theta, ccm.theta0, ccm.gr, ccm.gd)
+    theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.default_theta0, ccm.default_gr,
+                              ccm.default_gd)
+    alio_calc = ccm.theta_to_alio(theta, ccm.default_theta0, ccm.default_gr,
+                                  ccm.default_gd)
     # Unlike the other inversions, this is just an approximation
     assert np.isclose(alio_calc, SAMPLE_ALIO)
 
 
 def test_wavelength_theta_inversion():
     logger.debug('test_wavelength_theta_inversion')
-    wavelength = ccm.wavelength_to_theta(SAMPLE_THETA, ccm.dspacing)
-    theta_calc = ccm.theta_to_wavelength(wavelength, ccm.dspacing)
+    wavelength = ccm.wavelength_to_theta(SAMPLE_THETA, ccm.default_dspacing)
+    theta_calc = ccm.theta_to_wavelength(wavelength, ccm.default_dspacing)
     assert theta_calc == SAMPLE_THETA
 
 

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -66,6 +66,7 @@ def test_ccm_calc(fake_ccm):
     logger.debug('test_ccm_calc')
     calc = fake_ccm.calc
 
+    assert calc.alio.position == SAMPLE_ALIO
     theta = calc.theta.position
     theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.theta0, calc.gr, calc.gd)
     assert theta == theta_func
@@ -80,7 +81,7 @@ def test_ccm_calc(fake_ccm):
 
     calc.alio.readback.sim_put(0)
     calc.alio.setpoint.sim_put(0)
-    calc.move(energy, wait=True)
+    calc.move(energy, wait=False)
 
     assert calc.alio.setpoint.get() == SAMPLE_ALIO
 

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -1,9 +1,10 @@
 import logging
 
 import numpy as np
+from ophyd.sim import make_fake_device
+import pytest
 
 import pcdsdevices.ccm as ccm
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
 logger = logging.getLogger(__name__)
 
@@ -16,16 +17,16 @@ SAMPLE_WAVELENGTH = 10  # xray
 # Make sure the calcs are properly inverted
 def test_theta_alio_inversion():
     logger.debug('test_theta_alio_inversion')
-    theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.gTheta0, ccm.gR, ccm.gD)
-    alio_calc = ccm.theta_to_alio(theta, ccm.gTheta0, ccm.gR, ccm.gD)
+    theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.theta0, ccm.gr, ccm.gd)
+    alio_calc = ccm.theta_to_alio(theta, ccm.theta0, ccm.gr, ccm.gd)
     # Unlike the other inversions, this is just an approximation
     assert np.isclose(alio_calc, SAMPLE_ALIO)
 
 
 def test_wavelength_theta_inversion():
     logger.debug('test_wavelength_theta_inversion')
-    wavelength = ccm.wavelength_to_theta(SAMPLE_THETA, ccm.gdspacing)
-    theta_calc = ccm.theta_to_wavelength(wavelength, ccm.gdspacing)
+    wavelength = ccm.wavelength_to_theta(SAMPLE_THETA, ccm.dspacing)
+    theta_calc = ccm.theta_to_wavelength(wavelength, ccm.dspacing)
     assert theta_calc == SAMPLE_THETA
 
 
@@ -36,74 +37,75 @@ def test_energy_wavelength_inversion():
     assert wavelength_calc == SAMPLE_WAVELENGTH
 
 
+@pytest.fixture(scope='function')
+def fake_ccm():
+    FakeCCM = make_fake_device(ccm.CCM)
+    fake_ccm = FakeCCM(x_down='X:DOWN', x_up='X:UP', y_down='Y:DOWN',
+                       y_up_north='Y:UP:NORTH', y_up_south='Y:UP:SOUTH',
+                       alio='ALIO', theta2fine='THETA', inpos=8, outpos=0,
+                       name='fake_ccm')
+    fake_ccm.calc.alio.readback.sim_put(SAMPLE_ALIO)
+    fake_ccm.calc.alio.setpoint.sim_put(SAMPLE_ALIO)
+    fake_ccm.x.down.user_readback.sim_put(0)
+    fake_ccm.x.up.user_readback.sim_put(0)
+    fake_ccm.x.down.user_setpoint.sim_put(0)
+    fake_ccm.x.up.user_setpoint.sim_put(0)
+    fake_ccm.y.down.user_setpoint.sim_put(0)
+    fake_ccm.y.up_north.user_setpoint.sim_put(0)
+    fake_ccm.y.up_south.user_setpoint.sim_put(0)
+
+
 # Make sure we set up the forward/inverse to use the right methods
-@using_fake_epics_pv
-def test_ccm_calc():
+def test_ccm_calc(fake_ccm):
     logger.debug('test_ccm_calc')
-    calc = ccm.CCMCalc('TEST', name='calc')
-    calc.alio.setpoint._read_pv.put(SAMPLE_ALIO)
-    calc.alio.readback._read_pv.put(SAMPLE_ALIO)
-    calc.wait_for_connection()
+    calc = fake_ccm.calc
 
     theta = calc.theta.position
-    theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.gTheta0, calc.gR, calc.gD)
+    theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.theta0, calc.gr, calc.gd)
     assert theta == theta_func
 
     wavelength = calc.wavelength.position
-    wavelength_func = ccm.theta_to_wavelength(theta, calc.gdspacing)
+    wavelength_func = ccm.theta_to_wavelength(theta, calc.dspacing)
     assert wavelength == wavelength_func
 
     energy = calc.energy.position
     energy_func = ccm.wavelength_to_energy(energy)
     assert energy == energy_func
 
-    calc.alio.setpoint._read_pv.put(0)
-    calc.alio.readback._read_pv.put(0)
-
+    calc.alio.readback.sim_put(0)
+    calc.alio.setpoint.sim_put(0)
     calc.move(energy, wait=True)
-    assert calc.alio.setpoint._read_pv.get() == SAMPLE_ALIO
+
+    assert calc.alio.setpoint.get() == SAMPLE_ALIO
 
 
 # Make sure sync'd axes work and that unk/in/out states work
-@using_fake_epics_pv
-def test_ccm_main():
-    tst_ccm = ccm.CCM(x_down='X:DOWN', x_up='X:UP', y_down='Y:DOWN',
-                      y_up_north='Y:UPN', y_up_south='Y:UPS', alio='CC:ALIO',
-                      theta2fine='CC:TH', inpos=8, outpos=0, name='tst_ccm')
-    tst_ccm.x.down.user_readback._read_pv.put(0)
-    tst_ccm.x.up.user_readback._read_pv.put(0)
-    tst_ccm.x.down.user_setpoint._write_pv.put(0)
-    tst_ccm.x.up.user_setpoint._write_pv.put(0)
-    tst_ccm.y.down.user_setpoint._write_pv.put(0)
-    tst_ccm.y.up_north.user_setpoint._write_pv.put(0)
-    tst_ccm.y.up_south.user_setpoint._write_pv.put(0)
-    tst_ccm.wait_for_connection()
+def test_ccm_main(fake_ccm):
+    fake_ccm.y.move(5)
+    assert fake_ccm.y.down.user_setpoint.get() == 5
+    assert fake_ccm.y.up_north.user_setpoint.get() == 5
+    assert fake_ccm.y.up_south.user_setpoint.get() == 5
 
-    tst_ccm.y.move(5)
-    assert tst_ccm.y.down.user_setpoint._write_pv.get() == 5
-    assert tst_ccm.y.up_north.user_setpoint._write_pv.get() == 5
-    assert tst_ccm.y.up_south.user_setpoint._write_pv.get() == 5
+    assert fake_ccm.position == 'OUT'
+    assert fake_ccm.removed
+    assert not fake_ccm.inserted
 
-    assert tst_ccm.position == 'OUT'
-    assert tst_ccm.removed
-    assert not tst_ccm.inserted
+    fake_ccm.x.down.user_readback.sim_put(8)
+    fake_ccm.x.up.user_readback.sim_put(8)
+    assert fake_ccm.position == 'IN'
+    assert not fake_ccm.removed
+    assert fake_ccm.inserted
 
-    tst_ccm.x.down.user_readback._read_pv.put(8)
-    tst_ccm.x.up.user_readback._read_pv.put(8)
-    assert tst_ccm.position == 'IN'
-    assert not tst_ccm.removed
-    assert tst_ccm.inserted
+    fake_ccm.x.down.user_readback.sim_put(4)
+    fake_ccm.x.up.user_readback.sim_put(4)
+    assert fake_ccm.position == 'Unknown'
+    assert not fake_ccm.removed
+    assert not fake_ccm.inserted
 
-    tst_ccm.x.down.user_readback._read_pv.put(4)
-    tst_ccm.x.up.user_readback._read_pv.put(4)
-    assert tst_ccm.position == 'Unknown'
-    assert not tst_ccm.removed
-    assert not tst_ccm.inserted
+    fake_ccm.insert()
+    assert fake_ccm.x.down.user_setpoint.get() == 8
+    assert fake_ccm.x.up.user_setpoint.get() == 8
 
-    tst_ccm.insert()
-    assert tst_ccm.x.down.user_setpoint._write_pv.get() == 8
-    assert tst_ccm.x.up.user_setpoint._write_pv.get() == 8
-
-    tst_ccm.remove()
-    assert tst_ccm.x.down.user_setpoint._write_pv.get() == 0
-    assert tst_ccm.x.up.user_setpoint._write_pv.get() == 0
+    fake_ccm.remove()
+    assert fake_ccm.x.down.user_setpoint.get() == 0
+    assert fake_ccm.x.up.user_setpoint.get() == 0

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -47,9 +47,10 @@ def test_energy_wavelength_inversion():
 @pytest.fixture(scope='function')
 def fake_ccm():
     FakeCCM = make_fake_device(ccm.CCM)
-    fake_ccm = FakeCCM(x_down='X:DOWN', x_up='X:UP', y_down='Y:DOWN',
-                       y_up_north='Y:UP:NORTH', y_up_south='Y:UP:SOUTH',
-                       alio='ALIO', theta2fine='THETA', inpos=8, outpos=0,
+    fake_ccm = FakeCCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
+                       x_down_prefix='X:DOWN', x_up_prefix='X:UP',
+                       y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
+                       y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,
                        name='fake_ccm')
     fake_ccm.calc.alio.readback.sim_put(SAMPLE_ALIO)
     fake_ccm.calc.alio.setpoint.sim_put(SAMPLE_ALIO)
@@ -64,6 +65,11 @@ def fake_ccm():
     init_pos(fake_ccm.y.up_north)
     init_pos(fake_ccm.y.up_south)
     return fake_ccm
+
+
+def test_fake_ccm(fake_ccm):
+    logger.debug('test_fake_ccm')
+    fake_ccm.get()
 
 
 # Make sure we set up the forward/inverse to use the right methods

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -55,6 +55,7 @@ def fake_ccm():
     fake_ccm.y.down.user_setpoint.sim_put(0)
     fake_ccm.y.up_north.user_setpoint.sim_put(0)
     fake_ccm.y.up_south.user_setpoint.sim_put(0)
+    return fake_ccm
 
 
 # Make sure we set up the forward/inverse to use the right methods

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -90,7 +90,19 @@ def test_ccm_calc(fake_ccm):
     calc.alio.readback.sim_put(0)
     calc.alio.setpoint.sim_put(0)
     calc.move(energy, wait=False)
+    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
 
+    calc.alio.readback.sim_put(0)
+    calc.alio.setpoint.sim_put(0)
+    calc.move(wavelength=wavelength, wait=False)
+    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
+
+    calc.alio.readback.sim_put(0)
+    calc.alio.setpoint.sim_put(0)
+    calc.move(theta=theta, wait=False)
+    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
+
+    calc.move(energy=energy, wavelength=wavelength, theta=theta, wait=False)
     assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
 
 

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -1,5 +1,7 @@
 import logging
 
+import numpy as np
+
 import pcdsdevices.ccm as ccm
 from pcdsdevices.sim.pv import using_fake_epics_pv
 
@@ -16,7 +18,8 @@ def test_theta_alio_inversion():
     logger.debug('test_theta_alio_inversion')
     theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.gTheta0, ccm.gR, ccm.gD)
     alio_calc = ccm.theta_to_alio(theta, ccm.gTheta0, ccm.gR, ccm.gD)
-    assert alio_calc == SAMPLE_ALIO
+    # Unlike the other inversions, this is just an approximation
+    assert np.isclose(alio_calc, SAMPLE_ALIO)
 
 
 def test_wavelength_theta_inversion():

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -48,13 +48,16 @@ def fake_ccm():
                        name='fake_ccm')
     fake_ccm.calc.alio.readback.sim_put(SAMPLE_ALIO)
     fake_ccm.calc.alio.setpoint.sim_put(SAMPLE_ALIO)
-    fake_ccm.x.down.user_readback.sim_put(0)
-    fake_ccm.x.up.user_readback.sim_put(0)
-    fake_ccm.x.down.user_setpoint.sim_put(0)
-    fake_ccm.x.up.user_setpoint.sim_put(0)
-    fake_ccm.y.down.user_setpoint.sim_put(0)
-    fake_ccm.y.up_north.user_setpoint.sim_put(0)
-    fake_ccm.y.up_south.user_setpoint.sim_put(0)
+
+    def init_pos(mot, pos=0):
+        mot.user_readback.sim_put(0)
+        mot.user_setpoint.sim_put(0)
+
+    init_pos(fake_ccm.x.down)
+    init_pos(fake_ccm.x.up)
+    init_pos(fake_ccm.y.down)
+    init_pos(fake_ccm.y.up_north)
+    init_pos(fake_ccm.y.up_south)
     return fake_ccm
 
 
@@ -83,8 +86,9 @@ def test_ccm_calc(fake_ccm):
 
 
 # Make sure sync'd axes work and that unk/in/out states work
+@pytest.mark.timeout(5)
 def test_ccm_main(fake_ccm):
-    fake_ccm.y.move(5)
+    fake_ccm.y.move(5, wait=False)
     assert fake_ccm.y.down.user_setpoint.get() == 5
     assert fake_ccm.y.up_north.user_setpoint.get() == 5
     assert fake_ccm.y.up_south.user_setpoint.get() == 5
@@ -105,10 +109,10 @@ def test_ccm_main(fake_ccm):
     assert not fake_ccm.removed
     assert not fake_ccm.inserted
 
-    fake_ccm.insert()
+    fake_ccm.insert(wait=False)
     assert fake_ccm.x.down.user_setpoint.get() == 8
     assert fake_ccm.x.up.user_setpoint.get() == 8
 
-    fake_ccm.remove()
+    fake_ccm.remove(wait=False)
     assert fake_ccm.x.down.user_setpoint.get() == 0
     assert fake_ccm.x.up.user_setpoint.get() == 0

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -66,7 +66,10 @@ def test_ccm_calc(fake_ccm):
     logger.debug('test_ccm_calc')
     calc = fake_ccm.calc
 
-    assert calc.alio.position == SAMPLE_ALIO
+    logger.debug('physics pos is %s', calc.position)
+    logger.debug('real pos is %s', calc.real_position)
+    logger.debug('sample alio is %s', SAMPLE_ALIO)
+
     theta = calc.theta.position
     theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.theta0, calc.gr, calc.gd)
     assert theta == theta_func

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -102,13 +102,16 @@ def test_ccm_calc(fake_ccm):
     calc.move(theta=theta, wait=False)
     assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
 
-    calc.move(energy=energy, wavelength=wavelength, theta=theta, wait=False)
+    calc.alio.readback.sim_put(calc.alio.setpoint.get())
+    calc.move(energy=calc.energy.position, wavelength=calc.wavelength.position,
+              theta=calc.theta.position, wait=False)
     assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
 
 
 # Make sure sync'd axes work and that unk/in/out states work
 @pytest.mark.timeout(5)
 def test_ccm_main(fake_ccm):
+    logger.debug('test_ccm_main')
     fake_ccm.y.move(5, wait=False)
     assert fake_ccm.y.down.user_setpoint.get() == 5
     assert fake_ccm.y.up_north.user_setpoint.get() == 5

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -72,7 +72,7 @@ def test_ccm_calc(fake_ccm):
 
     theta = calc.theta.position
     theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.theta0, calc.gr, calc.gd)
-    assert theta == theta_func
+    assert theta == theta_func * 180 / np.pi
 
     wavelength = calc.wavelength.position
     wavelength_func = ccm.theta_to_wavelength(theta, calc.dspacing)

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -1,0 +1,106 @@
+import logging
+
+import pcdsdevices.ccm as ccm
+from pcdsdevices.sim.pv import using_fake_epics_pv
+
+logger = logging.getLogger(__name__)
+
+
+SAMPLE_ALIO = 4.575  # Current value as of writing this file
+SAMPLE_THETA = 1.2  # Modest angle
+SAMPLE_WAVELENGTH = 10  # xray
+
+
+# Make sure the calcs are properly inverted
+def test_theta_alio_inversion():
+    logger.debug('test_theta_alio_inversion')
+    theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.gTheta0, ccm.gR, ccm.gD)
+    alio_calc = ccm.theta_to_alio(theta, ccm.gTheta0, ccm.gR, ccm.gD)
+    assert alio_calc == SAMPLE_ALIO
+
+
+def test_wavelength_theta_inversion():
+    logger.debug('test_wavelength_theta_inversion')
+    wavelength = ccm.wavelength_to_theta(SAMPLE_THETA, ccm.gdspacing)
+    theta_calc = ccm.theta_to_wavelength(wavelength, ccm.gdspacing)
+    assert theta_calc == SAMPLE_THETA
+
+
+def test_energy_wavelength_inversion():
+    logger.debug('test_energy_wavelength_inversion')
+    energy = ccm.wavelength_to_energy(SAMPLE_WAVELENGTH)
+    wavelength_calc = ccm.energy_to_wavelength(energy)
+    assert wavelength_calc == SAMPLE_WAVELENGTH
+
+
+# Make sure we set up the forward/inverse to use the right methods
+@using_fake_epics_pv
+def test_ccm_calc():
+    logger.debug('test_ccm_calc')
+    calc = ccm.CCMCalc('TEST', name='calc')
+    calc.alio.setpoint._read_pv.put(SAMPLE_ALIO)
+    calc.alio.readback._read_pv.put(SAMPLE_ALIO)
+    calc.wait_for_connection()
+
+    theta = calc.theta.position
+    theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.gTheta0, calc.gR, calc.gD)
+    assert theta == theta_func
+
+    wavelength = calc.wavelength.position
+    wavelength_func = ccm.theta_to_wavelength(theta, calc.gdspacing)
+    assert wavelength == wavelength_func
+
+    energy = calc.energy.position
+    energy_func = ccm.wavelength_to_energy(energy)
+    assert energy == energy_func
+
+    calc.alio.setpoint._read_pv.put(0)
+    calc.alio.readback._read_pv.put(0)
+
+    calc.move(energy, wait=True)
+    assert calc.alio.setpoint._read_pv.get() == SAMPLE_ALIO
+
+
+# Make sure sync'd axes work and that unk/in/out states work
+@using_fake_epics_pv
+def test_ccm_main():
+    tst_ccm = ccm.CCM(x_down='X:DOWN', x_up='X:UP', y_down='Y:DOWN',
+                      y_up_north='Y:UPN', y_up_south='Y:UPS', alio='CC:ALIO',
+                      theta2fine='CC:TH', inpos=8, outpos=0, name='tst_ccm')
+    tst_ccm.x.down.user_readback._read_pv.put(0)
+    tst_ccm.x.up.user_readback._read_pv.put(0)
+    tst_ccm.x.down.user_setpoint._write_pv.put(0)
+    tst_ccm.x.up.user_setpoint._write_pv.put(0)
+    tst_ccm.y.down.user_setpoint._write_pv.put(0)
+    tst_ccm.y.up_north.user_setpoint._write_pv.put(0)
+    tst_ccm.y.up_south.user_setpoint._write_pv.put(0)
+    tst_ccm.wait_for_connection()
+
+    tst_ccm.y.move(5)
+    assert tst_ccm.y.down.user_setpoint._write_pv.get() == 5
+    assert tst_ccm.y.up_north.user_setpoint._write_pv.get() == 5
+    assert tst_ccm.y.up_south.user_setpoint._write_pv.get() == 5
+
+    assert tst_ccm.position == 'OUT'
+    assert tst_ccm.removed
+    assert not tst_ccm.inserted
+
+    tst_ccm.x.down.user_readback._read_pv.put(8)
+    tst_ccm.x.up.user_readback._read_pv.put(8)
+    assert tst_ccm.position == 'IN'
+    assert not tst_ccm.removed
+    assert tst_ccm.inserted
+
+    tst_ccm.x.down.user_readback._read_pv.put(4)
+    tst_ccm.x.up.user_readback._read_pv.put(4)
+    assert tst_ccm.position == 'Unknown'
+    assert not tst_ccm.removed
+    assert not tst_ccm.inserted
+
+    tst_ccm.insert()
+    assert tst_ccm.x.down.user_setpoint._write_pv.get() == 8
+    assert tst_ccm.x.up.user_setpoint._write_pv.get() == 8
+
+    tst_ccm.remove()
+    assert tst_ccm.x.down.user_setpoint._write_pv.get() == 0
+    assert tst_ccm.x.up.user_setpoint._write_pv.get() == 0

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -1,24 +1,25 @@
 import logging
 import pytest
 
-import numpy as np
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
 
-from pcdsdevices.pseudopos import SyncAxes
+from pcdsdevices.pseudopos import SyncAxesBase
 
 logger = logging.getLogger(__name__)
 
 
-AXES = ('one', 'two', 'three', 'four', 'five')
+class FiveSyncSoftPositioner(SyncAxesBase):
+    one = Cpt(SoftPositioner, init_pos=0)
+    two = Cpt(SoftPositioner, init_pos=0)
+    three = Cpt(SoftPositioner, init_pos=0)
+    four = Cpt(SoftPositioner, init_pos=0)
+    five = Cpt(SoftPositioner, init_pos=0)
 
 
 @pytest.fixture(scope='function')
 def five_axes():
-    kwargs = dict(name='sync', egu='five')
-    for ax in AXES:
-        kwargs[ax] = Cpt(SoftPositioner, init_pos=0)
-    return SyncAxes(**kwargs)
+    return FiveSyncSoftPositioner(name='sync', egu='five')
 
 
 def test_sync_passthrough(five_axes):
@@ -27,24 +28,34 @@ def test_sync_passthrough(five_axes):
     assert five_axes.egu == 'five'
 
 
-def test_sync_move(five_axes):
-    logger.debug('test_sync_move')
+def test_sync_basic(five_axes):
+    logger.debug('test_sync_basic')
     five_axes.move(5)
-    for ax in AXES:
-        axis = getattr(five_axes, ax)
-        assert axis.position == 5
+    for pos in five_axes.real_position:
+        assert pos == 5
     assert five_axes.position == 5
 
 
-def test_sync_mean(five_axes):
-    logger.debug('test_sync_mean')
-    for i, ax in enumerate(AXES):
-        axis = getattr(five_axes, ax)
-        axis.move(i)
-    assert five_axes.position == np.mean(range(len(AXES)))
-
-
-def test_bad_sync_kwarg():
-    logger.debug('test_bad_sync_kwarg')
-    with pytest.raises(ValueError):
-        SyncAxes(axes=Cpt(SoftPositioner, init_pos=0))
+def test_sync_offset(five_axes):
+    logger.debug('test_sync_offset')
+    five_axes.one.move(1)
+    five_axes.two.move(2)
+    five_axes.three.move(3)
+    five_axes.four.move(4)
+    five_axes.five.move(5)
+    five_axes.save_offsets()
+    assert five_axes.position == 1
+    five_axes.move(10)
+    assert five_axes.one.position == 10
+    assert five_axes.two.position == 11
+    assert five_axes.three.position == 12
+    assert five_axes.four.position == 13
+    assert five_axes.five.position == 14
+    five_axes.save_offsets(two=10)
+    five_axes.move(11)
+    assert five_axes.one.position == 11
+    assert five_axes.two.position == 21
+    assert five_axes.three.position == 13
+    five_axes._mode = max
+    five_axes.save_offsets()
+    assert five_axes.position == 21

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -42,3 +42,9 @@ def test_sync_mean(five_axes):
         axis = getattr(five_axes, ax)
         axis.move(i)
     assert five_axes.position == np.mean(range(len(AXES)))
+
+
+def test_bad_sync_kwarg():
+    logger.debug('test_bad_sync_kwarg')
+    with pytest.raises(ValueError):
+        SyncAxes(axes=Cpt(SoftPositioner, init_pos=0))

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -17,7 +17,7 @@ AXES = ('one', 'two', 'three', 'four', 'five')
 def five_axes():
     kwargs = dict(name='sync', egu='five')
     for ax in AXES:
-        kwargs[ax] = Cpt(SoftPositioner)
+        kwargs[ax] = Cpt(SoftPositioner, init_pos=0)
     return SyncAxes(**kwargs)
 
 

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -1,0 +1,44 @@
+import logging
+import pytest
+
+import numpy as np
+from ophyd.device import Component as Cpt
+from ophyd.position import SoftPositioner
+
+from pcdsdevices.pseudopos import SyncAxes
+
+logger = logging.getLogger(__name__)
+
+
+AXES = ('one', 'two', 'three', 'four', 'five')
+
+
+@pytest.fixture(scope='function')
+def five_axes():
+    kwargs = dict(name='sync', egu='five')
+    for ax in AXES:
+        kwargs[ax] = Cpt(SoftPositioner)
+    return SyncAxes(**kwargs)
+
+
+def test_sync_passthrough(five_axes):
+    logger.debug('test_sync_passthrough')
+    assert five_axes.name == 'sync'
+    assert five_axes.egu == 'five'
+
+
+def test_sync_move(five_axes):
+    logger.debug('test_sync_move')
+    five_axes.move(5)
+    for ax in AXES:
+        axis = getattr(five_axes, ax)
+        assert axis.position == 5
+    assert five_axes.position == 5
+
+
+def test_sync_mean(five_axes):
+    logger.debug('test_sync_mean')
+    for i, ax in enumerate(AXES):
+        axis = getattr(five_axes, ax)
+        axis.move(i)
+    assert five_axes.position == np.mean(range(len(AXES)))

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -3,7 +3,7 @@ import pytest
 
 import numpy as np
 from ophyd.device import Component as Cpt
-from ophyd.position import SoftPositioner
+from ophyd.positioner import SoftPositioner
 
 from pcdsdevices.pseudopos import SyncAxes
 

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -51,11 +51,6 @@ def test_sync_offset(five_axes):
     assert five_axes.three.position == 12
     assert five_axes.four.position == 13
     assert five_axes.five.position == 14
-    five_axes.save_offsets(two=10)
-    five_axes.move(11)
-    assert five_axes.one.position == 11
-    assert five_axes.two.position == 21
-    assert five_axes.three.position == 13
     five_axes._mode = max
     five_axes.save_offsets()
-    assert five_axes.pseudo.position == 21
+    assert five_axes.pseudo.position == 14

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -33,7 +33,7 @@ def test_sync_basic(five_axes):
     five_axes.move(5)
     for pos in five_axes.real_position:
         assert pos == 5
-    assert five_axes.position == 5
+    assert five_axes.pseudo.position == 5
 
 
 def test_sync_offset(five_axes):
@@ -44,7 +44,7 @@ def test_sync_offset(five_axes):
     five_axes.four.move(4)
     five_axes.five.move(5)
     five_axes.save_offsets()
-    assert five_axes.position == 1
+    assert five_axes.pseudo.position == 1
     five_axes.move(10)
     assert five_axes.one.position == 10
     assert five_axes.two.position == 11
@@ -58,4 +58,4 @@ def test_sync_offset(five_axes):
     assert five_axes.three.position == 13
     five_axes._mode = max
     five_axes.save_offsets()
-    assert five_axes.position == 21
+    assert five_axes.pseudo.position == 21


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `CCM`, which includes two coordinated motor assemblies and an `energy` pseudomotor
- Add `SyncAxes` class factory

Unfortunately, the CCM currently uses a bunch of magic constants for the calcs and kwargs for the in/out positions.

closes #222 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Need a CCM for XPP (eventually XCS will use theirs again maybe), and for downstream hutches to verify CCM is out
- Need conventions for synchronized axes and calculation motors

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to device docs
<!--
## Screenshots (if appropriate):
-->
