### PR TITLE
FIX: Valve Interlock

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -113,7 +113,7 @@ class GateValve(Stopper):
         Whether the interlock on the valve is active, preventing the valve from
         opening
         """
-        return bool(self.interlock.get())
+        return not bool(self.interlock.get())
 
 
 class PPSStopper(InOutPositioner):

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -32,7 +32,7 @@ def fake_stopper():
 def fake_valve():
     FakeValve = make_fake_device(GateValve)
     vlv = FakeValve("VGC:TST:", name="test_valve")
-    vlv.interlock.sim_put(0)
+    vlv.interlock.sim_put(1)
     return vlv
 
 
@@ -115,7 +115,7 @@ def test_valve_motion(fake_valve):
     # Check write PV
     assert valve.command.value == valve.commands.open_valve.value
     # Raises interlock
-    valve.interlock.sim_put(1)
+    valve.interlock.sim_put(0)
     assert valve.interlocked
     with pytest.raises(InterlockError):
         valve.open()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Noticed today in MFX. I guess we haven't been moving valves in `hutch-python` much...

The PV for the interlock is `OPN_OK` which means a value of 1 is okay to open. This logic was inverted in the class and corresponding tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated tests and confirmed on real hardware
