### PR TITLE
ENH: Reflaser

### DIFF
--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -11,16 +11,16 @@ Common EPICS Devices
     CCM
     EpicsMotor
     EventSequencer
-    LODCM
     GateValve
     IMS
     IPM
+    LODCM
     Newport
+    OffsetMirror
     PIM
     PMC100
-    OffsetMirror
-    PulsePicker
     PointingMirror
+    PulsePicker
     Slits
     Stopper
     Trigger

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -21,7 +21,9 @@ Common EPICS Devices
     PMC100
     PointingMirror
     PulsePicker
+    Reflaser
     Slits
     Stopper
     Trigger
+    TTReflaser
     XFLS

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -3,6 +3,7 @@ from .attenuator import Attenuator
 from .ccm import CCM
 from .epics_motor import IMS, Newport, PMC100, BeckhoffAxis, EpicsMotor
 from .evr import Trigger
+from .inout import Reflaser, TTReflaser
 from .ipm import IPM
 from .lens import XFLS
 from .lodcm import LODCM

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -126,12 +126,16 @@ class InOutRecordPositioner(StateRecordPositioner, InOutPositioner):
     __doc__ += basic_positioner_init
 
 
-class TTReflaser(InOutRecordPositioner):
+class Reflaser(InOutRecordPositioner):
+    """Simple ReferenceLaser with In/Out States"""
+    _icon = 'fa.empire'
+    __doc__ += basic_positioner_init
+
+
+class TTReflaser(Reflaser):
     """
     Motor stack that includes both a timetool and a reflaser.
     """
-    __doc__ += basic_positioner_init
-
     states_list = ['TT', 'REFL', 'OUT']
     in_states = ['TT', 'REFL']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,5 @@ style = pep440
 versionfile_source = pcdsdevices/_version.py
 versionfile_build  = pcdsdevices/_version.py
 tag_prefix = v
+[flake8]
+exclude = pcdsdevices/areadetector/*,docs/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Add a basic `Reflaser` class with an icon
* Change `TTReflaser` to inherit from the new base `Reflaser`

Also added a bit to `setup.cfg` so `flake8` wouldn't search in the `docs` or `pcdsdevices/areadetector` folders. Maybe something we should consider adding to standard packaging

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`Reflaser` wants an icon for the `lightpath` but we were just using `InOutRecordPositioner` before. This gives us a way to have a unique icon and also gives a nice blueprint if anyone wants to expand on the class.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to `device_types` table