### PR TITLE
FIX: Warn user about subclassing base classes

### DIFF
--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -15,8 +15,14 @@ from .state import StatePositioner, StateRecordPositioner, PVStatePositioner
 
 class InOutPositioner(StatePositioner):
     """
-    Basic in/out `StatePositioner`. It can be inserted, removed and queried for
-    insertion and removal state. It can also define transmission values for the
+    Base class for a device that can be inserted and removed from the beam.
+
+    This must be subclassed and given a ``state`` signal to work properly. You
+    should also update the ``states_list``, ``in_states``, and ``out_states``
+    lists appropriately.
+
+    These devices can be inserted, removed and queried for insertion and
+    removal state. They can also define transmission values for the
     various states.
 %s
     Attributes
@@ -41,6 +47,9 @@ class InOutPositioner(StatePositioner):
     _transmission = {}
 
     def __init__(self, prefix, *, name, **kwargs):
+        if self.__class__ is InOutPositioner:
+            raise TypeError(('InOutPositioner must be subclassed with at '
+                             'least a state signal'))
         super().__init__(prefix, name=name, **kwargs)
         self._trans_enum = {}
         self._extend_trans_enum(self.in_states, 0)
@@ -137,3 +146,9 @@ class InOutPVStatePositioner(PVStatePositioner, InOutPositioner):
     more information.
     """
     __doc__ += basic_positioner_init
+
+    def __init__(self, *args, **kwargs):
+        if self.__class__ is InOutPVStatePositioner:
+            raise TypeError(('InOutPVStatePositioner must be subclassed, '
+                             'adding signals and filling in the '
+                             '_state_logic dict.'))

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -152,3 +152,4 @@ class InOutPVStatePositioner(PVStatePositioner, InOutPositioner):
             raise TypeError(('InOutPVStatePositioner must be subclassed, '
                              'adding signals and filling in the '
                              '_state_logic dict.'))
+        super().__init__(*args, **kwargs)

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -33,6 +33,10 @@ class SyncAxesBase(PseudoPositioner):
     pseudo = Cpt(PseudoSingle)
 
     def __init__(self, *args, **kwargs):
+        if self.__class__ is SyncAxesBase:
+            raise TypeError(('SyncAxesBase must be subclassed with '
+                             'the axes to synchronize included as '
+                             'components'))
         super().__init__(*args, **kwargs)
         self._offsets = {}
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -65,6 +65,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
     egu = 'state'
 
     def __init__(self, prefix, *, name, **kwargs):
+        if self.__class__ is StatePositioner:
+            raise TypeError(('StatePositioner must be subclassed with at '
+                             'least a state signal'))
         super().__init__(prefix, name=name, **kwargs)
         self._valid_states = [state for state in self.states_list
                               if state not in self._invalid_states
@@ -360,6 +363,10 @@ class PVStatePositioner(StatePositioner):
     _state_logic_mode = 'ALL'
 
     def __init__(self, prefix, *, name, **kwargs):
+        if self.__class__ is PVStatePositioner:
+            raise TypeError(('PVStatePositioner must be subclassed, '
+                             'adding signals and filling in the '
+                             '_state_logic dict.'))
         if self._state_logic and not self.states_list:
             self.states_list = []
             for state_mapping in self._state_logic.values():

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -4,7 +4,9 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.inout import InOutRecordPositioner
+from pcdsdevices.inout import (InOutPositioner,
+                               InOutRecordPositioner,
+                               InOutPVStatePositioner)
 
 from conftest import HotfixFakeEpicsSignal
 
@@ -62,3 +64,11 @@ def test_inout_subscriptions(fake_inout):
     # Change the target state
     inout.state.put('OUT')
     assert cb.called
+
+
+def test_subcls_warning():
+    logger.debug('test_subcls_warning')
+    with pytest.raises(TypeError):
+        InOutPositioner('prefix', name='name')
+    with pytest.raises(TypeError):
+        InOutPVStatePositioner('prefix', name='name')

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -65,3 +65,9 @@ def test_sync_offset(five_axes, two_axes):
     assert five_axes.five.position == 14
 
     assert two_axes.pseudo.position == 5
+
+
+def test_subcls_warning():
+    logger.debug('test_subcls_warning')
+    with pytest.raises(TypeError):
+        SyncAxesBase('prefix', name='name')

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -175,5 +175,14 @@ class InconsistentState(StatePositioner):
 
 
 def test_state_error():
+    logger.debug('test_state_error')
     with pytest.raises(ValueError):
         InconsistentState('prefix', name='bad')
+
+
+def test_subcls_warning():
+    logger.debug('test_subcls_warning')
+    with pytest.raises(TypeError):
+        StatePositioner('prefix', name='name')
+    with pytest.raises(TypeError):
+        PVStatePositioner('prefix', name='name')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Raise a concise, helpful error when a user tries to create a base-class-only device.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This used to give a wide range of unintelligible errors depending on which class you picked.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Some docstrings updated to indicate that subclassing is needed

<!--
## Screenshots (if appropriate):
-->
