### PR TITLE
ENH: add common plugins to PCDSDetector

### DIFF
--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -42,7 +42,37 @@ class PCDSDetector(PCDSDetectorBase):
 
     Default port chains
     -------------------
+    The default configuration of ports is as follows::
 
+        CAM -> CC1
+        CAM -> CC2
+        CAM -> HDF51
+        CAM -> IMAGE1:CC
+        CAM -> IMAGE1:Proc
+        CAM -> IMAGE1:ROI
+        CAM -> IMAGE2:CC
+        CAM -> IMAGE2:Over
+        CAM -> IMAGE2:Proc
+        CAM -> IMAGE2:ROI -> IMAGE2
+        CAM -> JPEG1
+        CAM -> NetCDF1
+        CAM -> Over1
+        CAM -> Proc1
+        CAM -> ROI1 -> IMAGE1
+        CAM -> ROI1 -> Stats1
+        CAM -> ROI2
+        CAM -> ROI3
+        CAM -> ROI4
+        CAM -> Stats2
+        CAM -> Stats3
+        CAM -> Stats4
+        CAM -> Stats5
+        CAM -> THUMBNAIL:CC
+        CAM -> THUMBNAIL:Over
+        CAM -> THUMBNAIL:Proc
+        CAM -> THUMBNAIL:ROI -> THUMBNAIL
+        CAM -> TIFF1
+        CAM -> Trans1
 
     Note
     ----
@@ -97,3 +127,25 @@ class PCDSDetector(PCDSDetectorBase):
         self.stats2.stage_sigs['enable'] = 1
         self.stats2.stage_sigs['compute_statistics'] = 'Yes'
         self.stats2.stage_sigs['compute_centroid'] = 'Yes'
+
+    def get_plugin_graph_edges(self, *, use_names=True, include_cam=False):
+        '''Get a list of (source, destination) ports for all plugin chains
+
+        Parameters
+        ----------
+        use_names : bool, optional
+            By default, the ophyd names for each plugin are used. Set this to
+            False to instead get the AreaDetector port names.
+        include_cam : bool, optional
+            Include plugins with 'CAM' as the source.  As it is easy to assume
+            that a camera without an explicit source is CAM, by default this
+            method does not include it in the list.
+        '''
+        cam_port = self.cam.port_name.get()
+        graph, port_map = self.get_asyn_digraph()
+        port_edges = [(src, dest) for src, dest in graph.edges
+                      if src != cam_port or include_cam]
+        if use_names:
+            port_edges = [(port_map[src].name, port_map[dest].name)
+                          for src, dest in port_edges]
+        return port_edges

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -1,7 +1,7 @@
 """
 PCDS detectors and overrides for ophyd detectors.
 
-All components at the detector level such as plugins  or image processing
+All components at the detector level such as plugins or image processing
 functions needed by all instances of a detector are added here.
 """
 import logging
@@ -10,8 +10,9 @@ from ophyd.areadetector import cam
 from ophyd.areadetector.base import ADComponent
 from ophyd.areadetector.detectors import DetectorBase
 from ophyd.device import Component as Cpt
-
-from .plugins import ImagePlugin, StatsPlugin
+from .plugins import (ColorConvPlugin, HDF5Plugin, ImagePlugin, JPEGPlugin,
+                      NetCDFPlugin, OverlayPlugin, ProcessPlugin, ROIPlugin,
+                      StatsPlugin, TIFFPlugin, TransformPlugin, NexusPlugin)
 
 logger = logging.getLogger(__name__)
 
@@ -24,27 +25,75 @@ class PCDSDetectorBase(DetectorBase):
     """
     Standard area detector with no plugins.
     """
-    cam = ADComponent(cam.CamBase, ":")
+    cam = ADComponent(cam.CamBase, '')
 
 
 class PCDSDetector(PCDSDetectorBase):
     """
-    Standard area detector with standard plugins.
+    Standard area detector including all (*) standard PCDS plugins.
+    Notable plugins:
+        IMAGE2: reduced rate image, used for camera viewer
+        Stats2: reduced rate stats
 
-    Geared towards analyzing a beam spot.
+    (*) Currently excludes all PVAccess plugins:
+        IMAGE1:Pva
+        IMAGE2:Pva:
+        THUMBNAIL:Pva
 
-    IMAGE2: reduced rate image
-    Stats2: reduced rate stats
+    Default port chains
+    -------------------
+
+
+    Note
+    ----
+    Subclasses should replace 'cam' with that of the respective detector, such
+    as `ophyd.areadetector.cam.PilatusDetectorCam` for the Pilatus detector.
     """
-    image = Cpt(ImagePlugin, ':IMAGE2:', read_attrs=['array_data'])
-    stats = Cpt(StatsPlugin, ':Stats2:', read_attrs=['centroid',
-                                                     'mean_value',
-                                                     'sigma_x',
-                                                     'sigma_y'])
+    image1 = Cpt(ImagePlugin, 'IMAGE1:', read_attrs=['array_data'],
+                 doc='Image plugin for general usage')
+    image1_roi = Cpt(ROIPlugin, 'IMAGE1:ROI:')
+    image1_cc = Cpt(ColorConvPlugin, 'IMAGE1:CC:')
+    image1_proc = Cpt(ProcessPlugin, 'IMAGE1:Proc:')
+    image1_over = Cpt(OverlayPlugin, 'IMAGE1:Over:')
+    image2 = Cpt(ImagePlugin, 'IMAGE2:', read_attrs=['array_data'],
+                 doc='Image plugin used for the camera viewer')
+    image2_roi = Cpt(ROIPlugin, 'IMAGE2:ROI:')
+    image2_cc = Cpt(ColorConvPlugin, 'IMAGE2:CC:')
+    image2_proc = Cpt(ProcessPlugin, 'IMAGE2:Proc:')
+    image2_over = Cpt(OverlayPlugin, 'IMAGE2:Over:')
+    thumbnail = Cpt(ImagePlugin, 'THUMBNAIL:')
+    thumbnail_roi = Cpt(ROIPlugin, 'THUMBNAIL:ROI:')
+    thumbnail_cc = Cpt(ColorConvPlugin, 'THUMBNAIL:CC:')
+    thumbnail_proc = Cpt(ProcessPlugin, 'THUMBNAIL:Proc:')
+    thumbnail_over = Cpt(OverlayPlugin, 'THUMBNAIL:Over:')
+    cc1 = Cpt(ColorConvPlugin, 'CC1:')
+    cc2 = Cpt(ColorConvPlugin, 'CC2:')
+    hdf51 = Cpt(HDF5Plugin, 'HDF51:')
+    jpeg1 = Cpt(JPEGPlugin, 'JPEG1:')
+    netcdf1 = Cpt(NetCDFPlugin, 'NetCDF1:')
+    nexus1 = Cpt(NexusPlugin, 'Nexus1:')
+    over1 = Cpt(OverlayPlugin, 'Over1:')
+    proc1 = Cpt(ProcessPlugin, 'Proc1:')
+    roi1 = Cpt(ROIPlugin, 'ROI1:')
+    roi2 = Cpt(ROIPlugin, 'ROI2:')
+    roi3 = Cpt(ROIPlugin, 'ROI3:')
+    roi4 = Cpt(ROIPlugin, 'ROI4:')
+    stats1 = Cpt(StatsPlugin, 'Stats1:', read_attrs=['centroid', 'mean_value',
+                                                     'sigma_x', 'sigma_y'])
+    stats2 = Cpt(StatsPlugin, 'Stats2:', read_attrs=['centroid', 'mean_value',
+                                                     'sigma_x', 'sigma_y'])
+    stats3 = Cpt(StatsPlugin, 'Stats3:', read_attrs=['centroid', 'mean_value',
+                                                     'sigma_x', 'sigma_y'])
+    stats4 = Cpt(StatsPlugin, 'Stats4:', read_attrs=['centroid', 'mean_value',
+                                                     'sigma_x', 'sigma_y'])
+    stats5 = Cpt(StatsPlugin, 'Stats5:', read_attrs=['centroid', 'mean_value',
+                                                     'sigma_x', 'sigma_y'])
+    tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
+    trans1 = Cpt(TransformPlugin, 'Trans1:')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.image.stage_sigs['enable'] = 1
-        self.stats.stage_sigs['enable'] = 1
-        self.stats.stage_sigs['compute_statistics'] = 'Yes'
-        self.stats.stage_sigs['compute_centroid'] = 'Yes'
+        self.image2.stage_sigs['enable'] = 1
+        self.stats2.stage_sigs['enable'] = 1
+        self.stats2.stage_sigs['compute_statistics'] = 'Yes'
+        self.stats2.stage_sigs['compute_centroid'] = 'Yes'

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -44,7 +44,7 @@ class PCDSDetector(PCDSDetectorBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.image.stage_sigs[self.image.enable] = 1
-        self.stats.stage_sigs[self.stats.enable] = 1
-        self.stats.stage_sigs[self.stats.compute_statistics] = 'Yes'
-        self.stats.stage_sigs[self.stats.compute_centroid] = 'Yes'
+        self.image.stage_sigs['enable'] = 1
+        self.stats.stage_sigs['enable'] = 1
+        self.stats.stage_sigs['compute_statistics'] = 'Yes'
+        self.stats.stage_sigs['compute_centroid'] = 'Yes'

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -5,6 +5,7 @@ All components at the detector level such as plugins or image processing
 functions needed by all instances of a detector are added here.
 """
 import logging
+import warnings
 
 from ophyd.areadetector import cam
 from ophyd.areadetector.base import ADComponent
@@ -149,3 +150,17 @@ class PCDSDetector(PCDSDetectorBase):
             port_edges = [(port_map[src].name, port_map[dest].name)
                           for src, dest in port_edges]
         return port_edges
+
+    @property
+    def image(self):
+        'Deprecated - alias for `image2`'
+        warnings.warn('PCDSDetector.image is deprecated; use {}.image2 '
+                      'instead'.format(self.name))
+        return self.image2
+
+    @property
+    def stats(self):
+        'Deprecated - alias for `stats2`'
+        warnings.warn('PCDSDetector.image is deprecated; use {}.stats2 '
+                      'instead'.format(self.name))
+        return self.stats2

--- a/pcdsdevices/areadetector/plugins.py
+++ b/pcdsdevices/areadetector/plugins.py
@@ -152,7 +152,9 @@ class JPEGPlugin(ophyd.plugins.JPEGPlugin, FilePlugin):
 
 
 class NexusPlugin(ophyd.plugins.NexusPlugin, FilePlugin):
-    pass
+    # Skip plugin_type checks on this plugin, as old versions of AD did not
+    # reflect this correctly
+    _plugin_type = None
 
 
 class HDF5Plugin(ophyd.plugins.HDF5Plugin, FilePlugin):

--- a/pcdsdevices/areadetector/plugins.py
+++ b/pcdsdevices/areadetector/plugins.py
@@ -35,7 +35,7 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
     def _asyn_pipeline_configuration_names(self):
         # This broke any instantiated plugin b/c _asyn_pipeline is a list that
         # can have None.
-        return [_.configuration_names.name for _ in self._asyn_pipeline if 
+        return [_.configuration_names.name for _ in self._asyn_pipeline if
                 hasattr(_, 'configuration_names')]
 
     @property
@@ -64,7 +64,7 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
 
     def stage(self):
         # Ensure the plugin is enabled. We do not disable it on unstage
-        if self.enable not in self.stage_sigs:
+        if self.enable not in self.stage_sigs and 'enable' not in self.stage_sigs:
             if not self.enable.connected:
                 self.enable.get()
             set_and_wait(self.enable, 1, atol=0)
@@ -77,7 +77,7 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
         """
         array_size = list(self.array_size.get())
         dimensions = int(self.ndimensions.get())
-        
+
         if dimensions == 0:
             return 0
 
@@ -86,9 +86,9 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
             if dim:
                 pixels *= dim
 
-        return int(pixels)    
+        return int(pixels)
 
-    
+
 class ImagePlugin(ophyd.plugins.ImagePlugin, PluginBase):
     @property
     def image(self):
@@ -104,9 +104,9 @@ class ImagePlugin(ophyd.plugins.ImagePlugin, PluginBase):
 
         pixel_count = self.array_pixels
         image = self.array_data.get(count=pixel_count)
-        return np.array(image).reshape(array_size)    
+        return np.array(image).reshape(array_size)
 
-    
+
 class StatsPlugin(ophyd.plugins.StatsPlugin, PluginBase):
     pass
 

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 
 # OK, we have to screw with the class def here. I'm sorry. It's ophyd's fault
 # for checking an epics signal value in the __init__ statement.
-for comp in (PCDSDetector.image, PCDSDetector.stats):
-    plugin_class = comp.cls
-    plugin_class.plugin_type = Cpt(Signal, value=plugin_class._plugin_type)
+for attr in PCDSDetector._sub_devices:
+    plugin_class = getattr(PCDSDetector, attr).cls
+    if hasattr(plugin_class, 'plugin_type'):
+        plugin_class.plugin_type = Cpt(Signal, value=plugin_class._plugin_type)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds all common plugins to PCDSDetector

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Plugins are available for most (all?) PCDS detectors and should be accessible to the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with CXI inline detectors. Default port chain information from `CXI:SC2:INLINE:` as it appears unmodified - but this may need revision.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
See docstrings

## Backward incompatible changes
The leading `':'` has been stripped from all plugins. The logic is that the prefix should be what all PVs of a device have in common. This could be put back, but I wouldn't recommend it.

This means that beamline configurations need to be updated with the correct prefixes.

## TODO
PCDSDetector-related local changes should be brought back to ophyd. @teddyrendahl @ZLLentz and I should discuss what should remain for local customizations, if any.