### PR TITLE
MAINT: StateDevice accepts strings that are numbers

### DIFF
--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -205,6 +205,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
             The corresponding ``Enum`` entry for this value. It has two
             meaningful fields, ``name`` and ``value``.
         """
+        # Check for a malformed string digit
+        if isinstance(value, str) and value.isdigit():
+            value = int(value)
         try:
             return self.states_enum[value]
         except KeyError:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -56,6 +56,8 @@ def test_state_positioner_basic():
     states.hints
     states.move(3)
     assert states.position == 'OUT'
+    states.move('2')
+    assert states.position == 'IN'
 
 
 def test_pvstate_positioner_logic():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This is a tad bit of a hack but makes life easier for our users (a.k.a me). We now watch for input that looks like `device.move("2")`