### PR TITLE
WIP: LODCM Branching Specification

### DIFF
--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -8,6 +8,7 @@ downstream hutches.
 It will not be possible to align the device with the class, and there will be
 no readback into the device's alignment. This is intended for a future update.
 """
+import itertools
 import logging
 import functools
 
@@ -90,7 +91,7 @@ class LODCM(InOutRecordPositioner):
     # QIcon for UX
     _icon = 'fa.share-alt-square'
 
-    def __init__(self, prefix, *, name, main_line='MAIN', mono_line='MONO',
+    def __init__(self, prefix, *, name, main_line=['MAIN'], mono_line=['MONO'],
                  **kwargs):
         super().__init__(prefix, name=name, **kwargs)
         self.main_line = main_line
@@ -104,7 +105,7 @@ class LODCM(InOutRecordPositioner):
         branches: ``list`` of ``str``
             A list of possible destinations.
         """
-        return [self.main_line, self.mono_line]
+        return self.main_line + self.mono_line
 
     @property
     def destination(self):
@@ -120,17 +121,16 @@ class LODCM(InOutRecordPositioner):
             ``self.mono_line`` if the light continues on the mono line.
         """
         if self.position == 'OUT':
-            dest = [self.main_line]
-        elif self.position == 'Si':
-            dest = [self.mono_line]
+            dest = self.main_line
+        elif self.position == 'Si' and self._dia_clear:
+            dest = self.mono_line
         elif self.position == 'C':
-            dest = [self.main_line, self.mono_line]
+            if self._dia_clear:
+                dest = list(itertools.chain((self.mono_line, self.main_line)))
+            else:
+                dest = self.main_line
         else:
             dest = []
-
-        if not self._dia_clear and self.mono_line in dest:
-            dest.remove(self.mono_line)
-
         return dest
 
     @property

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -64,11 +64,11 @@ class LODCM(InOutRecordPositioner):
 
     This positioner only considers the h1n and diagnostic motors.
 %s
-    main_line: ``str``, optional
-        Name of the main, no-bounce beamline.
+    main_line: ``list`` of ``str``, optional
+        Name of no-bounce beamlines.
 
-    mono_line: ``str``, optional
-        Name of the mono, double-bounce beamline.
+    mono_line: ``list`` of ``str``, optional
+        Names of the mono, double-bounce beamlines.
     """
     __doc__ = __doc__ % basic_positioner_init
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The `lightpath` requires that an optic report all possible beamlines that may branch off the line it is on. Unfortunately, since both `LODCM` are on the `HXD` branch which has **all** the HXR beamlines it must report them. The `main_line` argument has been changed to accept a `list`. For consistency sake I changed the `mono_line` to use a list as well. This last choice is debatable. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Have the lightpath report accurately

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* I tried this with the `lightpath` and it correctly identified the LODCM as a blocking device for the `HXR` hutches. 
* Existing tests pass unmodified

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated docstrings