### PR TITLE
CI: require 3.7 build passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-  allow_failures:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
See title

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All the dependencies are available now, so we should be preparing for the long-delayed migration to 3.7 as the standard version