### PR TITLE
MAINT: Subscription States

### DIFF
--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -214,8 +214,7 @@ class AttBase(FltMvInterface, PVPositioner):
         if event_type is None:
             event_type = self._default_sub
         if event_type == self.SUB_STATE and not self._has_subscribed_state:
-            for filt in self.filters:
-                filt.subscribe(self._run_filt_state, run=False)
+            self.done.subscribe(self._run_filt_state, run=False)
             self._has_subscribed_state = True
         return cid
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -79,10 +79,13 @@ class AttBase(FltMvInterface, PVPositioner):
 
     # QIcon for UX
     _icon = 'fa.barcode'
+    # Subscription Types
+    SUB_STATE = 'state'
 
     def __init__(self, prefix, *, name, **kwargs):
         super().__init__(prefix, name=name, limits=(0, 1), **kwargs)
         self.filters = []
+        self._has_subscribed_state = False
         for i in range(1, MAX_FILTERS + 1):
             try:
                 self.filters.append(getattr(self, 'filter{}'.format(i)))
@@ -205,6 +208,21 @@ class AttBase(FltMvInterface, PVPositioner):
             moving_val = 1 - self.done_value
             self._move_changed(value=moving_val)
             self._move_changed(value=self.done_value)
+
+    def subscribe(self, cb, event_type=None, run=True):
+        cid = super().subscribe(cb, event_type=event_type, run=run)
+        if event_type is None:
+            event_type = self._default_sub
+        if event_type == self.SUB_STATE and not self._has_subscribed_state:
+            for filt in self.filters:
+                filt.subscribe(self._run_filt_state, run=False)
+            self._has_subscribed_state = True
+        return cid
+
+    def _run_filt_state(self, *args, **kwargs):
+        kwargs.pop('sub_type')
+        kwargs.pop('obj')
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)
 
 
 class AttBase3rd(AttBase):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -189,6 +189,8 @@ class OffsetMirror(Device):
     transmission = 1.0
     # QIcon for UX
     _icon = 'fa.minus-square'
+    # Subscription types
+    SUB_STATE = 'state'
 
     def __init__(self, prefix, *, prefix_xy=None,
                  xgantry_prefix=None, **kwargs):

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -98,6 +98,12 @@ def test_attenuator_subscriptions(fake_att):
     att.subscribe(cb, run=False)
     att.readback.sim_put(0.5)
     assert cb.called
+    state_cb = Mock()
+    att.subscribe(state_cb, event_type=att.SUB_STATE, run=False)
+    att.readback.sim_put(0.6)
+    assert not state_cb.called
+    att.filters[0].state.put('IN')
+    assert state_cb.called
 
 
 @pytest.mark.timeout(5)

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -102,7 +102,8 @@ def test_attenuator_subscriptions(fake_att):
     att.subscribe(state_cb, event_type=att.SUB_STATE, run=False)
     att.readback.sim_put(0.6)
     assert not state_cb.called
-    att.filters[0].state.put('IN')
+    att.done.sim_put(1)
+    att.done.sim_put(0)
     assert state_cb.called
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Both the `OffsetMirror` and the `Attenuator` classes didn't have `SUB_STATE` subscription types. This confused the `lightpath`:

### Attenuator
A call to subscribe to the  `SUB_STATE`  method subscribes to all of the filter states. Any change in state of a child filter triggers a call. This is better than the alternative of subscribing to the actual transmission value which jitters with beam energy.

### OffsetMirror
The `OffsetMirror` never changes states. It is always considered inserted. The `SUB_STATE` is never called. This is slightly hacky and I can be convinced to remove it, but it solves my problem for now 😄 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/pcdshub/lightpath/issues/75

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test in the attenuator class for the `SUB_STATE` subscription call