### PR TITLE
PCDSMotorBase .SPG Implementation

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -218,8 +218,8 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
                             "ignored until motor is set to 'Go'")
 
         if self.motor_spg.value in [1, 'Pause']:
-            raise Exception("Motor is paused.  If a move is set, motion
-            will resume when motor is set to 'Go'")
+            raise Exception("Motor is paused.  If a move is set, motion "
+                            "will resume when motor is set to 'Go'")
 
         # Find the soft limit values from EPICS records and check that this
         # command will be accepted by the motor

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -218,8 +218,8 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
                             "ignored until motor is set to 'Go'")
 
         if self.motor_spg.value in [1, 'Pause']:
-            raise Exception("Motor is paused.  Motion requests "
-                            "ignored until motor is set to 'Go'")
+            raise Exception("Motor is paused.  If a move is set, motion
+            will resume when motor is set to 'Go'")
 
         # Find the soft limit values from EPICS records and check that this
         # command will be accepted by the motor
@@ -238,8 +238,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         # Pass information to PositionerBase
         super()._pos_changed(timestamp=timestamp, old_value=old_value,
                              value=value, **kwargs)
-
-
+        
 class IMS(PCDSMotorBase):
     """
     PCDS implementation of the Motor Record for IMS motors.
@@ -269,7 +268,7 @@ class IMS(PCDSMotorBase):
 
     def stage(self):
         """
-        State the IMS motor
+        Stage the IMS motor
 
         This clears all present flags on the motor and reinitializes the motor
         if we don't register a valid part number

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -220,13 +220,13 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
             raise Exception("Motor is not enabled. Motion requests "
                             "ignored")
 
-        if self.motor_spg.value == 0:
+        if self.motor_spg.value in [0, 'Stop']:
             raise Exception("Motor is stopped.  Motion requests "
-                            "ignored until motor is set to 'Go')")
+                            "ignored until motor is set to 'Go'")
 
-        if self.motor_spg.value == 1:
+        if self.motor_spg.value in [1, 'Pause']:
             raise Exception("Motor is paused.  Motion requests "
-                            "ignored until motor is set to 'Go')")
+                            "ignored until motor is set to 'Go'")
 
         # Find the soft limit values from EPICS records and check that this
         # command will be accepted by the motor

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -43,10 +43,10 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         cache of the limits after the first get attempt. We therefore disregard
         the internal limits of the PV and use the soft limit records
         exclusively.
-        3. The ``SPG`` field implements the three states used in the LCLS 
-        motor record.  This is a reduced version of the standard EPICS 
+        3. The ``SPG`` field implements the three states used in the LCLS
+        motor record.  This is a reduced version of the standard EPICS
         ``SPMG`` field.  Setting to ``STOP``, ``PAUSE`` and ``GO``  will
-        respectively stop motor movement, pause a move in progress, or resume 
+        respectively stop motor movement, pause a move in progress, or resume
         a paused move.
     """
     # Reimplemented because pyepics does not recognize when the limits have
@@ -61,7 +61,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
     direction_of_travel = Cpt(Signal)
     # This attribute will show if the motor is disabled or not
     disabled = Cpt(EpicsSignal, ".DISP")
-    # This attribute changes if the motor is stopped and unable to move 'Stop', 
+    # This attribute changes if the motor is stopped and unable to move 'Stop',
     # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, ".SPG")
 
@@ -180,7 +180,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def resume(self):
         """
-        Sets motor ready to move or resumes a paused move 
+        Sets motor ready to move or resumes a paused move
         (same as <motor>.go()).
         """
         return self.motor_spg.put(value='Go')
@@ -238,7 +238,8 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         # Pass information to PositionerBase
         super()._pos_changed(timestamp=timestamp, old_value=old_value,
                              value=value, **kwargs)
-        
+
+
 class IMS(PCDSMotorBase):
     """
     PCDS implementation of the Motor Record for IMS motors.

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -162,12 +162,9 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def stop(self):
         """
-        Stops the motor.
-
-        Returns
-        -------
-        status: Status Object
-            Status object of the set
+        Stops the motor.  After which the motor 
+        must be set back to 'go' via <motor>.go()
+        in order to move again.
         """
         return self.motor_spg.put(value='Stop')
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -186,7 +186,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         Sets motor ready to move or resumes a paused move
         (same as <motor>.go()).
         """
-        return self.go():
+        return self.go()
 
     def go(self):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -43,6 +43,11 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         cache of the limits after the first get attempt. We therefore disregard
         the internal limits of the PV and use the soft limit records
         exclusively.
+        3. The ``SPG`` field implements the three states used in the LCLS 
+        motor record.  This is a reduced version of the standard EPICS 
+        ``SPMG`` field.  Setting to ``STOP``, ``PAUSE`` and ``GO``  will
+        respectively stop motor movement, pause a move in progress, or resume 
+        a paused move.
     """
     # Reimplemented because pyepics does not recognize when the limits have
     # been changed without a re-connection of the PV. Instead we trust the soft
@@ -56,7 +61,8 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
     direction_of_travel = Cpt(Signal)
     # This attribute will show if the motor is disabled or not
     disabled = Cpt(EpicsSignal, ".DISP")
-    # This attribute changes if the motor is stopped and unable to move 'Stop', paused and ready to resume on Go 'Paused', and able to move 'Go' or resume a move.
+    # This attribute changes if the motor is stopped and unable to move 'Stop', 
+    # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, ".SPG")
 
     @property
@@ -167,34 +173,21 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def pause(self):
         """
-        Pauses a move.
-
-        Returns
-        -------
-        status: Status Object
-            Status object of the set
+        Pauses a move.  Move will resume if <motor>.resume()
+        or <motor>.go() are called.
         """
         return self.motor_spg.put(value='Pause')
 
     def resume(self):
         """
-        Sets motor ready to move or resumes a paused move (same as <motor>.go())
-
-        Returns
-        -------
-        status: Status Object
-            Status object of the set
+        Sets motor ready to move or resumes a paused move 
+        (same as <motor>.go()).
         """
         return self.motor_spg.put(value='Go')
 
     def go(self):
         """
         Sets motor ready to move or resumes a paused move.
-
-        Returns
-        -------
-        status: Status Object
-            Status object of the set
         """
         return self.motor_spg.put(value='Go')
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -162,7 +162,9 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def stop(self):
         """
-        Stops the motor.  After which the motor 
+        Stops the motor.  
+        
+        After which the motor 
         must be set back to 'go' via <motor>.go()
         in order to move again.
         """
@@ -170,21 +172,28 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def pause(self):
         """
-        Pauses a move.  Move will resume if <motor>.resume()
+        Pauses a move.  
+        
+        Move will resume if <motor>.resume()
         or <motor>.go() are called.
         """
         return self.motor_spg.put(value='Pause')
 
     def resume(self):
         """
+        Resumes paused movement.
+
         Sets motor ready to move or resumes a paused move
         (same as <motor>.go()).
         """
-        return self.motor_spg.put(value='Go')
+        return self.go():
 
     def go(self):
         """
-        Sets motor ready to move or resumes a paused move.
+        Resumes paused movement.
+
+        Sets motor ready to move or resumes a paused move
+        (same as <motor>.resume()).
         """
         return self.motor_spg.put(value='Go')
 

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -109,20 +109,20 @@ def test_ims_stage_in_plan():
 def test_resume_pause_stop():
     m = fake_motor()
     m.stop()
-    assert m.motor_spg.get(as_string = True) == 'Stop'
+    assert m.motor_spg.get(as_string=True) == 'Stop'
     with pytest.raises(Exception):
         m.check_value(10)
     with pytest.raises(Exception):
         m.move(10, wait=False)
     m.pause()
-    assert m.motor_spg.get(as_string = True) == 'Pause'
+    assert m.motor_spg.get(as_string=True) == 'Pause'
     with pytest.raises(Exception):
         m.move(10, wait=False)
     m.go()
-    assert m.motor_spg.get(as_string = True) == 'Go'
+    assert m.motor_spg.get(as_string=True) == 'Go'
     m.check_value(10)
     m.resume()
-    assert m.motor_spg.get(as_string = True) == 'Go'
+    assert m.motor_spg.get(as_string=True) == 'Go'
     m.check_value(10)
     
     


### PR DESCRIPTION
Implemented motor SPG field to PCDSMotorBase
## Description
Calling <motor>.stop(), <motor>.pause(), and <motor>.go() will put to the EPICS .SPG field and stop pause or resume motion.  <motor>.check_value also considers the .SPG state 

## Motivation and Context
The .SPG field is used by operators all the time from the expert screen.  Having it in Python will help abort moves or contrain motors easily. 

## How Has This Been Tested?
Tested in pcdsdevices test suite (run_tests.py) with a test that checks .SPG puts in test_epics_motor.py

## Where Has This Been Documented?
I think Sphinx does this, right?
