### PR TITLE
ENH: sync BeckhoffAxis with the new IOC, and add status string

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -422,7 +422,8 @@ class BeckhoffAxis(EpicsMotorInterface):
     """
     __doc__ += basic_positioner_init
 
-    cmd_err_reset = Cpt(EpicsSignal, ':ErrRst', kind='omitted')
+    status = Cpt(EpicsSignalRO, '-MsgTxt', kind='normal', string=True)
+    cmd_err_reset = Cpt(EpicsSignal, '-ErrRst', kind='omitted')
 
     def clear_error(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Change the PV name for the error reset signal on beckhoff axis, add status string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These are useful signals. The ethercat motor IOC has these dashes hard-coded, so we'll just live with them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working live at my desk.