### PR TITLE
ENH: make states_list optional

### DIFF
--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -62,6 +62,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
     SUB_STATE = 'state'
     _default_sub = SUB_STATE
+    _state_meta_sub = EpicsSignal.SUB_VALUE
 
     egu = 'state'
 
@@ -76,7 +77,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
             self._state_init()
         else:
             cbid = self.state.subscribe(self._late_state_init,
-                                        event_type=EpicsSignal.SUB_VALUE,
+                                        event_type=self._state_meta_sub,
                                         run=False)
             self._state_init_cbid = cbid
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -72,7 +72,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         super().__init__(prefix, name=name, **kwargs)
         self._state_initialized = False
         self._state_init_cbid = False
-        if states_list:
+        if self.states_list:
             self._state_init()
         else:
             cbid = self.state.subscribe(self._late_state_init,

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -80,7 +80,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
                                         run=False)
             self._state_init_cbid = cbid
 
-    @required_for_connection
+    # @required_for_connection # This never made it into ophyd...
     def _state_init(self):
         if not self._state_initialized:
             self._valid_states = [state for state in self.states_list

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -99,6 +99,10 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
     def _late_state_init(self, *args, obj, **kwargs):
         self.states_list = list(obj.enum_strs)
+        # Unknown state is reserved for slot zero, automatically added later
+        # Removing and auto re-adding *feels* silly, but it was easy to do
+        if self._unknown:
+            self.states_list.pop(0)
         self._state_init()
 
     def move(self, position, moved_cb=None, timeout=None, wait=False):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -97,8 +97,8 @@ class StatePositioner(Device, PositionerBase, MvInterface):
             self.unsubscribe(self._state_init_cbid)
             self._state_init_cbid = False
 
-    def _late_state_init(self, *args, enum_strs, **kwargs):
-        self.states_list = list(enum_strs)
+    def _late_state_init(self, *args, obj, **kwargs):
+        self.states_list = list(obj.enum_strs)
         self._state_init()
 
     def move(self, position, moved_cb=None, timeout=None, wait=False):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -29,7 +29,9 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         This signal is the final authority on what state the object is in.
 
     states_list: ``list of str``
-        An exhaustive list of all possible states. This should be overridden in
+        This no longer has to be provided if the state signal contains enum
+        information, like an EPICS mbbi. If it is provided, it must be
+        an exhaustive list of all possible states. This should be overridden in
         a base class. Unknown must be omitted in the class definition and will
         be added dynamically in position 0 when the object is created.
 
@@ -55,7 +57,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
 
     state = None  # Override with Signal that represents state readback
 
-    states_list = []  # Override with an exhaustive list of states
+    states_list = []  # Optional: override with an exhaustive list of states
     _invalid_states = []  # Override with states that cannot be set
     _states_alias = {}  # Override with a mapping {'STATE': ['ALIAS', ...]}
     _unknown = 'Unknown'  # Set False if no Unknown state, can also change str
@@ -415,8 +417,7 @@ class StateRecordPositioner(StatePositioner):
     """
     A `StatePositioner` for an EPICS states record.
 
-    The `states_list` must match the EPICS PVs for adjusting the states
-    settings, in the same order as the state enum. Unknown must be omitted.
+    `states_list` does not have to be provided
     """
     state = Cpt(EpicsSignal, '', write_pv=':GO', kind='hinted')
     motor = Cpt(IMS, ':MOTOR', kind='normal')

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -75,9 +75,10 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         if states_list:
             self._state_init()
         else:
-            self.state.subscribe(self._late_state_init,
-                                 event_type=EpicsSignal.SUB_META,
-                                 run=False)
+            cbid = self.state.subscribe(self._late_state_init,
+                                        event_type=EpicsSignal.SUB_META,
+                                        run=False)
+            self._state_init_cbid = cbid
 
     @required_for_connection
     def _state_init(self):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -8,7 +8,7 @@ from enum import Enum
 from ophyd.positioner import PositionerBase
 from ophyd.status import wait as status_wait, SubscriptionStatus
 from ophyd.signal import EpicsSignal
-from ophyd.device import Device, Component as Cpt
+from ophyd.device import Device, Component as Cpt, required_for_connection
 
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
@@ -83,7 +83,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
                                         run=False)
             self._state_init_cbid = cbid
 
-    # @required_for_connection # This never made it into ophyd...
+    @required_for_connection
     def _state_init(self):
         if not self._state_initialized:
             self._valid_states = [state for state in self.states_list

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -76,7 +76,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
             self._state_init()
         else:
             cbid = self.state.subscribe(self._late_state_init,
-                                        event_type=EpicsSignal.SUB_META,
+                                        event_type=EpicsSignal.SUB_VALUE,
                                         run=False)
             self._state_init_cbid = cbid
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,7 +2,7 @@ import logging
 from unittest.mock import Mock
 
 import pytest
-from ophyd.device import Component as Cmp
+from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
 from ophyd.sim import make_fake_device
 
@@ -19,8 +19,8 @@ class PrefixSignal(Signal):
 
 # Define the class
 class LimCls(PVStatePositioner):
-    lowlim = Cmp(PrefixSignal, 'lowlim')
-    highlim = Cmp(PrefixSignal, 'highlim')
+    lowlim = Cpt(PrefixSignal, 'lowlim')
+    highlim = Cpt(PrefixSignal, 'highlim')
 
     _state_logic = {'lowlim': {0: 'in',
                                1: 'defer'},
@@ -44,7 +44,7 @@ class LimCls2(LimCls):
 
 # For additional tests
 class IntState(StatePositioner):
-    state = Cmp(PrefixSignal, 'int', value=2)
+    state = Cpt(PrefixSignal, 'int', value=2)
     states_list = [None, 'UNO', 'OUT']
     _states_alias = {'UNO': ['IN', 'in']}
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -188,3 +188,18 @@ def test_subcls_warning():
         StatePositioner('prefix', name='name')
     with pytest.raises(TypeError):
         PVStatePositioner('prefix', name='name')
+
+
+class InOutSignal(Signal):
+    enum_strs = ('Unknown', 'IN', 'OUT')
+
+
+class NoStatesList(StatePositioner):
+    state = Cpt(InOutSignal)
+
+
+def test_auto_states():
+    logger.debug('test_auto_states')
+    states = NoStatesList(prefix='NOSTATE', name='no_state')
+    states.state.put(1)  # Force callback to run
+    assert states.states_list == ['Unknown', 'IN', 'OUT']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If `states_list` isn't provided in a states device, use the metadata callback to get it.
Cleans up some device definitions to be simpler and more logically consistent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Silke asked for not having to make a separate timetool class for each hutch. I want to use this to clean up our device implementations and make it easier going forward.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
One test was added

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings and comments
<!--
## Screenshots (if appropriate):
-->
