### PR TITLE
ENH: Add make_fake_class factory function

### DIFF
--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -1,0 +1,148 @@
+import copy
+import logging
+
+from ophyd.device import (Device, Component as Cpt,
+                          DynamicDeviceComponent as DDCpt)
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
+from ophyd.utils import ReadOnlyError, LimitError
+
+logger = logging.getLogger(__name__)
+
+
+def make_fake_class(cls):
+    """
+    Inspect cls and construct a fake class that has the same structure.
+
+    This works by replacing EpicsSignal with FakeEpicsSignal and EpicsSignalRO
+    with FakeEpicsSignalRO. The fake class will be a subclass of the real
+    class.
+
+    This assumes that EPICS connections are done entirely in EpicsSignal and
+    EpicsSignalRO subcomponents. If this is not true, this will fail silently
+    until the test.
+
+    Parameters
+    ----------
+    cls: `ophyd.Device`
+
+    Returns
+    -------
+    fake_class: `ophyd.Device`
+    """
+    # Cache to avoid repeating work.
+    # EpicsSignal and EpicsSignalRO begin in the cache.
+    if cls not in fake_class_cache:
+        if not issubclass(cls, Device):
+            # Ignore non-devices and non-epics-signals
+            logger.debug('Ignore cls=%s, bases are %s', cls, cls.__bases__)
+            fake_class_cache[cls] = cls
+            return cls
+        fake_dict = {}
+        # Update all the components recursively
+        for cpt_name in cls.component_names:
+            cpt = getattr(cls, cpt_name)
+            fake_cpt = copy.copy(cpt)
+            if isinstance(cpt, Cpt):
+                fake_cpt.cls = make_fake_class(cpt.cls)
+                logger.debug('switch cpt_name=%s to cls=%s',
+                             cpt_name, fake_cpt.cls)
+            # DDCpt stores the classes in a different place
+            elif isinstance(cpt, DDCpt):
+                fake_defn = {}
+                for ddcpt_name, ddcpt_tuple in cpt.defn.items():
+                    subcls = make_fake_class(ddcpt_tuple[0])
+                    fake_defn[ddcpt_name] = [subcls] + list(ddcpt_tuple[1:])
+                fake_cpt.defn = fake_defn
+            else:
+                raise RuntimeError(("{} is not a component or a dynamic "
+                                    "device component. I don't know how you "
+                                    "found this error, should be impossible "
+                                    "to reach it.".format(cpt)))
+            fake_dict[cpt_name] = fake_cpt
+        fake_class = type('Fake{}'.format(cls.__name__), (cls,), fake_dict)
+        fake_class_cache[cls] = fake_class
+        logger.debug('fake_class_cache[%s] = %s', cls, fake_class)
+    return fake_class_cache[cls]
+
+
+class FakeEpicsSignal(Signal):
+    """
+    Fake version of EpicsSignal that's really just a signal.
+
+    We can emulate EPICS features here. Currently we just emulate the put
+    limits because it was involved in a kwarg.
+    """
+    def __init__(self, read_pv, write_pv=None, *, pv_kw=None,
+                 put_complete=False, string=False, limits=False,
+                 auto_monitor=False, name=None, **kwargs):
+        """
+        Mimic EpicsSignal signature
+        """
+        super().__init__(name=name, **kwargs)
+        self._use_limits = limits
+        self._sim_getter = None
+        self._sim_putter = None
+
+    def sim_set_getter(self, getter):
+        """
+        Set a method to call instead of get
+        """
+        self._sim_getter = getter
+
+    def sim_set_putter(self, putter):
+        """
+        Set a method to call instead of put
+        """
+        self._sim_putter = putter
+
+    def get(self, *args, **kwargs):
+        if self._sim_getter:
+            return self._sim_getter(*args, **kwargs)
+        return super().get(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        if self._sim_putter is not None:
+            return self._sim_putter(*args, **kwargs)
+        return super().put(*args, **kwargs)
+
+    def sim_put(self, *args, **kwargs):
+        """
+        Update the read-only signal's value.
+
+        Implement here instead of FakeEpicsSignalRO so you can call it with
+        every fake signal.
+        """
+        return Signal.put(self, *args, **kwargs)
+
+    @property
+    def limits(self):
+        return self._limits
+
+    def sim_limits(self, limits):
+        """
+        Set the fake signal's limits.
+        """
+        self._limits = limits
+
+    def check_value(self, value):
+        """
+        Check fake limits before putting
+        """
+        super().check_value(value)
+        if self._use_limits and not self.limits[0] < value < self.limits[1]:
+            raise LimitError('value={} limits={}'.format(value, self.limits))
+
+
+class FakeEpicsSignalRO(FakeEpicsSignal):
+    """
+    Read-only FakeEpicsSignal
+    """
+    def put(self, *args, **kwargs):
+        raise ReadOnlyError()
+
+    def set(self, *args, **kwargs):
+        raise ReadOnlyError()
+
+
+fake_class_cache = {EpicsSignal: FakeEpicsSignal,
+                    EpicsSignalRO: FakeEpicsSignalRO}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,102 @@
+import logging
+
+import pytest
+from ophyd.device import (Device, Component as Cpt,
+                          FormattedComponent as FCpt,
+                          DynamicDeviceComponent as DDCpt)
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
+from ophyd.utils import ReadOnlyError, LimitError, DisconnectedError
+
+from pcdsdevices.utils import (make_fake_class, FakeEpicsSignal,
+                               FakeEpicsSignalRO)
+
+logger = logging.getLogger(__name__)
+
+
+class SampleNested(Device):
+    yolk = Cpt(EpicsSignal, ':YOLK')
+    whites = Cpt(EpicsSignalRO, ':WHITES')
+
+
+class Sample(Device):
+    egg = Cpt(SampleNested, ':EGG')
+    butter = Cpt(EpicsSignal, ':BUTTER')
+    flour = Cpt(EpicsSignalRO, ':FLOUR')
+    sink = FCpt(EpicsSignal, '{self.sink_location}:SINK')
+    fridge = DDCpt({'milk': (EpicsSignal, ':MILK', {}),
+                    'cheese': (EpicsSignalRO, ':CHEESE', {})})
+    nothing = Cpt(Signal)
+
+    sink_location = 'COUNTER'
+
+
+def test_make_fake_class():
+    logger.debug('test_make_fake_class')
+    assert make_fake_class(EpicsSignal) == FakeEpicsSignal
+    assert make_fake_class(EpicsSignalRO) == FakeEpicsSignalRO
+
+    FakeSample = make_fake_class(Sample)
+    my_fake = FakeSample('KITCHEN', name='kitchen')
+    assert isinstance(my_fake, Sample)
+
+    # Skipped
+    assert my_fake.nothing.__class__ is Signal
+
+    # Normal
+    assert isinstance(my_fake.butter, FakeEpicsSignal)
+    assert isinstance(my_fake.flour, FakeEpicsSignalRO)
+    assert isinstance(my_fake.sink, FakeEpicsSignal)
+
+    # Nested
+    assert isinstance(my_fake.egg.yolk, FakeEpicsSignal)
+    assert isinstance(my_fake.egg.whites, FakeEpicsSignalRO)
+
+    # Dynamic
+    assert isinstance(my_fake.fridge.milk, FakeEpicsSignal)
+    assert isinstance(my_fake.fridge.cheese, FakeEpicsSignalRO)
+
+    my_fake.read()
+
+
+def test_do_not_break_real_class():
+    logger.debug('test_do_not_break_real_class')
+
+    make_fake_class(Sample)
+    assert Sample.butter.cls is EpicsSignal
+    assert Sample.egg.cls is SampleNested
+    assert SampleNested.whites.cls is EpicsSignalRO
+    assert Sample.fridge.defn['milk'][0] is EpicsSignal
+
+    with pytest.raises(DisconnectedError):
+        my_real = Sample('KITCHEN', name='kitchen')
+        my_real.read()
+
+
+def test_fake_epics_signal():
+    logger.debug('test_fake_epics_signals')
+    sig = FakeEpicsSignal('PVNAME', name='sig', limits=True)
+    sig.sim_limits((0, 10))
+    with pytest.raises(LimitError):
+        sig.put(11)
+    sig.put(4)
+    assert sig.get() == 4
+    sig.sim_put(5)
+    assert sig.get() == 5
+    sig.sim_set_putter(lambda x: sig.sim_put(x + 1))
+    sig.put(6)
+    assert sig.get() == 7
+    sig.sim_set_getter(lambda: 2.3)
+    assert sig.get() == 2.3
+
+
+def test_fake_epics_signal_ro():
+    logger.debug('test_fake_epics_signal_ro')
+    sig = FakeEpicsSignalRO('PVNAME', name='sig')
+    with pytest.raises(ReadOnlyError):
+        sig.put(3)
+    with pytest.raises(ReadOnlyError):
+        sig.put(4)
+    with pytest.raises(ReadOnlyError):
+        sig.set(5)
+    sig.sim_put(1)
+    assert sig.get() == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`make_fake_class(cls)` creates a fake version of `cls`. All `EpicsSignal` and `EpicsSignalRO` will be replaced. They will start at value `None` and stay at whatever value you set. There are minimal hooks for recreating functionality of the real things.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need a dead-simple way to test classes that doesn't have update loops or threading with the potential for race conditions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I will add to the docs once we agree on the filename it should go in

<!--
## Screenshots (if appropriate):
-->
