### PR TITLE
ENH: display current position in umv progress bars

### DIFF
--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -147,7 +147,7 @@ class FltMvInterface(MvInterface):
             will be use.
         """
         status = self.move(position, timeout=timeout, wait=False)
-        ProgressBar([status])
+        AbsProgressBar([status])
         try:
             status_wait(status)
         except KeyboardInterrupt:
@@ -732,3 +732,15 @@ def tweak_base(*args):
             else:
                 movement(scale, inp)
                 scale = _scale(scale, inp)
+
+
+class AbsProgressBar(ProgressBar):
+    """
+    Progress bar that displays the absolute position as well
+    """
+    def update(self, *args, name=None, current=None, **kwargs):
+        if None not in (name, current):
+            super().update(*args, name='{} ({:.3f})'.format(name, current),
+                           current=current, **kwargs)
+        else:
+            super().update(*args, name=name, current=current, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`tqdm` lets you put a prefix before your progress bar. The `bluesky` progress bar puts the name as the prefix. I extend the name with the current position and pass it in. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When doing moves from nonzero positions, the progress bar currently only displays how far we move. This is a loss in feature from the old python, where `umv` would continually update the absolute current position.
closes #245 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did the "feel" tests. The automated tests should still pass.