### PR TITLE
TST: make this test not hang on my local machine

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,5 +58,5 @@ def test_get_input_shift_arrow(sim_input):
 def test_cbreak(sim_input):
     logger.debug('test_cbreak')
     # send the ctrl+c character
-    input_later(sim_input, '\x03')
-    assert util.get_input() is None
+    input_later(sim_input, '\x03\n')
+    assert util.get_input() == '\n'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a newline terminator to the ctrl+c on inputs test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This test stalls on my local machines without the newline terminator and it's really annoying