### PR TITLE
MNT: Update tests for ophyd 1.2.0, fix minor bugs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,8 +17,9 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
-    - ophyd >=1.1.0
+    - ophyd >=1.2.0
     - bluesky >=1.2.0
+    - pyepics
     - pyyaml
 
 test:

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,4 +1,12 @@
 from ._version import get_versions
 
+# Hacky ophyd hotfix
+from ophyd.device import Device
+def __contains__(self, value):
+    return value in self._OphydAttrList__internal_list()
+Device.OphydAttrList.__contains__ = __contains__
+del Device
+del __contains__
+
 __version__ = get_versions()['version']
 del get_versions

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,7 +1,4 @@
-from ophyd import setup_ophyd
 from ._version import get_versions
 
-setup_ophyd()
-del setup_ophyd
 __version__ = get_versions()['version']
 del get_versions

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -2,8 +2,12 @@ from ._version import get_versions
 
 # Hacky ophyd hotfix
 from ophyd.device import Device
+
+
 def __contains__(self, value):
     return value in self._OphydAttrList__internal_list()
+
+
 Device.OphydAttrList.__contains__ = __contains__
 del Device
 del __contains__

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -27,7 +27,7 @@ class BeamStats(Device):
 class SxrGmd(Device):
     mj = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse')
 
-    def __init__(self, prefix='', name='SxrGmd', **kwargs):
+    def __init__(self, prefix='', name='sxr_gmd', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)
 
     @property

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -162,9 +162,9 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def stop(self):
         """
-        Stops the motor.  
-        
-        After which the motor 
+        Stops the motor.
+
+        After which the motor
         must be set back to 'go' via <motor>.go()
         in order to move again.
         """
@@ -172,8 +172,8 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
 
     def pause(self):
         """
-        Pauses a move.  
-        
+        Pauses a move.
+
         Move will resume if <motor>.resume()
         or <motor>.go() are called.
         """

--- a/pcdsdevices/mps.py
+++ b/pcdsdevices/mps.py
@@ -103,7 +103,7 @@ class MPS(MPSBase, Device):
     bypass = C(EpicsSignal,   '_BYPS')
 
     # Default read and configuration attributes
-    _default_read_attrs = ['read']
+    _default_read_attrs = ['fault']
     _default_configuration_attrs = ['bypass']
 
     @property
@@ -260,5 +260,5 @@ class MPSLimits(MPSBase, Device):
     def _sub_to_children(self):
         self.in_limit.subscribe(self._fault_change,
                                 event_type=self.in_limit.SUB_FAULT_CH)
-        self.in_limit.subscribe(self._fault_change,
-                                event_type=self.out_limit.SUB_FAULT_CH)
+        self.out_limit.subscribe(self._fault_change,
+                                 event_type=self.out_limit.SUB_FAULT_CH)

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -103,7 +103,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         """
         # Start the sequencer
         logger.debug("Starting EventSequencer ...")
-        self.play_control.set(1)
+        self.play_control.put(1)
 
     def pause(self):
         """Stop the event sequencer and stop monitoring events"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import time
 import inspect
 
-from ophyd.sim import FakeEpicsSignal
+from ophyd.areadetector.base import EpicsSignalWithRBV
+from ophyd.sim import FakeEpicsSignal, fake_device_cache
 
 
 class HotfixFakeEpicsSignal(FakeEpicsSignal):
@@ -10,8 +11,8 @@ class HotfixFakeEpicsSignal(FakeEpicsSignal):
     """
     def __init__(self, read_pv, write_pv=None, *, string=False, **kwargs):
         self.as_string = string
-        super().__init__(read_pv, write_pv=write_pv, string=string, **kwargs)
         self._enum_strs = None
+        super().__init__(read_pv, write_pv=write_pv, string=string, **kwargs)
         self._limits = None
 
     def get(self, *, as_string=None, connection_timeout=1.0, **kwargs):
@@ -66,6 +67,9 @@ class HotfixFakeEpicsSignal(FakeEpicsSignal):
         super().check_value(value)
         if value is None:
             raise ValueError('Cannot write None to epics PVs')
+
+
+fake_device_cache[EpicsSignalWithRBV] = HotfixFakeEpicsSignal
 
 
 def get_classes_in_module(module, subcls=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,71 @@
 import time
 import inspect
 
+from ophyd.sim import FakeEpicsSignal
+
+
+class HotfixFakeEpicsSignal(FakeEpicsSignal):
+    """
+    Extensions of FakeEpicsPV for ophyd=1.2.0 that should be submitted as a PR
+    """
+    def __init__(self, read_pv, write_pv=None, *, string=False, **kwargs):
+        self.as_string = string
+        super().__init__(read_pv, write_pv=write_pv, string=string, **kwargs)
+        self._enum_strs = None
+
+    def get(self, *, as_string=None, connection_timeout=1.0, **kwargs):
+        """
+        Implement getting as enum strings
+        """
+        if as_string is None:
+            as_string = self.as_string
+
+        value = super().get()
+
+        if as_string:
+            if self.enum_strs is not None and isinstance(value, int):
+                return self.enum_strs[value]
+            elif value is not None:
+                return str(value)
+        return value
+
+    def put(self, value, *args, **kwargs):
+        """
+        Implement putting as enum strings
+        """
+        if self.enum_strs is not None and value in self.enum_strs:
+            value = self.enum_strs.index(value)
+        super().put(value, *args, **kwargs)
+
+    @property
+    def enum_strs(self):
+        """
+        Simulated enum strings.
+
+        Use sim_enum_strs during setup to set the enum strs.
+        """
+        return self._enum_strs
+
+    def sim_enum_strs(self, enums):
+        """
+        Set the enum_strs for a fake devices
+
+        Parameters
+        ----------
+        enums: list or tuple of str
+            The enums will be accessed by array index, e.g. the first item in
+            enums will be 0, the next will be 1, etc.
+        """
+        self._enum_strs = enums
+
+    def check_value(self, value):
+        """
+        Implement some of the checks from epicsSignal
+        """
+        super().check_value(value)
+        if value is None:
+            raise ValueError('Cannot write None to epics PVs')
+
 
 def get_classes_in_module(module, subcls=None):
     classes = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ class HotfixFakeEpicsSignal(FakeEpicsSignal):
         self.as_string = string
         super().__init__(read_pv, write_pv=write_pv, string=string, **kwargs)
         self._enum_strs = None
+        self._limits = None
 
     def get(self, *, as_string=None, connection_timeout=1.0, **kwargs):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,11 +41,11 @@ class HotfixFakeEpicsSignal(FakeEpicsSignal):
         """
         Simulated enum strings.
 
-        Use sim_enum_strs during setup to set the enum strs.
+        Use sim_set_enum_strs during setup to set the enum strs.
         """
         return self._enum_strs
 
-    def sim_enum_strs(self, enums):
+    def sim_set_enum_strs(self, enums):
         """
         Set the enum_strs for a fake devices
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-import time
-import inspect
-
 from ophyd.areadetector.base import EpicsSignalWithRBV
 from ophyd.sim import FakeEpicsSignal, fake_device_cache
 
@@ -70,60 +67,3 @@ class HotfixFakeEpicsSignal(FakeEpicsSignal):
 
 
 fake_device_cache[EpicsSignalWithRBV] = HotfixFakeEpicsSignal
-
-
-def get_classes_in_module(module, subcls=None):
-    classes = []
-    all_classes = inspect.getmembers(module)
-    for _, cls in all_classes:
-        try:
-            if cls.__module__ == module.__name__:
-                if subcls is not None:
-                    try:
-                        if not issubclass(cls, subcls):
-                            continue
-                    except TypeError:
-                        continue
-                classes.append(cls)
-        except AttributeError:
-            pass
-    return classes
-
-
-def connect_rw_pvs(epics_signal):
-    """
-    Modify an epics signal using fake epics pvs such that writing to the
-    write_pv changes the read_pv
-    """
-    def make_put(original_put, read_pv):
-        def put(*args, **kwargs):
-            original_put(*args, **kwargs)
-            read_pv.put(*args, **kwargs)
-        return put
-    write_pv = epics_signal._write_pv
-    read_pv = epics_signal._read_pv
-    write_pv.put = make_put(write_pv.put, read_pv)
-
-
-def func_wait_true(func, timeout=1, step=0.1):
-    """
-    For things that don't happen immediately but don't have a good way to wait
-    for them. Does a simple timeout loop, returning after timeout or when
-    func() is True.
-    """
-    while not func() and timeout > 0:
-        timeout -= step
-        time.sleep(step)
-
-
-def attr_wait_true(obj, attr, timeout=1, step=0.1):
-    func_wait_true(lambda: getattr(obj, attr), timeout=timeout, step=step)
-
-
-def attr_wait_false(obj, attr, timeout=1, step=0.1):
-    func_wait_true(lambda: not getattr(obj, attr), timeout=timeout, step=step)
-
-
-def attr_wait_value(obj, attr, value, delta=0.01, timeout=1, step=0.1):
-    func_wait_true(lambda: abs(getattr(obj, attr) - value) < delta,
-                   timeout=timeout, step=step)

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -21,6 +21,7 @@ for name, cls in _att3_classes.items():
     _att3_classes[name] = make_fake_device(cls)
 
 
+@pytest.fixture(scope='function')
 def fake_att():
     att = Attenuator('TST:ATT', MAX_FILTERS-1, name='test_att')
     att.readback.sim_put(1)
@@ -32,9 +33,9 @@ def fake_att():
 
 
 @pytest.mark.timeout(5)
-def test_attenuator_states():
+def test_attenuator_states(fake_att):
     logger.debug('test_attenuator_states')
-    att = fake_att()
+    att = fake_att
     # Set no transmission
     att.readback.sim_put(0)
     assert not att.removed
@@ -63,9 +64,9 @@ def fake_move_transition(att, status, goal):
 
 
 @pytest.mark.timeout(5)
-def test_attenuator_motion():
+def test_attenuator_motion(fake_att):
     logger.debug('test_attenuator_motion')
-    att = fake_att()
+    att = fake_att
     # Set up the ceil and floor
     att.trans_ceil.sim_put(0.8001)
     att.trans_floor.sim_put(0.5001)
@@ -90,9 +91,9 @@ def test_attenuator_motion():
 
 
 @pytest.mark.timeout(5)
-def test_attenuator_subscriptions():
+def test_attenuator_subscriptions(fake_att):
     logger.debug('test_attenuator_subscriptions')
-    att = fake_att()
+    att = fake_att
     cb = Mock()
     att.subscribe(cb, run=False)
     att.readback.sim_put(0.5)
@@ -100,9 +101,9 @@ def test_attenuator_subscriptions():
 
 
 @pytest.mark.timeout(5)
-def test_attenuator_calcpend():
+def test_attenuator_calcpend(fake_att):
     logger.debug('test_attenuator_calcpend')
-    att = fake_att()
+    att = fake_att
     att.calcpend.sim_put(1)
     # Initialize to any value
     att.setpoint.sim_put(1)
@@ -126,9 +127,9 @@ def test_attenuator_calcpend():
 
 
 @pytest.mark.timeout(5)
-def test_attenuator_set_energy():
+def test_attenuator_set_energy(fake_att):
     logger.debug('test_attenuator_set_energy')
-    att = fake_att()
+    att = fake_att
     att.set_energy()
     assert att.eget_cmd.get() == 6
     energy = 1000
@@ -137,16 +138,16 @@ def test_attenuator_set_energy():
     assert att.user_energy.get() == energy
 
 
-def test_attenuator_transmission():
+def test_attenuator_transmission(fake_att):
     logger.debug('test_attenuator_transmission')
-    att = fake_att()
+    att = fake_att
     assert att.transmission == att.position
 
 
 @pytest.mark.timeout(5)
-def test_attenuator_staging():
+def test_attenuator_staging(fake_att):
     logger.debug('test_attenuator_staging')
-    att = fake_att()
+    att = fake_att
     # Set up at least one invalid state
     att.filter1.state.sim_put(att.filter1._unknown)
     att.stage()

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -4,48 +4,43 @@ import threading
 import pytest
 
 from unittest.mock import Mock
+from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
 
-from pcdsdevices.sim.pv import using_fake_epics_pv
-from pcdsdevices.attenuator import Attenuator, MAX_FILTERS
-
-from .conftest import attr_wait_true, attr_wait_value, connect_rw_pvs
+from pcdsdevices.attenuator import (Attenuator, MAX_FILTERS,
+                                    _att_classes, _att3_classes)
 
 logger = logging.getLogger(__name__)
 
 
+# Replace all the Attenuator classes with fake classes
+for name, cls in _att_classes.items():
+    _att_classes[name] = make_fake_device(cls)
+
+for name, cls in _att3_classes.items():
+    _att3_classes[name] = make_fake_device(cls)
+
+
 def fake_att():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
     att = Attenuator('TST:ATT', MAX_FILTERS-1, name='test_att')
-    att.wait_for_connection()
-    att.readback._read_pv.put(1)
-    att.done._read_pv.put(0)
-    att.calcpend._read_pv.put(0)
+    att.readback.sim_put(1)
+    att.done.sim_put(0)
+    att.calcpend.sim_put(0)
     for filt in att.filters:
-        connect_rw_pvs(filt.state)
         filt.state.put('OUT')
-    attr_wait_value(att.readback, 'value', 1)
-    attr_wait_value(att.done, 'value', 0)
-    attr_wait_value(att.calcpend, 'value', 0)
     return att
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_attenuator_states():
     logger.debug('test_attenuator_states')
     att = fake_att()
     # Set no transmission
-    att.readback._read_pv.put(0)
-    attr_wait_value(att, 'position', 0)
+    att.readback.sim_put(0)
     assert not att.removed
     assert att.inserted
     # Set full transmission
-    att.readback._read_pv.put(1)
-    attr_wait_value(att, 'position', 1)
+    att.readback.sim_put(1)
     assert att.removed
     assert not att.inserted
 
@@ -56,12 +51,11 @@ def fake_move_transition(att, status, goal):
     status
     """
     # Set status to "MOVING"
-    att.done._read_pv.put(1)
-    attr_wait_true(att, '_moving')  # This transition is important
+    att.done.sim_put(1)
     # Set transmission to the goal
-    att.readback._read_pv.put(goal)
+    att.readback.sim_put(goal)
     # Set status to "OK"
-    att.done._read_pv.put(0)
+    att.done.sim_put(0)
     # Check that the object responded properly
     status_wait(status, timeout=1)
     assert status.done
@@ -69,13 +63,12 @@ def fake_move_transition(att, status, goal):
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_attenuator_motion():
     logger.debug('test_attenuator_motion')
     att = fake_att()
     # Set up the ceil and floor
-    att.trans_ceil._read_pv.put(0.8001)
-    att.trans_floor._read_pv.put(0.5001)
+    att.trans_ceil.sim_put(0.8001)
+    att.trans_floor.sim_put(0.5001)
     # Move to ceil
     status = att.move(0.8, wait=False)
     fake_move_transition(att, status, 0.8001)
@@ -97,34 +90,35 @@ def test_attenuator_motion():
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_attenuator_subscriptions():
     logger.debug('test_attenuator_subscriptions')
     att = fake_att()
     cb = Mock()
     att.subscribe(cb, run=False)
-    att.readback._read_pv.put(0.5)
-    attr_wait_true(cb, 'called')
+    att.readback.sim_put(0.5)
     assert cb.called
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_attenuator_calcpend():
     logger.debug('test_attenuator_calcpend')
     att = fake_att()
-    att.calcpend._read_pv.put(1)
+    att.calcpend.sim_put(1)
+    # Initialize to any value
+    att.setpoint.sim_put(1)
+    att.trans_ceil.sim_put(1)
+    att.trans_floor.sim_put(1)
 
     def wait_put(sig, val, delay):
         time.sleep(delay)
-        sig._read_pv.put(val)
+        sig.sim_put(val)
     t = threading.Thread(target=wait_put, args=(att.calcpend, 0, 0.4))
     t.start()
     start = time.time()
     # Waits for calcpend to be 0
     att.actuate_value
     assert 0.1 < time.time() - start < 1
-    att.calcpend._read_pv.put(1)
+    att.calcpend.sim_put(1)
     # Gives up after one second
     start = time.time()
     att.actuate_value
@@ -132,19 +126,17 @@ def test_attenuator_calcpend():
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_attenuator_set_energy():
     logger.debug('test_attenuator_set_energy')
     att = fake_att()
     att.set_energy()
-    assert att.eget_cmd._write_pv.get() == 6
+    assert att.eget_cmd.get() == 6
     energy = 1000
     att.set_energy(energy)
-    assert att.eget_cmd._write_pv.get() == 0
+    assert att.eget_cmd.get() == 0
     assert att.user_energy.get() == energy
 
 
-@using_fake_epics_pv
 def test_attenuator_transmission():
     logger.debug('test_attenuator_transmission')
     att = fake_att()
@@ -152,12 +144,11 @@ def test_attenuator_transmission():
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_attenuator_staging():
     logger.debug('test_attenuator_staging')
     att = fake_att()
     # Set up at least one invalid state
-    att.filter1.state._read_pv.put(att.filter1._unknown)
+    att.filter1.state.sim_put(att.filter1._unknown)
     att.stage()
     for filt in att.filters:
         filt.insert(wait=True)
@@ -166,7 +157,6 @@ def test_attenuator_staging():
         assert filt.removed
 
 
-@using_fake_epics_pv
 def test_attenuator_third_harmonic():
     logger.debug('test_attenuator_third_harmonic')
     att = Attenuator('TRD:ATT', MAX_FILTERS-1, name='third', use_3rd=True)

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytest
 from ophyd.sim import make_fake_device
 
 from pcdsdevices.beam_stats import BeamStats
@@ -7,17 +8,24 @@ from pcdsdevices.beam_stats import BeamStats
 logger = logging.getLogger(__name__)
 
 
-def test_beam_stats():
+@pytest.fixture(scope='function')
+def fake_beam_stats():
+    FakeStats = make_fake_device(BeamStats)
+    stats = FakeStats()
+    stats.mj.sim_put(-1)
+    return stats
+
+
+def test_beam_stats(fake_beam_stats):
     logger.debug('test_beam_stats')
-    stats = make_fake_device(BeamStats)()
+    stats = fake_beam_stats
     stats.read()
     stats.hints
 
 
-def test_beam_stats_avg():
+def test_beam_stats_avg(fake_beam_stats):
     logger.debug('test_beam_stats_avg')
-    stats = make_fake_device(BeamStats)()
-    stats.mj.sim_put(-1)
+    stats = fake_beam_stats
 
     assert stats.mj_buffersize.value == 120
 

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -1,37 +1,32 @@
 import logging
 
+from ophyd.sim import make_fake_device
+
 from pcdsdevices.beam_stats import BeamStats
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
 logger = logging.getLogger(__name__)
 
 
-@using_fake_epics_pv
 def test_beam_stats():
     logger.debug('test_beam_stats')
-    stats = BeamStats()
-    stats.wait_for_connection()
+    stats = make_fake_device(BeamStats)()
     stats.read()
     stats.hints
 
 
-@using_fake_epics_pv
 def test_beam_stats_avg():
     logger.debug('test_beam_stats_avg')
-    stats = BeamStats()
-    stats.mj._read_pv.put(-1)
-    stats.wait_for_connection()
+    stats = make_fake_device(BeamStats)()
+    stats.mj.sim_put(-1)
 
     assert stats.mj_buffersize.value == 120
 
     stats.mj_buffersize.put(10)
 
-    with stats.mj._read_pv._lock:
-        for i in range(10):
-            stats.mj._read_pv._value = i
-            stats.mj._read_pv.run_callbacks()
+    for i in range(10):
+        stats.mj.sim_put(i)
 
-        assert stats.mj_avg.value == sum(range(10))/10
+    assert stats.mj_avg.value == sum(range(10))/10
 
     stats.configure(dict(mj_buffersize=20))
     cfg = stats.read_configuration()

--- a/tests/test_device_types.py
+++ b/tests/test_device_types.py
@@ -1,4 +1,2 @@
-
-
 def test_device_types_import():
     from pcdsdevices import device_types

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -17,7 +17,7 @@ def fake_inout():
     Fake.state.cls = HotfixFakeEpicsSignal
     inout = Fake('Test:Ref', name='test')
     inout.state.sim_put(0)
-    inout.state.sim_enum_strs(('Unknown', 'IN', 'OUT'))
+    inout.state.sim_set_enum_strs(('Unknown', 'IN', 'OUT'))
     return inout
 
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,27 +1,29 @@
 import logging
 from unittest.mock import Mock
 
-from pcdsdevices.sim.pv import using_fake_epics_pv
+import pytest
+from ophyd.sim import make_fake_device
+
 from pcdsdevices.inout import InOutRecordPositioner
 
-from .conftest import attr_wait_true, connect_rw_pvs
+from .conftest import HotfixFakeEpicsSignal
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_inout():
-    inout = InOutRecordPositioner('Test:Ref', name='test')
-    connect_rw_pvs(inout.state)
-    inout.state._write_pv.put('Unknown')
-    inout.state._read_pv.enum_strs = ('Unknown', 'IN', 'OUT')
-    inout.wait_for_connection()
+    Fake = make_fake_device(InOutRecordPositioner)
+    Fake.state.cls = HotfixFakeEpicsSignal
+    inout = Fake('Test:Ref', name='test')
+    inout.state.sim_put(0)
+    inout.state.sim_enum_strs(('Unknown', 'IN', 'OUT'))
     return inout
 
 
-@using_fake_epics_pv
-def test_inout_states():
+def test_inout_states(fake_inout):
     logger.debug('test_inout_states')
-    inout = fake_inout()
+    inout = fake_inout
     inout.state.put('IN')
     assert inout.inserted
     assert not inout.removed
@@ -30,20 +32,18 @@ def test_inout_states():
     assert inout.removed
 
 
-@using_fake_epics_pv
-def test_inout_trans():
+def test_inout_trans(fake_inout):
     logger.debug('test_inout_trans')
-    inout = fake_inout()
+    inout = fake_inout
     inout.state.put('IN')
     assert inout.transmission == 0
     inout.state.put('OUT')
     assert inout.transmission == 1
 
 
-@using_fake_epics_pv
-def test_inout_motion():
+def test_inout_motion(fake_inout):
     logger.debug('test_inout_motion')
-    inout = fake_inout()
+    inout = fake_inout
     inout.remove()
     assert inout.position == 'OUT'
     # Remove twice for branch coverage
@@ -53,14 +53,12 @@ def test_inout_motion():
     assert inout.position == 'IN'
 
 
-@using_fake_epics_pv
-def test_inout_subscriptions():
+def test_inout_subscriptions(fake_inout):
     logger.debug('test_inout_subscriptions')
-    inout = fake_inout()
+    inout = fake_inout
     # Subscribe a pseudo callback
     cb = Mock()
     inout.subscribe(cb, event_type=inout.SUB_STATE, run=False)
     # Change the target state
     inout.state.put('OUT')
-    attr_wait_true(cb, 'called')
     assert cb.called

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -1,71 +1,65 @@
 import logging
 
+import pytest
+from ophyd.sim import make_fake_device
 from unittest.mock import Mock
 
 from pcdsdevices.inout import InOutRecordPositioner
 from pcdsdevices.ipm import IPM
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
-from .conftest import connect_rw_pvs, attr_wait_true
+from .conftest import HotfixFakeEpicsSignal
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_ipm():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    ipm = IPM("Test:My:IPM", name='test_ipm')
-    connect_rw_pvs(ipm.diode.state)
-    connect_rw_pvs(ipm.state)
-    ipm.diode.state._write_pv.put('Unknown')
-    ipm.diode.state._read_pv.enum_strs = (['Unknown'] +
-                                          InOutRecordPositioner.states_list)
-    ipm.state._write_pv.put('Unknown')
-    ipm.state._read_pv.enum_strs = ['Unknown'] + IPM.states_list
-    ipm.wait_for_connection()
+    FakeIPM = make_fake_device(IPM)
+    FakeIPM.state.cls = HotfixFakeEpicsSignal
+    FakeIPM.diode.cls.state.cls = HotfixFakeEpicsSignal
+    ipm = FakeIPM("Test:My:IPM", name='test_ipm')
+    ipm.diode.state.sim_put(0)
+    ipm.diode.state.sim_enum_strs(['Unknown'] +
+                                  InOutRecordPositioner.states_list)
+    ipm.state.sim_put(0)
+    ipm.state.sim_enum_strs(['Unknown'] + IPM.states_list)
     return ipm
 
 
-@using_fake_epics_pv
-def test_ipm_states():
+def test_ipm_states(fake_ipm):
     logger.debug('test_ipm_states')
-    ipm = fake_ipm()
-    ipm.state._read_pv.put(5)
+    ipm = fake_ipm
+    ipm.state.put(5)
     assert ipm.removed
     assert not ipm.inserted
-    ipm.state._read_pv.put(1)
+    ipm.state.put(1)
     assert not ipm.removed
     assert ipm.inserted
 
 
-@using_fake_epics_pv
-def test_ipm_motion():
+def test_ipm_motion(fake_ipm):
     logger.debug('test_ipm_motion')
-    ipm = fake_ipm()
+    ipm = fake_ipm
     # Remove IPM Targets
     ipm.remove(wait=True, timeout=1.0)
-    assert ipm.state._write_pv.get() == 5
+    assert ipm.state.get() == 5
     # Insert IPM Targets
     ipm.set(1)
-    assert ipm.state._write_pv.get() == 1
+    assert ipm.state.get() == 1
     # Move diodes in
     ipm.diode.insert()
-    assert ipm.diode.state._write_pv.get() == 1
+    assert ipm.diode.state.get() == 1
     ipm.diode.remove()
     # Move diodes out
-    assert ipm.diode.state._write_pv.get() == 2
+    assert ipm.diode.state.get() == 2
 
 
-@using_fake_epics_pv
-def test_ipm_subscriptions():
+def test_ipm_subscriptions(fake_ipm):
     logger.debug('test_ipm_subscriptions')
-    ipm = fake_ipm()
+    ipm = fake_ipm
     # Subscribe a pseudo callback
     cb = Mock()
     ipm.subscribe(cb, event_type=ipm.SUB_STATE, run=False)
     # Change the target state
-    ipm.state._read_pv.put(2)
-    attr_wait_true(cb, 'called')
+    ipm.state.put(2)
     assert cb.called

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -19,10 +19,10 @@ def fake_ipm():
     FakeIPM.diode.cls.state.cls = HotfixFakeEpicsSignal
     ipm = FakeIPM("Test:My:IPM", name='test_ipm')
     ipm.diode.state.sim_put(0)
-    ipm.diode.state.sim_enum_strs(['Unknown'] +
-                                  InOutRecordPositioner.states_list)
+    ipm.diode.state.sim_set_enum_strs(['Unknown'] +
+                                      InOutRecordPositioner.states_list)
     ipm.state.sim_put(0)
-    ipm.state.sim_enum_strs(['Unknown'] + IPM.states_list)
+    ipm.state.sim_set_enum_strs(['Unknown'] + IPM.states_list)
     return ipm
 
 

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -1,56 +1,55 @@
+import logging
 from unittest.mock import Mock
 
-from pcdsdevices.sim.pv import using_fake_epics_pv
+import pytest
+from ophyd.sim import make_fake_device
+
 from pcdsdevices.lens import XFLS
 
-from .conftest import attr_wait_true, connect_rw_pvs
+from .conftest import HotfixFakeEpicsSignal
+
+logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_xfls():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    xfls = XFLS('TST:XFLS', name='lens')
-    connect_rw_pvs(xfls.state)
-    xfls.state.put(4)
-    xfls.state._read_pv.enum_strs = ('Unknown', 'LENS1', 'LENS2', 'LENS3',
-                                     'OUT')
-    xfls.wait_for_connection()
+    FakeXFLS = make_fake_device(XFLS)
+    FakeXFLS.state.cls = HotfixFakeEpicsSignal
+    xfls = FakeXFLS('TST:XFLS', name='lens')
+    xfls.state.sim_put(4)
+    xfls.state.sim_enum_strs(('Unknown', 'LENS1', 'LENS2', 'LENS3', 'OUT'))
     return xfls
 
 
-@using_fake_epics_pv
-def test_xfls_states():
-    xfls = fake_xfls()
+def test_xfls_states(fake_xfls):
+    logger.debug('test_xfls_states')
+    xfls = fake_xfls
     # Remove
-    xfls.state._read_pv.put(4)
+    xfls.state.put(4)
     assert xfls.removed
     assert not xfls.inserted
     # Insert
-    xfls.state._read_pv.put(3)
+    xfls.state.put(3)
     assert not xfls.removed
     assert xfls.inserted
     # Unknown
-    xfls.state._read_pv.put(0)
+    xfls.state.put(0)
     assert not xfls.removed
     assert not xfls.inserted
 
 
-@using_fake_epics_pv
-def test_xfls_motion():
-    xfls = fake_xfls()
+def test_xfls_motion(fake_xfls):
+    logger.debug('test_xfls_motion')
+    xfls = fake_xfls
     xfls.remove()
-    assert xfls.state._write_pv.get() == 4
+    assert xfls.state.get() == 4
 
 
-@using_fake_epics_pv
-def test_xfls_subscriptions():
-    xfls = fake_xfls()
+def test_xfls_subscriptions(fake_xfls):
+    xfls = fake_xfls
     # Subscribe a pseudo callback
     cb = Mock()
     xfls.subscribe(cb, event_type=xfls.SUB_STATE, run=False)
     # Change readback state
-    xfls.state._read_pv.put(4)
-    attr_wait_true(cb, 'called')
+    xfls.state.put(4)
     assert cb.called

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -17,7 +17,7 @@ def fake_xfls():
     FakeXFLS.state.cls = HotfixFakeEpicsSignal
     xfls = FakeXFLS('TST:XFLS', name='lens')
     xfls.state.sim_put(4)
-    xfls.state.sim_enum_strs(('Unknown', 'LENS1', 'LENS2', 'LENS3', 'OUT'))
+    xfls.state.sim_set_enum_strs(('Unknown', 'LENS1', 'LENS2', 'LENS3', 'OUT'))
     return xfls
 
 

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -21,15 +21,15 @@ def fake_lodcm():
     FakeLODCM.foil.cls.state.cls = HotfixFakeEpicsSignal
     lodcm = FakeLODCM('FAKE:LOM', name='fake_lom')
     lodcm.state.sim_put(1)
-    lodcm.state.sim_enum_strs(['Unknown'] + LODCM.states_list)
+    lodcm.state.sim_set_enum_strs(['Unknown'] + LODCM.states_list)
     lodcm.yag.state.sim_put(1)
-    lodcm.yag.state.sim_enum_strs(['Unknown'] + YagLom.states_list)
+    lodcm.yag.state.sim_set_enum_strs(['Unknown'] + YagLom.states_list)
     lodcm.dectris.state.sim_put(1)
-    lodcm.dectris.state.sim_enum_strs(['Unknown'] + Dectris.states_list)
+    lodcm.dectris.state.sim_set_enum_strs(['Unknown'] + Dectris.states_list)
     lodcm.diode.state.sim_put(1)
-    lodcm.diode.state.sim_enum_strs(['Unknown'] + Diode.states_list)
+    lodcm.diode.state.sim_set_enum_strs(['Unknown'] + Diode.states_list)
     lodcm.foil.state.sim_put(1)
-    lodcm.foil.state.sim_enum_strs(['Unknown'] + Foil.states_list)
+    lodcm.foil.state.sim_set_enum_strs(['Unknown'] + Foil.states_list)
     return lodcm
 
 

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -1,44 +1,41 @@
 import logging
 
+import pytest
+from ophyd.sim import make_fake_device
 from unittest.mock import Mock
 
 from pcdsdevices.lodcm import LODCM, YagLom, Dectris, Diode, Foil
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
-from .conftest import attr_wait_true, connect_rw_pvs
+from .conftest import HotfixFakeEpicsSignal
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_lodcm():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    lodcm = LODCM('FAKE:LOM', name='fake_lom')
-    connect_rw_pvs(lodcm.state)
-    connect_rw_pvs(lodcm.yag.state)
-    connect_rw_pvs(lodcm.dectris.state)
-    connect_rw_pvs(lodcm.diode.state)
-    connect_rw_pvs(lodcm.foil.state)
-    lodcm.state.put(1)
-    lodcm.state._read_pv.enum_strs = ['Unknown'] + LODCM.states_list
-    lodcm.yag.state.put(1)
-    lodcm.yag.state._read_pv.enum_strs = ['Unknown'] + YagLom.states_list
-    lodcm.dectris.state.put(1)
-    lodcm.dectris.state._read_pv.enum_strs = ['Unknown'] + Dectris.states_list
-    lodcm.diode.state.put(1)
-    lodcm.diode.state._read_pv.enum_strs = ['Unknown'] + Diode.states_list
-    lodcm.foil.state.put(1)
-    lodcm.foil.state._read_pv.enum_strs = ['Unknown'] + Foil.states_list
-    lodcm.wait_for_connection()
+    FakeLODCM = make_fake_device(LODCM)
+    FakeLODCM.state.cls = HotfixFakeEpicsSignal
+    FakeLODCM.yag.cls.state.cls = HotfixFakeEpicsSignal
+    FakeLODCM.dectris.cls.state.cls = HotfixFakeEpicsSignal
+    FakeLODCM.diode.cls.state.cls = HotfixFakeEpicsSignal
+    FakeLODCM.foil.cls.state.cls = HotfixFakeEpicsSignal
+    lodcm = FakeLODCM('FAKE:LOM', name='fake_lom')
+    lodcm.state.sim_put(1)
+    lodcm.state.sim_enum_strs(['Unknown'] + LODCM.states_list)
+    lodcm.yag.state.sim_put(1)
+    lodcm.yag.state.sim_enum_strs(['Unknown'] + YagLom.states_list)
+    lodcm.dectris.state.sim_put(1)
+    lodcm.dectris.state.sim_enum_strs(['Unknown'] + Dectris.states_list)
+    lodcm.diode.state.sim_put(1)
+    lodcm.diode.state.sim_enum_strs(['Unknown'] + Diode.states_list)
+    lodcm.foil.state.sim_put(1)
+    lodcm.foil.state.sim_enum_strs(['Unknown'] + Foil.states_list)
     return lodcm
 
 
-@using_fake_epics_pv
-def test_lodcm_destination():
+def test_lodcm_destination(fake_lodcm):
     logger.debug('test_lodcm_destination')
-    lodcm = fake_lodcm()
+    lodcm = fake_lodcm
     dest = lodcm.destination
     assert isinstance(dest, list)
     for d in dest:
@@ -57,27 +54,24 @@ def test_lodcm_destination():
     assert len(lodcm.destination) == 1
 
     # Unknown state
-    lodcm.state._read_pv.put('Unknown')
+    lodcm.state.sim_put('Unknown')
     assert len(lodcm.destination) == 0
 
 
-@using_fake_epics_pv
-def test_lodcm_branches():
+def test_lodcm_branches(fake_lodcm):
     logger.debug('test_lodcm_branches')
-    lodcm = fake_lodcm()
+    lodcm = fake_lodcm
     branches = lodcm.branches
     assert isinstance(branches, list)
     for b in branches:
         assert isinstance(b, str)
 
 
-@using_fake_epics_pv
-def test_lodcm_remove_dia():
+def test_lodcm_remove_dia(fake_lodcm):
     logger.debug('test_lodcm_remove_dia')
-    lodcm = fake_lodcm()
+    lodcm = fake_lodcm
     lodcm.yag.insert(wait=True)
     cb = Mock()
     lodcm.remove_dia(moved_cb=cb, wait=True)
-    attr_wait_true(cb, 'called')
     assert cb.called
     assert lodcm.yag.position == 'OUT'

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -3,53 +3,54 @@ from unittest.mock import Mock
 import math
 import pytest
 
+from ophyd.sim import make_fake_device
 from pcdsdevices.mirror import OffsetMirror, PointingMirror
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
-from .conftest import attr_wait_true, connect_rw_pvs
+from .conftest import HotfixFakeEpicsSignal
 
 
+@pytest.fixture(scope='function')
 def fake_branching_mirror():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    m = PointingMirror("TST:M1H", prefix_xy="STEP:TST:M1H",
-                       xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
-                       in_lines=['MFX', 'MEC'], out_lines=['CXI'])
-    connect_rw_pvs(m.state)
-    m.state._write_pv.put('Unknown')
-    m.state._read_pv.enum_strs = ['Unknown'] + PointingMirror.states_list
-    m.wait_for_connection()
+    FakeMirror = make_fake_device(PointingMirror)
+    FakeMirror.state.cls = HotfixFakeEpicsSignal
+    FakeMirror.xgantry.cls.setpoint.cls = HotfixFakeEpicsSignal
+    m = FakeMirror("TST:M1H", prefix_xy="STEP:TST:M1H",
+                   xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
+                   in_lines=['MFX', 'MEC'], out_lines=['CXI'])
+    m.state.sim_put(0)
+    m.state.sim_enum_strs(['Unknown'] + PointingMirror.states_list)
     # Couple the gantry
-    m.xgantry.decoupled._read_pv.put(0)
+    m.xgantry.decoupled.sim_put(0)
     # Make the pitch look reasonable
-    m.pitch.motor_egu._read_pv.put('urad')
+    m.pitch.motor_egu.sim_put('urad')
+    # Limits are enabled, pick something for the test
+    m.xgantry.setpoint.sim_set_limits((-100, 100))
     return m
 
 
-@using_fake_epics_pv
-def test_nan_protection():
-    branching_mirror = fake_branching_mirror()
+@pytest.fixture(scope='function')
+def fake_offset_mirror():
+    FakeOffset = make_fake_device(OffsetMirror)
+    return FakeOffset('TST:M1H', name="Test Mirror")
+
+
+def test_nan_protection(fake_branching_mirror):
     with pytest.raises(ValueError):
-        branching_mirror.pitch.check_value(math.nan)
+        fake_branching_mirror.pitch.check_value(math.nan)
 
 
-@using_fake_epics_pv
-def test_ommotor_positioner_egu():
-    branching_mirror = fake_branching_mirror()
-    assert branching_mirror.pitch.egu == 'urad'
+def test_ommotor_positioner_egu(fake_branching_mirror):
+    assert fake_branching_mirror.pitch.egu == 'urad'
 
 
-@using_fake_epics_pv
-def test_mirror_init():
-    bm = fake_branching_mirror()
+def test_mirror_init(fake_branching_mirror, fake_offset_mirror):
+    bm = fake_branching_mirror
     assert bm.pitch.prefix == 'MIRR:TST:M1H'
     assert bm.xgantry.prefix == 'STEP:TST:M1H:X:P'
     assert bm.xgantry.gantry_prefix == 'GANTRY:M1H:X'
     assert bm.ygantry.prefix == 'STEP:TST:M1H:Y:P'
     assert bm.ygantry.gantry_prefix == 'GANTRY:TST:M1H:Y'
-    m = OffsetMirror('TST:M1H', name="Test Mirror")
+    m = fake_offset_mirror
     assert m.pitch.prefix == 'MIRR:TST:M1H'
     assert m.xgantry.prefix == 'TST:M1H:X:P'
     assert m.xgantry.gantry_prefix == 'GANTRY:TST:M1H:X'
@@ -57,40 +58,37 @@ def test_mirror_init():
     assert m.ygantry.gantry_prefix == 'GANTRY:TST:M1H:Y'
 
 
-@using_fake_epics_pv
-def test_offsetmirror_lighpath():
-    m = OffsetMirror('XRT:M2H', name='XRT M2H')
+def test_offsetmirror_lighpath(fake_offset_mirror):
+    m = fake_offset_mirror
     assert m.inserted
     assert not m.removed
 
 
-@using_fake_epics_pv
-def test_branching_mirror_destination():
-    branching_mirror = fake_branching_mirror()
+def test_branching_mirror_destination(fake_branching_mirror):
+    branching_mirror = fake_branching_mirror
     assert branching_mirror.branches == ['MFX', 'MEC', 'CXI']
     # Unknown
-    branching_mirror.state._read_pv.put(0)
+    branching_mirror.state.sim_put(0)
     assert branching_mirror.position == 'Unknown'
     assert not branching_mirror.removed
     assert not branching_mirror.inserted
     assert branching_mirror.destination == []
     # Inserted
-    branching_mirror.state._read_pv.put(2)
+    branching_mirror.state.sim_put(2)
     assert branching_mirror.inserted
     assert not branching_mirror.removed
     assert branching_mirror.destination == ['MFX', 'MEC']
     # Removed
-    branching_mirror.state._read_pv.put(1)
+    branching_mirror.state.sim_put(1)
     assert branching_mirror.removed
     assert not branching_mirror.inserted
     assert branching_mirror.destination == ['CXI']
 
 
-@using_fake_epics_pv
-def test_branching_mirror_moves():
-    branching_mirror = fake_branching_mirror()
+def test_branching_mirror_moves(fake_branching_mirror):
+    branching_mirror = fake_branching_mirror
     # With gantry decoupled, should raise PermissionError
-    branching_mirror.xgantry.decoupled._read_pv.put(1)
+    branching_mirror.xgantry.decoupled.sim_put(1)
     with pytest.raises(PermissionError):
         branching_mirror.xgantry.move(0.1, wait=False)
     with pytest.raises(PermissionError):
@@ -98,28 +96,26 @@ def test_branching_mirror_moves():
     with pytest.raises(PermissionError):
         branching_mirror.insert()
     # Recouple gantry
-    branching_mirror.xgantry.decoupled._read_pv.put(0)
+    branching_mirror.xgantry.decoupled.sim_put(0)
     # Test small move
     branching_mirror.xgantry.move(0.2, wait=False)
-    assert branching_mirror.xgantry.setpoint._write_pv.get() == 0.2
+    assert branching_mirror.xgantry.setpoint.get() == 0.2
     # Test removal
     branching_mirror.remove()
-    assert branching_mirror.state._write_pv.value == 1
+    assert branching_mirror.state.value == 1
     # Finish simulated move manually
-    branching_mirror.state._read_pv.put(2)
+    branching_mirror.state.sim_put(2)
     # Insert
     branching_mirror.insert()
-    assert branching_mirror.state._write_pv.value == 2
+    assert branching_mirror.state.value == 2
 
 
-@using_fake_epics_pv
-def test_epics_mirror_subscription():
-    branching_mirror = fake_branching_mirror()
+def test_epics_mirror_subscription(fake_branching_mirror):
+    branching_mirror = fake_branching_mirror
     # Subscribe a pseudo callback
     cb = Mock()
     branching_mirror.subscribe(cb, event_type=branching_mirror.SUB_STATE,
                                run=False)
     # Change the target state
-    branching_mirror.state._read_pv.put('IN')
-    attr_wait_true(cb, 'called')
+    branching_mirror.state.put('IN')
     assert cb.called

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -18,7 +18,7 @@ def fake_branching_mirror():
                    xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
                    in_lines=['MFX', 'MEC'], out_lines=['CXI'])
     m.state.sim_put(0)
-    m.state.sim_enum_strs(['Unknown'] + PointingMirror.states_list)
+    m.state.sim_set_enum_strs(['Unknown'] + PointingMirror.states_list)
     # Couple the gantry
     m.xgantry.decoupled.sim_put(0)
     # Make the pitch look reasonable

--- a/tests/test_movablestand.py
+++ b/tests/test_movablestand.py
@@ -1,22 +1,21 @@
 import logging
 
 import pytest
+from ophyd.sim import make_fake_device
 
 from pcdsdevices.movablestand import MovableStand
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_stand():
-    stand = MovableStand('STAND:NAME', name='stand')
-    stand.wait_for_connection()
+    FakeStand = make_fake_device(MovableStand)
+    stand = FakeStand('STAND:NAME', name='stand')
     return stand
 
 
-@using_fake_epics_pv
-def test_movablestand_sanity():
+def test_movablestand_sanity(fake_stand):
     logger.debug('test_movablestand_sanity')
-    stand = fake_stand()
     with pytest.raises(NotImplementedError):
-        stand.move('OUT')
+        fake_stand.move('OUT')

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -1,115 +1,110 @@
-############
-# Standard #
-############
-import time
 import logging
 from functools import partial
 
-###############
-# Third Party #
-###############
 import pytest
 from ophyd import Device
+from ophyd.sim import make_fake_device
 from unittest.mock import Mock
 
-##########
-# Module #
-##########
-from pcdsdevices.sim.pv import using_fake_epics_pv
-from pcdsdevices.mps import MPS, MPSLimits, mps_factory, must_be_out, must_be_known
+import pcdsdevices.mps as mps_module
+from pcdsdevices.mps import (MPS, MPSLimits, mps_factory,
+                             must_be_out, must_be_known)
 
-from .conftest import attr_wait_true
+logger = logging.getLogger(__name__)
 
+
+@pytest.fixture(scope='function')
 def fake_mps():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    mps = MPS("TST:MPS", name='MPS Bit')
-    mps.wait_for_connection()
+    FakeMPS = make_fake_device(MPS)
+    # Hotpatch module to make the mps_factory behave
+    mps_module.MPS = FakeMPS
+    mps = FakeMPS("TST:MPS", name='MPS Bit')
     return mps
 
+
+@pytest.fixture(scope='function')
 def fake_mps_limits():
-    mps = MPSLimits("Tst:Mps:Lim", logic=lambda x,y: x, name='MPS Limits')
-    mps.wait_for_connection()
+    FakeLimits = make_fake_device(MPSLimits)
+    mps = FakeLimits("Tst:Mps:Lim", logic=lambda x, y: x, name='MPS Limits')
     # Not bypassed or faulted
-    mps.in_limit.fault._read_pv.put(0)
-    mps.in_limit.bypass._read_pv.put(0)
-    mps.out_limit.fault._read_pv.put(0)
-    mps.out_limit.bypass._read_pv.put(0)
+    mps.in_limit.fault.sim_put(0)
+    mps.in_limit.bypass.sim_put(0)
+    mps.out_limit.fault.sim_put(0)
+    mps.out_limit.bypass.sim_put(0)
     return mps
+
 
 def test_must_be_out():
+    logger.debug('test_must_be_out')
     assert not must_be_out(True, True)
     assert not must_be_out(True, False)
     assert must_be_out(False, True)
     assert not must_be_out(False, False)
 
+
 def test_must_be_known():
+    logger.debug('test_must_be_known')
     assert not must_be_known(True, True)
     assert must_be_known(True, False)
     assert must_be_known(False, True)
     assert not must_be_known(False, False)
 
-@using_fake_epics_pv
-def test_mps_faults():
-    mps = fake_mps()
-    #Faulted
-    mps.fault._read_pv.put(1)
-    mps.bypass._read_pv.put(0)
+
+def test_mps_faults(fake_mps):
+    mps = fake_mps
+    # Faulted
+    mps.fault.sim_put(1)
+    mps.bypass.sim_put(0)
     assert mps.faulted
-    #Faulted but bypassed
-    mps.bypass._read_pv.put(1)
+    # Faulted but bypassed
+    mps.bypass.sim_put(1)
     assert mps.bypassed
     assert mps.faulted
     assert not mps.tripped
 
-@using_fake_epics_pv
-def test_mps_subscriptions():
-    mps = fake_mps()
-    #Subscribe a pseudo callback
+
+def test_mps_subscriptions(fake_mps):
+    mps = fake_mps
+    # Subscribe a pseudo callback
     cb = Mock()
     mps.subscribe(cb, run=False)
-    #Cause a fault
-    mps.fault._read_pv.put(1)
-    attr_wait_true(cb, 'called')
+    # Cause a fault
+    mps.fault.sim_put(1)
     assert cb.called
 
-@using_fake_epics_pv
-def test_mps_factory():
-    mps = fake_mps()
-    #Create a custom device
+
+def test_mps_factory(fake_mps):
+    # Create a custom device
     class MyDevice(Device):
         pass
-    #Create a constructor for the MPS version of that device
+    # Create a constructor for the MPS version of that device
     MPSDevice = partial(mps_factory, 'MPSDevice', MyDevice)
-    #Create an instanace of the MPSDevice
+    # Create an instanace of the MPSDevice
     d = MPSDevice('Tst:Prefix', name='Tst', mps_prefix='Tst:Mps:Prefix')
-    #Check we made an MPS subcomponent
+    # Check we made an MPS subcomponent
     assert hasattr(d, 'mps')
     assert isinstance(d.mps, MPS)
     assert d.mps.prefix == 'Tst:Mps:Prefix'
-    #Check our original device constructor still worked
+    # Check our original device constructor still worked
     assert d.name == 'Tst'
 
-@using_fake_epics_pv
-def test_mpslimit_faults():
-    mps = fake_mps_limits()
+
+def test_mpslimit_faults(fake_mps_limits):
+    mps = fake_mps_limits
     assert not mps.faulted
-    mps.in_limit.fault._read_pv.put(1)
+    mps.in_limit.fault.sim_put(1)
     assert mps.faulted
-    mps.in_limit.bypass._read_pv.put(1)
+    mps.in_limit.bypass.sim_put(1)
     assert mps.faulted
     assert mps.bypassed
     assert not mps.tripped
 
-@using_fake_epics_pv
-def test_mpslimit_subscriptions():
-    mps = fake_mps_limits()
-    #Subscribe a pseudo callback
+
+def test_mpslimit_subscriptions(fake_mps_limits):
+    mps = fake_mps_limits
+    # Subscribe a pseudo callback
     cb = Mock()
     mps.subscribe(cb, run=False)
-    #Cause a fault
-    mps.out_limit.fault._read_pv.put(1)
-    attr_wait_true(cb, 'called')
+    # Cause a fault
+    mps.out_limit.fault.sim_put(1)
     assert cb.called

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -165,6 +165,7 @@ def test_presets(presets, motor):
     motor.presets.sync()
     assert hasattr(motor, 'mv_sample')
 
+
 def test_presets_type(presets, motor):
     logger.debug('test_presets_type')
     # Mess up the input types, fail before opening the file

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -2,14 +2,14 @@ import logging
 import pytest
 from unittest.mock import Mock
 
-from ophyd.device import Component as Cmp
+from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
+from ophyd.sim import make_fake_device
 
 from pcdsdevices.areadetector.detectors import PCDSDetector
 from pcdsdevices.pim import PIM, PIMMotor
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
-from .conftest import attr_wait_true, connect_rw_pvs
+from .conftest import HotfixFakeEpicsSignal
 
 logger = logging.getLogger(__name__)
 
@@ -18,27 +18,23 @@ logger = logging.getLogger(__name__)
 # for checking an epics signal value in the __init__ statement.
 for comp in (PCDSDetector.image, PCDSDetector.stats):
     plugin_class = comp.cls
-    plugin_class.plugin_type = Cmp(Signal, value=plugin_class._plugin_type)
+    plugin_class.plugin_type = Cpt(Signal, value=plugin_class._plugin_type)
 
 
+@pytest.fixture(scope='function')
 def fake_pim():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    pim = PIMMotor('Test:Yag', name='test')
-    connect_rw_pvs(pim.state)
-    pim.wait_for_connection()
-    pim.state.put(0, wait=True)
-    pim.state._read_pv.enum_strs = ['Unknown'] + PIMMotor.states_list
+    FakePIM = make_fake_device(PIMMotor)
+    FakePIM.state.cls = HotfixFakeEpicsSignal
+    pim = FakePIM('Test:Yag', name='test')
+    pim.state.sim_put(0)
+    pim.state.sim_enum_strs(['Unknown'] + PIMMotor.states_list)
     return pim
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_pim_stage():
+def test_pim_stage(fake_pim):
     logger.debug('test_pim_stage')
-    pim = fake_pim()
+    pim = fake_pim
     # Should return to original position on unstage
     pim.move('OUT', wait=True)
     assert pim.removed
@@ -57,22 +53,18 @@ def test_pim_stage():
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
 def test_pim_det():
     logger.debug('test_pim_det')
-    pim = PIM('Test:Yag', name='test', prefix_det='potato')
-    pim.wait_for_connection()
-    pim = PIM('Test:Yag', name='test')
-    pim.wait_for_connection()
+    FakePIM = make_fake_device(PIM)
+    FakePIM('Test:Yag', name='test', prefix_det='potato')
+    FakePIM('Test:Yag', name='test')
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_pim_subscription():
+def test_pim_subscription(fake_pim):
     logger.debug('test_pim_subscription')
-    pim = fake_pim()
+    pim = fake_pim
     cb = Mock()
     pim.subscribe(cb, event_type=pim.SUB_STATE, run=False)
-    pim.state._read_pv.put(2)
-    attr_wait_true(cb, 'called')
+    pim.state.sim_put(2)
     assert cb.called

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -27,7 +27,7 @@ def fake_pim():
     FakePIM.state.cls = HotfixFakeEpicsSignal
     pim = FakePIM('Test:Yag', name='test')
     pim.state.sim_put(0)
-    pim.state.sim_enum_strs(['Unknown'] + PIMMotor.states_list)
+    pim.state.sim_set_enum_strs(['Unknown'] + PIMMotor.states_list)
     return pim
 
 

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -24,8 +24,8 @@ def fake_picker():
     FakePicker.inout.cls.state.cls = HotfixFakeEpicsSignal
     picker = FakePicker('TST:SB1:MMS:35', name='picker')
     picker.inout.state.sim_put(0)
-    picker.inout.state.sim_enum_strs(['Unknown'] +
-                                     InOutRecordPositioner.states_list)
+    picker.inout.state.sim_set_enum_strs(['Unknown'] +
+                                         InOutRecordPositioner.states_list)
     picker.blade.sim_put(0)
     picker.mode.sim_put(0)
     return picker

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -5,44 +5,44 @@ import logging
 import pytest
 from unittest.mock import Mock
 from ophyd.status import wait as status_wait
+from ophyd.sim import make_fake_device
 
 from pcdsdevices.inout import InOutRecordPositioner
 from pcdsdevices.pulsepicker import PulsePickerInOut
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
-from .conftest import attr_wait_true, connect_rw_pvs
+from .conftest import HotfixFakeEpicsSignal
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_picker():
     """
     Picker starts IN and OPEN
     """
-    picker = PulsePickerInOut('TST:SB1:MMS:35', name='picker')
-    connect_rw_pvs(picker.inout.state)
-    picker.inout.state.put(0)
-    picker.inout.state._read_pv.enum_strs = (['Unknown'] +
-                                             InOutRecordPositioner.states_list)
-    picker.blade._read_pv.put(0)
-    picker.mode._read_pv.put(0)
-    picker.wait_for_connection()
+    FakePicker = make_fake_device(PulsePickerInOut)
+    FakePicker.inout.cls.state.cls = HotfixFakeEpicsSignal
+    picker = FakePicker('TST:SB1:MMS:35', name='picker')
+    picker.inout.state.sim_put(0)
+    picker.inout.state.sim_enum_strs(['Unknown'] +
+                                     InOutRecordPositioner.states_list)
+    picker.blade.sim_put(0)
+    picker.mode.sim_put(0)
     return picker
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_picker_states():
+def test_picker_states(fake_picker):
     logger.debug('test_picker_states')
-    picker = fake_picker()
+    picker = fake_picker
     # Insert and OPEN
     picker.inout.state.put('IN')
-    picker.blade._read_pv.put(0)
+    picker.blade.sim_put(0)
     assert not picker.inserted
     assert picker.removed
     assert picker.position == 'OPEN'
     # CLOSE it
-    picker.blade._read_pv.put(1)
+    picker.blade.sim_put(1)
     assert picker.inserted
     assert not picker.removed
     assert picker.position == 'CLOSED'
@@ -54,13 +54,12 @@ def test_picker_states():
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_picker_motion():
+def test_picker_motion(fake_picker):
     logger.debug('test_picker_motion')
-    picker = fake_picker()
+    picker = fake_picker
     # Light interface
     status = picker.insert(wait=False)
-    picker.blade._read_pv.put(1)
+    picker.blade.sim_put(1)
     status_wait(status, timeout=1)
     assert status.done
     assert status.success
@@ -81,7 +80,7 @@ def test_picker_motion():
     assert not picker.removed
     assert picker.position == 'CLOSED'
     status = picker.move('OPEN', wait=False)
-    picker.blade._read_pv.put(0)
+    picker.blade.sim_put(0)
     status_wait(status, timeout=1)
     assert status.done
     assert status.success
@@ -100,17 +99,16 @@ def test_picker_motion():
 def put_soon(sig, val):
     def inner():
         time.sleep(0.2)
-        sig._read_pv.put(val)
+        sig.sim_put(val)
     t = threading.Thread(target=inner, args=())
     t.start()
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_picker_mode():
+def test_picker_mode(fake_picker):
     logger.debug('test_picker_mode')
-    picker = fake_picker()
-    picker.mode._read_pv.put(1)
+    picker = fake_picker
+    picker.mode.sim_put(1)
     put_soon(picker.mode, 0)
     picker.reset(wait=True)
     assert picker.cmd_reset.get() == 1
@@ -127,10 +125,9 @@ def test_picker_mode():
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_picker_mode_wait():
+def test_picker_mode_wait(fake_picker):
     logger.debug('test_picker_mode_waits')
-    picker = fake_picker()
+    picker = fake_picker
 
     put_soon(picker.blade, 0)
     picker.open(wait=True)
@@ -139,24 +136,22 @@ def test_picker_mode_wait():
 
     put_soon(picker.mode, 2)
     picker.flipflop(wait=True)
-    picker.mode._read_pv.put(0)
+    picker.mode.sim_put(0)
     put_soon(picker.mode, 3)
     picker.burst(wait=True)
-    picker.mode._read_pv.put(0)
+    picker.mode.sim_put(0)
     put_soon(picker.mode, 6)
     picker.follower(wait=True)
-    picker.mode._read_pv.put(0)
+    picker.mode.sim_put(0)
 
 
 @pytest.mark.timeout(5)
-@using_fake_epics_pv
-def test_picker_subs():
+def test_picker_subs(fake_picker):
     logger.debug('test_picker_subs')
-    picker = fake_picker()
+    picker = fake_picker
     # Subscribe a pseudo callback
     cb = Mock()
     picker.subscribe(cb, event_type=picker.SUB_STATE, run=False)
     # Change the target state
     picker.insert()
-    attr_wait_true(cb, 'called')
     assert cb.called

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -1,130 +1,119 @@
-import time
+import logging
 
+import pytest
+from ophyd.sim import make_fake_device
 from unittest.mock import Mock
-from ophyd.status import wait as status_wait
 
-from pcdsdevices.sim.pv import using_fake_epics_pv
 from pcdsdevices.slits import Slits
 
-from .conftest import attr_wait_true, attr_wait_value
+logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='function')
 def fake_slits():
-    """
-    using_fake_epics_pv does cleanup routines after the fixture and before the
-    test, so we can't make this a fixture without destabilizing our tests.
-    """
-    slits = Slits("TST:JAWS:", name='Test Slits')
+    FakeSlits = make_fake_device(Slits)
+    slits = FakeSlits("TST:JAWS:", name='Test Slits')
     # Set centers
-    slits.xcenter.readback._read_pv.put(0.0)
-    slits.ycenter.readback._read_pv.put(0.0)
+    slits.xcenter.readback.sim_put(0.0)
+    slits.ycenter.readback.sim_put(0.0)
     # Set limits
-    slits.xwidth._limits = (-100.0, 100.0)
-    slits.ywidth._limits = (-100.0, 100.0)
-    slits.wait_for_connection()
+    slits.xwidth.setpoint.sim_set_limits((-100.0, 100.0))
+    slits.ywidth.setpoint.sim_set_limits((-100.0, 100.0))
+    # Initialize dmov
+    slits.xwidth.done.sim_put(0)
+    slits.ywidth.done.sim_put(0)
     return slits
 
 
-@using_fake_epics_pv
-def test_slit_states():
-    slits = fake_slits()
+def test_slit_states(fake_slits):
+    logger.debug('test_slit_states')
+    slits = fake_slits
     # Wide open
-    slits.xwidth.readback._read_pv.put(20.0)
-    slits.ywidth.readback._read_pv.put(20.0)
-    attr_wait_true(slits, 'removed')
+    slits.xwidth.readback.sim_put(20.0)
+    slits.ywidth.readback.sim_put(20.0)
     assert slits.removed
     assert not slits.inserted
 
     # Closed
-    slits.xwidth.readback._read_pv.put(-5.0)
-    slits.ywidth.readback._read_pv.put(-5.0)
-    attr_wait_true(slits, 'inserted')
+    slits.xwidth.readback.sim_put(-5.0)
+    slits.ywidth.readback.sim_put(-5.0)
     assert not slits.removed
     assert slits.inserted
 
 
-@using_fake_epics_pv
-def test_slit_motion():
-    slits = fake_slits()
+def test_slit_motion(fake_slits):
+    logger.debug('test_slit_motion')
+    slits = fake_slits
     # Uneven motion
     status = slits.move((5.0, 10.0))
-    assert slits.xwidth.setpoint._write_pv.get() == 5.0
-    assert slits.ywidth.setpoint._write_pv.get() == 10.0
+    assert slits.xwidth.setpoint.get() == 5.0
+    assert slits.ywidth.setpoint.get() == 10.0
     assert not status.done
     # Manually complete move
-    slits.xwidth.readback._read_pv.put(5.0)
-    slits.xwidth.done._read_pv.put(1)
-    slits.ywidth.readback._read_pv.put(10.0)
-    slits.ywidth.done._read_pv.put(1)
-    status_wait(status, timeout=5.0)
+    slits.xwidth.readback.sim_put(5.0)
+    slits.xwidth.done.sim_put(1)
+    slits.ywidth.readback.sim_put(10.0)
+    slits.ywidth.done.sim_put(1)
     assert status.done and status.success
     # Reset DMOV flags
-    slits.xwidth.done._read_pv.put(0)
-    slits.ywidth.done._read_pv.put(0)
-    time.sleep(1.0)
+    slits.xwidth.done.sim_put(0)
+    slits.ywidth.done.sim_put(0)
 
     status = slits.remove(40.0)
     # Command was registered
-    assert slits.xwidth.setpoint._write_pv.get() == 40.0
-    assert slits.ywidth.setpoint._write_pv.get() == 40.0
+    assert slits.xwidth.setpoint.get() == 40.0
+    assert slits.ywidth.setpoint.get() == 40.0
     # Status object reports done at correct moment
     assert not status.done
     # Manually complete move
-    slits.xwidth.readback._read_pv.put(40.0)
-    slits.xwidth.done._read_pv.put(1)
-    slits.ywidth.readback._read_pv.put(40.0)
-    slits.ywidth.done._read_pv.put(1)
-    status_wait(status, timeout=1)
+    slits.xwidth.readback.sim_put(40.0)
+    slits.xwidth.done.sim_put(1)
+    slits.ywidth.readback.sim_put(40.0)
+    slits.ywidth.done.sim_put(1)
     assert status.done and status.success
 
 
-@using_fake_epics_pv
-def test_slit_transmission():
-    slits = fake_slits()
+def test_slit_transmission(fake_slits):
+    logger.debug('test_slit_transmission')
+    slits = fake_slits
     # Set our nominal aperture
     slits.nominal_aperture = (5.0, 10.0)
     # Half-closed
-    slits.xwidth.readback._read_pv.put(2.5)
-    slits.ywidth.readback._read_pv.put(5.0)
-    attr_wait_value(slits, 'transmission', 0.5)
+    slits.xwidth.readback.sim_put(2.5)
+    slits.ywidth.readback.sim_put(5.0)
     assert slits.transmission == 0.5
     # Quarter-closed making sure we are using min
-    slits.ywidth.readback._read_pv.put(2.5)
-    slits.xwidth.readback._read_pv.put(5.0)
-    attr_wait_value(slits, 'transmission', 0.25)
+    slits.ywidth.readback.sim_put(2.5)
+    slits.xwidth.readback.sim_put(5.0)
     assert slits.transmission == 0.25
     # Nothing greater than 100%
-    slits.xwidth.readback._read_pv.put(40.0)
-    slits.ywidth.readback._read_pv.put(40.0)
-    attr_wait_value(slits, 'transmission', 1.0)
+    slits.xwidth.readback.sim_put(40.0)
+    slits.ywidth.readback.sim_put(40.0)
     assert slits.transmission == 1.0
 
 
-@using_fake_epics_pv
-def test_slit_subscriptions():
-    slits = fake_slits()
+def test_slit_subscriptions(fake_slits):
+    logger.debug('test_slit_subscriptions')
+    slits = fake_slits
     # Subscribe a pseudo callback
     cb = Mock()
     slits.subscribe(cb, event_type=slits.SUB_STATE, run=False)
     # Change the aperture size
-    slits.xwidth.readback._read_pv.put(40.0)
-    attr_wait_true(cb, 'called')
+    slits.xwidth.readback.sim_put(40.0)
     assert cb.called
 
 
-@using_fake_epics_pv
-def test_slit_staging():
-    slits = fake_slits()
+def test_slit_staging(fake_slits):
+    logger.debug('test_slit_staging')
+    slits = fake_slits
     # Check the starting location
-    slits.xwidth.readback._read_pv.put(2.5)
-    slits.ywidth.readback._read_pv.put(2.5)
-    time.sleep(1)
+    slits.xwidth.readback.sim_put(2.5)
+    slits.ywidth.readback.sim_put(2.5)
     # Stage the slits to record the values
     slits.stage()
     # Check that unstage places everything back
-    slits.xwidth.setpoint._read_pv.put(1.5)
-    slits.ywidth.setpoint._read_pv.put(1.5)
+    slits.xwidth.setpoint.sim_put(1.5)
+    slits.ywidth.setpoint.sim_put(1.5)
     slits.unstage()
-    time.sleep(1)
-    assert slits.xwidth.setpoint._write_pv.get() == 2.5
-    assert slits.ywidth.setpoint._write_pv.get() == 2.5
+    assert slits.xwidth.setpoint.get() == 2.5
+    assert slits.ywidth.setpoint.get() == 2.5

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock
 import pytest
 from ophyd.device import Component as Cmp
 from ophyd.signal import Signal
+from ophyd.sim import make_fake_device
 
 from pcdsdevices.state import (StatePositioner, PVStatePositioner,
                                StateRecordPositioner, StateStatus)
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
 from .conftest import attr_wait_true
 
@@ -131,7 +131,6 @@ def test_basic_subscribe():
     assert cb.called
 
 
-@using_fake_epics_pv
 def test_staterecord_positioner():
     """
     Nothing special can be done without live hosts, just make sure we can
@@ -139,14 +138,15 @@ def test_staterecord_positioner():
     """
     logger.debug('test_staterecord_positioner')
 
-    class MyStates(StateRecordPositioner):
+    FakeState = make_fake_device(StateRecordPositioner)
+
+    class MyStates(FakeState):
         states_list = ['YES', 'NO', 'MAYBE', 'SO']
 
     state = MyStates('A:PV', name='test')
     cb = Mock()
     state.subscribe(cb, event_type=state.SUB_READBACK, run=False)
-    state.readback._read_pv.put(1.23)
-    attr_wait_true(cb, 'called')
+    state.readback.sim_put(1.23)
     assert cb.called
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,8 +9,6 @@ from ophyd.sim import make_fake_device
 from pcdsdevices.state import (StatePositioner, PVStatePositioner,
                                StateRecordPositioner, StateStatus)
 
-from .conftest import attr_wait_true
-
 logger = logging.getLogger(__name__)
 
 
@@ -104,7 +102,6 @@ def test_pvstate_positioner_sets():
         lim_obj2.move('Unknown')
     cb = Mock()
     lim_obj2.move('OUT', moved_cb=cb)
-    attr_wait_true(cb, 'called')
     assert(cb.called)
     assert(lim_obj2.position == 'OUT')
     lim_obj2.move('IN', wait=True)

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -16,7 +16,7 @@ def fake_pps():
     FakePPS = make_fake_device(PPSStopper)
     FakePPS.state.cls = HotfixFakeEpicsSignal
     pps = FakePPS("PPS:H0:SUM", name="test_pps")
-    pps.state.sim_enum_strs(['Unknown', 'IN', 'OUT'])
+    pps.state.sim_set_enum_strs(['Unknown', 'IN', 'OUT'])
     pps.state.put('OUT')
     return pps
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- use `make_fake_device` instead of `using_fake_epics_pv` for testing reliability
- force `ophyd>=1.2.0`
- fix minor issues that I found while making tests
- Add a hotfix on top of the fake device maker, should be submitted as an `ophyd` PR but for now it makes the tests work

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- more reliable tests
- the tests broke the old way with the new ophyd

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It doesn't need explicit documentation.

Note that this will possibly necessitate changes in the other open PRs if this one comes first, or this will need additional changes if the other open PRs come first.
<!--
## Screenshots (if appropriate):
-->
