### PR TITLE
add CLF,CLZ as IMS motor types; add screen functions using motor-expe…

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -246,7 +246,7 @@ class PCDSMotorBase(EpicsMotorInterface):
         """
         executable = 'motor-expert-screen'
         if shutil.which(executable) is None:
-            print('%s is not on path, we cannot start the screen' % executable)
+            logger.error('%s is not on path, we cannot start the screen', executable)
             return
         arg = self.prefix
         os.system(executable + ' ' + arg)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -2,6 +2,8 @@
 Module for LCLS's special motor records.
 """
 import logging
+import shutil
+import os
 from ophyd.device import Component as Cpt
 from ophyd.epics_motor import EpicsMotor
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
@@ -237,6 +239,17 @@ class PCDSMotorBase(EpicsMotorInterface):
         # Pass information to PositionerBase
         super()._pos_changed(timestamp=timestamp, old_value=old_value,
                              value=value, **kwargs)
+
+    def screen(self):
+        """
+        Opens Epics motor expert screen for resetting motor after e.g. stalling
+        """
+        executable = 'motor-expert-screen'
+        if shutil.which(executable) is None:
+            print('%s is not on path, we cannot start the screen' % executable)
+            return
+        arg = self.prefix
+        os.system(executable + ' ' + arg)
 
 
 class IMS(PCDSMotorBase):
@@ -479,6 +492,8 @@ def Motor(prefix, **kwargs):
     """
     # Available motor types
     motor_types = (('MMS', IMS),
+                   ('CLZ', IMS),
+                   ('CLF', IMS),
                    ('MMN', Newport),
                    ('MZM', PMC100),
                    ('MMB', BeckhoffAxis),


### PR DESCRIPTION
…rt-screen

## Description
add CLF and CLZ to MMS as IMS motor types for factory faction
add screen() command (using motor-expert-screen command)

## Motivation and Context
start of working in issue #173 

## How Has This Been Tested?
opened motor screen for a few motors in an xcspython session

## Where Has This Been Documented?
