### PR TITLE
MAINT: SPG in a scan

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -170,6 +170,10 @@ class PCDSMotorBase(EpicsMotorInterface):
     # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, ".SPG", kind='omitted')
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stage_sigs[self.motor_spg] = 2
+
     def stop(self):
         """
         Stops the motor.

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -174,36 +174,22 @@ class PCDSMotorBase(EpicsMotorInterface):
         """
         Stops the motor.
 
-        After which the motor
-        must be set back to 'go' via <motor>.go()
-        in order to move again.
+        After which the motor must be set back to 'go' via <motor>.spg_go() in
+        order to move again.
         """
         return self.motor_spg.put(value='Stop')
 
-    def pause(self):
+    def spg_pause(self):
         """
         Pauses a move.
 
-        Move will resume if <motor>.resume()
-        or <motor>.go() are called.
+        Move will resume if <motor>.go() is called.
         """
         return self.motor_spg.put(value='Pause')
 
-    def resume(self):
+    def spg_go(self):
         """
         Resumes paused movement.
-
-        Sets motor ready to move or resumes a paused move
-        (same as <motor>.go()).
-        """
-        return self.go()
-
-    def go(self):
-        """
-        Resumes paused movement.
-
-        Sets motor ready to move or resumes a paused move
-        (same as <motor>.resume()).
         """
         return self.motor_spg.put(value='Go')
 

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -178,6 +178,13 @@ def test_resume_pause_stop(fake_pcds_motor):
         m.move(10, wait=False)
     m.spg_go()
     assert m.motor_spg.get(as_string=True) == 'Go'
+    # Test staging
+    m.motor_spg.put(0)
+    m.stage()
+    assert m.motor_spg.get() == 2
+    # Test unstaging
+    m.unstage()
+    assert m.motor_spg.get() == 0
 
 
 def test_disable(fake_pcds_motor):

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -172,16 +172,12 @@ def test_resume_pause_stop(fake_pcds_motor):
         m.check_value(10)
     with pytest.raises(MotorDisabledError):
         m.move(10, wait=False)
-    m.pause()
+    m.spg_pause()
     assert m.motor_spg.get(as_string=True) == 'Pause'
     with pytest.raises(MotorDisabledError):
         m.move(10, wait=False)
-    m.go()
+    m.spg_go()
     assert m.motor_spg.get(as_string=True) == 'Go'
-    m.check_value(10)
-    m.resume()
-    assert m.motor_spg.get(as_string=True) == 'Go'
-    m.check_value(10)
 
 
 def test_disable(fake_pcds_motor):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Setting the SPG field on `pause` proved very cumbersome in deployment. Largely because the SPG field is buried on most of the high level motor screens. It is also not clear if there is much added benefit. This PR:

* Renames `pause` and `go` to `spg_pause` and `spg_go`. This keeps the functionality but makes sure that they are not called via `bluesky`
* Removes the `resume` method. This was only necessary for the `bluesky` interface
* I left `stop`. I think this is actually the correct behavior for this function. 
* I put the `motor_spg`as a `stage_sig`. This means that at the end of the scan when we `unstage` we will always set the `SPG` field back to what it was at the start of the scan.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #276 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified and added tests
