### PR TITLE
Vacuum lcls i

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ Full API
    ~pcdsdevices.ccm
    ~pcdsdevices.epics_motor
    ~pcdsdevices.evr
+   ~pcdsdevices.gauge
    ~pcdsdevices.inout
    ~pcdsdevices.ipm
    ~pcdsdevices.lens
@@ -20,6 +21,7 @@ Full API
    ~pcdsdevices.pim
    ~pcdsdevices.pseudopos
    ~pcdsdevices.pulsepicker
+   ~pcdsdevices.pump
    ~pcdsdevices.signal
    ~pcdsdevices.sim
    ~pcdsdevices.slits

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -13,8 +13,10 @@ Common EPICS Devices
     EpicsMotor
     EventSequencer
     GateValve
+    GaugeSet
     IMS
     IPM
+    IonPump
     LODCM
     Motor
     Newport

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -6,12 +6,14 @@ from .epics_motor import (IMS, Newport, DelayNewport, PMC100, BeckhoffAxis,
 from .evr import Trigger
 from .inout import Reflaser, TTReflaser
 from .ipm import IPM
+from .gauge import GaugeSet
 from .lens import XFLS
 from .lodcm import LODCM
 from .mirror import OffsetMirror, PointingMirror
 from .movablestand import MovableStand
 from .pim import PIM
 from .pulsepicker import PulsePicker
+from .pump import IonPump
 from .sequencer import EventSequencer
 from .slits import Slits
 from .valve import Stopper, GateValve

--- a/pcdsdevices/doc_stubs.py
+++ b/pcdsdevices/doc_stubs.py
@@ -38,3 +38,48 @@ insert_remove = """
             ``Status`` that will be marked as done when the motion is complete.
 
 """
+
+PIM_base = """
+    Profile intensity monitor
+
+    Parameters
+    ----------
+    prefix : str
+        The EPICS base of the motor
+
+    name : str
+        A name to refer to the device
+
+    prefix_det : str
+        The EPICS base PV of the detector
+
+    prefix_zoom : str
+        The EPICS base PV of the zoom motor
+    """
+
+IonPump_base = """
+    Ion Pump
+
+    Parameters
+    ----------
+    prefix : ``str``
+        Ion Pump PV
+
+    name : ``str``
+        Alias for the ion pump
+    """
+
+GaugeSet_base = """
+    Class for a Gauge Set 
+
+    Parameters
+    ----------
+    prefix : ``str``
+        Gauge base PV (up to GCC/GPI)
+
+    name : ``str``
+        Alias for the gauge set
+
+    index : ``str`` or ``int``
+        Index for gauge (e.g. '02' or 3)
+    """

--- a/pcdsdevices/doc_stubs.py
+++ b/pcdsdevices/doc_stubs.py
@@ -70,7 +70,7 @@ IonPump_base = """
     """
 
 GaugeSet_base = """
-    Class for a Gauge Set 
+    Class for a Gauge Set
 
     Parameters
     ----------

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -479,6 +479,8 @@ def Motor(prefix, **kwargs):
     """
     # Available motor types
     motor_types = (('MMS', IMS),
+                   ('CLZ', IMS),
+                   ('CLF', IMS),
                    ('MMN', Newport),
                    ('MZM', PMC100),
                    ('MMB', BeckhoffAxis),

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -1,0 +1,64 @@
+"""
+Standard classes for LCLS Gauges
+"""
+import logging
+from ophyd import EpicsSignal, EpicsSignalRO, Device, Component as Cpt
+
+logger = logging.getLogger(__name__)
+
+class BaseGauge(Device):
+    """
+    Vacuum gauge
+
+    A base class for a device with two limits switches controlled via an
+    external command PV. This fully encompasses the controls `Stopper`
+    installations as well as un-interlocked `GateValves`
+
+    Parameters
+    ----------
+    prefix : ``str``
+        Full Gauge base PV
+
+    name : ``str``
+        Alias for the gauge
+    """
+    # 
+    pressure = Cpt(EpicsSignalRO, ':PMON', kind='normal')
+    status = Cpt(EpicsSignalRO, ':STATUSMON', kind='normal')
+    pressure_status = Cpt(EpicsSignalRO, ':PSTATMON', kind='normal')
+    pressure_status_enable = Cpt(EpicsSignal, ':PSTATMSP', kind='normal')
+
+    def __repr__(self):
+        print('Gauge is %s'%self.status)
+        if self.status>0:
+            print('Pressure: %g'%self.pressure)
+
+class GaugePirani(BaseGauge):
+    """
+    Class for Pirani gauge
+    """
+    pass
+
+class GaugeColdCathode(BaseGauge):
+    """
+    Class for Cold Cathode Gauge
+    """
+    enable = Cpt(EpicsSignalRO, ':ENB_DO_SW', kind='normal')
+    #this should be combined.
+    tripSetpointRB = Cpt(EpicsSignal, ':PSTATSPDES', kind='normal')
+    tripSetpoint = Cpt(EpicsSignalRO, ':PSTATSPRBCK', kind='normal')
+
+class GaugeSet(Device):
+    """
+    Class for a gauge set with a Pirani and Cold Cathode Gauge
+    argument is the base PV for the cold cathode gauge
+    """
+    gpi = Cpt(GaugePirani, self.prefix.replace('GCC','GPI'))
+    gcc = Cpt(GaugeColdCathode)
+    
+    def pressure(self):
+        if self.gcc.status > 0:
+            return self.gcc.pmon
+        else:
+            return self.gpi.pmon
+

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -72,18 +72,18 @@ class GaugeColdCathode(BaseGauge):
     Class for Cold Cathode Gauge
     """
     enable = Cpt(EpicsSignal, ':ENBL_SW', kind='normal')
-    relaySetpoint = Cpt(EpicsSignal, ':PSTATSPRBCK',
-                        write_pv=':PSTATSPDES', kind='normal')
-    relayEnable = Cpt(EpicsSignal, ':PSTATENRBCK',
-                      write_pv=':PSTATEN', kind='normal')
-    controlSetpoint = Cpt(EpicsSignal, ':PCTRLSPRBCK',
-                          write_pv=':PCTRLSPDES', kind='normal')
-    controlEnable = Cpt(EpicsSignal, ':PCTRLENRBCK',
-                        write_pv=':PCTRLEN', kind='normal')
-    protectionSetpoint = Cpt(EpicsSignal, ':PPROTSPRBCK',
-                             write_pv=':PPROTSPDES', kind='normal')
-    protectionEnable = Cpt(EpicsSignal, ':PPROTENRBCK',
-                           write_pv=':PPROTEN', kind='normal')
+    relay_setpoint = Cpt(EpicsSignal, ':PSTATSPRBCK',
+                         write_pv=':PSTATSPDES', kind='normal')
+    relay_enable = Cpt(EpicsSignal, ':PSTATENRBCK',
+                       write_pv=':PSTATEN', kind='normal')
+    control_setpoint = Cpt(EpicsSignal, ':PCTRLSPRBCK',
+                           write_pv=':PCTRLSPDES', kind='normal')
+    control_enable = Cpt(EpicsSignal, ':PCTRLENRBCK',
+                         write_pv=':PCTRLEN', kind='normal')
+    protection_setpoint = Cpt(EpicsSignal, ':PPROTSPRBCK',
+                              write_pv=':PPROTSPDES', kind='normal')
+    protection_enable = Cpt(EpicsSignal, ':PPROTENRBCK',
+                            write_pv=':PPROTEN', kind='normal')
 
 
 class GaugeSetBase(Device):
@@ -164,6 +164,26 @@ class GaugeSetPiraniMks(GaugeSetPirani):
 
 # factory function for IonPumps
 def GaugeSet(prefix, *, name, index, **kwargs):
+    """
+    Factory function for Gauge Set
+
+    Parameters
+    ----------
+    prefix : ``str``
+        Gauge base PV (up to GCC/GPI)
+
+    name : ``str``
+        Alias for the gauge set
+
+    index : ``str`` or ``int``
+        Index for gauge (e.g. '02' or 3)
+
+    (optional) prefix_controller : ``str``
+        Base PV for the controller
+
+    (optional) onlyGCC:
+        if defined and not false, set has no Pirani
+    """
 
     onlyGCC = kwargs.pop('onlyGCC', None)
     if onlyGCC:

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -1,0 +1,76 @@
+"""
+Standard classes for LCLS Gauges
+"""
+import logging
+from ophyd import EpicsSignal, EpicsSignalRO, Component as Cpt
+
+logger = logging.getLogger(__name__)
+
+class TurboPump(Device):
+    """
+    Vacuum Pump
+    """
+    # 
+    atspeed = Cpt(EpicsSignal, ':ATSPEED_DI', kind='normal')
+    start = Cpt(EpicsSignal, ':START_SW', kind='normal')
+
+    def run(self):
+        """Start the Turbo Pump"""
+        self.start.put(1)
+
+    def stop(self):
+        """Start the Turbo Pump"""
+        self.start.put(0)
+
+
+class EbaraPump(Device):
+    """
+    Ebara Turbo Pump
+    """
+    # 
+    start = Cpt(EpicsSignal, ':MPSTART_SW', kind='normal')
+
+    def run(self):
+        """Start the Turbo Pump"""
+        self.start.put(1)
+
+    def stop(self):
+        """Start the Turbo Pump"""
+        self.start.put(0)
+
+class IonPump(Device):
+    """
+    Ion Pump (Gamma controller)
+    """
+    # 
+    pressure = Cpt(EpicsSignalRO, ':PMON', kind='normal')
+    current = Cpt(EpicsSignalRO, ':IMON', kind='normal')
+    voltage = Cpt(EpicsSignalRO, ':VMON', kind='normal')
+    status_code = Cpt(EpicsSignalRO, ':STATUSCODE', kind='normal')
+    status = Cpt(EpicsSignalRO, ':STATUS', kind='normal')
+    #check if this work as its an enum
+    state = Cpt(EpicsSignal, ':STATEMON', write_pv=':STATEDES', kind='normal')
+    #state_rbk = Cpt(EpicsSignal, ':STATEMON', kind='normal')
+    #state_cmd = Cpt(EpicsSignal, ':STATEDES', kind='normal')
+
+    pumpsize = Cpt(EpicsSignal, ':PUMPSIZEDES', write_pv=':PUMPSIZE', kind='omitted')
+    controllername = Cpt(EpicsSignal, ':VPCNAME', kind='omitted')
+    hvstrapping = Cpt(EpicsSignal, ':VDESRBCK', kind='omitted')
+    supplysize = Cpt(EpicsSignalRO, ':SUPPLYSIZE', kind='omitted')
+    egu = Cpt(EpicsSignalRO, ':PMON.EGU', kind='omitted')
+
+    aomode = Cpt(EpicsSignal, ':AOMODEDES', write_pv=':AOMODE', kind='config')
+    calfactor = Cpt(EpicsSignal, ':CALFACTOREDES', write_pv=':CALFACTOR', kind='config')
+
+    def on(self):
+        self.state.put(1)
+
+    def off(self):
+        self.state.put(0)
+
+    def __repr__(self):
+        print('Pump is %s'%self.state)
+        if self.state>0:
+            print('Pressure: %g'%self.pressure)
+            print('Current: %g'%self.current)
+            print('Voltage: %g'%self.voltage)

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -138,6 +138,20 @@ class IonPumpWithController(IonPumpBase):
 
 # factory function for IonPumps
 def IonPump(prefix, *, name, **kwargs):
+    """
+    Ion Pump
+
+    Parameters
+    ----------
+    prefix : ``str``
+        Ion Pump PV
+
+    name : ``str``
+        Alias for the ion pump
+
+    (optional) prefix_controller : ``str``
+        Ion Pump Controller base PV
+    """
 
     if 'prefix_controller' not in kwargs:
         return IonPumpBase(prefix, name=name, **kwargs)

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -20,7 +20,6 @@ def fake_gauge_set():
     gs.gpi.pressure.sim_put(98)
     return gs
 
-@pytest.mark.timeout(5)
 def test_gauge_pressure(fake_gauge_set):
     logger.debug('test_gauge_pressure')
     gs = fake_gauge_set

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,16 +1,13 @@
 import logging
 import pytest
-from unittest.mock import Mock
 
-from ophyd.device import Component as Cpt
-from ophyd.signal import Signal
 from ophyd.sim import make_fake_device
-
-from pcdsdevices.gauge import GaugeSet, GaugeSetPirani, GaugeSetBase, GaugeSetMks, GaugeSetPiraniMks
+from pcdsdevices.gauge import GaugeSet, GaugeSetPirani, GaugeSetBase
+from pcdsdevices.gauge import GaugeSetMks, GaugeSetPiraniMks
 
 logger = logging.getLogger(__name__)
 
-#check pressure ...
+
 @pytest.fixture(scope='function')
 def fake_gauge_set():
     FakeGaugeSet = make_fake_device(GaugeSetPirani)
@@ -20,20 +17,24 @@ def fake_gauge_set():
     gs.gpi.pressure.sim_put(98)
     return gs
 
+
 def test_gauge_pressure(fake_gauge_set):
     logger.debug('test_gauge_pressure')
     gs = fake_gauge_set
     # Should return to original position on unstage
-    assert gs.pressure()==98
+    assert gs.pressure() == 98
     gs.gcc.state.sim_put(0)
-    assert gs.pressure()==99
+    assert gs.pressure() == 99
+
 
 def test_gauge_factory():
     m = GaugeSet('TST:MY', name='test_gauge', index='99')
     assert isinstance(m, GaugeSetPirani)
     m = GaugeSet('TST:MY', name='test_gauge', index='99', onlyGCC=1)
     assert isinstance(m, GaugeSetBase)
-    m = GaugeSet('TST:MY', name='test_gauge', index='99', prefix_controller='TST:R99:GCT:99:A')
+    m = GaugeSet('TST:MY', name='test_gauge', index='99',
+                 prefix_controller='TST:R99:GCT:99:A')
     assert isinstance(m, GaugeSetPiraniMks)
-    m = GaugeSet('TST:MY', name='test_gauge', index='99', prefix_controller='TST:R99:GCT:99:A', onlyGCC=True)
+    m = GaugeSet('TST:MY', name='test_gauge', index='99',
+                 prefix_controller='TST:R99:GCT:99:A', onlyGCC=True)
     assert isinstance(m, GaugeSetMks)

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,0 +1,40 @@
+import logging
+import pytest
+from unittest.mock import Mock
+
+from ophyd.device import Component as Cpt
+from ophyd.signal import Signal
+from ophyd.sim import make_fake_device
+
+from pcdsdevices.gauge import GaugeSet, GaugeSetPirani, GaugeSetBase, GaugeSetMks, GaugeSetPiraniMks
+
+logger = logging.getLogger(__name__)
+
+#check pressure ...
+@pytest.fixture(scope='function')
+def fake_gauge_set():
+    FakeGaugeSet = make_fake_device(GaugeSetPirani)
+    gs = FakeGaugeSet('Test:Gauge', name='test', index='99')
+    gs.gcc.state.sim_put(1)
+    gs.gcc.pressure.sim_put(99)
+    gs.gpi.pressure.sim_put(98)
+    return gs
+
+@pytest.mark.timeout(5)
+def test_gauge_pressure(fake_gauge_set):
+    logger.debug('test_gauge_pressure')
+    gs = fake_gauge_set
+    # Should return to original position on unstage
+    assert gs.pressure()==98
+    gs.gcc.state.sim_put(0)
+    assert gs.pressure()==99
+
+def test_gauge_factory():
+    m = GaugeSet('TST:MY', name='test_gauge', index='99')
+    assert isinstance(m, GaugeSetPirani)
+    m = GaugeSet('TST:MY', name='test_gauge', index='99', onlyGCC=1)
+    assert isinstance(m, GaugeSetBase)
+    m = GaugeSet('TST:MY', name='test_gauge', index='99', prefix_controller='TST:R99:GCT:99:A')
+    assert isinstance(m, GaugeSetPiraniMks)
+    m = GaugeSet('TST:MY', name='test_gauge', index='99', prefix_controller='TST:R99:GCT:99:A', onlyGCC=True)
+    assert isinstance(m, GaugeSetMks)

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -1,0 +1,36 @@
+import logging
+import pytest
+from unittest.mock import Mock
+
+from ophyd.device import Component as Cpt
+from ophyd.sim import make_fake_device
+from pcdsdevices.pump import IonPump, IonPumpBase, IonPumpWithController
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope='function')
+def fake_ionpump():
+    FakeIonPump = make_fake_device(IonPumpBase)
+    pump = FakeIonPump('Test:pump', name='test')
+    pump.state.sim_set_enum_strs(['OFF','ON'])
+    pump.state.sim_put(1)
+    pump._pressure.sim_put(99.)
+    return pump
+
+@pytest.mark.timeout(5)
+def test_pump_pressure(fake_ionpump):
+    logger.debug('test_ionpump')
+    pump = fake_ionpump
+    assert pump.state.get()=='ON'
+    pump.off()
+    assert pump.state.get()=='OFF'
+    assert pump.pressure()==-1.
+    pump.on()
+    assert pump.state.get()=='ON'
+    assert pump.pressure()==99.
+
+def test_ionpump_factory():
+    m = IonPump('TST:MY:PIP:01', name='test_pump', prefix_controller='gamma')
+    assert isinstance(m, IonPumpWithController)
+    m = IonPump('TST:MY:PIP:01', name='test_pump')
+    assert isinstance(m, IonPumpBase)

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -17,7 +17,6 @@ def fake_ionpump():
     pump._pressure.sim_put(99.)
     return pump
 
-@pytest.mark.timeout(5)
 def test_pump_pressure(fake_ionpump):
     logger.debug('test_ionpump')
     pump = fake_ionpump

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -1,32 +1,32 @@
 import logging
 import pytest
-from unittest.mock import Mock
-
-from ophyd.device import Component as Cpt
 from ophyd.sim import make_fake_device
 from pcdsdevices.pump import IonPump, IonPumpBase, IonPumpWithController
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture(scope='function')
 def fake_ionpump():
     FakeIonPump = make_fake_device(IonPumpBase)
     pump = FakeIonPump('Test:pump', name='test')
-    pump.state.sim_set_enum_strs(['OFF','ON'])
+    pump.state.sim_set_enum_strs(['OFF', 'ON'])
     pump.state.sim_put(1)
     pump._pressure.sim_put(99.)
     return pump
 
+
 def test_pump_pressure(fake_ionpump):
     logger.debug('test_ionpump')
     pump = fake_ionpump
-    assert pump.state.get()=='ON'
+    assert pump.state.get() == 'ON'
     pump.off()
-    assert pump.state.get()=='OFF'
-    assert pump.pressure()==-1.
+    assert pump.state.get() == 'OFF'
+    assert pump.pressure() == -1.
     pump.on()
-    assert pump.state.get()=='ON'
-    assert pump.pressure()==99.
+    assert pump.state.get() == 'ON'
+    assert pump.pressure() == 99.
+
 
 def test_ionpump_factory():
     m = IonPump('TST:MY:PIP:01', name='test_pump', prefix_controller='gamma')


### PR DESCRIPTION
Adding classes for (ion) pumps and vacuum gauges
## Description
new files for (ion) pumps and vacuum gauges have been created w/ tests
shared doc strings have been added to doc__stubs

## Motivation and Context
the old hutch python had classes for these devices and I would like to replicate coverage
additionally, these classes show allow us to inspect the vacuum along a beam line from the command line.

## How Has This Been Tested?
I have checked more complicated functions on a few vacuum devices in the XCS line.

## Where Has This Been Documented?
The classes have docstrings.
