### PR TITLE
MAINT: Slit Interface

### DIFF
--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -124,7 +124,6 @@ class Slits(Device, MvInterface):
 
     def __init__(self, *args, nominal_aperture=5.0, **kwargs):
         self._has_subscribed = False
-        self._nom = nominal_aperture
         super().__init__(*args, **kwargs)
         # Initialize nominal_aperture behind the scenes
         self.nominal_aperture._readback = nominal_aperture

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -18,7 +18,7 @@ import time
 from ophyd.status import wait as status_wait
 from ophyd.pv_positioner import PVPositioner
 from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as Cpt,
-                   FormattedComponent as FCpt, Kind)
+                   FormattedComponent as FCpt)
 from ophyd.signal import AttributeSignal
 
 from .mv_interface import MvInterface, FltMvInterface
@@ -128,8 +128,8 @@ class Slits(Device, MvInterface):
         self._nom = nominal_aperture
         super().__init__(*args, **kwargs)
         # Modify Kind of center readbacks
-        self.xcenter.readback.kind = Kind.normal
-        self.ycenter.readback.kind = Kind.normal
+        self.xcenter.readback.kind = 'normal'
+        self.ycenter.readback.kind = 'normal'
 
     def move(self, size, wait=False, moved_cb=None, timeout=None):
         """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -57,10 +57,10 @@ class SlitPositioner(FltMvInterface, PVPositioner, Device):
     ``ophyd.PVPositioner``
         ``SlitPositioner`` inherits directly from ``PVPositioner``.
     """
-    setpoint = FCpt(EpicsSignal, "{self.prefix}:{self._dirshort}_REQ",
-                    kind='normal')
     readback = FCpt(EpicsSignalRO, "{self.prefix}:ACTUAL_{self._dirlong}",
                     kind='hinted')
+    setpoint = FCpt(EpicsSignal, "{self.prefix}:{self._dirshort}_REQ",
+                    kind='normal')
     done = Cpt(EpicsSignalRO, ":DMOV", kind='omitted')
 
     def __init__(self, prefix, *, slit_type="", name=None,
@@ -116,11 +116,11 @@ class Slits(Device, MvInterface):
     make a rough back of the hand calculation without being over aggressive
     about changing slit widths during alignment
     """
-    xcenter = Cpt(SlitPositioner, '', slit_type="XCENTER", kind='hinted')
-    xwidth = Cpt(SlitPositioner, '', slit_type="XWIDTH", kind='normal')
-    ycenter = Cpt(SlitPositioner, '', slit_type="YCENTER", kind='hinted')
-    ywidth = Cpt(SlitPositioner, '', slit_type="YWIDTH", kind='normal')
+    xwidth = Cpt(SlitPositioner, '', slit_type="XWIDTH", kind='hinted')
+    ywidth = Cpt(SlitPositioner, '', slit_type="YWIDTH", kind='hinted')
     nominal_aperture = Cpt(AttributeSignal, attr='_nominal', kind='normal')
+    xcenter = Cpt(SlitPositioner, '', slit_type="XCENTER", kind='normal')
+    ycenter = Cpt(SlitPositioner, '', slit_type="YCENTER", kind='normal')
     blocked = Cpt(EpicsSignalRO, ":BLOCKED", kind='omitted')
     open_cmd = Cpt(EpicsSignal, ":OPEN", kind='omitted')
     close_cmd = Cpt(EpicsSignal, ":CLOSE", kind='omitted')
@@ -135,6 +135,9 @@ class Slits(Device, MvInterface):
         self._has_subscribed = False
         self._nom = nominal_aperture
         super().__init__(*args, **kwargs)
+        # Modify Kind of center readbacks
+        self.xcenter.readback.kind = Kind.normal
+        self.ycenter.readback.kind = Kind.normal
 
     def move(self, size, wait=False, moved_cb=None, timeout=None):
         """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -100,20 +100,13 @@ class Slits(Device, MvInterface):
 
     Notes
     -----
-    The slits represent a unique device when forming the lightpath as whether
-    the beam is being blocked or not depends on the pointing. In order to
-    create an estimate that will warn operators of narrowly closed slits while
-    still allowing slits to be closed along the beampath.
-
-    The simplest solution was to use a :attr:`.nominal_aperture` that stores
-    the slit width and height that the slits should use for general operation.
-    Using this the :attr:`.transmission` is calculated based on how the current
-    aperture compares to the nominal, always using the minimum of the width or
-    height. This means that if you have a nominal aperture of 2 mm, but your
-    slits are set to 0.5 mm, the total estimated transmission will be 25%.
-    Obviously this is greatly oversimplified, but it allows the lightpath to
-    make a rough back of the hand calculation without being over aggressive
-    about changing slit widths during alignment
+    The slits represent a unique device when forming the lightpath because
+    whether the beam is being blocked or not depends on the pointing. In order
+    to create an estimate that will warn operators of "closed" slits, we set a
+    ``nominal_aperture`` for each unique device along the beamline. This is
+    value is considered the smallest the slit aperture can become without
+    blocking the beamline. Both the ``width`` and the ``height`` need to exceed
+    this ``nominal_aperture`` for the ``Slits`` to be considered removed.
     """
     xwidth = Cpt(SlitPositioner, '', slit_type="XWIDTH", kind='hinted')
     ywidth = Cpt(SlitPositioner, '', slit_type="YWIDTH", kind='hinted')

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -15,7 +15,6 @@ used.
 import logging
 import time
 
-import numpy as np
 from ophyd.status import wait as status_wait
 from ophyd.pv_positioner import PVPositioner
 from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as Cpt,
@@ -326,7 +325,7 @@ class Slits(Device, MvInterface):
         # manually poke the nominal_aperture to update
         self.nominal_aperture._run_subs(
                 sub_type=self.nominal_aperture.SUB_VALUE,
-                old_value=old_value,value=self._nom,
+                old_value=old_value, value=self._nom,
                 timestamp=time.time())
         # Fire the state change callback as we have a new definition of
         # inserted and removed

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -201,18 +201,6 @@ class Slits(Device, MvInterface):
         return not self.inserted
 
     @property
-    def transmission(self):
-        """
-        Estimated transmission of the slits based on :attr:`.nominal_aperture`
-        """
-        # Find most restrictive side of slit aperture
-        min_dim = np.argmin(self.current_aperture)
-        # Don't allow transmissions over 1.0
-        return min([self.current_aperture[min_dim]
-                    / self.nominal_aperture[min_dim],
-                    1.0])
-
-    @property
     def current_aperture(self):
         """
         Current size of the aperture (width, height)

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -82,6 +82,12 @@ def test_slit_subscriptions(fake_slits):
     # Change the aperture size
     slits.xwidth.readback.sim_put(40.0)
     assert cb.called
+    # Subscribe a new pseudo callback
+    cb = Mock()
+    slits.subscribe(cb, event_type=slits.SUB_STATE, run=False)
+    # Change the nominal aperture
+    slits.nominal_aperture.put(12.0)
+    assert cb.called
 
 
 def test_slit_staging(fake_slits):

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -73,25 +73,6 @@ def test_slit_motion(fake_slits):
     assert status.done and status.success
 
 
-def test_slit_transmission(fake_slits):
-    logger.debug('test_slit_transmission')
-    slits = fake_slits
-    # Set our nominal aperture
-    slits.nominal_aperture = (5.0, 10.0)
-    # Half-closed
-    slits.xwidth.readback.sim_put(2.5)
-    slits.ywidth.readback.sim_put(5.0)
-    assert slits.transmission == 0.5
-    # Quarter-closed making sure we are using min
-    slits.ywidth.readback.sim_put(2.5)
-    slits.xwidth.readback.sim_put(5.0)
-    assert slits.transmission == 0.25
-    # Nothing greater than 100%
-    slits.xwidth.readback.sim_put(40.0)
-    slits.ywidth.readback.sim_put(40.0)
-    assert slits.transmission == 1.0
-
-
 def test_slit_subscriptions(fake_slits):
     logger.debug('test_slit_subscriptions')
     slits = fake_slits

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -82,12 +82,6 @@ def test_slit_subscriptions(fake_slits):
     # Change the aperture size
     slits.xwidth.readback.sim_put(40.0)
     assert cb.called
-    # Subscribe a new pseudo callback
-    cb = Mock()
-    slits.subscribe(cb, event_type=slits.SUB_STATE, run=False)
-    # Change the nominal aperture
-    slits.nominal_aperture.put(12.0)
-    assert cb.called
 
 
 def test_slit_staging(fake_slits):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
These are some changes to make the Slits nicer to work with in the `lightpath`. Largely reducing complexity and making their behavior easier to understand.

1. No more complex `transmission` calculation based on their `nominal_aperture`. If either dimension of the slit is closed past the `nominal_aperture` they are inserted, otherwise they removed.
2. `nominal_aperture` is now an `AttributeSignal`. This field will be populated by the `happi` database and now contained in the `Typhon` screen 😄
3. I added a few lines in the `Slits.__init__` to change the `Kind` of its children. I think this is the proper way to handle this situation in this case although it looks a bit strange. If you load the `SlitPositioner` by itself the `readback` should be a `hint` and the `setpoint` should be `normal`. If you load them in the context of the entire `Slits` object the `hints` should be the readback of the `width` and the `height` (not all four). Thoughts? 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Remove tests for `transmission` calculations
* Added tests for subscription callbacks
