### PR TITLE
ENH: Event Sequence Read/Write

### DIFF
--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -20,7 +20,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
 
     Parameters
     ----------
-    prefix: str
+    prefix : str
         Base prefix of the EventSequencer
 
     name : str
@@ -50,7 +50,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
     out the scan
 
     """
-    
+
     play_control = Cpt(EpicsSignal, ':PLYCTL', kind='omitted')
     sequence_length = Cpt(EpicsSignal, ':LEN', kind='config')
     current_step = Cpt(EpicsSignal, ':CURSTP', kind='normal')
@@ -69,10 +69,15 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         monitor_attrs = monitor_attrs or ['current_step', 'play_count']
 
         # Setup Event Sequence
-        hutch_map = {1:'AMO', 2:'SXR', 3:'XPP', 4:'XCS', 5:'CXI', 6:'MEC', 7:'MFX', 8:'XPP', 9:'MFX', 10:'SXR', 11:'XPP', 12:'XCS', 13:None, 14:None, 15:None, 16:'CXI', 100:'TST'}
+        hutch_map = {1: 'AMO', 2: 'SXR', 3: 'XPP', 4: 'XCS', 5: 'CXI',
+                     6: 'MEC', 7: 'MFX', 8: 'XPP', 9: 'MFX', 10: 'SXR',
+                     11: 'XPP', 12: 'XCS', 13: None, 14: None, 15: None,
+                     16: 'CXI', 100: 'TST'}
         hutch = hutch_map[int(prefix.split(':')[-1])]
-    
-        self.sequence = EventSequence('{}:ECS:IOC:01'.format(hutch), hutch_num=prefix[-1], name='{}_sequence'.format(hutch))
+ 
+        self.sequence = EventSequence('{}:ECS:IOC:01'.format(hutch),
+                                      hutch_num=prefix[-1],
+                                      name='{}_sequence'.format(hutch))
 
         # Device initialization
         super().__init__(prefix, name=name,
@@ -218,7 +223,7 @@ class SequenceLine(Device):
         super().__init__(prefix, **kwargs)
 
     def get(self):
-        """Read this line of the event sequence. 
+        """Read this line of the event sequence.
 
         Parameters
         ----------
@@ -234,13 +239,14 @@ class SequenceLine(Device):
         fiducial_delta = self.fd.get()
         burst_count = self.bc.get()
         description = self.ds.get()
-        
-        line = [event_code, beam_delta, fiducial_delta, burst_count, description]
+
+        line = [event_code, beam_delta, fiducial_delta, burst_count,
+                description]
 
         return line
 
     def put(self, line):
-        """Write to this line of the event sequence. 
+        """Write to this line of the event sequence.
 
         Parameters
         ----------
@@ -258,26 +264,29 @@ class SequenceLine(Device):
         if len(line) != 5:
             raise ValueError("The sequence line must be a 5 item list!")
         else:
-            self.ec.put(line[0])        
-            self.bd.put(line[1])        
-            self.fd.put(line[2])        
-            self.bc.put(line[3])        
-            self.ds.put(str(line[4]))        
+            self.ec.put(line[0])
+            self.bd.put(line[1])
+            self.fd.put(line[2])
+            self.bc.put(line[3])
+            self.ds.put(str(line[4]))
+
 
 class EventSequence():
     """Class for the event sequence of the event sequencer."""
 
     def __init__(self, prefix, hutch_num, **kwargs):
-        
+
         self._hutch_num = hutch_num
-      
-        self._lines = [] 
-        for i in range(0,20,1):
+ 
+        self._lines = []
+        for i in range(0, 20, 1):
             line_num = str(i)
             # Pad 1 digit numbers with 0
             if len(line_num) == 1:
                 line_num = '0' + line_num
-            line = SequenceLine(prefix, hutch_id=self._hutch_num, line=line_num, name='line{}'.format(line_num))
+            line = SequenceLine(prefix, hutch_id=self._hutch_num,
+                                line=line_num,
+                                name='line{}'.format(line_num))
             self._lines.append(line)
 
     def get(self):
@@ -291,7 +300,7 @@ class EventSequence():
         --------
 
         EventSequence.get()
-        
+ 
         """
         sequence = []
         for line in self._lines:
@@ -302,12 +311,12 @@ class EventSequence():
 
     def put(self, sequence):
         """Write a sequence to the event sequencer. Takes a list of lists,
-        with each sub-list representing one line of the event sequence. 
+        with each sub-list representing one line of the event sequence.
 
         Parameters
         ----------
         sequence: list
-            List of lists describing the event sequence. 
+            List of lists describing the event sequence.
 
         Examples
         --------
@@ -318,7 +327,7 @@ class EventSequence():
                [169,  0, 0, 0, 'Description5']]
 
         EventSequence.write(seq)
-        
+ 
         """
 
         if len(sequence) > 20:

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -69,7 +69,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
         monitor_attrs = monitor_attrs or ['current_step', 'play_count']
 
         # Setup Event Sequence
-        hutch_map = {1:'AMO', 2:'SXR', 3:'XPP', 4:'XCS', 5:'CXI', 6:'MEC', 7:'MFX', 8:'XPP', 9:'MFX', 10:'SXR', 11:'XPP', 12:'XCS', 13:None, 14:None, 15:None, 16:'CXI'}
+        hutch_map = {1:'AMO', 2:'SXR', 3:'XPP', 4:'XCS', 5:'CXI', 6:'MEC', 7:'MFX', 8:'XPP', 9:'MFX', 10:'SXR', 11:'XPP', 12:'XCS', 13:None, 14:None, 15:None, 16:'CXI', 100:'TST'}
         hutch = hutch_map[int(prefix.split(':')[-1])]
     
         self.sequence = EventSequence('{}:ECS:IOC:01'.format(hutch), hutch_num=prefix[-1], name='{}_sequence'.format(hutch))

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -74,7 +74,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
                      11: 'XPP', 12: 'XCS', 13: None, 14: None, 15: None,
                      16: 'CXI', 100: 'TST'}
         hutch = hutch_map[int(prefix.split(':')[-1])]
- 
+
         self.sequence = EventSequence('{}:ECS:IOC:01'.format(hutch),
                                       hutch_num=prefix[-1],
                                       name='{}_sequence'.format(hutch))
@@ -277,7 +277,7 @@ class EventSequence():
     def __init__(self, prefix, hutch_num, **kwargs):
 
         self._hutch_num = hutch_num
- 
+
         self._lines = []
         for i in range(0, 20, 1):
             line_num = str(i)
@@ -300,7 +300,7 @@ class EventSequence():
         --------
 
         EventSequence.get()
- 
+
         """
         sequence = []
         for line in self._lines:
@@ -327,7 +327,7 @@ class EventSequence():
                [169,  0, 0, 0, 'Description5']]
 
         EventSequence.write(seq)
- 
+
         """
 
         if len(sequence) > 20:

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -6,12 +6,13 @@ from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from bluesky.plan_stubs import sleep
 from ophyd.sim import NullStatus, make_fake_device
 
-from pcdsdevices.sequencer import EventSequencer, EventSequence
+from pcdsdevices.sequencer import EventSequencer, SequencerLine
 
 logger = logging.getLogger(__name__)
 
+
 FakeSequencer = make_fake_device(EventSequencer)
-FakeSequencer.sequence = make_fake_device(EventSequence)
+SequenceLine = make_fake_device(SequenceLine)
 
 @pytest.fixture(scope='function')
 def sequence():

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -6,13 +6,15 @@ from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from bluesky.plan_stubs import sleep
 from ophyd.sim import NullStatus, make_fake_device
 
-from pcdsdevices.sequencer import EventSequencer, SequencerLine
+from pcdsdevices.sequencer import EventSequencer, SequenceLine
+import pcdsdevices.sequencer
 
 logger = logging.getLogger(__name__)
 
 
 FakeSequencer = make_fake_device(EventSequencer)
-SequenceLine = make_fake_device(SequenceLine)
+pcdsdevices.sequencer.SequenceLine = make_fake_device(SequenceLine)
+
 
 @pytest.fixture(scope='function')
 def sequence():
@@ -45,7 +47,7 @@ class SimSequencer(FakeSequencer):
         # Initialize sequence
         initial_sequence = [[0, 0, 0, 0, 'Initial0'],
                             [1, 0, 0, 0, 'Initial1'],
-                            [2, 0, 0, 0, 'Initial2'], 
+                            [2, 0, 0, 0, 'Initial2'],
                             [3, 0, 0, 0, 'Initial3'],
                             [4, 0, 0, 0, 'Initial4'],
                             [5, 0, 0, 0, 'Initial5'],
@@ -171,7 +173,7 @@ def test_sequence_get_put():
 
     dummy_sequence = [[0, 0, 0, 0, 'Dummy0'],
                       [1, 0, 0, 0, 'Dummy1'],
-                      [2, 0, 0, 0, 'Dummy2'], 
+                      [2, 0, 0, 0, 'Dummy2'],
                       [3, 0, 0, 0, 'Dummy3'],
                       [4, 0, 0, 0, 'Dummy4'],
                       [5, 0, 0, 0, 'Dummy5'],
@@ -195,4 +197,4 @@ def test_sequence_get_put():
 
     # Read back the sequence, and compare to dummy sequence
     curr_seq = seq.sequence.get()
-    assert dummy_seq == curr_seq
+    assert dummy_sequence == curr_seq

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -6,11 +6,12 @@ from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from bluesky.plan_stubs import sleep
 from ophyd.sim import NullStatus, make_fake_device
 
-from pcdsdevices.sequencer import EventSequencer
+from pcdsdevices.sequencer import EventSequencer, EventSequence
 
 logger = logging.getLogger(__name__)
-FakeSequencer = make_fake_device(EventSequencer)
 
+FakeSequencer = make_fake_device(EventSequencer)
+FakeSequencer.sequence = make_fake_device(EventSequence)
 
 @pytest.fixture(scope='function')
 def sequence():

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -40,6 +40,30 @@ class SimSequencer(FakeSequencer):
         self.pulse_req.sim_put(0)
         self.sequence_owner.sim_put(0)
 
+        # Initialize sequence
+        initial_sequence = [[0, 0, 0, 0, 'Initial0'],
+                            [1, 0, 0, 0, 'Initial1'],
+                            [2, 0, 0, 0, 'Initial2'], 
+                            [3, 0, 0, 0, 'Initial3'],
+                            [4, 0, 0, 0, 'Initial4'],
+                            [5, 0, 0, 0, 'Initial5'],
+                            [6, 0, 0, 0, 'Initial6'],
+                            [7, 0, 0, 0, 'Initial7'],
+                            [8, 0, 0, 0, 'Initial8'],
+                            [9, 0, 0, 0, 'Initial9'],
+                            [10, 0, 0, 0, 'Initial10'],
+                            [11, 0, 0, 0, 'Initial11'],
+                            [12, 0, 0, 0, 'Initial12'],
+                            [13, 0, 0, 0, 'Initial13'],
+                            [14, 0, 0, 0, 'Initial14'],
+                            [15, 0, 0, 0, 'Initial15'],
+                            [16, 0, 0, 0, 'Initial16'],
+                            [17, 0, 0, 0, 'Initial17'],
+                            [18, 0, 0, 0, 'Initial18'],
+                            [19, 0, 0, 0, 'Initial19']]
+
+        self.sequence.put(initial_sequence)
+
     def kickoff(self):
         super().kickoff()
         return NullStatus()
@@ -129,7 +153,7 @@ def test_pause_and_resume(sequence):
 
 
 def test_fly_scan_smoke():
-    seq = SimSequencer(Fake_Prefix, name='seq')
+    seq = SimSequencer('ECS:TST:100', name='seq')
     RE = RunEngine()
 
     # Create a plan where we fly for a second

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -14,7 +14,7 @@ FakeSequencer = make_fake_device(EventSequencer)
 
 @pytest.fixture(scope='function')
 def sequence():
-    seq = FakeSequencer('ECS:TST', name='seq')
+    seq = FakeSequencer('ECS:TST:100', name='seq')
     # Running forever
     seq.play_mode.put(2)
     seq.play_control.put(0)
@@ -129,7 +129,7 @@ def test_pause_and_resume(sequence):
 
 
 def test_fly_scan_smoke():
-    seq = SimSequencer('ECS:TST', name='seq')
+    seq = SimSequencer(Fake_Prefix, name='seq')
     RE = RunEngine()
 
     # Create a plan where we fly for a second
@@ -138,3 +138,35 @@ def test_fly_scan_smoke():
 
     # Run the plan
     RE(plan())
+
+
+def test_sequence_get_put():
+    seq = SimSequencer('ECS:TST:100', name='seq')
+
+    dummy_sequence = [[0, 0, 0, 0, 'Dummy0'],
+                      [1, 0, 0, 0, 'Dummy1'],
+                      [2, 0, 0, 0, 'Dummy2'], 
+                      [3, 0, 0, 0, 'Dummy3'],
+                      [4, 0, 0, 0, 'Dummy4'],
+                      [5, 0, 0, 0, 'Dummy5'],
+                      [6, 0, 0, 0, 'Dummy6'],
+                      [7, 0, 0, 0, 'Dummy7'],
+                      [8, 0, 0, 0, 'Dummy8'],
+                      [9, 0, 0, 0, 'Dummy9'],
+                      [10, 0, 0, 0, 'Dummy10'],
+                      [11, 0, 0, 0, 'Dummy11'],
+                      [12, 0, 0, 0, 'Dummy12'],
+                      [13, 0, 0, 0, 'Dummy13'],
+                      [14, 0, 0, 0, 'Dummy14'],
+                      [15, 0, 0, 0, 'Dummy15'],
+                      [16, 0, 0, 0, 'Dummy16'],
+                      [17, 0, 0, 0, 'Dummy17'],
+                      [18, 0, 0, 0, 'Dummy18'],
+                      [19, 0, 0, 0, 'Dummy19']]
+
+    # Write the dummy sequence
+    seq.sequence.put(dummy_sequence)
+
+    # Read back the sequence, and compare to dummy sequence
+    curr_seq = seq.sequence.get()
+    assert dummy_seq == curr_seq


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add in ability to read/write sequences to the event sequencer. 

<sequencer_object>.sequence.read() to read the current sequence,  <sequencer_object>.sequence.write(sequence) to write a new sequence.

Should not require any adjustment to the instantiation of the event sequencer  object. The sequence class initializes itself based on the prefix for the event sequencer. 

<!--- Describe your changes in detail -->

## Motivation and Context

Needed for MEC to run the laser in BlueSky/Ophyd hutch python. Should be useful for other hutches as well.

Appears to address issue #198.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested it on  MEC event sequencer with my local copy of mecpython and pcdsdevices.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?

I put in docstrings as I thought appropriate. I'm sure these could be improved. 

<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
