### PR TITLE
ENH: Beckhoff Axis Class (and some refactor)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
   - coverage run run_tests.py
   - coverage report -m
   - flake8 pcdsdevices/*.py
+  - flake8 tests/*.py
   - set -e
   #Build docs
   - |

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -7,7 +7,7 @@ Common EPICS Devices
     :toctree: generated
     
     Attenuator
-    Beckhoff
+    BeckhoffAxis
     EpicsMotor
     EventSequencer
     LODCM

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -7,6 +7,7 @@ Common EPICS Devices
     :toctree: generated
     
     Attenuator
+    Beckhoff
     EpicsMotor
     EventSequencer
     LODCM

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -1,6 +1,6 @@
 # flake8: NOQA
 from .attenuator import Attenuator
-from .epics_motor import IMS, Newport, PMC100, Beckhoff, EpicsMotor
+from .epics_motor import IMS, Newport, PMC100, BeckhoffAxis, EpicsMotor
 from .ipm import IPM
 from .lens import XFLS
 from .lodcm import LODCM

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -1,6 +1,6 @@
 # flake8: NOQA
 from .attenuator import Attenuator
-from .epics_motor import IMS, Newport, PMC100, EpicsMotor
+from .epics_motor import IMS, Newport, PMC100, Beckhoff, EpicsMotor
 from .ipm import IPM
 from .lens import XFLS
 from .lodcm import LODCM

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -19,7 +19,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     """
     The standard EpicsMotor class, but with our interface attached.
 
-    This includes some pcds preferences, but not any IOC differences.
+    This includes some PCDS preferences, but not any IOC differences.
 
     Notes
     -----

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -25,13 +25,15 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     -----
     The full list of preferences implemented here are:
 
-        1. Instead of using the limit fields on the setpoint PV, the EPICS
+        1. Use the FltMvInterface mixin class for some name aliases and
+        bells-and-whistles level functions
+        2. Instead of using the limit fields on the setpoint PV, the EPICS
         motor class has the ``LLM`` and ``HLM`` soft limit fields for
         convenient usage. Unfortunately, pyepics does not update its internal
         cache of the limits after the first get attempt. We therefore disregard
         the internal limits of the PV and use the soft limit records
         exclusively.
-        2. The disable puts field ``.DISP`` is added, along with ``enable`` and
+        3. The disable puts field ``.DISP`` is added, along with ``enable`` and
         ``disable`` convenience methods. When ``.DISP`` is 1, puts to the motor
         record will be ignored, effectively disabling the interface.
     """
@@ -411,6 +413,8 @@ class Beckhoff(EpicsMotorInterface):
     This class simply adds a convenience `clear_error` method, and makes
     sure to call it on stage.
     """
+    __doc__ += basic_positioner_init
+
     cmd_err_reset = Cpt(EpicsSignal, '-ErrRst')
 
     def clear_error(self):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -2,7 +2,6 @@
 Module for LCLS's special motor records.
 """
 import logging
-
 from ophyd.device import Component as Cpt
 from ophyd.epics_motor import EpicsMotor
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -15,7 +15,118 @@ from .mv_interface import FltMvInterface
 logger = logging.getLogger(__name__)
 
 
-class PCDSMotorBase(FltMvInterface, EpicsMotor):
+class EpicsMotorInterface(FltMvInterface, EpicsMotor):
+    """
+    The standard EpicsMotor class, but with our interface attached.
+
+    This includes some pcds preferences, but not any IOC differences.
+
+    Notes
+    -----
+    The full list of preferences implemented here are:
+
+        1. Instead of using the limit fields on the setpoint PV, the EPICS
+        motor class has the ``LLM`` and ``HLM`` soft limit fields for
+        convenient usage. Unfortunately, pyepics does not update its internal
+        cache of the limits after the first get attempt. We therefore disregard
+        the internal limits of the PV and use the soft limit records
+        exclusively.
+        2. The disable puts field ``.DISP`` is added, along with ``enable`` and
+        ``disable`` convenience methods. When ``.DISP`` is 1, puts to the motor
+        record will be ignored, effectively disabling the interface.
+    """
+    # Reimplemented because pyepics does not recognize when the limits have
+    # been changed without a re-connection of the PV. Instead we trust the soft
+    # limits records
+    user_setpoint = Cpt(EpicsSignal, ".VAL", limits=False)
+    # Additional soft limit configurations
+    low_soft_limit = Cpt(EpicsSignal, ".LLM")
+    high_soft_limit = Cpt(EpicsSignal, ".HLM")
+    # Enable/Disable puts
+    disabled = Cpt(EpicsSignal, ".DISP")
+
+    @property
+    def low_limit(self):
+        """
+        The lower soft limit for the motor.
+        """
+        return self.low_soft_limit.value
+
+    @low_limit.setter
+    def low_limit(self, value):
+        self.low_soft_limit.put(value)
+
+    @property
+    def high_limit(self):
+        """
+        The higher soft limit for the motor.
+        """
+        return self.high_soft_limit.value
+
+    @high_limit.setter
+    def high_limit(self, value):
+        self.high_soft_limit.put(value)
+
+    @property
+    def limits(self):
+        """
+        The soft limits of the motor.
+        """
+        return (self.low_limit, self.high_limit)
+
+    @limits.setter
+    def limits(self, limits):
+        self.low_limit = limits[0]
+        self.high_limit = limits[1]
+
+    def enable(self):
+        """
+        Enables the motor.
+
+        When disabled, all EPICS puts to the base record will be dropped.
+        """
+        return self.disabled.put(value=0)
+
+    def disable(self):
+        """
+        Disables the motor.
+
+        When disabled, all EPICS puts to the base record will be dropped.
+        """
+        return self.disabled.put(value=1)
+
+    def check_value(self, value):
+        """
+        Check if the motor is disabled
+        Check if the value is within the soft limits of the motor.
+
+        Raises
+        ------
+        MotorDisabledError
+            If the motor is passed any motion command when disabled
+        LimitError(ValueError)
+            When the provided value is outside the range of the low
+            and high limits
+        """
+        # First check that the user has returned a valid EPICS value. It will
+        # not consult the limits of the PV itself because limits=False
+        super().check_value(value)
+
+        # Find the soft limit values from EPICS records and check that this
+        # command will be accepted by the motor
+        if any(self.limits):
+            if not (self.low_limit <= value <= self.high_limit):
+                raise LimitError("Value {} outside of range: [{}, {}]"
+                                 .format(value, self.low_limit,
+                                         self.high_limit))
+
+        # Find the value for the disabled attribute
+        if self.disabled.value == 1:
+            raise MotorDisabledError("Motor is not enabled. Motion requests "
+                                     "ignored")
+
+
+class PCDSMotorBase(EpicsMotorInterface):
     """
     EpicsMotor for PCDS
 
@@ -36,128 +147,18 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         this difference, we use the `_pos_changed` callback to keep track of
         which direction we believe the motor to be travelling and store this in
         a simple ``ophyd.Signal``
-        2. Instead of using the limit fields on the setpoint PV, the EPICS
-        motor class has the ``LLM`` and ``HLM`` soft limit fields for
-        convenient usage. Unfortunately, pyepics does not update its internal
-        cache of the limits after the first get attempt. We therefore disregard
-        the internal limits of the PV and use the soft limit records
-        exclusively.
-        3. The ``SPG`` field implements the three states used in the LCLS
+        2. The ``SPG`` field implements the three states used in the LCLS
         motor record.  This is a reduced version of the standard EPICS
         ``SPMG`` field.  Setting to ``STOP``, ``PAUSE`` and ``GO``  will
         respectively stop motor movement, pause a move in progress, or resume
         a paused move.
     """
-    # Reimplemented because pyepics does not recognize when the limits have
-    # been changed without a re-connection of the PV. Instead we trust the soft
-    # limits records
-    user_setpoint = Cpt(EpicsSignal, ".VAL", limits=False)
-    # Additional soft limit configurations
-    low_soft_limit = Cpt(EpicsSignal, ".LLM")
-    high_soft_limit = Cpt(EpicsSignal, ".HLM")
     # Disable missing field that our EPICS motor record lacks
     # This attribute is tracked by the _pos_changed callback
     direction_of_travel = Cpt(Signal)
-    # This attribute will show if the motor is disabled or not
-    disabled = Cpt(EpicsSignal, ".DISP")
     # This attribute changes if the motor is stopped and unable to move 'Stop',
     # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, ".SPG")
-
-    @property
-    def low_limit(self):
-        """
-        Returns the lower soft limit for the motor.
-
-        Returns
-        -------
-        low_limit : float
-            The lower soft limit of the motor.
-        """
-        return self.low_soft_limit.value
-
-    @low_limit.setter
-    def low_limit(self, value):
-        """
-        Sets the low limit for the motor.
-
-        Returns
-        -------
-        status : StatusObject
-            Status object of the set.
-        """
-        return self.low_soft_limit.put(value)
-
-    @property
-    def high_limit(self):
-        """
-        Returns the higher soft limit for the motor.
-
-        Returns
-        -------
-        high_limit : float
-            The higher soft limit of the motor.
-        """
-        return self.high_soft_limit.value
-
-    @high_limit.setter
-    def high_limit(self, value):
-        """
-        Sets the high limit for the motor.
-
-        Returns
-        -------
-        status : StatusObject
-            Status object of the set.
-        """
-        return self.high_soft_limit.put(value)
-
-    @property
-    def limits(self):
-        """
-        Returns the soft limits of the motor.
-
-        Returns
-        -------
-        limits : tuple
-            Soft limits of the motor.
-        """
-        return (self.low_limit, self.high_limit)
-
-    @limits.setter
-    def limits(self, limits):
-        """
-        Sets the limits for the motor.
-
-        Parameters
-        ----------
-        limits : tuple
-            Desired low and high limits.
-        """
-        self.low_limit = limits[0]
-        self.high_limit = limits[1]
-
-    def enable(self):
-        """
-        Sets the motor to enabled.
-
-        Returns
-        -------
-        status: Status Object
-            Status object of the set
-        """
-        return self.disabled.set(value=0)
-
-    def disable(self):
-        """
-        Sets the motor to disabled.
-
-        Returns
-        -------
-        status: Status Object
-            Status object of the set
-        """
-        return self.disabled.set(value=1)
 
     def stop(self):
         """
@@ -200,39 +201,28 @@ class PCDSMotorBase(FltMvInterface, EpicsMotor):
         """
         Check if the motor is disabled
         Check if the value is within the soft limits of the motor.
+        Check if the spg field is on "pause" or "stop"
 
         Raises
         ------
-        Exception
+        MotorDisabledError(MoveForbiddenError)
             If the motor is passed any motion command when disabled
-        ValueError
+        LimitError(ValueError)
             When the provided value is outside the range of the low
             and high limits
+        MotorSPGError(MoveForbiddenError)
+            If the motor is stopped (MotorStopError) or paused
+            (MotorPauseError)
         """
-        # First check that the user has returned a valid EPICS value. It will
-        # not consult the limits of the PV itself because limits=False
         super().check_value(value)
 
-        # Find the value for the disabled attribute
-        if self.disabled.value == 1:
-            raise Exception("Motor is not enabled. Motion requests "
-                            "ignored")
-
         if self.motor_spg.value in [0, 'Stop']:
-            raise Exception("Motor is stopped.  Motion requests "
-                            "ignored until motor is set to 'Go'")
+            raise MotorStopError("Motor is stopped.  Motion requests "
+                                 "ignored until motor is set to 'Go'")
 
         if self.motor_spg.value in [1, 'Pause']:
-            raise Exception("Motor is paused.  If a move is set, motion "
-                            "will resume when motor is set to 'Go'")
-
-        # Find the soft limit values from EPICS records and check that this
-        # command will be accepted by the motor
-        low_limit, high_limit = self.limits
-
-        if not (low_limit <= value <= high_limit):
-            raise LimitError("Value {} outside of range: [{}, {}]"
-                             .format(value, low_limit, high_limit))
+            raise MotorPauseError("Motor is paused.  If a move is set, motion "
+                                  "will resume when motor is set to 'Go'")
 
     def _pos_changed(self, timestamp=None, old_value=None,
                      value=None, **kwargs):
@@ -412,3 +402,64 @@ class PMC100(PCDSMotorBase):
 
     def home(self, *args, **kwargs):
         raise NotImplementedError("PMC100 motors have no homing procedure")
+
+
+class Beckhoff(EpicsMotorInterface):
+    """
+    Beckhoff Axis motor record as implemented by ESS.
+
+    This class simply adds a convenience `clear_error` method, and makes
+    sure to call it on stage.
+    """
+    cmd_err_reset = Cpt(EpicsSignal, '-ErrRst')
+
+    def clear_error(self):
+        """
+        Clear any active motion errors on this axis.
+        """
+        self.cmd_err_reset.put(1)
+
+    def stage(self):
+        """
+        Stage the Beckhoff axis.
+
+        This simply clears any errors. Stage is called at the start of most
+        ``bluesky`` plans.
+        """
+        self.clear_error()
+        return super().stage()
+
+
+class MoveForbiddenError(Exception):
+    """
+    Error that indicates that we are not allowed to move.
+    """
+    pass
+
+
+class MotorDisabledError(MoveForbiddenError):
+    """
+    Error that indicates that we can't move because the DISP field is set to 1.
+    """
+    pass
+
+
+class MotorSPGError(MoveForbiddenError):
+    """
+    Error that indicates that we can't move because the SPG field is not "Go".
+    """
+    pass
+
+
+class MotorStopError(MotorSPGError):
+    """
+    Error that indicates that we can't move because SPG is "Stop".
+    """
+    pass
+
+
+class MotorPauseError(MotorSPGError):
+    """
+    Error that indicates that we can't move because SPG is "Pause"
+    """
+    pass

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -413,7 +413,7 @@ class PMC100(PCDSMotorBase):
         raise NotImplementedError("PMC100 motors have no homing procedure")
 
 
-class Beckhoff(EpicsMotorInterface):
+class BeckhoffAxis(EpicsMotorInterface):
     """
     Beckhoff Axis motor record as implemented by ESS.
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -236,7 +236,7 @@ class PCDSMotorBase(EpicsMotorInterface):
     def _pos_changed(self, timestamp=None, old_value=None,
                      value=None, **kwargs):
         # Store the internal travelling direction of the motor to account for
-        # the fact that our EPICS motor does not have DIR field
+        # the fact that our EPICS motor does not have TDIR field
         if None not in (value, old_value):
             self.direction_of_travel.put(int(value > old_value))
         # Pass information to PositionerBase

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -72,6 +72,17 @@ class MvInterface:
         else:
             self.mv(position, timeout=timeout, wait=wait)
 
+    def camonitor(self):
+        """
+        Updates current position of the motor.
+        """
+        try:
+            while True:
+                time.sleep(0.1)
+                print("\r {0:4f}".format(self.position), end=" ")
+        except KeyboardInterrupt:
+            pass
+
 
 class FltMvInterface(MvInterface):
     """

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -78,8 +78,8 @@ class MvInterface:
         """
         try:
             while True:
-                time.sleep(0.1)
                 print("\r {0:4f}".format(self.position), end=" ")
+                time.sleep(0.1)
         except KeyboardInterrupt:
             pass
 

--- a/tests/test_device_types.py
+++ b/tests/test_device_types.py
@@ -1,2 +1,2 @@
 def test_device_types_import():
-    from pcdsdevices import device_types
+    from pcdsdevices import device_types  # NOQA

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -7,9 +7,8 @@ from ophyd.status import wait as status_wait
 import pytest
 
 from pcdsdevices.epics_motor import (EpicsMotorInterface, PCDSMotorBase, IMS,
-                                     Newport, PMC100, Beckhoff,
-                                     MotorDisabledError, MotorStopError,
-                                     MotorPauseError)
+                                     Newport, PMC100, BeckhoffAxis,
+                                     MotorDisabledError)
 
 from .conftest import HotfixFakeEpicsSignal
 
@@ -60,7 +59,7 @@ def fake_motor(cls):
 
 @pytest.fixture(scope='function',
                 params=[EpicsMotorInterface, PCDSMotorBase, IMS, Newport,
-                        PMC100, Beckhoff])
+                        PMC100, BeckhoffAxis])
 def fake_epics_motor(request):
     """
     Test EpicsMotorInterface and subclasses
@@ -90,7 +89,7 @@ def fake_beckhoff():
     """
     Test Beckhoff-specific overrides
     """
-    return fake_motor(Beckhoff)
+    return fake_motor(BeckhoffAxis)
 
 
 def test_epics_motor_soft_limits(fake_epics_motor):
@@ -169,13 +168,13 @@ def test_resume_pause_stop(fake_pcds_motor):
     m = fake_pcds_motor
     m.stop()
     assert m.motor_spg.get(as_string=True) == 'Stop'
-    with pytest.raises(MotorStopError):
+    with pytest.raises(MotorDisabledError):
         m.check_value(10)
-    with pytest.raises(MotorStopError):
+    with pytest.raises(MotorDisabledError):
         m.move(10, wait=False)
     m.pause()
     assert m.motor_spg.get(as_string=True) == 'Pause'
-    with pytest.raises(MotorPauseError):
+    with pytest.raises(MotorDisabledError):
         m.move(10, wait=False)
     m.go()
     assert m.motor_spg.get(as_string=True) == 'Go'

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -1,46 +1,101 @@
-import pytest
-import os
-import signal
-import time
-from threading import Thread
+import logging
+
 from bluesky import RunEngine
 from bluesky.plan_stubs import stage, unstage, open_run, close_run
 from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
+import pytest
 
-from pcdsdevices.epics_motor import PCDSMotorBase, IMS
+from pcdsdevices.epics_motor import (EpicsMotorInterface, PCDSMotorBase, IMS,
+                                     Newport, PMC100, Beckhoff,
+                                     MotorDisabledError, MotorStopError,
+                                     MotorPauseError)
 
 from .conftest import HotfixFakeEpicsSignal
 
+logger = logging.getLogger(__name__)
 
-@pytest.fixture(scope='function')
-def fake_motor():
-    FakeMotor = make_fake_device(PCDSMotorBase)
-    FakeMotor.motor_spg.cls = HotfixFakeEpicsSignal
-    m = FakeMotor("Tst:MMS:02", name='Test Motor')
-    m.limits = (-100, 100)
-    m.motor_spg.sim_put(2)
-    m.motor_spg.sim_set_enum_strs(['Stop', 'Pause', 'Go'])
-    m.user_readback.sim_put(0)
-    return m
+
+def fake_class_setup(cls):
+    """
+    Make the fake class and modify if needed
+    """
+    FakeClass = make_fake_device(cls)
+    if issubclass(FakeClass, PCDSMotorBase):
+        FakeClass.motor_spg.cls = HotfixFakeEpicsSignal
+    return FakeClass
+
+
+def motor_setup(motor):
+    """
+    Set up the motor based on the class
+    """
+    if isinstance(motor, EpicsMotorInterface):
+        motor.user_readback.sim_put(0)
+        motor.limits = (-100, 100)
+
+    if isinstance(motor, PCDSMotorBase):
+        motor.motor_spg.sim_put(2)
+        motor.motor_spg.sim_set_enum_strs(['Stop', 'Pause', 'Go'])
+
+    if isinstance(motor, IMS):
+        motor.bit_status.sim_put(0)
+        motor.part_number.sim_put('PN123')
+        motor.error_severity.sim_put(0)
+        motor.reinit_command.sim_put(0)
+
+
+def fake_motor(cls):
+    """
+    Given a real class, lets get a fake motor
+    """
+    FakeCls = fake_class_setup(cls)
+    motor = FakeCls('TST:MTR', name='test_motor')
+    motor_setup(motor)
+    return motor
+
+
+# Here I set up fixtures that test each level's overrides
+# Test in subclasses too to make sure we didn't break it!
+
+@pytest.fixture(scope='function',
+                params=[EpicsMotorInterface, PCDSMotorBase, IMS, Newport,
+                        PMC100, Beckhoff])
+def fake_epics_motor(request):
+    """
+    Test EpicsMotorInterface and subclasses
+    """
+    return fake_motor(request.param)
+
+
+@pytest.fixture(scope='function',
+                params=[PCDSMotorBase, IMS, Newport, PMC100])
+def fake_pcds_motor(request):
+    """
+    Test PCDSMotorBase and subclasses
+    """
+    return fake_motor(request.param)
 
 
 @pytest.fixture(scope='function')
 def fake_ims():
-    FakeIMS = make_fake_device(IMS)
-    FakeIMS.motor_spg.cls = HotfixFakeEpicsSignal
-    m = FakeIMS('Tst:Mtr:1', name='motor')
-    m.bit_status.sim_put(0)
-    m.part_number.sim_put('PN123')
-    m.error_severity.sim_put(0)
-    m.reinit_command.sim_put(0)
-    m.motor_spg.sim_put(2)
-    m.motor_spg.sim_set_enum_strs(['Stop', 'Pause', 'Go'])
-    return m
+    """
+    Test IMS-specific overrides
+    """
+    return fake_motor(IMS)
 
 
-def test_epics_motor_soft_limits(fake_motor):
-    m = fake_motor
+@pytest.fixture(scope='function')
+def fake_beckhoff():
+    """
+    Test Beckhoff-specific overrides
+    """
+    return fake_motor(Beckhoff)
+
+
+def test_epics_motor_soft_limits(fake_epics_motor):
+    logger.debug('test_epics_motor_soft_limits')
+    m = fake_epics_motor
     # Check that our limits were set correctly
     assert m.limits == (-100, 100)
     # Check that we can not move past the soft limits
@@ -48,8 +103,9 @@ def test_epics_motor_soft_limits(fake_motor):
         m.move(-150)
 
 
-def test_epics_motor_tdir(fake_motor):
-    m = fake_motor
+def test_epics_motor_tdir(fake_pcds_motor):
+    logger.debug('test_epics_motor_tdir')
+    m = fake_pcds_motor
     # Simulate a moving motor
     m._pos_changed(value=-1.0, old_value=0.0)
     assert m.direction_of_travel.get() == 0
@@ -58,6 +114,7 @@ def test_epics_motor_tdir(fake_motor):
 
 
 def test_ims_clear_flag(fake_ims):
+    logger.debug('test_ims_clear_flag')
     m = fake_ims
     # Already cleared
     m.clear_all_flags()
@@ -74,6 +131,7 @@ def test_ims_clear_flag(fake_ims):
 
 
 def test_ims_reinitialize(fake_ims):
+    logger.debug('test_ims_reinitialize')
     m = fake_ims
     # Do not reinitialize on auto-setup
     m.auto_setup()
@@ -93,6 +151,7 @@ def test_ims_reinitialize(fake_ims):
 
 
 def test_ims_stage_in_plan(fake_ims):
+    logger.debug('test_ims_stage_in_plan')
     RE = RunEngine()
     m = fake_ims
 
@@ -105,17 +164,18 @@ def test_ims_stage_in_plan(fake_ims):
     RE(plan())
 
 
-def test_resume_pause_stop(fake_motor):
-    m = fake_motor
+def test_resume_pause_stop(fake_pcds_motor):
+    logger.debug('test_resume_pause_stop')
+    m = fake_pcds_motor
     m.stop()
     assert m.motor_spg.get(as_string=True) == 'Stop'
-    with pytest.raises(Exception):
+    with pytest.raises(MotorStopError):
         m.check_value(10)
-    with pytest.raises(Exception):
+    with pytest.raises(MotorStopError):
         m.move(10, wait=False)
     m.pause()
     assert m.motor_spg.get(as_string=True) == 'Pause'
-    with pytest.raises(Exception):
+    with pytest.raises(MotorPauseError):
         m.move(10, wait=False)
     m.go()
     assert m.motor_spg.get(as_string=True) == 'Go'
@@ -123,11 +183,23 @@ def test_resume_pause_stop(fake_motor):
     m.resume()
     assert m.motor_spg.get(as_string=True) == 'Go'
     m.check_value(10)
-def test_camonitor(fake_motor):
-    motor=fake_motor
-    pid=os.getpid()
-    def interrupt():
-        time.sleep(0.1)
-        os.kill(pid, signal.SIGINT)
-    Thread(target=interrupt,args=()).start()
-    motor.camonitor() 
+
+
+def test_disable(fake_pcds_motor):
+    logger.debug('test_disable')
+    m = fake_pcds_motor
+    m.disable()
+    with pytest.raises(MotorDisabledError):
+        m.check_value(1)
+    with pytest.raises(MotorDisabledError):
+        m.move(1, wait=False)
+    m.enable()
+    m.move(1, wait=False)
+
+
+def test_beckhoff_error_clear(fake_beckhoff):
+    m = fake_beckhoff
+    m.clear_error()
+    assert m.cmd_err_reset.get() == 1
+    m.stage()
+    m.unstage()

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -1,9 +1,10 @@
 import fcntl
 import logging
 import multiprocessing as mp
-import time
 import threading
+import time
 import os
+import signal
 import shutil
 from pathlib import Path
 
@@ -88,6 +89,18 @@ def test_umv(motor):
     motor._set_position(5)
     motor.umvr(2)
     assert motor.position == 7
+
+
+def test_camonitor(motor):
+    logger.debug('test_camonitor')
+    pid = os.getpid()
+
+    def interrupt():
+        time.sleep(0.1)
+        os.kill(pid, signal.SIGINT)
+
+    threading.Thread(target=interrupt, args=()).start()
+    motor.camonitor()
 
 
 def test_presets_device(presets):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add the `Beckhoff` class for controlling the motor record from ESS.
- Add specific error classes for things like SPG and DISP
- Pare down unnecessarily wordy docstrings (when your function just sets the property, you don't have to copy the whole thing again...)
- Refactor `epics_motor` module to split the things we voluntarily add to the base `EpicsMotor` class from the things we are forced to add because our "motor-record-like" IOCs aren't quite compliant.
- Refactor the tests to be more thorough

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- We needed a `Beckhoff` class that could at least reset the errors. We may need to add more later, but it's unclear.
- The refactor was the cleanest way to include the `Beckhoff` class.
- I felt like the tests were weak here, we didn't even instantiate most of the classes. I parametrized the tests so that we can run each set of tests on all subclasses that should have the functionality. I also added the missing `DISP` test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We're all green captain

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to the `device_types` page

<!--
## Screenshots (if appropriate):
-->
