### PR TITLE
DOC: update release notes for 0.8.0

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,7 +1,7 @@
 Release History
 ###############
 
-Next Release
+v0.8.0 (2018-05-27)
 ============
 
 Features
@@ -14,6 +14,7 @@ Features
 Bugfixes
 --------
 - Fix a bug where the `LODCM` class had a ``readback`` signal with an invalid PV. (#232)
+- Fix a bug where the tests would never pass, ever (#238)
 
 v0.7.0 (2018-05-08)
 ===================


### PR DESCRIPTION
Making a `pcdsdevices` release today because I need the hotfix moved from `hxrsnd` to complete the environment