### PR TITLE
ENH: Add utils with keypress getter

### DIFF
--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -1,22 +1,22 @@
-import sys
 import select
-import tty
+import sys
 import termios
 import time
+import tty
 
-arrow_up   = '\x1b[A'
+arrow_up = '\x1b[A'
 arrow_down = '\x1b[B'
 arrow_right = '\x1b[C'
 arrow_left = '\x1b[D'
-shift_arrow_up   = '\x1b[1;2A'
+shift_arrow_up = '\x1b[1;2A'
 shift_arrow_down = '\x1b[1;2B'
 shift_arrow_right = '\x1b[1;2C'
 shift_arrow_left = '\x1b[1;2D'
-alt_arrow_up   = '\x1b[1;3A'
+alt_arrow_up = '\x1b[1;3A'
 alt_arrow_down = '\x1b[1;3B'
 alt_arrow_right = '\x1b[1;3C'
 alt_arrow_left = '\x1b[1;3D'
-ctrl_arrow_up   = '\x1b[1;5A'
+ctrl_arrow_up = '\x1b[1;5A'
 ctrl_arrow_down = '\x1b[1;5B'
 ctrl_arrow_right = '\x1b[1;5C'
 ctrl_arrow_left = '\x1b[1;5D'
@@ -46,9 +46,12 @@ def get_input():
     -------
     input: ``str``
     """
+    # Save old terminal settings
     old_settings = termios.tcgetattr(sys.stdin)
+    # Stash a None here in case we get interrupted
     inp = None
     try:
+        # Swap to cbreak mode to get raw inputs
         tty.setcbreak(sys.stdin.fileno())
         # Poll for input. This is interruptable with ctrl+c
         while (not is_input()):
@@ -60,8 +63,9 @@ def get_input():
             extra_inp = sys.stdin.read(2)
             inp += extra_inp
             # Read even more if we had a shift/alt/ctrl modifier
-            if extra_inp =='[1':
-                inp +=  sys.stdin.read(3)
+            if extra_inp == '[1':
+                inp += sys.stdin.read(3)
     finally:
+        # Restore the terminal to normal input mode
         termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
         return inp

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -1,0 +1,67 @@
+import sys
+import select
+import tty
+import termios
+import time
+
+arrow_up   = '\x1b[A'
+arrow_down = '\x1b[B'
+arrow_right = '\x1b[C'
+arrow_left = '\x1b[D'
+shift_arrow_up   = '\x1b[1;2A'
+shift_arrow_down = '\x1b[1;2B'
+shift_arrow_right = '\x1b[1;2C'
+shift_arrow_left = '\x1b[1;2D'
+alt_arrow_up   = '\x1b[1;3A'
+alt_arrow_down = '\x1b[1;3B'
+alt_arrow_right = '\x1b[1;3C'
+alt_arrow_left = '\x1b[1;3D'
+ctrl_arrow_up   = '\x1b[1;5A'
+ctrl_arrow_down = '\x1b[1;5B'
+ctrl_arrow_right = '\x1b[1;5C'
+ctrl_arrow_left = '\x1b[1;5D'
+
+
+def is_input():
+    """
+    Utility to check if there is input available.
+
+    Returns
+    -------
+    is_input: ``bool``
+        ``True`` if there is data in sys.stdin
+    """
+    return select.select([sys.stdin], [], [], 1) == ([sys.stdin], [], [])
+
+
+def get_input():
+    """
+    Waits for a single character input and returns it.
+
+    You can compare the input to the keys stored in this module e.g.
+
+    ``utils.arrow_up == get_input()``
+
+    Returns
+    -------
+    input: ``str``
+    """
+    old_settings = termios.tcgetattr(sys.stdin)
+    inp = None
+    try:
+        tty.setcbreak(sys.stdin.fileno())
+        # Poll for input. This is interruptable with ctrl+c
+        while (not is_input()):
+            time.sleep(0.01)
+        # Read the first character
+        inp = sys.stdin.read(1)
+        # Read more if we have a control sequence
+        if inp == '\x1b':
+            extra_inp = sys.stdin.read(2)
+            inp += extra_inp
+            # Read even more if we had a shift/alt/ctrl modifier
+            if extra_inp =='[1':
+                inp +=  sys.stdin.read(3)
+    finally:
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+        return inp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Port of old hutch-python `keypress` module, but only the useful functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need this for `tweak`. This should be ported to a utilities module at some point, but I didn't feel like making a module with one file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have not written tests, but I plan to do this later at the same time we do the tweak tests.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This has really good comments, but I'd prefer to leave it out of the sphinx docs until it's in the correct module.
<!--
## Screenshots (if appropriate):
-->
