### PR TITLE
MAINT: PVStateSignal Description

### DIFF
--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -281,7 +281,8 @@ class PVStateSignal(AggregateSignal):
         desc = {'source': 'SUM:{}'.format(','.join(sub_sigs)),
                 'dtype': 'string',
                 'shape': [],
-                'enum_strs': [state.name for state in self.parent.states_enum]}
+                'enum_strs': tuple(state.name
+                                   for state in self.parent.states_enum)}
         return {self.name: desc}
 
     def _calc_readback(self):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -275,6 +275,15 @@ class PVStateSignal(AggregateSignal):
             self._sub_signals.append(sig)
             self._sub_map[signal_name] = sig
 
+    def describe(self):
+        # Base description information
+        sub_sigs = [sig.name for sig in self._sub_signals]
+        desc = {'source': 'SUM:{}'.format(','.join(sub_sigs)),
+                'dtype': 'string',
+                'shape': [],
+                'enum_strs': [state.name for state in self.parent.states_enum]}
+        return {self.name: desc}
+
     def _calc_readback(self):
         state_value = None
         for signal_name, info in self.parent._state_logic.items():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -93,6 +93,15 @@ def test_pvstate_positioner_logic():
         lim_obj.states_enum['defer']
 
 
+def test_pvstate_positioner_describe():
+    logger.debug('test_pvstate_positioner_describe')
+    lim_obj = LimCls('BASE', name='test')
+    # No smoke please
+    desc = lim_obj.state.describe()[lim_obj.state.name]
+    assert len(desc['enum_strs']) == 3  # In, Out, Unknown
+    assert desc['dtype'] == 'string'
+
+
 def test_pvstate_positioner_sets():
     logger.debug('test_pvstate_positioner_sets')
     lim_obj2 = LimCls2('BASE', name='test')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`PVStateSignal` now gives more information about itself in the `describe` dictionary for downstream consumers. This includes the `enum_strs` and which signals it is summarizing. This was largely for compatibility with `Typhon`, but I think it could be a helpful debugging tool.

#### Example
```python
{'mfx_dg1_vgc_01_state': {'dtype': 'string',
  'enum_strs': ['Unknown', 'IN', 'OUT'],
  'shape': [],
  'source': 'SUM:mfx_dg1_vgc_01_open_limit,mfx_dg1_vgc_01_closed_limit'}}
```
## Tests
Added a test for the contents of the `describe` dictionary