### PR TITLE
ENH: Update event sequencer to take more human readable event sequences

### DIFF
--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -157,10 +157,10 @@ def test_fly_scan_smoke():
 def test_sequence_get_put():
     seq = SimSequencer('ECS:TST:100', name='seq')
 
-    dummy_sequence = [[i for i in range(0, 20)],
-                      [i for i in range(20, 40)],
-                      [i for i in range(40, 60)],
-                      [i for i in range(60, 80)]]
+    dummy_sequence = [[ 1,  2,  3,  4],
+                      [ 5,  6,  7,  8],
+                      [ 9, 10, 11, 12],
+                      [13, 14, 15, 16]]
 
     # Write the dummy sequence
     seq.sequence.put_seq(dummy_sequence)
@@ -168,5 +168,4 @@ def test_sequence_get_put():
     # Read back the sequence, and compare to dummy sequence
     curr_seq = seq.sequence.get_seq()
 
-    for i, array_sub in enumerate(dummy_sequence):
-        assert array_sub == curr_seq[i][0:20]
+    assert curr_seq == dummy_sequence

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -157,9 +157,9 @@ def test_fly_scan_smoke():
 def test_sequence_get_put():
     seq = SimSequencer('ECS:TST:100', name='seq')
 
-    dummy_sequence = [[ 1,  2,  3,  4],
-                      [ 5,  6,  7,  8],
-                      [ 9, 10, 11, 12],
+    dummy_sequence = [[1,  2,  3,  4],
+                      [5,  6,  7,  8],
+                      [9, 10, 11, 12],
                       [13, 14, 15, 16]]
 
     # Write the dummy sequence


### PR DESCRIPTION
## Description
Updated the event sequencer to take more readable sequences. Now, instead of giving the event sequencer a list of four lists that contain the beam codes, beam deltas, fiducial deltas, and burst counts for each line, you give the sequencer a list of lists, where each sub-list represents a single line of the event sequence. For example:
> seq = [[182,12,0,0], [170,2,0,0], [169,0,0,0], ....]
> sequencer.sequence.put_seq(seq)

## Motivation and Context
This should make writing code to generate sequences for the event sequencer a little simpler and more straight forward. Also, I like it more.

## How Has This Been Tested?
Tested on MEC event sequencer. I basically wrote in the wrapper that I used in MEC for LU57 into the ophyd device. I wrote a wrapper because the old way was kind of annoying. I updated the tests for the sequencer as well, and they pass.

## Where Has This Been Documented?
I updated the docstrings to reflect these changes. 