### PR TITLE
Motor Factory

### DIFF
--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -16,6 +16,7 @@ Common EPICS Devices
     IMS
     IPM
     LODCM
+    Motor
     Newport
     OffsetMirror
     PIM

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -2,7 +2,7 @@
 from .attenuator import Attenuator
 from .ccm import CCM
 from .epics_motor import (IMS, Newport, DelayNewport, PMC100, BeckhoffAxis,
-                          EpicsMotor)
+                          EpicsMotor, Motor)
 from .evr import Trigger
 from .inout import Reflaser, TTReflaser
 from .ipm import IPM

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -456,3 +456,50 @@ class MotorDisabledError(Exception):
     Error that indicates that we are not allowed to move.
     """
     pass
+
+
+def Motor(prefix, **kwargs):
+    """
+    Load a PCDSMotor with the correct class based on prefix
+
+    The prefix is searched for one of the component keys in the table below. If
+    none of these are found, by default a ``ophyd.EpicsMotor`` will be used.
+
+    +---------------+------------------------+
+    | Component Key + Python Class           |
+    +===============+========================+
+    | MMS           | :class:`.IMS`          |
+    +---------------+------------------------+
+    | MMN           | :class:`.Newport`      |
+    +---------------+------------------------+
+    | MZM           | :class:`.PMC100`       |
+    +---------------+------------------------+
+    | MMB           | :class:`.BeckhoffAxis  |
+    +---------------+------------------------+
+    | PIC           | :class:`.PCDSMotorBase |
+    +---------------+------------------------+
+
+    Parameters
+    ----------
+    prefix: str
+        Prefix of motor
+
+    kwargs:
+        Passed to class constructor
+    """
+    # Available motor types
+    motor_types = (('MMS', IMS),
+                   ('MMN', Newport),
+                   ('MZM', PMC100),
+                   ('MMB', BeckhoffAxis),
+                   ('PIC', PCDSMotorBase))
+    # Search for component type in prefix
+    for cpt_abbrev, _type in motor_types:
+        if f':{cpt_abbrev}:' in prefix:
+            logger.debug("Found %r in prefix %r, loading %r",
+                         cpt_abbrev, prefix, _type)
+            return _type(prefix, **kwargs)
+    # Default to ophyd.EpicsMotor
+    logger.warning("Unable to find type of motor based on component. "
+                   "Using 'ophyd.EpicsMotor")
+    return EpicsMotor(prefix, **kwargs)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -463,21 +463,21 @@ def Motor(prefix, **kwargs):
     Load a PCDSMotor with the correct class based on prefix
 
     The prefix is searched for one of the component keys in the table below. If
-    none of these are found, by default a ``ophyd.EpicsMotor`` will be used.
+    none of these are found, by default an ``ophyd.EpicsMotor`` will be used.
 
-    +---------------+------------------------+
-    | Component Key + Python Class           |
-    +===============+========================+
-    | MMS           | :class:`.IMS`          |
-    +---------------+------------------------+
-    | MMN           | :class:`.Newport`      |
-    +---------------+------------------------+
-    | MZM           | :class:`.PMC100`       |
-    +---------------+------------------------+
-    | MMB           | :class:`.BeckhoffAxis  |
-    +---------------+------------------------+
-    | PIC           | :class:`.PCDSMotorBase |
-    +---------------+------------------------+
+    +---------------+-------------------------+
+    | Component Key + Python Class            |
+    +===============+=========================+
+    | MMS           | :class:`.IMS`           |
+    +---------------+-------------------------+
+    | MMN           | :class:`.Newport`       |
+    +---------------+-------------------------+
+    | MZM           | :class:`.PMC100`        |
+    +---------------+-------------------------+
+    | MMB           | :class:`.BeckhoffAxis`  |
+    +---------------+-------------------------+
+    | PIC           | :class:`.PCDSMotorBase` |
+    +---------------+-------------------------+
 
     Parameters
     ----------
@@ -501,5 +501,5 @@ def Motor(prefix, **kwargs):
             return _type(prefix, **kwargs)
     # Default to ophyd.EpicsMotor
     logger.warning("Unable to find type of motor based on component. "
-                   "Using 'ophyd.EpicsMotor")
+                   "Using 'ophyd.EpicsMotor'")
     return EpicsMotor(prefix, **kwargs)

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -8,7 +8,7 @@ import pytest
 
 from pcdsdevices.epics_motor import (EpicsMotorInterface, PCDSMotorBase, IMS,
                                      Newport, PMC100, BeckhoffAxis,
-                                     MotorDisabledError)
+                                     MotorDisabledError, Motor, EpicsMotor)
 
 from conftest import HotfixFakeEpicsSignal
 
@@ -202,3 +202,10 @@ def test_beckhoff_error_clear(fake_beckhoff):
     assert m.cmd_err_reset.get() == 1
     m.stage()
     m.unstage()
+
+
+def test_motor_factory():
+    m = Motor('TST:MY:MMS:01', name='test_motor')
+    assert isinstance(m, IMS)
+    m = Motor('TST:RANDOM:MTR:01', name='test_motor')
+    assert isinstance(m, EpicsMotor)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Instead of sorting out which kind of motor you have, we should be able to tell based on the prefix it self. To solve this I wrote `Motor`. This snoops the `prefix` finds the correct class and instantiates it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Main motivation is ease of use for `happi`. Instead of having a one to one relationship between containers and classes, we should be building these factories that do the correct thing with the information provided. This simplifies the dependencies between the two libraries as we can repoint the objects by modifying the factories, not changing class specifications on both ends.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Add to `device_types` table
<!--
## Screenshots (if appropriate):
-->
