### PR TITLE
MNT: remove hotfix

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
-    - ophyd >=1.2.0
+    - ophyd >=1.3.1
     - bluesky >=1.2.0
     - pyepics
     - pyyaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,78 +1,9 @@
-from ophyd.areadetector.base import EpicsSignalWithRBV
-from ophyd.sim import FakeEpicsSignal, fake_device_cache
 from pathlib import Path
 from pcdsdevices.mv_interface import setup_preset_paths
 
 import os
 import pytest
 import shutil
-
-
-class HotfixFakeEpicsSignal(FakeEpicsSignal):
-    """
-    Extensions of FakeEpicsPV for ophyd=1.2.0 that should be submitted as a PR
-    """
-    def __init__(self, read_pv, write_pv=None, *, string=False, **kwargs):
-        self.as_string = string
-        self._enum_strs = None
-        super().__init__(read_pv, write_pv=write_pv, string=string, **kwargs)
-        self._limits = None
-
-    def get(self, *, as_string=None, connection_timeout=1.0, **kwargs):
-        """
-        Implement getting as enum strings
-        """
-        if as_string is None:
-            as_string = self.as_string
-
-        value = super().get()
-
-        if as_string:
-            if self.enum_strs is not None and isinstance(value, int):
-                return self.enum_strs[value]
-            elif value is not None:
-                return str(value)
-        return value
-
-    def put(self, value, *args, **kwargs):
-        """
-        Implement putting as enum strings
-        """
-        if self.enum_strs is not None and value in self.enum_strs:
-            value = self.enum_strs.index(value)
-        super().put(value, *args, **kwargs)
-
-    @property
-    def enum_strs(self):
-        """
-        Simulated enum strings.
-
-        Use sim_set_enum_strs during setup to set the enum strs.
-        """
-        return self._enum_strs
-
-    def sim_set_enum_strs(self, enums):
-        """
-        Set the enum_strs for a fake devices
-
-        Parameters
-        ----------
-        enums: list or tuple of str
-            The enums will be accessed by array index, e.g. the first item in
-            enums will be 0, the next will be 1, etc.
-        """
-        self._enum_strs = enums
-
-    def check_value(self, value):
-        """
-        Implement some of the checks from epicsSignal
-        """
-        super().check_value(value)
-        if value is None:
-            raise ValueError('Cannot write None to epics PVs')
-
-
-fake_device_cache[EpicsSignalWithRBV] = HotfixFakeEpicsSignal
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -10,8 +10,6 @@ from pcdsdevices.epics_motor import (EpicsMotorInterface, PCDSMotorBase, IMS,
                                      Newport, PMC100, BeckhoffAxis,
                                      MotorDisabledError, Motor, EpicsMotor)
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
@@ -20,8 +18,6 @@ def fake_class_setup(cls):
     Make the fake class and modify if needed
     """
     FakeClass = make_fake_device(cls)
-    if issubclass(FakeClass, PCDSMotorBase):
-        FakeClass.motor_spg.cls = HotfixFakeEpicsSignal
     return FakeClass
 
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -8,15 +8,12 @@ from pcdsdevices.inout import (InOutPositioner,
                                InOutRecordPositioner,
                                InOutPVStatePositioner)
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_inout():
     Fake = make_fake_device(InOutRecordPositioner)
-    Fake.state.cls = HotfixFakeEpicsSignal
     inout = Fake('Test:Ref', name='test')
     inout.state.sim_put(0)
     inout.state.sim_set_enum_strs(('Unknown', 'IN', 'OUT'))

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -7,16 +7,12 @@ from unittest.mock import Mock
 from pcdsdevices.inout import InOutRecordPositioner
 from pcdsdevices.ipm import IPM
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_ipm():
     FakeIPM = make_fake_device(IPM)
-    FakeIPM.state.cls = HotfixFakeEpicsSignal
-    FakeIPM.diode.cls.state.cls = HotfixFakeEpicsSignal
     ipm = FakeIPM("Test:My:IPM", name='test_ipm')
     ipm.diode.state.sim_put(0)
     ipm.diode.state.sim_set_enum_strs(['Unknown'] +

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -6,15 +6,12 @@ from ophyd.sim import make_fake_device
 
 from pcdsdevices.lens import XFLS, LensStack, SimLensStack
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_xfls():
     FakeXFLS = make_fake_device(XFLS)
-    FakeXFLS.state.cls = HotfixFakeEpicsSignal
     xfls = FakeXFLS('TST:XFLS', name='lens')
     xfls.state.sim_put(4)
     xfls.state.sim_set_enum_strs(('Unknown', 'LENS1', 'LENS2', 'LENS3', 'OUT'))

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -6,19 +6,12 @@ from unittest.mock import Mock
 
 from pcdsdevices.lodcm import LODCM, YagLom, Dectris, Diode, Foil
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_lodcm():
     FakeLODCM = make_fake_device(LODCM)
-    FakeLODCM.state.cls = HotfixFakeEpicsSignal
-    FakeLODCM.yag.cls.state.cls = HotfixFakeEpicsSignal
-    FakeLODCM.dectris.cls.state.cls = HotfixFakeEpicsSignal
-    FakeLODCM.diode.cls.state.cls = HotfixFakeEpicsSignal
-    FakeLODCM.foil.cls.state.cls = HotfixFakeEpicsSignal
     lodcm = FakeLODCM('FAKE:LOM', name='fake_lom')
     lodcm.state.sim_put(1)
     lodcm.state.sim_set_enum_strs(['Unknown'] + LODCM.states_list)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -6,14 +6,10 @@ import pytest
 from ophyd.sim import make_fake_device
 from pcdsdevices.mirror import OffsetMirror, PointingMirror
 
-from conftest import HotfixFakeEpicsSignal
-
 
 @pytest.fixture(scope='function')
 def fake_branching_mirror():
     FakeMirror = make_fake_device(PointingMirror)
-    FakeMirror.state.cls = HotfixFakeEpicsSignal
-    FakeMirror.xgantry.cls.setpoint.cls = HotfixFakeEpicsSignal
     m = FakeMirror("TST:M1H", prefix_xy="STEP:TST:M1H",
                    xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
                    in_lines=['MFX', 'MEC'], out_lines=['CXI'])

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -9,8 +9,6 @@ from ophyd.sim import make_fake_device
 from pcdsdevices.areadetector.detectors import PCDSDetector
 from pcdsdevices.pim import PIM, PIMMotor
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
@@ -24,7 +22,6 @@ for comp in (PCDSDetector.image, PCDSDetector.stats):
 @pytest.fixture(scope='function')
 def fake_pim():
     FakePIM = make_fake_device(PIMMotor)
-    FakePIM.state.cls = HotfixFakeEpicsSignal
     pim = FakePIM('Test:Yag', name='test')
     pim.state.sim_put(0)
     pim.state.sim_set_enum_strs(['Unknown'] + PIMMotor.states_list)

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -10,8 +10,6 @@ from ophyd.sim import make_fake_device
 from pcdsdevices.inout import InOutRecordPositioner
 from pcdsdevices.pulsepicker import PulsePickerInOut
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
@@ -21,7 +19,6 @@ def fake_picker():
     Picker starts IN and OPEN
     """
     FakePicker = make_fake_device(PulsePickerInOut)
-    FakePicker.inout.cls.state.cls = HotfixFakeEpicsSignal
     picker = FakePicker('TST:SB1:MMS:35', name='picker')
     picker.inout.state.sim_put(0)
     picker.inout.state.sim_set_enum_strs(['Unknown'] +

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -6,15 +6,12 @@ from ophyd.sim import make_fake_device
 
 from pcdsdevices.valve import GateValve, PPSStopper, Stopper, InterlockError
 
-from conftest import HotfixFakeEpicsSignal
-
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_pps():
     FakePPS = make_fake_device(PPSStopper)
-    FakePPS.state.cls = HotfixFakeEpicsSignal
     pps = FakePPS("PPS:H0:SUM", name="test_pps")
     pps.state.sim_set_enum_strs(['Unknown', 'IN', 'OUT'])
     pps.state.put('OUT')

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -14,7 +14,7 @@ def fake_pps():
     FakePPS = make_fake_device(PPSStopper)
     pps = FakePPS("PPS:H0:SUM", name="test_pps")
     pps.state.sim_set_enum_strs(['Unknown', 'IN', 'OUT'])
-    pps.state.put('OUT')
+    pps.state.sim_put('OUT')
     return pps
 
 
@@ -36,11 +36,11 @@ def fake_valve():
 def test_pps_states(fake_pps):
     pps = fake_pps
     # Removed
-    pps.state.put("OUT")
+    pps.state.sim_put("OUT")
     assert pps.removed
     assert not pps.inserted
     # Inserted
-    pps.state.put("IN")
+    pps.state.sim_put("IN")
     assert pps.inserted
     assert not pps.removed
 
@@ -49,7 +49,7 @@ def test_pps_motion(fake_pps):
     pps = fake_pps
     with pytest.raises(PermissionError):
         pps.insert()
-    pps.state.put("IN")
+    pps.state.sim_put("IN")
     with pytest.raises(PermissionError):
         pps.remove()
 
@@ -60,7 +60,7 @@ def test_pps_subscriptions(fake_pps):
     cb = Mock()
     pps.subscribe(cb, event_type=pps.SUB_STATE, run=False)
     # Change readback state
-    pps.state.put(4)
+    pps.state.sim_put(4)
     assert cb.called
 
 


### PR DESCRIPTION
Removes unnecessary (*) hotfix for FakeEpicsSignal.

\* as of ophyd V1.3.1

All are passing locally except for test_lodcm_destination.