### PR TITLE
MNT: Use a normal separator for BeckhoffAxis

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -422,7 +422,7 @@ class BeckhoffAxis(EpicsMotorInterface):
     """
     __doc__ += basic_positioner_init
 
-    cmd_err_reset = Cpt(EpicsSignal, '-ErrRst', kind='omitted')
+    cmd_err_reset = Cpt(EpicsSignal, ':ErrRst', kind='omitted')
 
     def clear_error(self):
         """


### PR DESCRIPTION
Probably the longest, most complicated pull request from November. Had to get something in before my github contributions grid goes blank.

Originally, there was a dash in here, but I'm going to make it a colon in the L2SI IOC. It's a choice made by the IOC developer. The colon is more consistent with what we do elsewhere in SLAC.

The dash IOC doesn't even exist anymore and was solely a test/prototype.