### PR TITLE
TST: fix lodcm test

### DIFF
--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -41,16 +41,16 @@ def test_lodcm_destination(fake_lodcm):
     for d in dest:
         assert isinstance(d, str)
 
-    lodcm.state.put('OUT')
+    lodcm.move('OUT')
     assert len(lodcm.destination) == 1
-    lodcm.state.put('C')
+    lodcm.move('C')
     assert len(lodcm.destination) == 2
     # Block the mono line
-    lodcm.yag.state.put('IN')
+    lodcm.yag.move('IN')
     assert len(lodcm.destination) == 1
-    lodcm.state.put('Si')
+    lodcm.move('Si')
     assert len(lodcm.destination) == 0
-    lodcm.yag.state.put('OUT')
+    lodcm.yag.move('OUT')
     assert len(lodcm.destination) == 1
 
     # Unknown state


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Call `move` method in lodcm tests so that aliases are respected

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Was calling `put` directly on the fake pvs, which fails with enum checking
closes #323 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Same tests, new pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
