### PR TITLE
ENH: EventSequencer Trigger

### DIFF
--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -39,13 +39,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
 
     .. code::
 
-        def step_then_sequence(detectors, step, pos_cache)
-            yield from one_nd_step(detectors, step, pos_cache)
-            yield from kickoff(sequencer)
-            yield from complete(sequencer)  # Waits for sequence to complete if
-                                            # not in "Run Forever" mode
-
-        scan([det], motor, ..., per_step=step_then_sequence)
+        scan([sequencer], motor, ....)
 
     Note
     ----
@@ -111,7 +105,21 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         self.play_control.put(1)
 
     def trigger(self):
-        """Trigger the EventSequencer"""
+        """
+        Trigger the EventSequencer
+
+        This method reconfigures the EventSequencer to take a new reading. This
+        means:
+
+            * Stopping the EventSequencer if it is already running
+            * Restarting the EventSequencer
+
+        The returned status object will indicate different behavior based on
+        the configuration of the EventSequencer itself. If set to "Run
+        Forever", the status object merely indicates that we have succesfully
+        started our sequence. Otherwise, the status object will be completed
+        when the sequence we have set it to play is complete.
+        """
         # Stop the Sequencer if it is already running
         self.stop()
         if self.DEFAULT_SLEEP:

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -112,6 +112,8 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
 
     def trigger(self):
         """Trigger the EventSequencer"""
+        # Stop the Sequencer if it is already running
+        self.stop()
         if self.DEFAULT_SLEEP:
             logger.debug("EventSequencer sleeping %s s ...",
                          self.DEFAULT_SLEEP)

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from ophyd import Device, EpicsSignal, EpicsSignalRO, Component as Cpt
 from ophyd.status import DeviceStatus, SubscriptionStatus

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -59,6 +59,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
     sequence_length = Cpt(EpicsSignal, ':LEN', kind='config')
     current_step = Cpt(EpicsSignal, ':CURSTP', kind='normal')
     play_count = Cpt(EpicsSignal, ':PLYCNT', kind='normal')
+    total_play_count = Cpt(EpicsSignalRO, ':TPLCNT', kind='normal')
     play_status = Cpt(EpicsSignalRO, ':PLSTAT', auto_monitor=True,
                       kind='normal')
     play_mode = Cpt(EpicsSignal, ':PLYMOD', kind='config')

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -102,6 +102,24 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         logger.debug("Starting EventSequencer ...")
         self.play_control.put(1)
 
+
+    def trigger(self):
+        """Trigger the EventSequencer"""
+        # Fire the EventSequencer
+        self.start()
+        # If we are running forever, count this is as triggered
+        if self.play_mode.get() == 2:
+            logger.debug("EventSequencer is set to run forever, "
+                         "trigger is complete")
+            return DeviceStatus(self, done=True, success=True)
+
+        # Create our status
+        def done(*args, value=None, old_value=None, **kwargs):
+            return value == 2 and old_value == 0
+
+        # Create our status object
+        return SubscriptionStatus(self.play_status, done, run=True)
+
     def pause(self):
         """Stop the event sequencer and stop monitoring events"""
         # Order a stop

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -63,11 +63,6 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
     rep_count = Cpt(EpicsSignal, ":REPCNT", kind='config')
     sequence_owner = Cpt(EpicsSignalRO, ':HUTCH_NAME', kind='omitted')
 
-    # Used to put an artificial sleep in before triggering the EventSequener.
-    # This gives us some room for the DAQ to arm its triggers before the
-    # sequence starts
-    DEFAULT_SLEEP = 0
-
     def __init__(self, prefix, *, name=None, monitor_attrs=None, **kwargs):
         monitor_attrs = monitor_attrs or ['current_step', 'play_count']
         # Device initialization
@@ -122,10 +117,6 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         """
         # Stop the Sequencer if it is already running
         self.stop()
-        if self.DEFAULT_SLEEP:
-            logger.debug("EventSequencer sleeping %s s ...",
-                         self.DEFAULT_SLEEP)
-            time.sleep(self.DEFAULT_SLEEP)
         # Fire the EventSequencer
         self.start()
         # If we are running forever, count this is as triggered

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -71,7 +71,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
 
     # Used to put an artificial sleep in before triggering the EventSequener.
     # This gives us some room for the DAQ to arm its triggers before the
-    # sequence starts 
+    # sequence starts
     DEFAULT_SLEEP = 0
 
     def __init__(self, prefix, *, name=None, monitor_attrs=None, **kwargs):
@@ -109,7 +109,6 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         # Start the sequencer
         logger.debug("Starting EventSequencer ...")
         self.play_control.put(1)
-
 
     def trigger(self):
         """Trigger the EventSequencer"""

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -63,6 +63,32 @@ def test_kickoff(sequence):
     assert st.success
 
 
+def test_trigger(sequence):
+    # Not currently playing
+    sequence.play_status.sim_put(0)
+    # Set to run forever
+    sequence.play_mode.put(2)
+    trig_status = sequence.trigger()
+    # Sequencer has started
+    assert sequence.play_control.get() == 1
+    # Trigger is automatically complete
+    assert trig_status.done
+    assert trig_status.success
+    # Stop sequencer
+    # Not currently playing
+    sequence.play_status.sim_put(0)
+    sequence.play_control.put(0)
+    # Set to run once
+    sequence.play_mode.put(0)
+    trig_status = sequence.trigger()
+    # Not done until sequencer is done
+    assert sequence.play_control.get() == 1
+    assert not trig_status.done
+    sequence.play_status.sim_put(2)
+    assert trig_status.done
+    assert trig_status.success
+
+
 def test_complete_run_forever(sequence):
     logger.debug('test_complete_run_forever')
     seq = sequence


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The EventSequencer now has a `trigger` method that institutes the following behavior:
* If set to run forever, the returns a Status thats is done right away
* If set to a finite run time, wait for the Sequencer to complete its run

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for use in of both the DAQ and the EventSequencer together with a simple:
`trigger_and_read` call.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for new behavior

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings updated. A thorough explanation of how to utilize this object in conjunction with the DAQ is probably owed, but maybe not in this repository
