### PR TITLE
MAINT: Interlocks belong in check_value

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -95,7 +95,6 @@ class GateValve(Stopper):
     command = Cpt(EpicsSignal,   ':OPN_SW', kind='omitted')
     interlock = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal')
 
-
     def check_value(self, value):
         """Check when removing GateValve interlock is off"""
         value = super().check_value(value)
@@ -146,7 +145,6 @@ class PPSStopper(InOutPositioner):
         self.states_list = self.in_states + self.out_states
         # Load InOutPositioner
         super().__init__(prefix, **kwargs)
-
 
     def check_value(self, state):
         """

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -95,6 +95,14 @@ class GateValve(Stopper):
     command = Cpt(EpicsSignal,   ':OPN_SW', kind='omitted')
     interlock = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal')
 
+
+    def check_value(self, value):
+        """Check when removing GateValve interlock is off"""
+        value = super().check_value(value)
+        if value == self.states_enum.OUT and self.interlocked:
+            raise InterlockError('Valve is currently forced closed')
+        return value
+
     @property
     def interlocked(self):
         """
@@ -102,15 +110,6 @@ class GateValve(Stopper):
         opening
         """
         return bool(self.interlock.get())
-
-    def remove(self, **kwargs):
-        """
-        Remove the valve from the beam
-        """
-        if self.interlocked:
-            raise InterlockError('Valve is currently forced closed')
-
-        return super().remove(**kwargs)
 
 
 class PPSStopper(InOutPositioner):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -148,7 +148,8 @@ class PPSStopper(InOutPositioner):
         # Load InOutPositioner
         super().__init__(prefix, **kwargs)
 
-    def _do_move(self, state):
+
+    def check_value(self, state):
         """
         PPSStopper can not be commanded via EPICS
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
External applications may want to check whether a move is possible without requesting one. Because `PPSStopper` and `GateValve` had interlock logic hidden in `_do_move` this was not possible. This places that functionality within `check_value`. 

We may still want to make this process more explicit, but this is the first step.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related but might not fully close #259 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing interlock tests still pass
