### PR TITLE
API: rename PCDSDetector to PCDSAreaDetector

### DIFF
--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -18,18 +18,18 @@ from .plugins import (ColorConvPlugin, HDF5Plugin, ImagePlugin, JPEGPlugin,
 logger = logging.getLogger(__name__)
 
 
-__all__ = ['PCDSDetectorBase',
-           'PCDSDetector']
+__all__ = ['PCDSAreaDetectorBase',
+           'PCDSAreaDetector']
 
 
-class PCDSDetectorBase(DetectorBase):
+class PCDSAreaDetectorBase(DetectorBase):
     """
     Standard area detector with no plugins.
     """
     cam = ADComponent(cam.CamBase, '')
 
 
-class PCDSDetector(PCDSDetectorBase):
+class PCDSAreaDetector(PCDSAreaDetectorBase):
     """
     Standard area detector including all (*) standard PCDS plugins.
     Notable plugins:
@@ -154,13 +154,13 @@ class PCDSDetector(PCDSDetectorBase):
     @property
     def image(self):
         'Deprecated - alias for `image2`'
-        warnings.warn('PCDSDetector.image is deprecated; use {}.image2 '
+        warnings.warn('PCDSAreaDetector.image is deprecated; use {}.image2 '
                       'instead'.format(self.name))
         return self.image2
 
     @property
     def stats(self):
         'Deprecated - alias for `stats2`'
-        warnings.warn('PCDSDetector.image is deprecated; use {}.stats2 '
+        warnings.warn('PCDSAreaDetector.image is deprecated; use {}.stats2 '
                       'instead'.format(self.name))
         return self.stats2

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -9,7 +9,7 @@ import logging
 
 from ophyd import FormattedComponent as FCpt
 
-from .areadetector.detectors import PCDSDetector
+from .areadetector.detectors import PCDSAreaDetector
 from .inout import InOutRecordPositioner
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class PIM(PIMMotor):
         The EPICS base PV of the detector. If None, it will be inferred from
         the motor prefix
     """
-    detector = FCpt(PCDSDetector, "{self._prefix_det}", kind='normal')
+    detector = FCpt(PCDSAreaDetector, "{self._prefix_det}", kind='normal')
 
     def __init__(self, prefix, *, name, prefix_det=None, **kwargs):
         # Infer the detector PV from the motor PV

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -6,7 +6,7 @@ from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.areadetector.detectors import PCDSDetector
+from pcdsdevices.areadetector.detectors import PCDSAreaDetector
 from pcdsdevices.pim import PIM, PIMMotor
 
 logger = logging.getLogger(__name__)
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 # OK, we have to screw with the class def here. I'm sorry. It's ophyd's fault
 # for checking an epics signal value in the __init__ statement.
-for attr in PCDSDetector._sub_devices:
-    plugin_class = getattr(PCDSDetector, attr).cls
+for attr in PCDSAreaDetector._sub_devices:
+    plugin_class = getattr(PCDSAreaDetector, attr).cls
     if hasattr(plugin_class, 'plugin_type'):
         plugin_class.plugin_type = Cpt(Signal, value=plugin_class._plugin_type)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use sed to replace `PCDSDetector` with `PCDSAreaDetector`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested by @silkenelson to avoid confusion with other pcds-group detectors that are not epics area detectors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It might pass the tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It will need to end up in the release notes under API breaks.

Note that this probably needs corresponding changes in some other libraries...

<!--
## Screenshots (if appropriate):
-->
