### PR TITLE
Beam stats additions

### DIFF
--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -6,13 +6,14 @@ from .signal import AvgSignal
 
 class BeamStats(Device):
     mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC')
-    ev = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO541')
+    ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY')
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID')
-    # This one is much faster than ev
-    accel_ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY')
-    sxr_gmd = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse')
-
+    
+    #########
+    xpp_ipm2 = Cpt(EpicsSignalRO, 'XPP:SB2:IPM:01:SUM')
+    xpp_ipm3 = Cpt(EpicsSignalRO, 'XPP:SB3:IPM:01:SUM')
+    #########
     mj_avg = Cpt(AvgSignal, 'mj', averages=120)
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages')
 
@@ -22,6 +23,16 @@ class BeamStats(Device):
     def __init__(self, prefix='', name='beam_stats', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)
 
+    @property
+    def hints(self):
+        return {'fields': [self.mj.name]}
+
+class SxrGmd(Device):
+    mj = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse')
+    
+    def __init__(self, prefix='', name='SxrGmd', **kwargs):
+        super().__init__(prefix=prefix, name=name, **kwargs)
+    
     @property
     def hints(self):
         return {'fields': [self.mj.name]}

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -9,6 +9,8 @@ class BeamStats(Device):
     ev = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO541')
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID')
+    accel_ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY')
+    sxr_gmd = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse')
 
     mj_avg = Cpt(AvgSignal, 'mj', averages=120)
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages')

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -10,10 +10,6 @@ class BeamStats(Device):
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID')
     
-    #########
-    xpp_ipm2 = Cpt(EpicsSignalRO, 'XPP:SB2:IPM:01:SUM')
-    xpp_ipm3 = Cpt(EpicsSignalRO, 'XPP:SB3:IPM:01:SUM')
-    #########
     mj_avg = Cpt(AvgSignal, 'mj', averages=120)
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages')
 

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -9,7 +9,7 @@ class BeamStats(Device):
     ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY')
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID')
-    
+
     mj_avg = Cpt(AvgSignal, 'mj', averages=120)
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages')
 
@@ -23,12 +23,13 @@ class BeamStats(Device):
     def hints(self):
         return {'fields': [self.mj.name]}
 
+
 class SxrGmd(Device):
     mj = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse')
-    
+
     def __init__(self, prefix='', name='SxrGmd', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)
-    
+
     @property
     def hints(self):
         return {'fields': [self.mj.name]}

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -9,6 +9,7 @@ class BeamStats(Device):
     ev = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO541')
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID')
+    # This one is much faster than ev
     accel_ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY')
     sxr_gmd = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse')
 


### PR DESCRIPTION
This PR adds new static components to BeamStats object.

## Description
The BeamStats objects now has two additional PVs. `accel_ev` watches the accelerator-reported ev levels and the other, `sxr_gmd`, watches the SXR GMD. The accelerator-reported ev levels, `accel_ev`, update much more quickly than the `ev` component that already exists in the object.

## Motivation and Context
These additions provide the necessary PVs for basic tests of the [auto_monochromator](https://github.com/pcdshub/auto_monochromator). The module uses a tiny event builder and so requires high time-resolution information in order to better generate complete event-built sets with which to generate histograms.

## How Has This Been Tested?
The object has been instantiated in an iPython session and the new components are able to get values and subscribe callbacks.

## Where Has This Been Documented?
An in-line comment has been added to differentiate the two pv's reporting accelerator packet energy.

