### PR TITLE
FIX: split the XPP and XCS lodcm foils

### DIFF
--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -43,6 +43,14 @@ class Foil(InOutRecordPositioner):
     states_list = ['OUT']
     in_states = []
 
+    def __init__(self, prefix, *args, **kwargs):
+        if 'XPP' in prefix:
+            self.in_states = ['Mo', 'Zr', 'Zn', 'Cu', 'Ni', 'Fe', 'Ti']
+        elif 'XCS' in prefix:
+            self.in_states = ['Mo', 'Zr', 'Ge', 'Cu', 'Ni', 'Fe', 'Ti']
+        self.states_list = ['OUT'] + self.in_states
+        super().__init__(prefix, *args, **kwargs)
+
 
 class LODCM(InOutRecordPositioner):
     """

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -75,3 +75,9 @@ def test_lodcm_remove_dia(fake_lodcm):
     lodcm.remove_dia(moved_cb=cb, wait=True)
     assert cb.called
     assert lodcm.yag.position == 'OUT'
+
+
+def test_hutch_foils():
+    FakeFoil = make_fake_device(Foil)
+    assert 'Zn' in FakeFoil('XPP', name='foil').in_states
+    assert 'Ge' in FakeFoil('XCS', name='foil').in_states


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Basic split between XCS and XPP foils...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #137 
classes should work out of the box

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added in_states check.