### PR TITLE
FIX: Look for end transition instead of start transition

### DIFF
--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -254,7 +254,7 @@ class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface):
 
         # Create our status
         def done(*args, value=None, old_value=None, **kwargs):
-            return value == 2 and old_value == 0
+            return value == 0 and old_value == 2
 
         # Create our status object
         return SubscriptionStatus(self.play_status, done, run=True)

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -95,10 +95,13 @@ def test_trigger(sequence):
     # Set to run once
     sequence.play_mode.put(0)
     trig_status = sequence.trigger()
+    # Simulate the sequence starting
+    sequence.play_status.sim_put(2)
     # Not done until sequencer is done
     assert sequence.play_control.get() == 1
     assert not trig_status.done
-    sequence.play_status.sim_put(2)
+    # Simulate the sequence ending
+    sequence.play_status.sim_put(0)
     assert trig_status.done
     assert trig_status.success
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The event sequencer's `trigger` method will now correctly look for the sequence done transition instead of the sequence start transition

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are not ready to read our detectors until the sequence is done, so the trigger should not return done until after the sequence