### PR TITLE
FIX: The build was broken because Matplotlib/Conda

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pyyaml
     - cf_units >=2.0.1
     - scipy
-    - matplotlib
+    - matplotlib <3
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,8 +23,7 @@ requirements:
     - pyyaml
     - cf_units >=2.0.1
     - scipy
-    - matplotlib >=3
-    - pyqt >=5
+    - matplotlib
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - pyyaml
     - cf_units >=2.0.1
     - scipy
+    - matplotlib >=3
+    - pyqt >=5
 
 test:
   imports:

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -12,8 +12,8 @@ from threading import Thread, Event
 from types import SimpleNamespace, MethodType
 from weakref import WeakSet
 
-import pylab
 import yaml
+import matplotlib.pyplot as plt
 from bluesky.utils import ProgressBar
 from ophyd.status import wait as status_wait
 
@@ -194,7 +194,7 @@ class FltMvInterface(MvInterface):
         """
         logger.info(("Select new motor x-position in current plot "
                      "by mouseclick"))
-        if not pylab.get_fignums():
+        if not plt.get_fignums():
             upper_limit = 0
             lower_limit = self.limits[0]
             if self.limits[0] == self.limits[1]:
@@ -204,8 +204,8 @@ class FltMvInterface(MvInterface):
             limit_plot = []
             for x in range(lower_limit, upper_limit):
                 limit_plot.append(x)
-            pylab.plot(limit_plot)
-        pos = pylab.ginput(1)[0][0]
+            plt.plot(limit_plot)
+        pos = plt.ginput(1)[0][0]
         self.move(pos, timeout=timeout)
 
     def tweak(self):

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -13,7 +13,6 @@ from types import SimpleNamespace, MethodType
 from weakref import WeakSet
 
 import yaml
-import matplotlib.pyplot as plt
 from bluesky.utils import ProgressBar
 from ophyd.status import wait as status_wait
 
@@ -192,6 +191,9 @@ class FltMvInterface(MvInterface):
         recently active plot. If there are no existing plots, an empty plot
         will be created with the motor's limits as the range.
         """
+        # This is usually bad, but importing this at module level forces
+        # matplotlib to select a backend on import, breaking some things
+        import matplotlib.pyplot as plt  # NOQA
         logger.info(("Select new motor x-position in current plot "
                      "by mouseclick"))
         if not plt.get_fignums():

--- a/pcdsdevices/mv_interface.py
+++ b/pcdsdevices/mv_interface.py
@@ -191,8 +191,7 @@ class FltMvInterface(MvInterface):
         recently active plot. If there are no existing plots, an empty plot
         will be created with the motor's limits as the range.
         """
-        # This is usually bad, but importing this at module level forces
-        # matplotlib to select a backend on import, breaking some things
+        # Importing forces backend selection, so do inside method
         import matplotlib.pyplot as plt  # NOQA
         logger.info(("Select new motor x-position in current plot "
                      "by mouseclick"))

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -55,8 +55,8 @@ def test_camonitor(fast_motor):
 
 def test_mv_ginput(monkeypatch, fast_motor):
     logger.debug('test_mv_ginput')
+    # Importing forces backend selection, so do inside method
     from matplotlib import pyplot as plt  # NOQA
-    # Importing forces backend selection
 
     def fake_plot(*args, **kwargs):
         return

--- a/tests/test_mv_interface.py
+++ b/tests/test_mv_interface.py
@@ -6,7 +6,6 @@ import time
 import os
 import signal
 
-import pylab
 import pytest
 
 from pcdsdevices.mv_interface import setup_preset_paths
@@ -56,6 +55,8 @@ def test_camonitor(fast_motor):
 
 def test_mv_ginput(monkeypatch, fast_motor):
     logger.debug('test_mv_ginput')
+    from matplotlib import pyplot as plt  # NOQA
+    # Importing forces backend selection
 
     def fake_plot(*args, **kwargs):
         return
@@ -66,9 +67,9 @@ def test_mv_ginput(monkeypatch, fast_motor):
     def fake_get_fignums(*args, **kwargs):
         return local_get_fignums
 
-    monkeypatch.setattr(pylab, 'plot', fake_plot)
-    monkeypatch.setattr(pylab, 'ginput', fake_ginput)
-    monkeypatch.setattr(pylab, 'get_fignums', fake_get_fignums)
+    monkeypatch.setattr(plt, 'plot', fake_plot)
+    monkeypatch.setattr(plt, 'ginput', fake_ginput)
+    monkeypatch.setattr(plt, 'get_fignums', fake_get_fignums)
 
     def inner_test():
         fast_motor.mv_ginput()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Stop using `pylab` directly to simplify things
- Move imports of `pyplot` into methods to avoid selecting a backend early
- Pin `matplotlib` to under 3 because the conda builds are a mess

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- No reason to use `matplotlib` indirectly, made things harder to debug
- Backends why
- `3.0.0`+ conflicts with `pmgr` because something something `pyqt` must be `5.9`, but then it also breaks the travis here because it somehow installs `3.0.0` with pyqt `4.11`. I have no idea what is going on, I assume the recipes are broken.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
