### PR TITLE
BLD: Use Jinja magic to feed conda-recipe from requirements.txt

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,17 +17,16 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
+    # Inspect requirements.txt for the reqs
     {% for spec in data['install_requires'] %}
-      {% if '<' in spec %}
-        {% set newspec = spec.replace('<', ' <') %}
-      {% elif '>' in spec %}
-        {% set newspec = spec.replace('>', ' >') %}
-      {% elif '=' in spec %}
-        {% set newpsec = spec.replace('=', ' =') %}
-      {% else %}
-        {% set newspec = spec %}
-      {% endif %}
-    - {{ newspec }}
+      {% set ns = namespace(spec=spec) %}
+      # Need to add a space before the first symbol. List order matters.
+      {% for sep in ['=', '<', '>'] %}
+        {% if sep in spec %}
+          {% set ns.spec = spec.replace(sep, ' ' + sep) %}
+        {% endif %}
+      {% endfor %}
+    - {{ ns.spec }}
     {% endfor %}
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: pcdsdevices
-  version : {{ data.get('version') }}
+  version: {{ data['version'] }}
 
 source:
   path: ..
@@ -17,13 +17,18 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
-    - ophyd >=1.2.0
-    - bluesky >=1.2.0
-    - pyepics
-    - pyyaml
-    - cf_units >=2.0.1
-    - scipy
-    - matplotlib <3
+    {% for spec in data['install_requires'] %}
+      {% if '<' in spec %}
+        {% set newspec = spec.replace('<', ' <') %}
+      {% elif '>' in spec %}
+        {% set newspec = spec.replace('>', ' >') %}
+      {% elif '=' in spec %}
+        {% set newpsec = spec.replace('=', ' =') %}
+      {% else %}
+        {% set newspec = spec %}
+      {% endif %}
+    - {{ newspec }}
+    {% endfor %}
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 import versioneer
 from setuptools import setup, find_packages
 
+with open('requirements.txt') as f:
+    requirements = f.read().split()
+
 setup(name='pcdsdevices',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       license='BSD',
       author='SLAC National Accelerator Laboratory',
       packages=find_packages(),
+      install_requires=requirements,
       description='IOC definitions for LCLS Beamline Devices',
       )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This isn't super important, but the idea snagged me today and I had to see it through. Curious what you think about this.

## Description
<!--- Describe your changes in detail -->
- Add `install_requires` to the `setup.py` file, feeding from `requirements.txt`
- Make `meta.yaml` read through the `install_requires` field and populate the run requirements
- Remove `matplotlib` pin, builds were fixed to avoid the issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I always forget to keep `meta.yaml` and `requirements.txt` in sync. Now it's easy. The requirements used by `pip` and the requirements used by `conda` should always be exactly the same.