### PR TITLE
Camonitor Implementation 

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -375,14 +375,6 @@ class IMS(PCDSMotorBase):
             status_wait(st, timeout=timeout)
         return st
 
-    def camonitor(self):
-        try:
-            while True:
-                time.sleep(0.1)
-                print("\r {0:4f}".format(self.user_readback.value), end=" ")
-        except KeyboardInterrupt:
-            pass
-
 
 class Newport(PCDSMotorBase):
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -375,6 +375,25 @@ class IMS(PCDSMotorBase):
         if wait:
             status_wait(st, timeout=timeout)
         return st
+    def cb(self,moving,timeout):
+    """Display motor position second by second"""
+        import time
+        if timeout<=0:
+           timeout=float("inf")
+        start=time.time()
+        try:
+           if moving==True:
+              now=time.time()
+              if now-start>timeout:
+                 moving=True
+              print("Position: ")
+              print("\r {0}".format(self.user_setpoint.value))
+        except KeyboardInterrupt:
+           moving=False
+           pass
+    def camonitor(self):
+        display=self.cb(1,0)
+        return display
 
 
 class Newport(PCDSMotorBase):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -376,24 +376,24 @@ class IMS(PCDSMotorBase):
             status_wait(st, timeout=timeout)
         return st
     def cb(self,moving,timeout):
-    """Display motor position second by second"""
         import time
         if timeout<=0:
            timeout=float("inf")
         start=time.time()
-        try:
-           if moving==True:
-              now=time.time()
-              if now-start>timeout:
-                 moving=True
-              print("Position: ")
-              print("\r {0}".format(self.user_setpoint.value))
-        except KeyboardInterrupt:
-           moving=False
-           pass
+        if moving==True:
+           now=time.time()
+           if now-start>timeout:
+              moving=True
+           print("\r {}".format(self.user_setpoint.value),end=" ")
+
     def camonitor(self):
-        display=self.cb(1,0)
-        return display
+        import time 
+        self.cb(1,0)
+        try:
+           while True:
+             time.sleep(0.1)
+        except KeyboardInterrupt:
+           pass
 
 
 class Newport(PCDSMotorBase):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -2,7 +2,6 @@
 Module for LCLS's special motor records.
 """
 import logging
-import time
 from ophyd.device import Component as Cpt
 from ophyd.epics_motor import EpicsMotor
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
@@ -244,6 +243,7 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         # Pass information to PositionerBase
         super()._pos_changed(timestamp=timestamp, old_value=old_value,
                              value=value, **kwargs)
+
 
 class IMS(PCDSMotorBase):
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -375,12 +375,14 @@ class IMS(PCDSMotorBase):
         if wait:
             status_wait(st, timeout=timeout)
         return st
-    def camonitor(self): 
+
+    def camonitor(self):
         try:
-           while True:
-             print("\r {0:4f}".format(self.user_readback.value),end=" ")
+            while True:
+                print("\r {0:4f}".format(self.user_readback.value), end=" ")
         except KeyboardInterrupt:
-           pass
+            pass
+
 
 class Newport(PCDSMotorBase):
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -375,26 +375,12 @@ class IMS(PCDSMotorBase):
         if wait:
             status_wait(st, timeout=timeout)
         return st
-    def cb(self,moving,timeout):
-        import time
-        if timeout<=0:
-           timeout=float("inf")
-        start=time.time()
-        if moving==True:
-           now=time.time()
-           if now-start>timeout:
-              moving=True
-           print("\r {}".format(self.user_setpoint.value),end=" ")
-
-    def camonitor(self):
-        import time 
-        self.cb(1,0)
+    def camonitor(self): 
         try:
            while True:
-             time.sleep(0.1)
+             print("\r {0:4f}".format(self.user_readback.value),end=" ")
         except KeyboardInterrupt:
            pass
-
 
 class Newport(PCDSMotorBase):
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -2,7 +2,7 @@
 Module for LCLS's special motor records.
 """
 import logging
-
+import time
 from ophyd.device import Component as Cpt
 from ophyd.epics_motor import EpicsMotor
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
@@ -245,7 +245,6 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         super()._pos_changed(timestamp=timestamp, old_value=old_value,
                              value=value, **kwargs)
 
-
 class IMS(PCDSMotorBase):
     """
     PCDS implementation of the Motor Record for IMS motors.
@@ -379,6 +378,7 @@ class IMS(PCDSMotorBase):
     def camonitor(self):
         try:
             while True:
+                time.sleep(0.1)
                 print("\r {0:4f}".format(self.user_readback.value), end=" ")
         except KeyboardInterrupt:
             pass

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -73,6 +73,9 @@ class MvInterface:
             self.mv(position, timeout=timeout, wait=wait)
 
     def camonitor(self):
+        """
+        Updates current position of the motor.
+        """
         try:
             while True:
                 time.sleep(0.1)

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -75,7 +75,7 @@ class MvInterface:
         try:
             while True:
                 time.sleep(0.1)
-                print("\r {0:4f}".format(self.user_readback.value), end=" ")
+                print("\r {0:4f}".format(self.position), end=" ")
         except KeyboardInterrupt:
             pass
 

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -71,6 +71,7 @@ class MvInterface:
             return self.wm()
         else:
             self.mv(position, timeout=timeout, wait=wait)
+
     def camonitor(self):
         try:
             while True:
@@ -78,6 +79,7 @@ class MvInterface:
                 print("\r {0:4f}".format(self.position), end=" ")
         except KeyboardInterrupt:
             pass
+
 
 class FltMvInterface(MvInterface):
     """

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -71,7 +71,13 @@ class MvInterface:
             return self.wm()
         else:
             self.mv(position, timeout=timeout, wait=wait)
-
+    def camonitor(self):
+        try:
+            while True:
+                time.sleep(0.1)
+                print("\r {0:4f}".format(self.user_readback.value), end=" ")
+        except KeyboardInterrupt:
+            pass
 
 class FltMvInterface(MvInterface):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Implemented the camonitor such that it displays the current position of the motor until Ctrl+C is used.
<!--- Describe your changes in detail -->

## Motivation and Context
- Transfering old wm_update into python 3 code.
- addresses issue:  https://github.com/pcdshub/pcdsdevices/issues/183
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- used a disconnected moving motor to test current moving position 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
- Function was implemented in IMS(PCDSMotorBase)
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
