### PR TITLE
ENH: Add motor to state devices

### DIFF
--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -1,37 +1,59 @@
 """
 Module for the `IPM` intensity position monitor class
 """
-from ophyd import Component as Cpt, FormattedComponent as FCpt
-from ophyd.signal import EpicsSignal, EpicsSignalRO
+from ophyd.device import Device, Component as Cpt
 
-from .doc_stubs import basic_positioner_init
+from .doc_stubs import basic_positioner_init, insert_remove
 from .inout import InOutRecordPositioner
 
 
-class IPM(InOutRecordPositioner):
+class IPMTarget(InOutRecordPositioner):
     """
-    Standard intensity position monitor.
+    Target of a standard intensity position monitor.
 
     This is an `InOutRecordPositioner` that moves
     the target position to any of the four set positions, or out. Valid states
     are (1, 2, 3, 4, 5) or the equivalent
     (TARGET1, TARGET2, TARGET3, TARGET4, OUT).
-
-    IPMs each also have a diode, which is implemented as the diode attribute of
-    this class. This can easily be controlled using ``ipm.diode.insert()`` or
-    ``ipm.diode.remove()``.
     """
     __doc__ += basic_positioner_init
-
-    state = Cpt(EpicsSignal, ':TARGET', write_pv=':TARGET:GO', kind='hinted')
-    diode = Cpt(InOutRecordPositioner, ':DIODE', kind='omitted')
-    readback = FCpt(EpicsSignalRO, '{self.prefix}:TARGET:{self._readback}',
-                    kind='normal')
 
     in_states = ['TARGET1', 'TARGET2', 'TARGET3', 'TARGET4']
     states_list = in_states + ['OUT']
 
     # Assume that having any target in gives transmission 0.8
     _transmission = {st: 0.8 for st in in_states}
+
+
+class IPM(Device):
+    """
+    Standard intensity position monitor.
+
+    This contains two state devices, a target and a diode.
+    """
+    target = Cpt(IPMTarget, ':TARGET', kind='hinted')
+    diode = Cpt(InOutRecordPositioner, ':DIODE', kind='omitted')
+
     # QIcon for UX
     _icon = 'ei.screenshot'
+
+    @property
+    def inserted(self):
+        """Returns ``True`` if target is inserted. Diode never blocks."""
+        return self.target.inserted
+
+    @property
+    def removed(self):
+        """Returns ``True`` if target is removed. Diode never blocks."""
+        return self.target.removed
+
+    def remove(self, moved_cb=None, timeout=None, wait=False):
+        """Moves the target out of the beam. Diode never blocks."""
+        return self.target.remove(moved_cb=moved_cb, timeout=timeout, wait=wait)
+
+    remove.__doc__ += insert_remove
+
+    @property
+    def transmission(self):
+        """Returns the target's transmission value. Diode never blocks."""
+        return self.target.transmission

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -49,7 +49,9 @@ class IPM(Device):
 
     def remove(self, moved_cb=None, timeout=None, wait=False):
         """Moves the target out of the beam. Diode never blocks."""
-        return self.target.remove(moved_cb=moved_cb, timeout=timeout, wait=wait)
+        return self.target.remove(moved_cb=moved_cb,
+                                  timeout=timeout,
+                                  wait=wait)
 
     remove.__doc__ += insert_remove
 

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -12,11 +12,10 @@ import logging
 import functools
 
 from ophyd.device import Device, Component as Cpt
-from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.sim import NullStatus
 from ophyd.status import wait as status_wait
 
-from .doc_stubs import basic_positioner_init, insert_remove
+from .doc_stubs import insert_remove
 from .inout import InOutRecordPositioner
 
 logger = logging.getLogger(__name__)

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -11,7 +11,7 @@ no readback into the device's alignment. This is intended for a future update.
 import logging
 import functools
 
-from ophyd import Component as Cpt, FormattedComponent as FCpt
+from ophyd.device import Device, Component as Cpt
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.sim import NullStatus
 from ophyd.status import wait as status_wait
@@ -20,6 +20,13 @@ from .doc_stubs import basic_positioner_init, insert_remove
 from .inout import InOutRecordPositioner
 
 logger = logging.getLogger(__name__)
+
+
+class H1N(InOutRecordPositioner):
+    states_list = ['OUT', 'C', 'Si']
+    in_states = ['C', 'Si']
+    _states_alias = {'C': 'IN'}
+    _transmission = {'C': 0.8, 'Si': 0.7}
 
 
 class YagLom(InOutRecordPositioner):
@@ -52,7 +59,7 @@ class Foil(InOutRecordPositioner):
         super().__init__(prefix, *args, **kwargs)
 
 
-class LODCM(InOutRecordPositioner):
+class LODCM(Device):
     """
     Large Offset Dual Crystal Monochromator
 
@@ -62,31 +69,27 @@ class LODCM(InOutRecordPositioner):
     the mono line, onto both, or onto neither.
 
     This positioner only considers the h1n and diagnostic motors.
-%s
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The PV prefix
+
+    name: ``str``, required keyword
+        The name of this device
+
     main_line: ``str``, optional
         Name of the main, no-bounce beamline.
 
     mono_line: ``str``, optional
         Name of the mono, double-bounce beamline.
     """
-    __doc__ = __doc__ % basic_positioner_init
-
-    state = Cpt(EpicsSignal, ':H1N', write_pv=':H1N:GO', kind='hinted')
-    readback = FCpt(EpicsSignalRO, '{self.prefix}:H1N:{self._readback}',
-                    kind='normal')
-
+    h1n = Cpt(H1N, ':H1N', kind='hinted')
     yag = Cpt(YagLom, ":DV", kind='omitted')
     dectris = Cpt(Dectris, ":DH", kind='omitted')
     diode = Cpt(Diode, ":DIODE", kind='omitted')
     foil = Cpt(Foil, ":FOIL", kind='omitted')
 
-    states_list = ['OUT', 'C', 'Si']
-    in_states = ['C', 'Si']
-
-    # TBH these are guessed. Please replace if you know better. These don't
-    # need to be 100% accurate, but they should reflect a reasonable reduction
-    # in transmission.
-    _transmission = {'C': 0.8, 'Si': 0.7}
     # QIcon for UX
     _icon = 'fa.share-alt-square'
 
@@ -95,6 +98,25 @@ class LODCM(InOutRecordPositioner):
         super().__init__(prefix, name=name, **kwargs)
         self.main_line = main_line
         self.mono_line = mono_line
+
+    @property
+    def inserted(self):
+        """Returns ``True`` if either h1n crystal is in."""
+        return self.h1n.inserted
+
+    @property
+    def removed(self):
+        """Returns ``True`` if neither h1n crystal is in."""
+        return self.h1n.removed
+
+    def remove(self, moved_cb=None, timeout=None, wait=False):
+        """Moves the h1n crystal out of the beam."""
+        return self.h1n.remove(moved_cb=moved_cb, timeout=timeout, wait=wait)
+
+    @property
+    def transmission(self):
+        """Returns h1n's transmission value"""
+        return self.h1n.transmission
 
     @property
     def branches(self):
@@ -119,11 +141,11 @@ class LODCM(InOutRecordPositioner):
             ``self.main_line`` if the light continues on the main line.
             ``self.mono_line`` if the light continues on the mono line.
         """
-        if self.position == 'OUT':
+        if self.h1n.position == 'OUT':
             dest = [self.main_line]
-        elif self.position == 'Si':
+        elif self.h1n.position == 'Si':
             dest = [self.mono_line]
-        elif self.position == 'C':
+        elif self.h1n.position == 'C':
             dest = [self.main_line, self.mono_line]
         else:
             dest = []

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -1,5 +1,5 @@
 """
-Module to deoine positioners that move between discrete named states.
+Module to define positioners that move between discrete named states.
 """
 import logging
 import functools

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -7,8 +7,8 @@ from enum import Enum
 
 from ophyd.positioner import PositionerBase
 from ophyd.status import wait as status_wait, SubscriptionStatus
-from ophyd.signal import EpicsSignal, EpicsSignalRO
-from ophyd.device import Device, Component as Cpt, FormattedComponent as FCpt
+from ophyd.signal import EpicsSignal
+from ophyd.device import Device, Component as Cpt
 
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -5,7 +5,7 @@ from ophyd.sim import make_fake_device
 from unittest.mock import Mock
 
 from pcdsdevices.inout import InOutRecordPositioner
-from pcdsdevices.ipm import IPM
+from pcdsdevices.ipm import IPMTarget
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ def fake_ipm():
     ipm.diode.state.sim_set_enum_strs(['Unknown'] +
                                       InOutRecordPositioner.states_list)
     ipm.target.state.sim_put(0)
-    ipm.target.state.sim_set_enum_strs(['Unknown'] + IPM.states_list)
+    ipm.target.state.sim_set_enum_strs(['Unknown'] + IPMTarget.states_list)
     return ipm
 
 

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -5,7 +5,7 @@ from ophyd.sim import make_fake_device
 from unittest.mock import Mock
 
 from pcdsdevices.inout import InOutRecordPositioner
-from pcdsdevices.ipm import IPMTarget
+from pcdsdevices.ipm import IPM, IPMTarget
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -55,7 +55,7 @@ def test_ipm_subscriptions(fake_ipm):
     ipm = fake_ipm
     # Subscribe a pseudo callback
     cb = Mock()
-    ipm.subscribe(cb, event_type=ipm.SUB_STATE, run=False)
+    ipm.target.subscribe(cb, event_type=ipm.target.SUB_STATE, run=False)
     # Change the target state
     ipm.target.state.put(2)
     assert cb.called

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -17,18 +17,18 @@ def fake_ipm():
     ipm.diode.state.sim_put(0)
     ipm.diode.state.sim_set_enum_strs(['Unknown'] +
                                       InOutRecordPositioner.states_list)
-    ipm.state.sim_put(0)
-    ipm.state.sim_set_enum_strs(['Unknown'] + IPM.states_list)
+    ipm.target.state.sim_put(0)
+    ipm.target.state.sim_set_enum_strs(['Unknown'] + IPM.states_list)
     return ipm
 
 
 def test_ipm_states(fake_ipm):
     logger.debug('test_ipm_states')
     ipm = fake_ipm
-    ipm.state.put(5)
+    ipm.target.state.put(5)
     assert ipm.removed
     assert not ipm.inserted
-    ipm.state.put(1)
+    ipm.target.state.put(1)
     assert not ipm.removed
     assert ipm.inserted
 
@@ -38,10 +38,10 @@ def test_ipm_motion(fake_ipm):
     ipm = fake_ipm
     # Remove IPM Targets
     ipm.remove(wait=True, timeout=1.0)
-    assert ipm.state.get() == 5
+    assert ipm.target.state.get() == 5
     # Insert IPM Targets
-    ipm.set(1)
-    assert ipm.state.get() == 1
+    ipm.target.set(1)
+    assert ipm.target.state.get() == 1
     # Move diodes in
     ipm.diode.insert()
     assert ipm.diode.state.get() == 1
@@ -57,5 +57,5 @@ def test_ipm_subscriptions(fake_ipm):
     cb = Mock()
     ipm.subscribe(cb, event_type=ipm.SUB_STATE, run=False)
     # Change the target state
-    ipm.state.put(2)
+    ipm.target.state.put(2)
     assert cb.called

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -4,7 +4,7 @@ import pytest
 from ophyd.sim import make_fake_device
 from unittest.mock import Mock
 
-from pcdsdevices.lodcm import LODCM, YagLom, Dectris, Diode, Foil
+from pcdsdevices.lodcm import LODCM, H1N, YagLom, Dectris, Diode, Foil
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 def fake_lodcm():
     FakeLODCM = make_fake_device(LODCM)
     lodcm = FakeLODCM('FAKE:LOM', name='fake_lom')
-    lodcm.state.sim_put(1)
-    lodcm.state.sim_set_enum_strs(['Unknown'] + LODCM.states_list)
+    lodcm.h1n.state.sim_put(1)
+    lodcm.h1n.state.sim_set_enum_strs(['Unknown'] + H1N.states_list)
     lodcm.yag.state.sim_put(1)
     lodcm.yag.state.sim_set_enum_strs(['Unknown'] + YagLom.states_list)
     lodcm.dectris.state.sim_put(1)
@@ -34,20 +34,20 @@ def test_lodcm_destination(fake_lodcm):
     for d in dest:
         assert isinstance(d, str)
 
-    lodcm.move('OUT')
+    lodcm.h1n.move('OUT')
     assert len(lodcm.destination) == 1
-    lodcm.move('C')
+    lodcm.h1n.move('C')
     assert len(lodcm.destination) == 2
     # Block the mono line
     lodcm.yag.move('IN')
     assert len(lodcm.destination) == 1
-    lodcm.move('Si')
+    lodcm.h1n.move('Si')
     assert len(lodcm.destination) == 0
     lodcm.yag.move('OUT')
     assert len(lodcm.destination) == 1
 
     # Unknown state
-    lodcm.state.sim_put('Unknown')
+    lodcm.h1n.state.sim_put('Unknown')
     assert len(lodcm.destination) == 0
 
 

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -26,6 +26,9 @@ def fake_pim():
     pim = FakePIM('Test:Yag', name='test')
     pim.state.sim_put(0)
     pim.state.sim_set_enum_strs(['Unknown'] + PIMMotor.states_list)
+    pim.motor.error_severity.sim_put(0)
+    pim.motor.bit_status.sim_put(0)
+    pim.motor.motor_spg.sim_put(2)
     return pim
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -154,7 +154,7 @@ def test_staterecord_positioner():
     state = MyStates('A:PV', name='test')
     cb = Mock()
     state.subscribe(cb, event_type=state.SUB_READBACK, run=False)
-    state.readback.sim_put(1.23)
+    state.motor.user_readback.sim_put(1.23)
     assert cb.called
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
As of the newest `IMS` release I did, all state device records contain a convenient `:MOTOR` alias to the motor whose position is associated with the state. This PR replaces the previous janky `readback` signal with this `motor` subcomponent.

This PR adjusts the `IPM` and `LODCM` classes as well, because their previous structures were an unstable abuse of inheritance and doing this change broke the classes entirely. The previous structure was a state positioner that contained other state positioners, but this is not how the PVs are structured at all, giving an awkward class definition. These are now container devices that, while not positioners themselves, contain many subcomponent state positioners.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was the cleanest way to allow us to have state devices with direct access to the motor.
closes #177 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This worked on real IPMs that Silke has updated to the newest IMS release. Note that this will not work on devices without the newest IOC release, we need to update these as we find them.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings updated appropriately. Apologies for overtly breaking API.
<!--
## Screenshots (if appropriate):
-->
