### PR TITLE
New vacuum ophyd devices

### DIFF
--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -2,6 +2,7 @@
 Standard classes for LCLS Gauges
 """
 import logging
+
 from ophyd import EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV, Device
 from ophyd import Component as Cpt, FormattedComponent as FCpt
 
@@ -131,7 +132,7 @@ class GaugeSetMks(GaugeSetBase):
     controller = FCpt(MKS937a, '{self.prefix_controller}')
     tab_component_names = True
 
-    def __init__(self, prefix, *, name, index, prefix_controller,  **kwargs):
+    def __init__(self, prefix, *, name, index, prefix_controller, **kwargs):
         self.prefix_controller = prefix_controller
         super().__init__(prefix, name=name, index=index, **kwargs)
 
@@ -166,172 +167,201 @@ class GaugeSetPiraniMks(GaugeSetPirani):
     controller = FCpt(MKS937a, '{self.prefix_controller}')
     tab_component_names = True
 
-    def __init__(self, prefix, *, name, index, prefix_controller,  **kwargs):
+    def __init__(self, prefix, *, name, index, prefix_controller, **kwargs):
         self.prefix_controller = prefix_controller
         super().__init__(prefix, name=name, index=index, **kwargs)
 
     def egu(self):
         return self.controller.unit.get()
 
-class Gauge_PLC(Device):
+
+class GaugePLC(Device):
     """
     Base class for gauges controlled by PLC
 
     Newer class. This and below are still missing some functionality.
     Still need to work out replacement of old classes.
     """
-    pressure = Cpt(EpicsSignalRO, ':PRESS_RBV' , kind='hinted', doc='gauge pressure reading')
-    gauge_at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV' , kind='normal', doc='gauge is at VAC')
-    pressure_ok = Cpt(EpicsSignalRO, ':PRESS_OK_RBV' , kind='normal', doc='pressure reading ok')
-    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':VAC_SP' , kind='config', doc='At vacuum setpoint for all gauges')
-    state = Cpt(EpicsSignalRO, ':State_RBV' , kind='hinted', doc='state of the gague')
+    pressure = Cpt(EpicsSignalRO, ':PRESS_RBV', kind='hinted',
+        doc='gauge pressure reading')
+    gauge_at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV', kind='normal',
+        doc='gauge is at VAC')
+    pressure_ok = Cpt(EpicsSignalRO, ':PRESS_OK_RBV', kind='normal',
+        doc='pressure reading ok')
+    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':VAC_SP', kind='config',
+        doc='At vacuum setpoint for all gauges')
+    state = Cpt(EpicsSignalRO, ':State_RBV', kind='hinted',
+        doc='state of the gauge')
 
-class GCC_PLC(Gauge_PLC):
+
+class GCCPLC(GaugePLC):
     """
     Class for Cold Cathode Gauge controlled by PLC
 
     """
-    high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW' , kind='normal', doc='command to switch the hight voltage on')
-    high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_RBV' , kind='normal', doc='enables the high voltage on the cold cathode gauge')
-    protection_setpoint = Cpt(EpicsSignalRO, ':PRO_SP_RBV' , kind='normal', doc='Protection setpoint for ion gauges at which the gauge turns off')
-    setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':SP_HYS' , kind='config', doc='Protection setpoint hysteresis')
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='Interlock is ok')
+    high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='normal',
+        doc='command to switch the hight voltage on')
+    high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_RBV', kind='normal',
+        doc='enables the high voltage on the cold cathode gauge')
+    protection_setpoint = Cpt(EpicsSignalRO, ':PRO_SP_RBV', kind='normal',
+        doc='Protection setpoint for ion gauges at which the gauge turns off')
+    setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':SP_HYS', kind='config',
+        doc='Protection setpoint hysteresis')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+        doc='Interlock is ok')
 
-class GCC500_PLC(GCC_PLC):
+
+class GCC500PLC(GCCPLC):
     """
     Class for GCC500 controlled by PLC
 
     """
-    high_voltage_is_on = Cpt(EpicsSignalRO, ':HV_ON_RBV' , kind='normal', doc='state of the HV')
-    disc_active = Cpt(EpicsSignalRO, ':DISC_ACTIVE_RBV' , kind='normal', doc='discharge current active')
+    high_voltage_is_on = Cpt(EpicsSignalRO, ':HV_ON_RBV', kind='normal',
+        doc='state of the HV')
+    disc_active = Cpt(EpicsSignalRO, ':DISC_ACTIVE_RBV', kind='normal',
+        doc='discharge current active')
+
 
 class GCT(Device):
     """
     Base class for Gauge Controllers accessed via serial
 
     """
-    unit = Cpt(EpicsSignal, ':UNIT' , kind='omitted', doc='')
-    cal = Cpt(EpicsSignal, ':CAL' , kind='omitted', doc='')
-    version = Cpt(EpicsSignalRO, ':VERSION' , kind='omitted', doc='')
+    unit = Cpt(EpicsSignal, ':UNIT', kind='omitted', doc='')
+    cal = Cpt(EpicsSignal, ':CAL', kind='omitted', doc='')
+    version = Cpt(EpicsSignalRO, ':VERSION', kind='omitted', doc='')
 
-class MKS937B_controller(GCT):
+
+class MKS937BController(GCT):
     """
     Class for MKS937B accessed via serial
 
     """
-    addr = Cpt(EpicsSignal, ':ADDR' , kind='omitted', doc='')
-    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A' , kind='omitted', doc='')
-    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B' , kind='omitted', doc='')
-    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C' , kind='omitted', doc='')
-    pstatall = Cpt(EpicsSignalRO, ':PSTATALL' , kind='omitted', doc='')
-    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL' , kind='omitted', doc='')
-    slota = Cpt(EpicsSignal, ':SLOTA' , kind='omitted', doc='')
-    slotb = Cpt(EpicsSignal, ':SLOTB' , kind='omitted', doc='')
-    slotc = Cpt(EpicsSignal, ':SLOTC' , kind='omitted', doc='')
+    addr = Cpt(EpicsSignal, ':ADDR', kind='omitted', doc='')
+    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A', kind='omitted', doc='')
+    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B', kind='omitted', doc='')
+    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C', kind='omitted', doc='')
+    pstatall = Cpt(EpicsSignalRO, ':PSTATALL', kind='omitted', doc='')
+    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL', kind='omitted', doc='')
+    slota = Cpt(EpicsSignal, ':SLOTA', kind='omitted', doc='')
+    slotb = Cpt(EpicsSignal, ':SLOTB', kind='omitted', doc='')
+    slotc = Cpt(EpicsSignal, ':SLOTC', kind='omitted', doc='')
 
-class MKS937A_controller(GCT):
+
+class MKS937AController(GCT):
     """
     Class for MKS937A accessed via serial
 
     """
-    pstatenout = Cpt(EpicsSignal, ':PSTATENOUT' , kind='omitted', doc='')
-    pstatspout = Cpt(EpicsSignal, ':PSTATSPOUT' , kind='omitted', doc='')
-    freq = Cpt(EpicsSignal, ':FREQ' , kind='omitted', doc='')
-    gauges = Cpt(EpicsSignalRO, ':GAUGES' , kind='omitted', doc='')
-    modcc = Cpt(EpicsSignalRO, ':MODCC' , kind='omitted', doc='')
-    moda = Cpt(EpicsSignalRO, ':MODA' , kind='omitted', doc='')
-    modb = Cpt(EpicsSignalRO, ':MODB' , kind='omitted', doc='')
-    com_des = Cpt(EpicsSignal, ':COM_DES' , kind='omitted', doc='')
-    com = Cpt(EpicsSignal, ':COM' , kind='omitted', doc='')
-    delay = Cpt(EpicsSignal, ':DELAY' , kind='omitted', doc='')
-    front = Cpt(EpicsSignal, ':FRONT' , kind='omitted', doc='')
+    pstatenout = Cpt(EpicsSignal, ':PSTATENOUT', kind='omitted', doc='')
+    pstatspout = Cpt(EpicsSignal, ':PSTATSPOUT', kind='omitted', doc='')
+    freq = Cpt(EpicsSignal, ':FREQ', kind='omitted', doc='')
+    gauges = Cpt(EpicsSignalRO, ':GAUGES', kind='omitted', doc='')
+    modcc = Cpt(EpicsSignalRO, ':MODCC', kind='omitted', doc='')
+    moda = Cpt(EpicsSignalRO, ':MODA', kind='omitted', doc='')
+    modb = Cpt(EpicsSignalRO, ':MODB', kind='omitted', doc='')
+    com_des = Cpt(EpicsSignal, ':COM_DES', kind='omitted', doc='')
+    com = Cpt(EpicsSignal, ':COM', kind='omitted', doc='')
+    delay = Cpt(EpicsSignal, ':DELAY', kind='omitted', doc='')
+    front = Cpt(EpicsSignal, ':FRONT', kind='omitted', doc='')
 
-class Gauge_Serial(Device):
+
+class GaugeSerial(Device):
     """
     Base class for Vacuum Gauge controlled via serial
 
     """
-    gastype = Cpt(EpicsSignal, ':GASTYPE' , kind='omitted', doc='')
-    gastypedes = Cpt(EpicsSignal, ':GASTYPEDES' , kind='omitted', doc='')
-    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1' , kind='omitted', doc='')
-    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2' , kind='omitted', doc='')
-    p = Cpt(EpicsSignal, ':P' , kind='omitted', doc='')
-    padel = Cpt(EpicsSignal, ':PADEL' , kind='omitted', doc='')
-    plog = Cpt(EpicsSignal, ':PLOG' , kind='omitted', doc='')
-    pmon = Cpt(EpicsSignal, ':PMON' , kind='omitted', doc='')
-    pmonraw = Cpt(EpicsSignal, ':PMONRAW' , kind='omitted', doc='')
-    pstat_1 = Cpt(EpicsSignal, ':PSTAT_1' , kind='omitted', doc='')
-    pstat_2 = Cpt(EpicsSignal, ':PSTAT_2' , kind='omitted', doc='')
-    pstat_calc = Cpt(EpicsSignal, ':PSTAT_CALC' , kind='omitted', doc='')
-    pstat_sum = Cpt(EpicsSignal, ':PSTAT_SUM' , kind='omitted', doc='')
-    pstatdirdes_1 = Cpt(EpicsSignal, ':PSTATDIRDES_1' , kind='omitted', doc='')
-    pstatdirdes_2 = Cpt(EpicsSignal, ':PSTATDIRDES_2' , kind='omitted', doc='')
-    pstatenable_1 = Cpt(EpicsSignal, ':PSTATENABLE_1' , kind='omitted', doc='')
-    pstatenable_2 = Cpt(EpicsSignal, ':PSTATENABLE_2' , kind='omitted', doc='')
-    pstatenades_1 = Cpt(EpicsSignal, ':PSTATENADES_1' , kind='omitted', doc='')
-    pstatenades_2 = Cpt(EpicsSignal, ':PSTATENADES_2' , kind='omitted', doc='')
-    pstatspdes_1 = Cpt(EpicsSignal, ':PSTATSPDES_1' , kind='omitted', doc='')
-    pstatspdes_2 = Cpt(EpicsSignal, ':PSTATSPDES_2' , kind='omitted', doc='')
-    pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1' , kind='omitted', doc='')
-    pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2' , kind='omitted', doc='')
-    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1' , kind='omitted', doc='')
-    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2' , kind='omitted', doc='')
-    state = Cpt(EpicsSignal, ':STATE' , kind='omitted', doc='')
-    statedes = Cpt(EpicsSignal, ':STATEDES' , kind='omitted', doc='')
-    staterbck = Cpt(EpicsSignalRO, ':STATERBCK' , kind='omitted', doc='')
-    status_rs = Cpt(EpicsSignal, ':STATUS_RS' , kind='omitted', doc='')
-    status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1' , kind='omitted', doc='')
-    status_rs_calc2 = Cpt(EpicsSignal, ':STATUS_RS_CALC2' , kind='omitted', doc='')
-    status_rscalc = Cpt(EpicsSignal, ':STATUS_RSCALC' , kind='omitted', doc='')
-    status_rscalc2 = Cpt(EpicsSignal, ':STATUS_RSCALC2' , kind='omitted', doc='')
-    status_rsmon = Cpt(EpicsSignal, ':STATUS_RSMON' , kind='omitted', doc='')
-    status_rsout = Cpt(EpicsSignal, ':STATUS_RSOUT' , kind='omitted', doc='')
+    gastype = Cpt(EpicsSignal, ':GASTYPE', kind='omitted', doc='')
+    gastypedes = Cpt(EpicsSignal, ':GASTYPEDES', kind='omitted', doc='')
+    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1', kind='omitted', doc='')
+    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2', kind='omitted', doc='')
+    p = Cpt(EpicsSignal, ':P', kind='omitted', doc='')
+    padel = Cpt(EpicsSignal, ':PADEL', kind='omitted', doc='')
+    plog = Cpt(EpicsSignal, ':PLOG', kind='omitted', doc='')
+    pmon = Cpt(EpicsSignal, ':PMON', kind='omitted', doc='')
+    pmonraw = Cpt(EpicsSignal, ':PMONRAW', kind='omitted', doc='')
+    pstat_1 = Cpt(EpicsSignal, ':PSTAT_1', kind='omitted', doc='')
+    pstat_2 = Cpt(EpicsSignal, ':PSTAT_2', kind='omitted', doc='')
+    pstat_calc = Cpt(EpicsSignal, ':PSTAT_CALC', kind='omitted', doc='')
+    pstat_sum = Cpt(EpicsSignal, ':PSTAT_SUM', kind='omitted', doc='')
+    pstatdirdes_1 = Cpt(EpicsSignal, ':PSTATDIRDES_1', kind='omitted', doc='')
+    pstatdirdes_2 = Cpt(EpicsSignal, ':PSTATDIRDES_2', kind='omitted', doc='')
+    pstatenable_1 = Cpt(EpicsSignal, ':PSTATENABLE_1', kind='omitted', doc='')
+    pstatenable_2 = Cpt(EpicsSignal, ':PSTATENABLE_2', kind='omitted', doc='')
+    pstatenades_1 = Cpt(EpicsSignal, ':PSTATENADES_1', kind='omitted', doc='')
+    pstatenades_2 = Cpt(EpicsSignal, ':PSTATENADES_2', kind='omitted', doc='')
+    pstatspdes_1 = Cpt(EpicsSignal, ':PSTATSPDES_1', kind='omitted', doc='')
+    pstatspdes_2 = Cpt(EpicsSignal, ':PSTATSPDES_2', kind='omitted', doc='')
+    pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1', kind='omitted', doc='')
+    pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2', kind='omitted', doc='')
+    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1', kind='omitted',
+        doc='')
+    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2', kind='omitted',
+        doc='')
+    state = Cpt(EpicsSignal, ':STATE', kind='omitted', doc='')
+    statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
+    staterbck = Cpt(EpicsSignalRO, ':STATERBCK', kind='omitted', doc='')
+    status_rs = Cpt(EpicsSignal, ':STATUS_RS', kind='omitted', doc='')
+    status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1', kind='omitted',
+        doc='')
+    status_rs_calc2 = Cpt(EpicsSignal, ':STATUS_RS_CALC2', kind='omitted',
+        doc='')
+    status_rscalc = Cpt(EpicsSignal, ':STATUS_RSCALC', kind='omitted',
+        doc='')
+    status_rscalc2 = Cpt(EpicsSignal, ':STATUS_RSCALC2', kind='omitted',
+        doc='')
+    status_rsmon = Cpt(EpicsSignal, ':STATUS_RSMON', kind='omitted', doc='')
+    status_rsout = Cpt(EpicsSignal, ':STATUS_RSOUT', kind='omitted', doc='')
 
-class Gauge_Serial_GPI(Gauge_Serial):
+
+class GaugeSerialGPI(GaugeSerial):
     """
     Class for Pirani Vacuum Gauge controlled via serial
 
     """
-    atmcalib = Cpt(EpicsSignal, ':ATMCALIB' , kind='omitted', doc='')
-    atmcalibdes = Cpt(EpicsSignal, ':ATMCALIBDES' , kind='omitted', doc='')
-    autozero = Cpt(EpicsSignal, ':AUTOZERO' , kind='omitted', doc='')
-    autozerodes = Cpt(EpicsSignal, ':AUTOZERODES' , kind='omitted', doc='')
-    zeropr = Cpt(EpicsSignal, ':ZEROPR' , kind='omitted', doc='')
+    atmcalib = Cpt(EpicsSignal, ':ATMCALIB', kind='omitted', doc='')
+    atmcalibdes = Cpt(EpicsSignal, ':ATMCALIBDES', kind='omitted', doc='')
+    autozero = Cpt(EpicsSignal, ':AUTOZERO', kind='omitted', doc='')
+    autozerodes = Cpt(EpicsSignal, ':AUTOZERODES', kind='omitted', doc='')
+    zeropr = Cpt(EpicsSignal, ':ZEROPR', kind='omitted', doc='')
 
-class Gauge_Serial_GCC(Gauge_Serial):
+
+class GaugeSerialGCC(GaugeSerial):
     """
     Class for Cold Cathode Gauge controlled via serial
 
     """
-    pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES' , kind='omitted', doc='')
-    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK' , kind='omitted', doc='')
-    pctrldes = Cpt(EpicsSignal, ':PCTRLDES' , kind='omitted', doc='')
-    pctrlen = Cpt(EpicsSignal, ':PCTRLEN' , kind='omitted', doc='')
-    pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC' , kind='omitted', doc='')
-    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK' , kind='omitted', doc='')
-    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK' , kind='omitted', doc='')
-    pctrlspdes = Cpt(EpicsSignal, ':PCTRLSPDES' , kind='omitted', doc='')
-    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK' , kind='omitted', doc='')
-    pprotencalc = Cpt(EpicsSignal, ':PPROTENCALC' , kind='omitted', doc='')
-    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK' , kind='omitted', doc='')
-    pprotspdes = Cpt(EpicsSignal, ':PPROTSPDES' , kind='omitted', doc='')
-    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK' , kind='omitted', doc='')
-    pstat_3 = Cpt(EpicsSignal, ':PSTAT_3' , kind='omitted', doc='')
-    pstat_4 = Cpt(EpicsSignal, ':PSTAT_4' , kind='omitted', doc='')
-    pstatdirdes_3 = Cpt(EpicsSignal, ':PSTATDIRDES_3' , kind='omitted', doc='')
-    pstatdirdes_4 = Cpt(EpicsSignal, ':PSTATDIRDES_4' , kind='omitted', doc='')
-    pstatenable_3 = Cpt(EpicsSignal, ':PSTATENABLE_3' , kind='omitted', doc='')
-    pstatenable_4 = Cpt(EpicsSignal, ':PSTATENABLE_4' , kind='omitted', doc='')
-    pstatenades_3 = Cpt(EpicsSignal, ':PSTATENADES_3' , kind='omitted', doc='')
-    pstatenades_4 = Cpt(EpicsSignal, ':PSTATENADES_4' , kind='omitted', doc='')
-    pstatspdes_3 = Cpt(EpicsSignal, ':PSTATSPDES_3' , kind='omitted', doc='')
-    pstatspdes_4 = Cpt(EpicsSignal, ':PSTATSPDES_4' , kind='omitted', doc='')
-    pstatspdes_fs = Cpt(EpicsSignal, ':PSTATSPDES_FS' , kind='omitted', doc='')
-    pstatspdir_3 = Cpt(EpicsSignal, ':PSTATSPDIR_3' , kind='omitted', doc='')
-    pstatspdir_4 = Cpt(EpicsSignal, ':PSTATSPDIR_4' , kind='omitted', doc='')
-    pstatsprbck_3 = Cpt(EpicsSignal, ':PSTATSPRBCK_3' , kind='omitted', doc='')
-    pstatsprbck_4 = Cpt(EpicsSignal, ':PSTATSPRBCK_4' , kind='omitted', doc='')
-    pstatsprbck_fs = Cpt(EpicsSignal, ':PSTATSPRBCK_FS' , kind='omitted', doc='')
+    pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES', kind='omitted', doc='')
+    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK', kind='omitted',
+        doc='')
+    pctrldes = Cpt(EpicsSignal, ':PCTRLDES', kind='omitted', doc='')
+    pctrlen = Cpt(EpicsSignal, ':PCTRLEN', kind='omitted', doc='')
+    pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC', kind='omitted', doc='')
+    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK', kind='omitted', doc='')
+    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK', kind='omitted', doc='')
+    pctrlspdes = Cpt(EpicsSignal, ':PCTRLSPDES', kind='omitted', doc='')
+    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK', kind='omitted', doc='')
+    pprotencalc = Cpt(EpicsSignal, ':PPROTENCALC', kind='omitted', doc='')
+    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK', kind='omitted', doc='')
+    pprotspdes = Cpt(EpicsSignal, ':PPROTSPDES', kind='omitted', doc='')
+    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK', kind='omitted', doc='')
+    pstat_3 = Cpt(EpicsSignal, ':PSTAT_3', kind='omitted', doc='')
+    pstat_4 = Cpt(EpicsSignal, ':PSTAT_4', kind='omitted', doc='')
+    pstatdirdes_3 = Cpt(EpicsSignal, ':PSTATDIRDES_3', kind='omitted', doc='')
+    pstatdirdes_4 = Cpt(EpicsSignal, ':PSTATDIRDES_4', kind='omitted', doc='')
+    pstatenable_3 = Cpt(EpicsSignal, ':PSTATENABLE_3', kind='omitted', doc='')
+    pstatenable_4 = Cpt(EpicsSignal, ':PSTATENABLE_4', kind='omitted', doc='')
+    pstatenades_3 = Cpt(EpicsSignal, ':PSTATENADES_3', kind='omitted', doc='')
+    pstatenades_4 = Cpt(EpicsSignal, ':PSTATENADES_4', kind='omitted', doc='')
+    pstatspdes_3 = Cpt(EpicsSignal, ':PSTATSPDES_3', kind='omitted', doc='')
+    pstatspdes_4 = Cpt(EpicsSignal, ':PSTATSPDES_4', kind='omitted', doc='')
+    pstatspdes_fs = Cpt(EpicsSignal, ':PSTATSPDES_FS', kind='omitted', doc='')
+    pstatspdir_3 = Cpt(EpicsSignal, ':PSTATSPDIR_3', kind='omitted', doc='')
+    pstatspdir_4 = Cpt(EpicsSignal, ':PSTATSPDIR_4', kind='omitted', doc='')
+    pstatsprbck_3 = Cpt(EpicsSignal, ':PSTATSPRBCK_3', kind='omitted', doc='')
+    pstatsprbck_4 = Cpt(EpicsSignal, ':PSTATSPRBCK_4', kind='omitted', doc='')
+    pstatsprbck_fs = Cpt(EpicsSignal, ':PSTATSPRBCK_FS', kind='omitted',
+        doc='')
 
 # factory function for IonPumps
 def GaugeSet(prefix, *, name, index, **kwargs):

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -2,7 +2,7 @@
 Standard classes for LCLS Gauges
 """
 import logging
-from ophyd import EpicsSignal, EpicsSignalRO, Device
+from ophyd import EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV, Device
 from ophyd import Component as Cpt, FormattedComponent as FCpt
 
 from .doc_stubs import GaugeSet_base
@@ -173,6 +173,165 @@ class GaugeSetPiraniMks(GaugeSetPirani):
     def egu(self):
         return self.controller.unit.get()
 
+class Gauge_PLC(Device):
+    """
+    Base class for gauges controlled by PLC
+
+    Newer class. This and below are still missing some functionality.
+    Still need to work out replacement of old classes.
+    """
+    pressure = Cpt(EpicsSignalRO, ':PRESS_RBV' , kind='hinted', doc='gauge pressure reading')
+    gauge_at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV' , kind='normal', doc='gauge is at VAC')
+    pressure_ok = Cpt(EpicsSignalRO, ':PRESS_OK_RBV' , kind='normal', doc='pressure reading ok')
+    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':VAC_SP' , kind='config', doc='At vacuum setpoint for all gauges')
+    state = Cpt(EpicsSignalRO, ':State_RBV' , kind='hinted', doc='state of the gague')
+
+class GCC_PLC(Gauge_PLC):
+    """
+    Class for Cold Cathode Gauge controlled by PLC
+
+    """
+    high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW' , kind='normal', doc='command to switch the hight voltage on')
+    high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_RBV' , kind='normal', doc='enables the high voltage on the cold cathode gauge')
+    protection_setpoint = Cpt(EpicsSignalRO, ':PRO_SP_RBV' , kind='normal', doc='Protection setpoint for ion gauges at which the gauge turns off')
+    setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':SP_HYS' , kind='config', doc='Protection setpoint hysteresis')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='Interlock is ok')
+
+class GCC500_PLC(GCC_PLC):
+    """
+    Class for GCC500 controlled by PLC
+
+    """
+    high_voltage_is_on = Cpt(EpicsSignalRO, ':HV_ON_RBV' , kind='normal', doc='state of the HV')
+    disc_active = Cpt(EpicsSignalRO, ':DISC_ACTIVE_RBV' , kind='normal', doc='discharge current active')
+
+class GCT(Device):
+    """
+    Base class for Gauge Controllers accessed via serial
+
+    """
+    unit = Cpt(EpicsSignal, ':UNIT' , kind='omitted', doc='')
+    cal = Cpt(EpicsSignal, ':CAL' , kind='omitted', doc='')
+    version = Cpt(EpicsSignalRO, ':VERSION' , kind='omitted', doc='')
+
+class MKS937B_controller(GCT):
+    """
+    Class for MKS937B accessed via serial
+
+    """
+    addr = Cpt(EpicsSignal, ':ADDR' , kind='omitted', doc='')
+    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A' , kind='omitted', doc='')
+    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B' , kind='omitted', doc='')
+    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C' , kind='omitted', doc='')
+    pstatall = Cpt(EpicsSignalRO, ':PSTATALL' , kind='omitted', doc='')
+    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL' , kind='omitted', doc='')
+    slota = Cpt(EpicsSignal, ':SLOTA' , kind='omitted', doc='')
+    slotb = Cpt(EpicsSignal, ':SLOTB' , kind='omitted', doc='')
+    slotc = Cpt(EpicsSignal, ':SLOTC' , kind='omitted', doc='')
+
+class MKS937A_controller(GCT):
+    """
+    Class for MKS937A accessed via serial
+
+    """
+    pstatenout = Cpt(EpicsSignal, ':PSTATENOUT' , kind='omitted', doc='')
+    pstatspout = Cpt(EpicsSignal, ':PSTATSPOUT' , kind='omitted', doc='')
+    freq = Cpt(EpicsSignal, ':FREQ' , kind='omitted', doc='')
+    gauges = Cpt(EpicsSignalRO, ':GAUGES' , kind='omitted', doc='')
+    modcc = Cpt(EpicsSignalRO, ':MODCC' , kind='omitted', doc='')
+    moda = Cpt(EpicsSignalRO, ':MODA' , kind='omitted', doc='')
+    modb = Cpt(EpicsSignalRO, ':MODB' , kind='omitted', doc='')
+    com_des = Cpt(EpicsSignal, ':COM_DES' , kind='omitted', doc='')
+    com = Cpt(EpicsSignal, ':COM' , kind='omitted', doc='')
+    delay = Cpt(EpicsSignal, ':DELAY' , kind='omitted', doc='')
+    front = Cpt(EpicsSignal, ':FRONT' , kind='omitted', doc='')
+
+class Gauge_Serial(Device):
+    """
+    Base class for Vacuum Gauge controlled via serial
+
+    """
+    gastype = Cpt(EpicsSignal, ':GASTYPE' , kind='omitted', doc='')
+    gastypedes = Cpt(EpicsSignal, ':GASTYPEDES' , kind='omitted', doc='')
+    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1' , kind='omitted', doc='')
+    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2' , kind='omitted', doc='')
+    p = Cpt(EpicsSignal, ':P' , kind='omitted', doc='')
+    padel = Cpt(EpicsSignal, ':PADEL' , kind='omitted', doc='')
+    plog = Cpt(EpicsSignal, ':PLOG' , kind='omitted', doc='')
+    pmon = Cpt(EpicsSignal, ':PMON' , kind='omitted', doc='')
+    pmonraw = Cpt(EpicsSignal, ':PMONRAW' , kind='omitted', doc='')
+    pstat_1 = Cpt(EpicsSignal, ':PSTAT_1' , kind='omitted', doc='')
+    pstat_2 = Cpt(EpicsSignal, ':PSTAT_2' , kind='omitted', doc='')
+    pstat_calc = Cpt(EpicsSignal, ':PSTAT_CALC' , kind='omitted', doc='')
+    pstat_sum = Cpt(EpicsSignal, ':PSTAT_SUM' , kind='omitted', doc='')
+    pstatdirdes_1 = Cpt(EpicsSignal, ':PSTATDIRDES_1' , kind='omitted', doc='')
+    pstatdirdes_2 = Cpt(EpicsSignal, ':PSTATDIRDES_2' , kind='omitted', doc='')
+    pstatenable_1 = Cpt(EpicsSignal, ':PSTATENABLE_1' , kind='omitted', doc='')
+    pstatenable_2 = Cpt(EpicsSignal, ':PSTATENABLE_2' , kind='omitted', doc='')
+    pstatenades_1 = Cpt(EpicsSignal, ':PSTATENADES_1' , kind='omitted', doc='')
+    pstatenades_2 = Cpt(EpicsSignal, ':PSTATENADES_2' , kind='omitted', doc='')
+    pstatspdes_1 = Cpt(EpicsSignal, ':PSTATSPDES_1' , kind='omitted', doc='')
+    pstatspdes_2 = Cpt(EpicsSignal, ':PSTATSPDES_2' , kind='omitted', doc='')
+    pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1' , kind='omitted', doc='')
+    pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2' , kind='omitted', doc='')
+    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1' , kind='omitted', doc='')
+    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2' , kind='omitted', doc='')
+    state = Cpt(EpicsSignal, ':STATE' , kind='omitted', doc='')
+    statedes = Cpt(EpicsSignal, ':STATEDES' , kind='omitted', doc='')
+    staterbck = Cpt(EpicsSignalRO, ':STATERBCK' , kind='omitted', doc='')
+    status_rs = Cpt(EpicsSignal, ':STATUS_RS' , kind='omitted', doc='')
+    status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1' , kind='omitted', doc='')
+    status_rs_calc2 = Cpt(EpicsSignal, ':STATUS_RS_CALC2' , kind='omitted', doc='')
+    status_rscalc = Cpt(EpicsSignal, ':STATUS_RSCALC' , kind='omitted', doc='')
+    status_rscalc2 = Cpt(EpicsSignal, ':STATUS_RSCALC2' , kind='omitted', doc='')
+    status_rsmon = Cpt(EpicsSignal, ':STATUS_RSMON' , kind='omitted', doc='')
+    status_rsout = Cpt(EpicsSignal, ':STATUS_RSOUT' , kind='omitted', doc='')
+
+class Gauge_Serial_GPI(Gauge_Serial):
+    """
+    Class for Pirani Vacuum Gauge controlled via serial
+
+    """
+    atmcalib = Cpt(EpicsSignal, ':ATMCALIB' , kind='omitted', doc='')
+    atmcalibdes = Cpt(EpicsSignal, ':ATMCALIBDES' , kind='omitted', doc='')
+    autozero = Cpt(EpicsSignal, ':AUTOZERO' , kind='omitted', doc='')
+    autozerodes = Cpt(EpicsSignal, ':AUTOZERODES' , kind='omitted', doc='')
+    zeropr = Cpt(EpicsSignal, ':ZEROPR' , kind='omitted', doc='')
+
+class Gauge_Serial_GCC(Gauge_serial):
+    """
+    Class for Cold Cathode Gauge controlled via serial
+
+    """
+    pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES' , kind='omitted', doc='')
+    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK' , kind='omitted', doc='')
+    pctrldes = Cpt(EpicsSignal, ':PCTRLDES' , kind='omitted', doc='')
+    pctrlen = Cpt(EpicsSignal, ':PCTRLEN' , kind='omitted', doc='')
+    pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC' , kind='omitted', doc='')
+    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK' , kind='omitted', doc='')
+    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK' , kind='omitted', doc='')
+    pctrlspdes = Cpt(EpicsSignal, ':PCTRLSPDES' , kind='omitted', doc='')
+    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK' , kind='omitted', doc='')
+    pprotencalc = Cpt(EpicsSignal, ':PPROTENCALC' , kind='omitted', doc='')
+    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK' , kind='omitted', doc='')
+    pprotspdes = Cpt(EpicsSignal, ':PPROTSPDES' , kind='omitted', doc='')
+    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK' , kind='omitted', doc='')
+    pstat_3 = Cpt(EpicsSignal, ':PSTAT_3' , kind='omitted', doc='')
+    pstat_4 = Cpt(EpicsSignal, ':PSTAT_4' , kind='omitted', doc='')
+    pstatdirdes_3 = Cpt(EpicsSignal, ':PSTATDIRDES_3' , kind='omitted', doc='')
+    pstatdirdes_4 = Cpt(EpicsSignal, ':PSTATDIRDES_4' , kind='omitted', doc='')
+    pstatenable_3 = Cpt(EpicsSignal, ':PSTATENABLE_3' , kind='omitted', doc='')
+    pstatenable_4 = Cpt(EpicsSignal, ':PSTATENABLE_4' , kind='omitted', doc='')
+    pstatenades_3 = Cpt(EpicsSignal, ':PSTATENADES_3' , kind='omitted', doc='')
+    pstatenades_4 = Cpt(EpicsSignal, ':PSTATENADES_4' , kind='omitted', doc='')
+    pstatspdes_3 = Cpt(EpicsSignal, ':PSTATSPDES_3' , kind='omitted', doc='')
+    pstatspdes_4 = Cpt(EpicsSignal, ':PSTATSPDES_4' , kind='omitted', doc='')
+    pstatspdes_fs = Cpt(EpicsSignal, ':PSTATSPDES_FS' , kind='omitted', doc='')
+    pstatspdir_3 = Cpt(EpicsSignal, ':PSTATSPDIR_3' , kind='omitted', doc='')
+    pstatspdir_4 = Cpt(EpicsSignal, ':PSTATSPDIR_4' , kind='omitted', doc='')
+    pstatsprbck_3 = Cpt(EpicsSignal, ':PSTATSPRBCK_3' , kind='omitted', doc='')
+    pstatsprbck_4 = Cpt(EpicsSignal, ':PSTATSPRBCK_4' , kind='omitted', doc='')
+    pstatsprbck_fs = Cpt(EpicsSignal, ':PSTATSPRBCK_FS' , kind='omitted', doc='')
 
 # factory function for IonPumps
 def GaugeSet(prefix, *, name, index, **kwargs):

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -190,7 +190,7 @@ class GaugePLC(Device):
                       doc='pressure reading ok')
     at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':VAC_SP', kind='config',
                           doc='At vacuum setpoint for all gauges')
-    state = Cpt(EpicsSignalRO, ':State_RBV', kind='hinted',
+    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted',
                 doc='state of the gauge')
 
 
@@ -231,7 +231,7 @@ class GCT(Device):
     """
     unit = Cpt(EpicsSignal, ':UNIT', kind='omitted', doc='')
     cal = Cpt(EpicsSignal, ':CAL', kind='omitted', doc='')
-    version = Cpt(EpicsSignalRO, ':VERSION', kind='omitted', doc='')
+    version = Cpt(EpicsSignalRO, ':VERSION_RBV', kind='omitted', doc='')
 
 
 class MKS937BController(GCT):
@@ -240,11 +240,11 @@ class MKS937BController(GCT):
 
     """
     addr = Cpt(EpicsSignal, ':ADDR', kind='omitted', doc='')
-    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A', kind='omitted', doc='')
-    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B', kind='omitted', doc='')
-    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C', kind='omitted', doc='')
-    pstatall = Cpt(EpicsSignalRO, ':PSTATALL', kind='omitted', doc='')
-    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL', kind='omitted', doc='')
+    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A_RBV', kind='omitted', doc='')
+    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B_RBV', kind='omitted', doc='')
+    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C_RBV', kind='omitted', doc='')
+    pstatall = Cpt(EpicsSignalRO, ':PSTATALL_RBV', kind='omitted', doc='')
+    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL_RBV', kind='omitted', doc='')
     slota = Cpt(EpicsSignal, ':SLOTA', kind='omitted', doc='')
     slotb = Cpt(EpicsSignal, ':SLOTB', kind='omitted', doc='')
     slotc = Cpt(EpicsSignal, ':SLOTC', kind='omitted', doc='')
@@ -258,10 +258,10 @@ class MKS937AController(GCT):
     pstatenout = Cpt(EpicsSignal, ':PSTATENOUT', kind='omitted', doc='')
     pstatspout = Cpt(EpicsSignal, ':PSTATSPOUT', kind='omitted', doc='')
     freq = Cpt(EpicsSignal, ':FREQ', kind='omitted', doc='')
-    gauges = Cpt(EpicsSignalRO, ':GAUGES', kind='omitted', doc='')
-    modcc = Cpt(EpicsSignalRO, ':MODCC', kind='omitted', doc='')
-    moda = Cpt(EpicsSignalRO, ':MODA', kind='omitted', doc='')
-    modb = Cpt(EpicsSignalRO, ':MODB', kind='omitted', doc='')
+    gauges = Cpt(EpicsSignalRO, ':GAUGES_RBV', kind='omitted', doc='')
+    modcc = Cpt(EpicsSignalRO, ':MODCC_RBV', kind='omitted', doc='')
+    moda = Cpt(EpicsSignalRO, ':MODA_RBV', kind='omitted', doc='')
+    modb = Cpt(EpicsSignalRO, ':MODB_RBV', kind='omitted', doc='')
     com_des = Cpt(EpicsSignal, ':COM_DES', kind='omitted', doc='')
     com = Cpt(EpicsSignal, ':COM', kind='omitted', doc='')
     delay = Cpt(EpicsSignal, ':DELAY', kind='omitted', doc='')
@@ -275,8 +275,8 @@ class GaugeSerial(Device):
     """
     gastype = Cpt(EpicsSignal, ':GASTYPE', kind='omitted', doc='')
     gastypedes = Cpt(EpicsSignal, ':GASTYPEDES', kind='omitted', doc='')
-    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1', kind='omitted', doc='')
-    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2', kind='omitted', doc='')
+    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1_RBV', kind='omitted', doc='')
+    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2_RBV', kind='omitted', doc='')
     p = Cpt(EpicsSignal, ':P', kind='omitted', doc='')
     padel = Cpt(EpicsSignal, ':PADEL', kind='omitted', doc='')
     plog = Cpt(EpicsSignal, ':PLOG', kind='omitted', doc='')
@@ -296,13 +296,13 @@ class GaugeSerial(Device):
     pstatspdes_2 = Cpt(EpicsSignal, ':PSTATSPDES_2', kind='omitted', doc='')
     pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1', kind='omitted', doc='')
     pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2', kind='omitted', doc='')
-    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1', kind='omitted',
+    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1_RBV', kind='omitted',
                         doc='')
-    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2', kind='omitted',
+    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2_RBV', kind='omitted',
                         doc='')
     state = Cpt(EpicsSignal, ':STATE', kind='omitted', doc='')
     statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
-    staterbck = Cpt(EpicsSignalRO, ':STATERBCK', kind='omitted', doc='')
+    staterbck = Cpt(EpicsSignalRO, ':STATERBCK_RBV', kind='omitted', doc='')
     status_rs = Cpt(EpicsSignal, ':STATUS_RS', kind='omitted', doc='')
     status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1', kind='omitted',
                           doc='')
@@ -323,7 +323,7 @@ class GaugeSerialGPI(GaugeSerial):
     """
     atmcalib = Cpt(EpicsSignal, ':ATMCALIB', kind='omitted', doc='')
     atmcalibdes = Cpt(EpicsSignal, ':ATMCALIBDES', kind='omitted', doc='')
-    autozero = Cpt(EpicsSignal, ':AUTOZERO', kind='omitted', doc='')
+    autozero = Cpt(EpicsSignal, ':AUTOZERO_RBV', kind='omitted', doc='')
     autozerodes = Cpt(EpicsSignal, ':AUTOZERODES', kind='omitted', doc='')
     zeropr = Cpt(EpicsSignal, ':ZEROPR', kind='omitted', doc='')
 
@@ -334,19 +334,19 @@ class GaugeSerialGCC(GaugeSerial):
 
     """
     pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES', kind='omitted', doc='')
-    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK', kind='omitted',
+    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK_RBV', kind='omitted',
                         doc='')
     pctrldes = Cpt(EpicsSignal, ':PCTRLDES', kind='omitted', doc='')
     pctrlen = Cpt(EpicsSignal, ':PCTRLEN', kind='omitted', doc='')
     pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC', kind='omitted', doc='')
-    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK', kind='omitted', doc='')
-    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK', kind='omitted', doc='')
+    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK_RBV', kind='omitted', doc='')
+    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK_RBV', kind='omitted', doc='')
     pctrlspdes = Cpt(EpicsSignal, ':PCTRLSPDES', kind='omitted', doc='')
-    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK', kind='omitted', doc='')
+    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK_RBV', kind='omitted', doc='')
     pprotencalc = Cpt(EpicsSignal, ':PPROTENCALC', kind='omitted', doc='')
-    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK', kind='omitted', doc='')
+    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK_RBV', kind='omitted', doc='')
     pprotspdes = Cpt(EpicsSignal, ':PPROTSPDES', kind='omitted', doc='')
-    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK', kind='omitted', doc='')
+    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK_RBV', kind='omitted', doc='')
     pstat_3 = Cpt(EpicsSignal, ':PSTAT_3', kind='omitted', doc='')
     pstat_4 = Cpt(EpicsSignal, ':PSTAT_4', kind='omitted', doc='')
     pstatdirdes_3 = Cpt(EpicsSignal, ':PSTATDIRDES_3', kind='omitted', doc='')

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -201,7 +201,7 @@ class GCCPLC(GaugePLC):
     """
     high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='normal',
                           doc='command to switch the hight voltage on')
-    high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_RBV', kind='normal',
+    high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_DO_RBV', kind='normal',
                                doc=('enables the high voltage on the cold '
                                     'cathode gauge'))
     protection_setpoint = Cpt(EpicsSignalRO, ':PRO_SP_RBV', kind='normal',

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -229,9 +229,9 @@ class GCT(Device):
     Base class for Gauge Controllers accessed via serial
 
     """
-    unit = Cpt(EpicsSignal, ':UNIT', kind='omitted', doc='')
-    cal = Cpt(EpicsSignal, ':CAL', kind='omitted', doc='')
-    version = Cpt(EpicsSignalRO, ':VERSION_RBV', kind='omitted', doc='')
+    unit = Cpt(EpicsSignal, ':UNIT', kind='omitted')
+    cal = Cpt(EpicsSignal, ':CAL', kind='omitted')
+    version = Cpt(EpicsSignalRO, ':VERSION_RBV', kind='omitted')
 
 
 class MKS937BController(GCT):
@@ -239,15 +239,15 @@ class MKS937BController(GCT):
     Class for MKS937B accessed via serial
 
     """
-    addr = Cpt(EpicsSignal, ':ADDR', kind='omitted', doc='')
-    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A_RBV', kind='omitted', doc='')
-    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B_RBV', kind='omitted', doc='')
-    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C_RBV', kind='omitted', doc='')
-    pstatall = Cpt(EpicsSignalRO, ':PSTATALL_RBV', kind='omitted', doc='')
-    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL_RBV', kind='omitted', doc='')
-    slota = Cpt(EpicsSignal, ':SLOTA', kind='omitted', doc='')
-    slotb = Cpt(EpicsSignal, ':SLOTB', kind='omitted', doc='')
-    slotc = Cpt(EpicsSignal, ':SLOTC', kind='omitted', doc='')
+    addr = Cpt(EpicsSignal, ':ADDR', kind='omitted')
+    modtype_a = Cpt(EpicsSignalRO, ':MODTYPE_A_RBV', kind='omitted')
+    modtype_b = Cpt(EpicsSignalRO, ':MODTYPE_B_RBV', kind='omitted')
+    modtype_c = Cpt(EpicsSignalRO, ':MODTYPE_C_RBV', kind='omitted')
+    pstatall = Cpt(EpicsSignalRO, ':PSTATALL_RBV', kind='omitted')
+    pstatenall = Cpt(EpicsSignalRO, ':PSTATENALL_RBV', kind='omitted')
+    slota = Cpt(EpicsSignal, ':SLOTA', kind='omitted')
+    slotb = Cpt(EpicsSignal, ':SLOTB', kind='omitted')
+    slotc = Cpt(EpicsSignal, ':SLOTC', kind='omitted')
 
 
 class MKS937AController(GCT):
@@ -255,17 +255,17 @@ class MKS937AController(GCT):
     Class for MKS937A accessed via serial
 
     """
-    pstatenout = Cpt(EpicsSignal, ':PSTATENOUT', kind='omitted', doc='')
-    pstatspout = Cpt(EpicsSignal, ':PSTATSPOUT', kind='omitted', doc='')
-    freq = Cpt(EpicsSignal, ':FREQ', kind='omitted', doc='')
-    gauges = Cpt(EpicsSignalRO, ':GAUGES_RBV', kind='omitted', doc='')
-    modcc = Cpt(EpicsSignalRO, ':MODCC_RBV', kind='omitted', doc='')
-    moda = Cpt(EpicsSignalRO, ':MODA_RBV', kind='omitted', doc='')
-    modb = Cpt(EpicsSignalRO, ':MODB_RBV', kind='omitted', doc='')
-    com_des = Cpt(EpicsSignal, ':COM_DES', kind='omitted', doc='')
-    com = Cpt(EpicsSignal, ':COM', kind='omitted', doc='')
-    delay = Cpt(EpicsSignal, ':DELAY', kind='omitted', doc='')
-    front = Cpt(EpicsSignal, ':FRONT', kind='omitted', doc='')
+    pstatenout = Cpt(EpicsSignal, ':PSTATENOUT', kind='omitted')
+    pstatspout = Cpt(EpicsSignal, ':PSTATSPOUT', kind='omitted')
+    freq = Cpt(EpicsSignal, ':FREQ', kind='omitted')
+    gauges = Cpt(EpicsSignalRO, ':GAUGES_RBV', kind='omitted')
+    modcc = Cpt(EpicsSignalRO, ':MODCC_RBV', kind='omitted')
+    moda = Cpt(EpicsSignalRO, ':MODA_RBV', kind='omitted')
+    modb = Cpt(EpicsSignalRO, ':MODB_RBV', kind='omitted')
+    com_des = Cpt(EpicsSignal, ':COM_DES', kind='omitted')
+    com = Cpt(EpicsSignal, ':COM', kind='omitted')
+    delay = Cpt(EpicsSignal, ':DELAY', kind='omitted')
+    front = Cpt(EpicsSignal, ':FRONT', kind='omitted')
 
 
 class GaugeSerial(Device):
@@ -273,47 +273,41 @@ class GaugeSerial(Device):
     Base class for Vacuum Gauge controlled via serial
 
     """
-    gastype = Cpt(EpicsSignal, ':GASTYPE', kind='omitted', doc='')
-    gastypedes = Cpt(EpicsSignal, ':GASTYPEDES', kind='omitted', doc='')
-    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1_RBV', kind='omitted', doc='')
-    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2_RBV', kind='omitted', doc='')
-    p = Cpt(EpicsSignal, ':P', kind='omitted', doc='')
-    padel = Cpt(EpicsSignal, ':PADEL', kind='omitted', doc='')
-    plog = Cpt(EpicsSignal, ':PLOG', kind='omitted', doc='')
-    pmon = Cpt(EpicsSignal, ':PMON', kind='omitted', doc='')
-    pmonraw = Cpt(EpicsSignal, ':PMONRAW', kind='omitted', doc='')
-    pstat_1 = Cpt(EpicsSignal, ':PSTAT_1', kind='omitted', doc='')
-    pstat_2 = Cpt(EpicsSignal, ':PSTAT_2', kind='omitted', doc='')
-    pstat_calc = Cpt(EpicsSignal, ':PSTAT_CALC', kind='omitted', doc='')
-    pstat_sum = Cpt(EpicsSignal, ':PSTAT_SUM', kind='omitted', doc='')
-    pstatdirdes_1 = Cpt(EpicsSignal, ':PSTATDIRDES_1', kind='omitted', doc='')
-    pstatdirdes_2 = Cpt(EpicsSignal, ':PSTATDIRDES_2', kind='omitted', doc='')
-    pstatenable_1 = Cpt(EpicsSignal, ':PSTATENABLE_1', kind='omitted', doc='')
-    pstatenable_2 = Cpt(EpicsSignal, ':PSTATENABLE_2', kind='omitted', doc='')
-    pstatenades_1 = Cpt(EpicsSignal, ':PSTATENADES_1', kind='omitted', doc='')
-    pstatenades_2 = Cpt(EpicsSignal, ':PSTATENADES_2', kind='omitted', doc='')
-    pstatspdes_1 = Cpt(EpicsSignal, ':PSTATSPDES_1', kind='omitted', doc='')
-    pstatspdes_2 = Cpt(EpicsSignal, ':PSTATSPDES_2', kind='omitted', doc='')
-    pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1', kind='omitted', doc='')
-    pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2', kind='omitted', doc='')
-    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1_RBV', kind='omitted',
-                        doc='')
-    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2_RBV', kind='omitted',
-                        doc='')
-    state = Cpt(EpicsSignal, ':STATE', kind='omitted', doc='')
-    statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
-    staterbck = Cpt(EpicsSignalRO, ':STATERBCK_RBV', kind='omitted', doc='')
-    status_rs = Cpt(EpicsSignal, ':STATUS_RS', kind='omitted', doc='')
-    status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1', kind='omitted',
-                          doc='')
-    status_rs_calc2 = Cpt(EpicsSignal, ':STATUS_RS_CALC2', kind='omitted',
-                          doc='')
-    status_rscalc = Cpt(EpicsSignal, ':STATUS_RSCALC', kind='omitted',
-                        doc='')
-    status_rscalc2 = Cpt(EpicsSignal, ':STATUS_RSCALC2', kind='omitted',
-                         doc='')
-    status_rsmon = Cpt(EpicsSignal, ':STATUS_RSMON', kind='omitted', doc='')
-    status_rsout = Cpt(EpicsSignal, ':STATUS_RSOUT', kind='omitted', doc='')
+    gastype = Cpt(EpicsSignal, ':GASTYPE', kind='omitted')
+    gastypedes = Cpt(EpicsSignal, ':GASTYPEDES', kind='omitted')
+    hystsprbck_1 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_1_RBV', kind='omitted')
+    hystsprbck_2 = Cpt(EpicsSignalRO, ':HYSTSPRBCK_2_RBV', kind='omitted')
+    p = Cpt(EpicsSignal, ':P', kind='omitted')
+    padel = Cpt(EpicsSignal, ':PADEL', kind='omitted')
+    plog = Cpt(EpicsSignal, ':PLOG', kind='omitted')
+    pmon = Cpt(EpicsSignal, ':PMON', kind='omitted')
+    pmonraw = Cpt(EpicsSignal, ':PMONRAW', kind='omitted')
+    pstat_1 = Cpt(EpicsSignal, ':PSTAT_1', kind='omitted')
+    pstat_2 = Cpt(EpicsSignal, ':PSTAT_2', kind='omitted')
+    pstat_calc = Cpt(EpicsSignal, ':PSTAT_CALC', kind='omitted')
+    pstat_sum = Cpt(EpicsSignal, ':PSTAT_SUM', kind='omitted')
+    pstatdirdes_1 = Cpt(EpicsSignal, ':PSTATDIRDES_1', kind='omitted')
+    pstatdirdes_2 = Cpt(EpicsSignal, ':PSTATDIRDES_2', kind='omitted')
+    pstatenable_1 = Cpt(EpicsSignal, ':PSTATENABLE_1', kind='omitted')
+    pstatenable_2 = Cpt(EpicsSignal, ':PSTATENABLE_2', kind='omitted')
+    pstatenades_1 = Cpt(EpicsSignal, ':PSTATENADES_1', kind='omitted')
+    pstatenades_2 = Cpt(EpicsSignal, ':PSTATENADES_2', kind='omitted')
+    pstatspdes_1 = Cpt(EpicsSignal, ':PSTATSPDES_1', kind='omitted')
+    pstatspdes_2 = Cpt(EpicsSignal, ':PSTATSPDES_2', kind='omitted')
+    pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1', kind='omitted')
+    pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2', kind='omitted')
+    pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1_RBV', kind='omitted')
+    pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2_RBV', kind='omitted')
+    state = Cpt(EpicsSignal, ':STATE', kind='omitted')
+    statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted')
+    staterbck = Cpt(EpicsSignalRO, ':STATERBCK_RBV', kind='omitted')
+    status_rs = Cpt(EpicsSignal, ':STATUS_RS', kind='omitted')
+    status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1', kind='omitted')
+    status_rs_calc2 = Cpt(EpicsSignal, ':STATUS_RS_CALC2', kind='omitted')
+    status_rscalc = Cpt(EpicsSignal, ':STATUS_RSCALC', kind='omitted')
+    status_rscalc2 = Cpt(EpicsSignal, ':STATUS_RSCALC2', kind='omitted')
+    status_rsmon = Cpt(EpicsSignal, ':STATUS_RSMON', kind='omitted')
+    status_rsout = Cpt(EpicsSignal, ':STATUS_RSOUT', kind='omitted')
 
 
 class GaugeSerialGPI(GaugeSerial):
@@ -321,11 +315,11 @@ class GaugeSerialGPI(GaugeSerial):
     Class for Pirani Vacuum Gauge controlled via serial
 
     """
-    atmcalib = Cpt(EpicsSignal, ':ATMCALIB', kind='omitted', doc='')
-    atmcalibdes = Cpt(EpicsSignal, ':ATMCALIBDES', kind='omitted', doc='')
-    autozero = Cpt(EpicsSignal, ':AUTOZERO_RBV', kind='omitted', doc='')
-    autozerodes = Cpt(EpicsSignal, ':AUTOZERODES', kind='omitted', doc='')
-    zeropr = Cpt(EpicsSignal, ':ZEROPR', kind='omitted', doc='')
+    atmcalib = Cpt(EpicsSignal, ':ATMCALIB', kind='omitted')
+    atmcalibdes = Cpt(EpicsSignal, ':ATMCALIBDES', kind='omitted')
+    autozero = Cpt(EpicsSignal, ':AUTOZERO_RBV', kind='omitted')
+    autozerodes = Cpt(EpicsSignal, ':AUTOZERODES', kind='omitted')
+    zeropr = Cpt(EpicsSignal, ':ZEROPR', kind='omitted')
 
 
 class GaugeSerialGCC(GaugeSerial):
@@ -333,37 +327,35 @@ class GaugeSerialGCC(GaugeSerial):
     Class for Cold Cathode Gauge controlled via serial
 
     """
-    pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES', kind='omitted', doc='')
-    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK_RBV', kind='omitted',
-                        doc='')
-    pctrldes = Cpt(EpicsSignal, ':PCTRLDES', kind='omitted', doc='')
-    pctrlen = Cpt(EpicsSignal, ':PCTRLEN', kind='omitted', doc='')
-    pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC', kind='omitted', doc='')
-    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK_RBV', kind='omitted', doc='')
-    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK_RBV', kind='omitted', doc='')
-    pctrlspdes = Cpt(EpicsSignal, ':PCTRLSPDES', kind='omitted', doc='')
-    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK_RBV', kind='omitted', doc='')
-    pprotencalc = Cpt(EpicsSignal, ':PPROTENCALC', kind='omitted', doc='')
-    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK_RBV', kind='omitted', doc='')
-    pprotspdes = Cpt(EpicsSignal, ':PPROTSPDES', kind='omitted', doc='')
-    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK_RBV', kind='omitted', doc='')
-    pstat_3 = Cpt(EpicsSignal, ':PSTAT_3', kind='omitted', doc='')
-    pstat_4 = Cpt(EpicsSignal, ':PSTAT_4', kind='omitted', doc='')
-    pstatdirdes_3 = Cpt(EpicsSignal, ':PSTATDIRDES_3', kind='omitted', doc='')
-    pstatdirdes_4 = Cpt(EpicsSignal, ':PSTATDIRDES_4', kind='omitted', doc='')
-    pstatenable_3 = Cpt(EpicsSignal, ':PSTATENABLE_3', kind='omitted', doc='')
-    pstatenable_4 = Cpt(EpicsSignal, ':PSTATENABLE_4', kind='omitted', doc='')
-    pstatenades_3 = Cpt(EpicsSignal, ':PSTATENADES_3', kind='omitted', doc='')
-    pstatenades_4 = Cpt(EpicsSignal, ':PSTATENADES_4', kind='omitted', doc='')
-    pstatspdes_3 = Cpt(EpicsSignal, ':PSTATSPDES_3', kind='omitted', doc='')
-    pstatspdes_4 = Cpt(EpicsSignal, ':PSTATSPDES_4', kind='omitted', doc='')
-    pstatspdes_fs = Cpt(EpicsSignal, ':PSTATSPDES_FS', kind='omitted', doc='')
-    pstatspdir_3 = Cpt(EpicsSignal, ':PSTATSPDIR_3', kind='omitted', doc='')
-    pstatspdir_4 = Cpt(EpicsSignal, ':PSTATSPDIR_4', kind='omitted', doc='')
-    pstatsprbck_3 = Cpt(EpicsSignal, ':PSTATSPRBCK_3', kind='omitted', doc='')
-    pstatsprbck_4 = Cpt(EpicsSignal, ':PSTATSPRBCK_4', kind='omitted', doc='')
-    pstatsprbck_fs = Cpt(EpicsSignal, ':PSTATSPRBCK_FS', kind='omitted',
-                         doc='')
+    pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES', kind='omitted')
+    pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK_RBV', kind='omitted')
+    pctrldes = Cpt(EpicsSignal, ':PCTRLDES', kind='omitted')
+    pctrlen = Cpt(EpicsSignal, ':PCTRLEN', kind='omitted')
+    pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC', kind='omitted')
+    pctrlenrbck = Cpt(EpicsSignalRO, ':PCTRLENRBCK_RBV', kind='omitted')
+    pctrlrbck = Cpt(EpicsSignalRO, ':PCTRLRBCK_RBV', kind='omitted')
+    pctrlspdes = Cpt(EpicsSignal, ':PCTRLSPDES', kind='omitted')
+    pctrlsprbck = Cpt(EpicsSignalRO, ':PCTRLSPRBCK_RBV', kind='omitted')
+    pprotencalc = Cpt(EpicsSignal, ':PPROTENCALC', kind='omitted')
+    pprotenrbck = Cpt(EpicsSignalRO, ':PPROTENRBCK_RBV', kind='omitted')
+    pprotspdes = Cpt(EpicsSignal, ':PPROTSPDES', kind='omitted')
+    pprotsprbck = Cpt(EpicsSignalRO, ':PPROTSPRBCK_RBV', kind='omitted')
+    pstat_3 = Cpt(EpicsSignal, ':PSTAT_3', kind='omitted')
+    pstat_4 = Cpt(EpicsSignal, ':PSTAT_4', kind='omitted')
+    pstatdirdes_3 = Cpt(EpicsSignal, ':PSTATDIRDES_3', kind='omitted')
+    pstatdirdes_4 = Cpt(EpicsSignal, ':PSTATDIRDES_4', kind='omitted')
+    pstatenable_3 = Cpt(EpicsSignal, ':PSTATENABLE_3', kind='omitted')
+    pstatenable_4 = Cpt(EpicsSignal, ':PSTATENABLE_4', kind='omitted')
+    pstatenades_3 = Cpt(EpicsSignal, ':PSTATENADES_3', kind='omitted')
+    pstatenades_4 = Cpt(EpicsSignal, ':PSTATENADES_4', kind='omitted')
+    pstatspdes_3 = Cpt(EpicsSignal, ':PSTATSPDES_3', kind='omitted')
+    pstatspdes_4 = Cpt(EpicsSignal, ':PSTATSPDES_4', kind='omitted')
+    pstatspdes_fs = Cpt(EpicsSignal, ':PSTATSPDES_FS', kind='omitted')
+    pstatspdir_3 = Cpt(EpicsSignal, ':PSTATSPDIR_3', kind='omitted')
+    pstatspdir_4 = Cpt(EpicsSignal, ':PSTATSPDIR_4', kind='omitted')
+    pstatsprbck_3 = Cpt(EpicsSignal, ':PSTATSPRBCK_3', kind='omitted')
+    pstatsprbck_4 = Cpt(EpicsSignal, ':PSTATSPRBCK_4', kind='omitted')
+    pstatsprbck_fs = Cpt(EpicsSignal, ':PSTATSPRBCK_FS', kind='omitted')
 
 
 # factory function for IonPumps

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -298,7 +298,7 @@ class Gauge_Serial_GPI(Gauge_Serial):
     autozerodes = Cpt(EpicsSignal, ':AUTOZERODES' , kind='omitted', doc='')
     zeropr = Cpt(EpicsSignal, ':ZEROPR' , kind='omitted', doc='')
 
-class Gauge_Serial_GCC(Gauge_serial):
+class Gauge_Serial_GCC(Gauge_Serial):
     """
     Class for Cold Cathode Gauge controlled via serial
 

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -183,15 +183,15 @@ class GaugePLC(Device):
     Still need to work out replacement of old classes.
     """
     pressure = Cpt(EpicsSignalRO, ':PRESS_RBV', kind='hinted',
-        doc='gauge pressure reading')
+                   doc='gauge pressure reading')
     gauge_at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV', kind='normal',
-        doc='gauge is at VAC')
+                       doc='gauge is at VAC')
     pressure_ok = Cpt(EpicsSignalRO, ':PRESS_OK_RBV', kind='normal',
-        doc='pressure reading ok')
+                      doc='pressure reading ok')
     at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':VAC_SP', kind='config',
-        doc='At vacuum setpoint for all gauges')
+                          doc='At vacuum setpoint for all gauges')
     state = Cpt(EpicsSignalRO, ':State_RBV', kind='hinted',
-        doc='state of the gauge')
+                doc='state of the gauge')
 
 
 class GCCPLC(GaugePLC):
@@ -200,15 +200,17 @@ class GCCPLC(GaugePLC):
 
     """
     high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='normal',
-        doc='command to switch the hight voltage on')
+                          doc='command to switch the hight voltage on')
     high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_RBV', kind='normal',
-        doc='enables the high voltage on the cold cathode gauge')
+                               doc=('enables the high voltage on the cold '
+                                    'cathode gauge'))
     protection_setpoint = Cpt(EpicsSignalRO, ':PRO_SP_RBV', kind='normal',
-        doc='Protection setpoint for ion gauges at which the gauge turns off')
+                              doc=('Protection setpoint for ion gauges at '
+                                   'which the gauge turns off'))
     setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':SP_HYS', kind='config',
-        doc='Protection setpoint hysteresis')
+                              doc='Protection setpoint hysteresis')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
-        doc='Interlock is ok')
+                       doc='Interlock is ok')
 
 
 class GCC500PLC(GCCPLC):
@@ -217,9 +219,9 @@ class GCC500PLC(GCCPLC):
 
     """
     high_voltage_is_on = Cpt(EpicsSignalRO, ':HV_ON_RBV', kind='normal',
-        doc='state of the HV')
+                             doc='state of the HV')
     disc_active = Cpt(EpicsSignalRO, ':DISC_ACTIVE_RBV', kind='normal',
-        doc='discharge current active')
+                      doc='discharge current active')
 
 
 class GCT(Device):
@@ -295,21 +297,21 @@ class GaugeSerial(Device):
     pstatspdir_1 = Cpt(EpicsSignal, ':PSTATSPDIR_1', kind='omitted', doc='')
     pstatspdir_2 = Cpt(EpicsSignal, ':PSTATSPDIR_2', kind='omitted', doc='')
     pstatsprbck_1 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_1', kind='omitted',
-        doc='')
+                        doc='')
     pstatsprbck_2 = Cpt(EpicsSignalRO, ':PSTATSPRBCK_2', kind='omitted',
-        doc='')
+                        doc='')
     state = Cpt(EpicsSignal, ':STATE', kind='omitted', doc='')
     statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
     staterbck = Cpt(EpicsSignalRO, ':STATERBCK', kind='omitted', doc='')
     status_rs = Cpt(EpicsSignal, ':STATUS_RS', kind='omitted', doc='')
     status_rs_calc1 = Cpt(EpicsSignal, ':STATUS_RS_CALC1', kind='omitted',
-        doc='')
+                          doc='')
     status_rs_calc2 = Cpt(EpicsSignal, ':STATUS_RS_CALC2', kind='omitted',
-        doc='')
+                          doc='')
     status_rscalc = Cpt(EpicsSignal, ':STATUS_RSCALC', kind='omitted',
-        doc='')
+                        doc='')
     status_rscalc2 = Cpt(EpicsSignal, ':STATUS_RSCALC2', kind='omitted',
-        doc='')
+                         doc='')
     status_rsmon = Cpt(EpicsSignal, ':STATUS_RSMON', kind='omitted', doc='')
     status_rsout = Cpt(EpicsSignal, ':STATUS_RSOUT', kind='omitted', doc='')
 
@@ -333,7 +335,7 @@ class GaugeSerialGCC(GaugeSerial):
     """
     pctrl_ch_des = Cpt(EpicsSignal, ':PCTRL_CH_DES', kind='omitted', doc='')
     pctrl_ch_rbck = Cpt(EpicsSignalRO, ':PCTRL_CH_RBCK', kind='omitted',
-        doc='')
+                        doc='')
     pctrldes = Cpt(EpicsSignal, ':PCTRLDES', kind='omitted', doc='')
     pctrlen = Cpt(EpicsSignal, ':PCTRLEN', kind='omitted', doc='')
     pctrlencalc = Cpt(EpicsSignal, ':PCTRLENCALC', kind='omitted', doc='')
@@ -361,7 +363,8 @@ class GaugeSerialGCC(GaugeSerial):
     pstatsprbck_3 = Cpt(EpicsSignal, ':PSTATSPRBCK_3', kind='omitted', doc='')
     pstatsprbck_4 = Cpt(EpicsSignal, ':PSTATSPRBCK_4', kind='omitted', doc='')
     pstatsprbck_fs = Cpt(EpicsSignal, ':PSTATSPRBCK_FS', kind='omitted',
-        doc='')
+                         doc='')
+
 
 # factory function for IonPumps
 def GaugeSet(prefix, *, name, index, **kwargs):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -188,7 +188,7 @@ class PTMPLC(Device):
     bp_sp = Cpt(EpicsSignalWithRBV, ':BP_SP', kind='omitted')
     ip_sp = Cpt(EpicsSignalWithRBV, ':IP_SP', kind='omitted')
     interlock_status = Cpt(EpicsSignalRO, ':ILK_STATUS_RBV', kind='normal',
-                       doc='interlock  is ok when true')
+                           doc='interlock  is ok when true')
 
 
 class PROPLC(Device):
@@ -287,7 +287,7 @@ class GammaPCT(Device):
 
 class QPCPCT(GammaPCT):
     """
-    Class for Quad Pump Controller accessed via serial
+    Class for Quad Pump Controller accessed via ethernet
 
     """
     do_reset = Cpt(EpicsSignal, ':DO_RESET', kind='omitted')

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -1,8 +1,8 @@
 """
-Standard classes for LCLS Gauges
+Standard classes for LCLS Pumps
 """
 import logging
-from ophyd import EpicsSignal, EpicsSignalRO, Device
+from ophyd import EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV, Device
 from ophyd import Component as Cpt, FormattedComponent as FCpt
 from .doc_stubs import IonPump_base
 from .interface import BaseInterface
@@ -147,6 +147,155 @@ class IonPumpWithController(IonPumpBase):
     def egu(self):
         return self.controller.unit.get()
 
+class PIP_PLC(Device):
+    """
+    Class for PLC-controlled Ion Pumps
+
+    Newer class. This and below are still missing some functionality.
+    Still need to work out replacement of old classes.
+    """
+    pressure = Cpt(EpicsSignalRO, ':PRESS_RBV' , kind='hinted', doc='pressure reading')
+    high_voltage_do = Cpt(EpicsSignalRO, ':HV_DO_RBV' , kind='normal', doc='high voltage digital output')
+    high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW' , kind='omitted', doc='epics command to witch on the high voltage')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='interlock  is ok when true')
+    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP' , kind='omitted', doc='at vacuum set point')
+    set_point_relay = Cpt(EpicsSignalRO, ':SP_DI_RBV' , kind='normal', doc='set point digital input relay')
+
+class PTM_PLC(Device):
+    """
+    Class for PLC-controlled Turbo Pump
+
+    """
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW' , kind='omitted', doc='')
+    reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW' , kind='normal', doc='')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV' , kind='normal', doc='')
+    run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV' , kind='omitted', doc='')
+    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV' , kind='omitted', doc='')
+    pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV' , kind='normal', doc='')
+    pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV' , kind='normal', doc='')
+    fault = Cpt(EpicsSignalRO, ':FAULT_RBV' , kind='normal', doc='')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV' , kind='normal', doc='')
+    alarm = Cpt(EpicsSignalWithRBV, ':ALARM' , kind='normal', doc='')
+    backing_pressure_sp = Cpt(EpicsSignalWithRBV, ':BackingPressureSP' , kind='omitted', doc='')
+    inlet_pressure_sp = Cpt(EpicsSignalWithRBV, ':InletPressureSP' , kind='omitted', doc='')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='interlock  is ok when true')
+
+class PRO_PLC(Device):
+    """
+    Class for PLC-controlled Roughing Pump
+
+    """
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW' , kind='omitted', doc='')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='interlock  is ok when true')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV' , kind='normal', doc='')
+    error = Cpt(EpicsSignalRO, ':ERROR_RBV' , kind='normal', doc='')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV' , kind='normal', doc='')
+    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV' , kind='normal', doc='')
+
+class Agilent_Serial(Device):
+    """
+    Class for Agilent Turbo Pump controlled via serial
+
+    """
+    run = Cpt(EpicsSignal, ':RUN' , kind='omitted', doc='')
+    config = Cpt(EpicsSignal, ':CONFIG' , kind='omitted', doc='')
+    softstart = Cpt(EpicsSignal, ':SOFTSTART' , kind='omitted', doc='')
+    sp_type = Cpt(EpicsSignal, ':SP_TYPE' , kind='omitted', doc='')
+    sp_calcdis = Cpt(EpicsSignal, ':SP_CALCDIS' , kind='omitted', doc='')
+    sp_dis = Cpt(EpicsSignal, ':SP_DIS' , kind='omitted', doc='')
+    sp_writeval = Cpt(EpicsSignal, ':SP_WRITEVAL' , kind='omitted', doc='')
+    sp_freq = Cpt(EpicsSignal, ':SP_FREQ' , kind='omitted', doc='')
+    sp_current = Cpt(EpicsSignal, ':SP_CURRENT' , kind='omitted', doc='')
+    sp_time = Cpt(EpicsSignal, ':SP_TIME' , kind='omitted', doc='')
+    sp_delay = Cpt(EpicsSignal, ':SP_DELAY' , kind='omitted', doc='')
+    sp_polarity = Cpt(EpicsSignal, ':SP_POLARITY' , kind='omitted', doc='')
+    sp_hys = Cpt(EpicsSignal, ':SP_HYS' , kind='omitted', doc='')
+    water_cooling = Cpt(EpicsSignal, ':WATER_COOLING' , kind='normal', doc='')
+    active_stop = Cpt(EpicsSignal, ':ACTIVE_STOP' , kind='normal', doc='')
+    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE' , kind='omitted', doc='')
+    ao_type = Cpt(EpicsSignal, ':AO_TYPE' , kind='omitted', doc='')
+    rot_freq = Cpt(EpicsSignal, ':ROT_FREQ' , kind='normal', doc='')
+    vent_valve = Cpt(EpicsSignal, ':VENT_VALVE' , kind='omitted', doc='')
+    vent_valve_operation = Cpt(EpicsSignal, ':VENT_VALVE_OPERATION' , kind='omitted', doc='')
+    vent_valve_delay = Cpt(EpicsSignal, ':VENT_VALVE_DELAY' , kind='omitted', doc='')
+    vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW' , kind='omitted', doc='')
+    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT' , kind='omitted', doc='')
+    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE' , kind='normal', doc='')
+    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER' , kind='normal', doc='')
+    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ' , kind='normal', doc='')
+    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP' , kind='normal', doc='')
+    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS' , kind='normal', doc='')
+    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR' , kind='normal', doc='')
+
+class Navigator(Agilent_Serial):
+    """
+    Class for Navigator Pump controlled via serial
+
+    """
+    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED' , kind='omitted', doc='')
+    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ' , kind='omitted', doc='')
+    sp_power = Cpt(EpicsSignalRO, ':SP_POWER' , kind='omitted', doc='')
+    sp_time = Cpt(EpicsSignalRO, ':SP_TIME' , kind='omitted', doc='')
+    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL' , kind='omitted', doc='')
+    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE' , kind='omitted', doc='')
+    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME' , kind='omitted', doc='')
+    vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW' , kind='omitted', doc='')
+    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT' , kind='omitted', doc='')
+    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE' , kind='omitted', doc='')
+    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR' , kind='omitted', doc='')
+    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT' , kind='omitted', doc='')
+    sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT' , kind='omitted', doc='')
+    stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING' , kind='omitted', doc='')
+    ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP' , kind='omitted', doc='')
+    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP' , kind='omitted', doc='')
+
+class Gamma_PCT(Device):
+    """
+    Class for Gamma Pump Controller accessed via serial
+
+    """
+    model = Cpt(EpicsSignalRO, ':MODEL' , kind='normal', doc='')
+    fwversion = Cpt(EpicsSignalRO, ':FWVERSION' , kind='normal', doc='')
+    ashvedes = Cpt(EpicsSignal, ':ASHVEDES' , kind='omitted', doc='')
+    ashve = Cpt(EpicsSignalRO, ':ASHVE' , kind='normal', doc='')
+    aspowerdes = Cpt(EpicsSignal, ':ASPOWERDES' , kind='omitted', doc='')
+    aspower = Cpt(EpicsSignalRO, ':ASPOWER' , kind='normal', doc='')
+    pegudes = Cpt(EpicsSignal, ':PEGUDES' , kind='omitted', doc='')
+    masterreset = Cpt(EpicsSignal, ':MASTERRESET' , kind='omitted', doc='')
+
+class QPC_PCT(Gamma_PCT):
+    """
+    Class for Quad Pump Controller accessed via serial
+
+    """
+    do_reset = Cpt(EpicsSignal, ':DO_RESET' , kind='omitted', doc='')
+
+class PIP_Serial(Device):
+    """
+    Class for Positive Ion Pump controlled via serial
+
+    """
+    imon = Cpt(EpicsSignalRO, ':IMON' , kind='hinted', doc='')
+    pmon = Cpt(EpicsSignalRO, ':PMON' , kind='hinted', doc='')
+    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG' , kind='normal', doc='')
+    vmon = Cpt(EpicsSignalRO, ':VMON' , kind='normal', doc='')
+    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW' , kind='omitted', doc='')
+    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC' , kind='omitted', doc='')
+    status = Cpt(EpicsSignalRO, ':STATUS' , kind='normal', doc='')
+    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL' , kind='omitted', doc='')
+    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE' , kind='omitted', doc='')
+    pumpsizedes = Cpt(EpicsSignal, ':PUMPSIZEDES' , kind='omitted', doc='')
+    pumpsize = Cpt(EpicsSignal, ':PUMPSIZE' , kind='omitted', doc='')
+    calfactordes = Cpt(EpicsSignal, ':CALFACTORDES' , kind='omitted', doc='')
+    calfactor = Cpt(EpicsSignal, ':CALFACTOR' , kind='omitted', doc='')
+    aomodedes = Cpt(EpicsSignal, ':AOMODEDES' , kind='omitted', doc='')
+    aomode = Cpt(EpicsSignal, ':AOMODE' , kind='omitted', doc='')
+    statedes = Cpt(EpicsSignal, ':STATEDES' , kind='omitted', doc='')
+    statemon = Cpt(EpicsSignalRO, ':STATEMON' , kind='normal', doc='')
+    dispdes = Cpt(EpicsSignal, ':DISPDES' , kind='omitted', doc='')
+    pname = Cpt(EpicsSignalRO, ':PNAME' , kind='normal', doc='')
+    pnamedes = Cpt(EpicsSignal, ':PNAMEDES' , kind='omitted', doc='')
+    vpcname = Cpt(EpicsSignal, ':VPCNAME' , kind='omitted', doc='')
 
 # factory function for IonPumps
 def IonPump(prefix, *, name, **kwargs):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -2,8 +2,10 @@
 Standard classes for LCLS Pumps
 """
 import logging
+
 from ophyd import EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV, Device
 from ophyd import Component as Cpt, FormattedComponent as FCpt
+
 from .doc_stubs import IonPump_base
 from .interface import BaseInterface
 
@@ -106,7 +108,7 @@ class IonPumpBase(Device, BaseInterface):
 
     def info(self):
         outString = (
-            '%s is an ion pump  with base PV %s which is %s \n' %
+            '%s is an ion pump with base PV %s which is %s \n' %
             (self.name, self.prefix, self.state.get()))
         if self.state.get() == 'ON':
             outString += 'Pressure: %g \n' % self.pressure()
@@ -147,155 +149,194 @@ class IonPumpWithController(IonPumpBase):
     def egu(self):
         return self.controller.unit.get()
 
-class PIP_PLC(Device):
+
+class PIPPLC(Device):
     """
     Class for PLC-controlled Ion Pumps
 
     Newer class. This and below are still missing some functionality.
     Still need to work out replacement of old classes.
     """
-    pressure = Cpt(EpicsSignalRO, ':PRESS_RBV' , kind='hinted', doc='pressure reading')
-    high_voltage_do = Cpt(EpicsSignalRO, ':HV_DO_RBV' , kind='normal', doc='high voltage digital output')
-    high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW' , kind='omitted', doc='epics command to witch on the high voltage')
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='interlock  is ok when true')
-    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP' , kind='omitted', doc='at vacuum set point')
-    set_point_relay = Cpt(EpicsSignalRO, ':SP_DI_RBV' , kind='normal', doc='set point digital input relay')
+    pressure = Cpt(EpicsSignalRO, ':PRESS_RBV', kind='hinted',
+        doc='pressure reading')
+    high_voltage_do = Cpt(EpicsSignalRO, ':HV_DO_RBV', kind='normal',
+        doc='high voltage digital output')
+    high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='omitted',
+        doc='epics command to witch on the high voltage')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+        doc='interlock  is ok when true')
+    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
+        doc='at vacuum set point')
+    set_point_relay = Cpt(EpicsSignalRO, ':SP_DI_RBV', kind='normal',
+        doc='set point digital input relay')
 
-class PTM_PLC(Device):
+
+class PTMPLC(Device):
     """
     Class for PLC-controlled Turbo Pump
 
     """
-    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW' , kind='omitted', doc='')
-    reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW' , kind='normal', doc='')
-    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV' , kind='normal', doc='')
-    run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV' , kind='omitted', doc='')
-    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV' , kind='omitted', doc='')
-    pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV' , kind='normal', doc='')
-    pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV' , kind='normal', doc='')
-    fault = Cpt(EpicsSignalRO, ':FAULT_RBV' , kind='normal', doc='')
-    warn = Cpt(EpicsSignalRO, ':WARN_RBV' , kind='normal', doc='')
-    alarm = Cpt(EpicsSignalWithRBV, ':ALARM' , kind='normal', doc='')
-    backing_pressure_sp = Cpt(EpicsSignalWithRBV, ':BackingPressureSP' , kind='omitted', doc='')
-    inlet_pressure_sp = Cpt(EpicsSignalWithRBV, ':InletPressureSP' , kind='omitted', doc='')
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='interlock  is ok when true')
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted',
+        doc='')
+    reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='normal', doc='')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal', doc='')
+    run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV', kind='omitted', doc='')
+    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='omitted',
+        doc='')
+    pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV', kind='normal',
+        doc='')
+    pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV', kind='normal', doc='')
+    fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal', doc='')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
+    alarm = Cpt(EpicsSignalWithRBV, ':ALARM', kind='normal', doc='')
+    backing_pressure_sp = Cpt(EpicsSignalWithRBV, ':BackingPressureSP',
+        kind='omitted', doc='')
+    inlet_pressure_sp = Cpt(EpicsSignalWithRBV, ':InletPressureSP',
+        kind='omitted', doc='')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+        doc='interlock  is ok when true')
 
-class PRO_PLC(Device):
+
+class PROPLC(Device):
     """
     Class for PLC-controlled Roughing Pump
 
     """
-    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW' , kind='omitted', doc='')
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV' , kind='normal', doc='interlock  is ok when true')
-    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV' , kind='normal', doc='')
-    error = Cpt(EpicsSignalRO, ':ERROR_RBV' , kind='normal', doc='')
-    warn = Cpt(EpicsSignalRO, ':WARN_RBV' , kind='normal', doc='')
-    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV' , kind='normal', doc='')
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted',
+        doc='')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+        doc='interlock is ok when true')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal', doc='')
+    error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal', doc='')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
+    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='normal', doc='')
 
-class Agilent_Serial(Device):
+
+class AgilentSerial(Device):
     """
     Class for Agilent Turbo Pump controlled via serial
 
     """
-    run = Cpt(EpicsSignal, ':RUN' , kind='omitted', doc='')
-    config = Cpt(EpicsSignal, ':CONFIG' , kind='omitted', doc='')
-    softstart = Cpt(EpicsSignal, ':SOFTSTART' , kind='omitted', doc='')
-    sp_type = Cpt(EpicsSignal, ':SP_TYPE' , kind='omitted', doc='')
-    sp_calcdis = Cpt(EpicsSignal, ':SP_CALCDIS' , kind='omitted', doc='')
-    sp_dis = Cpt(EpicsSignal, ':SP_DIS' , kind='omitted', doc='')
-    sp_writeval = Cpt(EpicsSignal, ':SP_WRITEVAL' , kind='omitted', doc='')
-    sp_freq = Cpt(EpicsSignal, ':SP_FREQ' , kind='omitted', doc='')
-    sp_current = Cpt(EpicsSignal, ':SP_CURRENT' , kind='omitted', doc='')
-    sp_time = Cpt(EpicsSignal, ':SP_TIME' , kind='omitted', doc='')
-    sp_delay = Cpt(EpicsSignal, ':SP_DELAY' , kind='omitted', doc='')
-    sp_polarity = Cpt(EpicsSignal, ':SP_POLARITY' , kind='omitted', doc='')
-    sp_hys = Cpt(EpicsSignal, ':SP_HYS' , kind='omitted', doc='')
-    water_cooling = Cpt(EpicsSignal, ':WATER_COOLING' , kind='normal', doc='')
-    active_stop = Cpt(EpicsSignal, ':ACTIVE_STOP' , kind='normal', doc='')
-    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE' , kind='omitted', doc='')
-    ao_type = Cpt(EpicsSignal, ':AO_TYPE' , kind='omitted', doc='')
-    rot_freq = Cpt(EpicsSignal, ':ROT_FREQ' , kind='normal', doc='')
-    vent_valve = Cpt(EpicsSignal, ':VENT_VALVE' , kind='omitted', doc='')
-    vent_valve_operation = Cpt(EpicsSignal, ':VENT_VALVE_OPERATION' , kind='omitted', doc='')
-    vent_valve_delay = Cpt(EpicsSignal, ':VENT_VALVE_DELAY' , kind='omitted', doc='')
-    vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW' , kind='omitted', doc='')
-    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT' , kind='omitted', doc='')
-    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE' , kind='normal', doc='')
-    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER' , kind='normal', doc='')
-    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ' , kind='normal', doc='')
-    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP' , kind='normal', doc='')
-    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS' , kind='normal', doc='')
-    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR' , kind='normal', doc='')
+    run = Cpt(EpicsSignal, ':RUN', kind='omitted', doc='')
+    config = Cpt(EpicsSignal, ':CONFIG', kind='omitted', doc='')
+    softstart = Cpt(EpicsSignal, ':SOFTSTART', kind='omitted', doc='')
+    sp_type = Cpt(EpicsSignal, ':SP_TYPE', kind='omitted', doc='')
+    sp_calcdis = Cpt(EpicsSignal, ':SP_CALCDIS', kind='omitted', doc='')
+    sp_dis = Cpt(EpicsSignal, ':SP_DIS', kind='omitted', doc='')
+    sp_writeval = Cpt(EpicsSignal, ':SP_WRITEVAL', kind='omitted', doc='')
+    sp_freq = Cpt(EpicsSignal, ':SP_FREQ', kind='omitted', doc='')
+    sp_current = Cpt(EpicsSignal, ':SP_CURRENT', kind='omitted', doc='')
+    sp_time = Cpt(EpicsSignal, ':SP_TIME', kind='omitted', doc='')
+    sp_delay = Cpt(EpicsSignal, ':SP_DELAY', kind='omitted', doc='')
+    sp_polarity = Cpt(EpicsSignal, ':SP_POLARITY', kind='omitted', doc='')
+    sp_hys = Cpt(EpicsSignal, ':SP_HYS', kind='omitted', doc='')
+    water_cooling = Cpt(EpicsSignal, ':WATER_COOLING', kind='normal', doc='')
+    active_stop = Cpt(EpicsSignal, ':ACTIVE_STOP', kind='normal', doc='')
+    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE', kind='omitted', doc='')
+    ao_type = Cpt(EpicsSignal, ':AO_TYPE', kind='omitted', doc='')
+    rot_freq = Cpt(EpicsSignal, ':ROT_FREQ', kind='normal', doc='')
+    vent_valve = Cpt(EpicsSignal, ':VENT_VALVE', kind='omitted', doc='')
+    vent_valve_operation = Cpt(EpicsSignal, ':VENT_VALVE_OPERATION',
+        kind='omitted', doc='')
+    vent_valve_delay = Cpt(EpicsSignal, ':VENT_VALVE_DELAY', kind='omitted',
+        doc='')
+    vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW', kind='omitted',
+        doc='')
+    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT', kind='omitted',
+        doc='')
+    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE', kind='normal',
+        doc='')
+    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER', kind='normal', doc='')
+    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ', kind='normal',
+        doc='')
+    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP', kind='normal', doc='')
+    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS', kind='normal', doc='')
+    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR', kind='normal', doc='')
 
-class Navigator(Agilent_Serial):
+
+class Navigator(AgilentSerial):
     """
     Class for Navigator Pump controlled via serial
 
     """
-    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED' , kind='omitted', doc='')
-    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ' , kind='omitted', doc='')
-    sp_power = Cpt(EpicsSignalRO, ':SP_POWER' , kind='omitted', doc='')
-    sp_time = Cpt(EpicsSignalRO, ':SP_TIME' , kind='omitted', doc='')
-    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL' , kind='omitted', doc='')
-    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE' , kind='omitted', doc='')
-    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME' , kind='omitted', doc='')
-    vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW' , kind='omitted', doc='')
-    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT' , kind='omitted', doc='')
-    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE' , kind='omitted', doc='')
-    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR' , kind='omitted', doc='')
-    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT' , kind='omitted', doc='')
-    sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT' , kind='omitted', doc='')
-    stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING' , kind='omitted', doc='')
-    ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP' , kind='omitted', doc='')
-    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP' , kind='omitted', doc='')
+    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED', kind='omitted', doc='')
+    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ', kind='omitted',
+        doc='')
+    sp_power = Cpt(EpicsSignalRO, ':SP_POWER', kind='omitted', doc='')
+    sp_time = Cpt(EpicsSignalRO, ':SP_TIME', kind='omitted', doc='')
+    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL', kind='omitted', doc='')
+    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE', kind='omitted', doc='')
+    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME', kind='omitted',
+        doc='')
+    vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW',
+        kind='omitted', doc='')
+    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT', kind='omitted', doc='')
+    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE', kind='omitted',
+        doc='')
+    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR', kind='omitted',
+        doc='')
+    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT', kind='omitted',
+        doc='')
+    sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT',
+        kind='omitted', doc='')
+    stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING',
+        kind='omitted', doc='')
+    ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP',
+        kind='omitted', doc='')
+    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP', kind='omitted',
+        doc='')
 
-class Gamma_PCT(Device):
+
+class GammaPCT(Device):
     """
     Class for Gamma Pump Controller accessed via serial
 
     """
-    model = Cpt(EpicsSignalRO, ':MODEL' , kind='normal', doc='')
-    fwversion = Cpt(EpicsSignalRO, ':FWVERSION' , kind='normal', doc='')
-    ashvedes = Cpt(EpicsSignal, ':ASHVEDES' , kind='omitted', doc='')
-    ashve = Cpt(EpicsSignalRO, ':ASHVE' , kind='normal', doc='')
-    aspowerdes = Cpt(EpicsSignal, ':ASPOWERDES' , kind='omitted', doc='')
-    aspower = Cpt(EpicsSignalRO, ':ASPOWER' , kind='normal', doc='')
-    pegudes = Cpt(EpicsSignal, ':PEGUDES' , kind='omitted', doc='')
-    masterreset = Cpt(EpicsSignal, ':MASTERRESET' , kind='omitted', doc='')
+    model = Cpt(EpicsSignalRO, ':MODEL', kind='normal', doc='')
+    fwversion = Cpt(EpicsSignalRO, ':FWVERSION', kind='normal', doc='')
+    ashvedes = Cpt(EpicsSignal, ':ASHVEDES', kind='omitted', doc='')
+    ashve = Cpt(EpicsSignalRO, ':ASHVE', kind='normal', doc='')
+    aspowerdes = Cpt(EpicsSignal, ':ASPOWERDES', kind='omitted', doc='')
+    aspower = Cpt(EpicsSignalRO, ':ASPOWER', kind='normal', doc='')
+    pegudes = Cpt(EpicsSignal, ':PEGUDES', kind='omitted', doc='')
+    masterreset = Cpt(EpicsSignal, ':MASTERRESET', kind='omitted', doc='')
 
-class QPC_PCT(Gamma_PCT):
+
+class QPCPCT(GammaPCT):
     """
     Class for Quad Pump Controller accessed via serial
 
     """
-    do_reset = Cpt(EpicsSignal, ':DO_RESET' , kind='omitted', doc='')
+    do_reset = Cpt(EpicsSignal, ':DO_RESET', kind='omitted', doc='')
 
-class PIP_Serial(Device):
+
+class PIPSerial(Device):
     """
     Class for Positive Ion Pump controlled via serial
 
     """
-    imon = Cpt(EpicsSignalRO, ':IMON' , kind='hinted', doc='')
-    pmon = Cpt(EpicsSignalRO, ':PMON' , kind='hinted', doc='')
-    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG' , kind='normal', doc='')
-    vmon = Cpt(EpicsSignalRO, ':VMON' , kind='normal', doc='')
-    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW' , kind='omitted', doc='')
-    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC' , kind='omitted', doc='')
-    status = Cpt(EpicsSignalRO, ':STATUS' , kind='normal', doc='')
-    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL' , kind='omitted', doc='')
-    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE' , kind='omitted', doc='')
-    pumpsizedes = Cpt(EpicsSignal, ':PUMPSIZEDES' , kind='omitted', doc='')
-    pumpsize = Cpt(EpicsSignal, ':PUMPSIZE' , kind='omitted', doc='')
-    calfactordes = Cpt(EpicsSignal, ':CALFACTORDES' , kind='omitted', doc='')
-    calfactor = Cpt(EpicsSignal, ':CALFACTOR' , kind='omitted', doc='')
-    aomodedes = Cpt(EpicsSignal, ':AOMODEDES' , kind='omitted', doc='')
-    aomode = Cpt(EpicsSignal, ':AOMODE' , kind='omitted', doc='')
-    statedes = Cpt(EpicsSignal, ':STATEDES' , kind='omitted', doc='')
-    statemon = Cpt(EpicsSignalRO, ':STATEMON' , kind='normal', doc='')
-    dispdes = Cpt(EpicsSignal, ':DISPDES' , kind='omitted', doc='')
-    pname = Cpt(EpicsSignalRO, ':PNAME' , kind='normal', doc='')
-    pnamedes = Cpt(EpicsSignal, ':PNAMEDES' , kind='omitted', doc='')
-    vpcname = Cpt(EpicsSignal, ':VPCNAME' , kind='omitted', doc='')
+    imon = Cpt(EpicsSignalRO, ':IMON', kind='hinted', doc='')
+    pmon = Cpt(EpicsSignalRO, ':PMON', kind='hinted', doc='')
+    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG', kind='normal', doc='')
+    vmon = Cpt(EpicsSignalRO, ':VMON', kind='normal', doc='')
+    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW', kind='omitted', doc='')
+    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC', kind='omitted', doc='')
+    status = Cpt(EpicsSignalRO, ':STATUS', kind='normal', doc='')
+    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL', kind='omitted', doc='')
+    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE', kind='omitted', doc='')
+    pumpsizedes = Cpt(EpicsSignal, ':PUMPSIZEDES', kind='omitted', doc='')
+    pumpsize = Cpt(EpicsSignal, ':PUMPSIZE', kind='omitted', doc='')
+    calfactordes = Cpt(EpicsSignal, ':CALFACTORDES', kind='omitted', doc='')
+    calfactor = Cpt(EpicsSignal, ':CALFACTOR', kind='omitted', doc='')
+    aomodedes = Cpt(EpicsSignal, ':AOMODEDES', kind='omitted', doc='')
+    aomode = Cpt(EpicsSignal, ':AOMODE', kind='omitted', doc='')
+    statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
+    statemon = Cpt(EpicsSignalRO, ':STATEMON', kind='normal', doc='')
+    dispdes = Cpt(EpicsSignal, ':DISPDES', kind='omitted', doc='')
+    pname = Cpt(EpicsSignalRO, ':PNAME', kind='normal', doc='')
+    pnamedes = Cpt(EpicsSignal, ':PNAMEDES', kind='omitted', doc='')
+    vpcname = Cpt(EpicsSignal, ':VPCNAME', kind='omitted', doc='')
+
 
 # factory function for IonPumps
 def IonPump(prefix, *, name, **kwargs):
@@ -317,4 +358,4 @@ def IonPump(prefix, *, name, **kwargs):
     if 'prefix_controller' not in kwargs:
         return IonPumpBase(prefix, name=name, **kwargs)
 
-    return IonPumpWithController(prefix, name=name,  **kwargs)
+    return IonPumpWithController(prefix, name=name, **kwargs)

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -189,10 +189,8 @@ class PTMPLC(Device):
     fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal', doc='')
     warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
     alarm = Cpt(EpicsSignalWithRBV, ':ALARM', kind='normal', doc='')
-    backing_pressure_sp = Cpt(EpicsSignalWithRBV, ':BackingPressureSP',
-                              kind='omitted', doc='')
-    inlet_pressure_sp = Cpt(EpicsSignalWithRBV, ':InletPressureSP',
-                            kind='omitted', doc='')
+    bp_sp = Cpt(EpicsSignalWithRBV, ':BP_SP', kind='omitted', doc='')
+    ip_sp = Cpt(EpicsSignalWithRBV, ':IP_SP', kind='omitted', doc='')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock  is ok when true')
 
@@ -243,16 +241,16 @@ class AgilentSerial(Device):
                            doc='')
     vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW', kind='omitted',
                          doc='')
-    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT', kind='omitted',
+    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT_RBV', kind='omitted',
                        doc='')
-    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE', kind='normal',
+    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE_RBV', kind='normal',
                        doc='')
-    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER', kind='normal', doc='')
-    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ', kind='normal',
+    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER_RBV', kind='normal', doc='')
+    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ_RBV', kind='normal',
                           doc='')
-    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP', kind='normal', doc='')
-    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS', kind='normal', doc='')
-    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR', kind='normal', doc='')
+    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP_RBV', kind='normal', doc='')
+    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS_RBV', kind='normal', doc='')
+    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR_RBV', kind='normal', doc='')
 
 
 class Navigator(AgilentSerial):
@@ -260,31 +258,31 @@ class Navigator(AgilentSerial):
     Class for Navigator Pump controlled via serial
 
     """
-    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED', kind='omitted', doc='')
-    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ', kind='omitted',
+    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED_RBV', kind='omitted', doc='')
+    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ_RBV', kind='omitted',
                          doc='')
-    sp_power = Cpt(EpicsSignalRO, ':SP_POWER', kind='omitted', doc='')
-    sp_time = Cpt(EpicsSignalRO, ':SP_TIME', kind='omitted', doc='')
-    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL', kind='omitted', doc='')
-    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE', kind='omitted', doc='')
-    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME', kind='omitted',
+    sp_power = Cpt(EpicsSignalRO, ':SP_POWER_RBV', kind='omitted', doc='')
+    sp_time = Cpt(EpicsSignalRO, ':SP_TIME_RBV', kind='omitted', doc='')
+    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL_RBV', kind='omitted', doc='')
+    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE_RBV', kind='omitted', doc='')
+    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RBV', kind='omitted',
                          doc='')
-    vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW',
+    vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW_RBV',
                              kind='omitted', doc='')
-    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT', kind='omitted', doc='')
-    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE', kind='omitted',
+    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT_RBV', kind='omitted', doc='')
+    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE_RBV', kind='omitted',
                         doc='')
-    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR', kind='omitted',
+    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR_RBV', kind='omitted',
                           doc='')
-    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT', kind='omitted',
+    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT_RBV', kind='omitted',
                         doc='')
-    sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT',
+    sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT_RBV',
                               kind='omitted', doc='')
-    stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING',
+    stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING_RBV',
                              kind='omitted', doc='')
-    ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP',
+    ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP_RBV',
                              kind='omitted', doc='')
-    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP', kind='omitted',
+    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP_RBV', kind='omitted',
                         doc='')
 
 
@@ -293,12 +291,12 @@ class GammaPCT(Device):
     Class for Gamma Pump Controller accessed via serial
 
     """
-    model = Cpt(EpicsSignalRO, ':MODEL', kind='normal', doc='')
-    fwversion = Cpt(EpicsSignalRO, ':FWVERSION', kind='normal', doc='')
+    model = Cpt(EpicsSignalRO, ':MODEL_RBV', kind='normal', doc='')
+    fwversion = Cpt(EpicsSignalRO, ':FWVERSION_RBV', kind='normal', doc='')
     ashvedes = Cpt(EpicsSignal, ':ASHVEDES', kind='omitted', doc='')
-    ashve = Cpt(EpicsSignalRO, ':ASHVE', kind='normal', doc='')
+    ashve = Cpt(EpicsSignalRO, ':ASHVE_RBV', kind='normal', doc='')
     aspowerdes = Cpt(EpicsSignal, ':ASPOWERDES', kind='omitted', doc='')
-    aspower = Cpt(EpicsSignalRO, ':ASPOWER', kind='normal', doc='')
+    aspower = Cpt(EpicsSignalRO, ':ASPOWER_RBV', kind='normal', doc='')
     pegudes = Cpt(EpicsSignal, ':PEGUDES', kind='omitted', doc='')
     masterreset = Cpt(EpicsSignal, ':MASTERRESET', kind='omitted', doc='')
 
@@ -316,15 +314,15 @@ class PIPSerial(Device):
     Class for Positive Ion Pump controlled via serial
 
     """
-    imon = Cpt(EpicsSignalRO, ':IMON', kind='hinted', doc='')
-    pmon = Cpt(EpicsSignalRO, ':PMON', kind='hinted', doc='')
-    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG', kind='normal', doc='')
-    vmon = Cpt(EpicsSignalRO, ':VMON', kind='normal', doc='')
-    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW', kind='omitted', doc='')
-    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC', kind='omitted', doc='')
-    status = Cpt(EpicsSignalRO, ':STATUS', kind='normal', doc='')
-    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL', kind='omitted', doc='')
-    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE', kind='omitted', doc='')
+    imon = Cpt(EpicsSignalRO, ':IMON_RBV', kind='hinted', doc='')
+    pmon = Cpt(EpicsSignalRO, ':PMON_RBV', kind='hinted', doc='')
+    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG_RBV', kind='normal', doc='')
+    vmon = Cpt(EpicsSignalRO, ':VMON_RBV', kind='normal', doc='')
+    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW_RBV', kind='omitted', doc='')
+    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC_RBV', kind='omitted', doc='')
+    status = Cpt(EpicsSignalRO, ':STATUS_RBV', kind='normal', doc='')
+    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL_RBV', kind='omitted', doc='')
+    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE_RBV', kind='omitted', doc='')
     pumpsizedes = Cpt(EpicsSignal, ':PUMPSIZEDES', kind='omitted', doc='')
     pumpsize = Cpt(EpicsSignal, ':PUMPSIZE', kind='omitted', doc='')
     calfactordes = Cpt(EpicsSignal, ':CALFACTORDES', kind='omitted', doc='')
@@ -332,9 +330,9 @@ class PIPSerial(Device):
     aomodedes = Cpt(EpicsSignal, ':AOMODEDES', kind='omitted', doc='')
     aomode = Cpt(EpicsSignal, ':AOMODE', kind='omitted', doc='')
     statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
-    statemon = Cpt(EpicsSignalRO, ':STATEMON', kind='normal', doc='')
+    statemon = Cpt(EpicsSignalRO, ':STATEMON_RBV', kind='normal', doc='')
     dispdes = Cpt(EpicsSignal, ':DISPDES', kind='omitted', doc='')
-    pname = Cpt(EpicsSignalRO, ':PNAME', kind='normal', doc='')
+    pname = Cpt(EpicsSignalRO, ':PNAME_RBV', kind='normal', doc='')
     pnamedes = Cpt(EpicsSignal, ':PNAMEDES', kind='omitted', doc='')
     vpcname = Cpt(EpicsSignal, ':VPCNAME', kind='omitted', doc='')
 

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -176,21 +176,18 @@ class PTMPLC(Device):
     Class for PLC-controlled Turbo Pump
 
     """
-    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted',
-                         doc='')
-    reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='normal', doc='')
-    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal', doc='')
-    run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV', kind='omitted', doc='')
-    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='omitted',
-                        doc='')
-    pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV', kind='normal',
-                            doc='')
-    pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV', kind='normal', doc='')
-    fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal', doc='')
-    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
-    alarm = Cpt(EpicsSignalWithRBV, ':ALARM', kind='normal', doc='')
-    bp_sp = Cpt(EpicsSignalWithRBV, ':BP_SP', kind='omitted', doc='')
-    ip_sp = Cpt(EpicsSignalWithRBV, ':IP_SP', kind='omitted', doc='')
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted')
+    reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='normal')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal')
+    run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV', kind='omitted')
+    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='omitted')
+    pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV', kind='normal')
+    pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV', kind='normal')
+    fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal')
+    alarm = Cpt(EpicsSignalWithRBV, ':ALARM', kind='normal')
+    bp_sp = Cpt(EpicsSignalWithRBV, ':BP_SP', kind='omitted')
+    ip_sp = Cpt(EpicsSignalWithRBV, ':IP_SP', kind='omitted')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock  is ok when true')
 
@@ -200,14 +197,13 @@ class PROPLC(Device):
     Class for PLC-controlled Roughing Pump
 
     """
-    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted',
-                         doc='')
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock is ok when true')
-    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal', doc='')
-    error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal', doc='')
-    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
-    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='normal', doc='')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal')
+    error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal')
+    pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='normal')
 
 
 class AgilentSerial(Device):
@@ -215,42 +211,36 @@ class AgilentSerial(Device):
     Class for Agilent Turbo Pump controlled via serial
 
     """
-    run = Cpt(EpicsSignal, ':RUN', kind='omitted', doc='')
-    config = Cpt(EpicsSignal, ':CONFIG', kind='omitted', doc='')
-    softstart = Cpt(EpicsSignal, ':SOFTSTART', kind='omitted', doc='')
-    sp_type = Cpt(EpicsSignal, ':SP_TYPE', kind='omitted', doc='')
-    sp_calcdis = Cpt(EpicsSignal, ':SP_CALCDIS', kind='omitted', doc='')
-    sp_dis = Cpt(EpicsSignal, ':SP_DIS', kind='omitted', doc='')
-    sp_writeval = Cpt(EpicsSignal, ':SP_WRITEVAL', kind='omitted', doc='')
-    sp_freq = Cpt(EpicsSignal, ':SP_FREQ', kind='omitted', doc='')
-    sp_current = Cpt(EpicsSignal, ':SP_CURRENT', kind='omitted', doc='')
-    sp_time = Cpt(EpicsSignal, ':SP_TIME', kind='omitted', doc='')
-    sp_delay = Cpt(EpicsSignal, ':SP_DELAY', kind='omitted', doc='')
-    sp_polarity = Cpt(EpicsSignal, ':SP_POLARITY', kind='omitted', doc='')
-    sp_hys = Cpt(EpicsSignal, ':SP_HYS', kind='omitted', doc='')
-    water_cooling = Cpt(EpicsSignal, ':WATER_COOLING', kind='normal', doc='')
-    active_stop = Cpt(EpicsSignal, ':ACTIVE_STOP', kind='normal', doc='')
-    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE', kind='omitted',
-                         doc='')
-    ao_type = Cpt(EpicsSignal, ':AO_TYPE', kind='omitted', doc='')
-    rot_freq = Cpt(EpicsSignal, ':ROT_FREQ', kind='normal', doc='')
-    vent_valve = Cpt(EpicsSignal, ':VENT_VALVE', kind='omitted', doc='')
+    run = Cpt(EpicsSignal, ':RUN', kind='omitted')
+    config = Cpt(EpicsSignal, ':CONFIG', kind='omitted')
+    softstart = Cpt(EpicsSignal, ':SOFTSTART', kind='omitted')
+    sp_type = Cpt(EpicsSignal, ':SP_TYPE', kind='omitted')
+    sp_calcdis = Cpt(EpicsSignal, ':SP_CALCDIS', kind='omitted')
+    sp_dis = Cpt(EpicsSignal, ':SP_DIS', kind='omitted')
+    sp_writeval = Cpt(EpicsSignal, ':SP_WRITEVAL', kind='omitted')
+    sp_freq = Cpt(EpicsSignal, ':SP_FREQ', kind='omitted')
+    sp_current = Cpt(EpicsSignal, ':SP_CURRENT', kind='omitted')
+    sp_time = Cpt(EpicsSignal, ':SP_TIME', kind='omitted')
+    sp_delay = Cpt(EpicsSignal, ':SP_DELAY', kind='omitted')
+    sp_polarity = Cpt(EpicsSignal, ':SP_POLARITY', kind='omitted')
+    sp_hys = Cpt(EpicsSignal, ':SP_HYS', kind='omitted')
+    water_cooling = Cpt(EpicsSignal, ':WATER_COOLING', kind='normal')
+    active_stop = Cpt(EpicsSignal, ':ACTIVE_STOP', kind='normal')
+    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE', kind='omitted')
+    ao_type = Cpt(EpicsSignal, ':AO_TYPE', kind='omitted')
+    rot_freq = Cpt(EpicsSignal, ':ROT_FREQ', kind='normal')
+    vent_valve = Cpt(EpicsSignal, ':VENT_VALVE', kind='omitted')
     vent_valve_operation = Cpt(EpicsSignal, ':VENT_VALVE_OPERATION',
-                               kind='omitted', doc='')
-    vent_valve_delay = Cpt(EpicsSignal, ':VENT_VALVE_DELAY', kind='omitted',
-                           doc='')
-    vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW', kind='omitted',
-                         doc='')
-    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT_RBV', kind='omitted',
-                       doc='')
-    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE_RBV', kind='normal',
-                       doc='')
-    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER_RBV', kind='normal', doc='')
-    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ_RBV', kind='normal',
-                          doc='')
-    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP_RBV', kind='normal', doc='')
-    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS_RBV', kind='normal', doc='')
-    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR_RBV', kind='normal', doc='')
+                               kind='omitted')
+    vent_valve_delay = Cpt(EpicsSignal, ':VENT_VALVE_DELAY', kind='omitted')
+    vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW', kind='omitted')
+    pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT_RBV', kind='omitted')
+    pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE_RBV', kind='normal')
+    pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER_RBV', kind='normal')
+    pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ_RBV', kind='normal')
+    pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP_RBV', kind='normal')
+    pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS_RBV', kind='normal')
+    pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR_RBV', kind='normal')
 
 
 class Navigator(AgilentSerial):
@@ -258,32 +248,27 @@ class Navigator(AgilentSerial):
     Class for Navigator Pump controlled via serial
 
     """
-    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED_RBV', kind='omitted', doc='')
-    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ_RBV', kind='omitted',
-                         doc='')
-    sp_power = Cpt(EpicsSignalRO, ':SP_POWER_RBV', kind='omitted', doc='')
-    sp_time = Cpt(EpicsSignalRO, ':SP_TIME_RBV', kind='omitted', doc='')
-    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL_RBV', kind='omitted', doc='')
-    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE_RBV', kind='omitted', doc='')
-    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RBV', kind='omitted',
-                         doc='')
+    low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED_RBV', kind='omitted')
+    low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ_RBV', kind='omitted')
+    sp_power = Cpt(EpicsSignalRO, ':SP_POWER_RBV', kind='omitted')
+    sp_time = Cpt(EpicsSignalRO, ':SP_TIME_RBV', kind='omitted')
+    sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL_RBV', kind='omitted')
+    sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE_RBV', kind='omitted')
+    vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RBV', kind='omitted')
     vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW_RBV',
-                             kind='omitted', doc='')
-    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT_RBV', kind='omitted', doc='')
-    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE_RBV', kind='omitted',
-                        doc='')
-    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR_RBV', kind='omitted',
-                          doc='')
-    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT_RBV', kind='omitted',
-                        doc='')
+                             kind='omitted')
+    power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT_RBV', kind='omitted')
+    gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE_RBV', kind='omitted')
+    press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR_RBV',
+                          kind='omitted')
+    sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT_RBV', kind='omitted')
     sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT_RBV',
-                              kind='omitted', doc='')
+                              kind='omitted')
     stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING_RBV',
-                             kind='omitted', doc='')
+                             kind='omitted')
     ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP_RBV',
-                             kind='omitted', doc='')
-    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP_RBV', kind='omitted',
-                        doc='')
+                             kind='omitted')
+    ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP_RBV', kind='omitted')
 
 
 class GammaPCT(Device):
@@ -291,14 +276,14 @@ class GammaPCT(Device):
     Class for Gamma Pump Controller accessed via serial
 
     """
-    model = Cpt(EpicsSignalRO, ':MODEL_RBV', kind='normal', doc='')
-    fwversion = Cpt(EpicsSignalRO, ':FWVERSION_RBV', kind='normal', doc='')
-    ashvedes = Cpt(EpicsSignal, ':ASHVEDES', kind='omitted', doc='')
-    ashve = Cpt(EpicsSignalRO, ':ASHVE_RBV', kind='normal', doc='')
-    aspowerdes = Cpt(EpicsSignal, ':ASPOWERDES', kind='omitted', doc='')
-    aspower = Cpt(EpicsSignalRO, ':ASPOWER_RBV', kind='normal', doc='')
-    pegudes = Cpt(EpicsSignal, ':PEGUDES', kind='omitted', doc='')
-    masterreset = Cpt(EpicsSignal, ':MASTERRESET', kind='omitted', doc='')
+    model = Cpt(EpicsSignalRO, ':MODEL_RBV', kind='normal')
+    fwversion = Cpt(EpicsSignalRO, ':FWVERSION_RBV', kind='normal')
+    ashvedes = Cpt(EpicsSignal, ':ASHVEDES', kind='omitted')
+    ashve = Cpt(EpicsSignalRO, ':ASHVE_RBV', kind='normal')
+    aspowerdes = Cpt(EpicsSignal, ':ASPOWERDES', kind='omitted')
+    aspower = Cpt(EpicsSignalRO, ':ASPOWER_RBV', kind='normal')
+    pegudes = Cpt(EpicsSignal, ':PEGUDES', kind='omitted')
+    masterreset = Cpt(EpicsSignal, ':MASTERRESET', kind='omitted')
 
 
 class QPCPCT(GammaPCT):
@@ -306,7 +291,7 @@ class QPCPCT(GammaPCT):
     Class for Quad Pump Controller accessed via serial
 
     """
-    do_reset = Cpt(EpicsSignal, ':DO_RESET', kind='omitted', doc='')
+    do_reset = Cpt(EpicsSignal, ':DO_RESET', kind='omitted')
 
 
 class PIPSerial(Device):
@@ -314,27 +299,27 @@ class PIPSerial(Device):
     Class for Positive Ion Pump controlled via serial
 
     """
-    imon = Cpt(EpicsSignalRO, ':IMON_RBV', kind='hinted', doc='')
-    pmon = Cpt(EpicsSignalRO, ':PMON_RBV', kind='hinted', doc='')
-    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG_RBV', kind='normal', doc='')
-    vmon = Cpt(EpicsSignalRO, ':VMON_RBV', kind='normal', doc='')
-    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW_RBV', kind='omitted', doc='')
-    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC_RBV', kind='omitted', doc='')
-    status = Cpt(EpicsSignalRO, ':STATUS_RBV', kind='normal', doc='')
-    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL_RBV', kind='omitted', doc='')
-    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE_RBV', kind='omitted', doc='')
-    pumpsizedes = Cpt(EpicsSignal, ':PUMPSIZEDES', kind='omitted', doc='')
-    pumpsize = Cpt(EpicsSignal, ':PUMPSIZE', kind='omitted', doc='')
-    calfactordes = Cpt(EpicsSignal, ':CALFACTORDES', kind='omitted', doc='')
-    calfactor = Cpt(EpicsSignal, ':CALFACTOR', kind='omitted', doc='')
-    aomodedes = Cpt(EpicsSignal, ':AOMODEDES', kind='omitted', doc='')
-    aomode = Cpt(EpicsSignal, ':AOMODE', kind='omitted', doc='')
-    statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted', doc='')
-    statemon = Cpt(EpicsSignalRO, ':STATEMON_RBV', kind='normal', doc='')
-    dispdes = Cpt(EpicsSignal, ':DISPDES', kind='omitted', doc='')
-    pname = Cpt(EpicsSignalRO, ':PNAME_RBV', kind='normal', doc='')
-    pnamedes = Cpt(EpicsSignal, ':PNAMEDES', kind='omitted', doc='')
-    vpcname = Cpt(EpicsSignal, ':VPCNAME', kind='omitted', doc='')
+    imon = Cpt(EpicsSignalRO, ':IMON_RBV', kind='hinted')
+    pmon = Cpt(EpicsSignalRO, ':PMON_RBV', kind='hinted')
+    pmonlog = Cpt(EpicsSignalRO, ':PMONLOG_RBV', kind='normal')
+    vmon = Cpt(EpicsSignalRO, ':VMON_RBV', kind='normal')
+    statusraw = Cpt(EpicsSignalRO, ':STATUSRAW_RBV', kind='omitted')
+    statuscalc = Cpt(EpicsSignalRO, ':STATUSCALC_RBV', kind='omitted')
+    status = Cpt(EpicsSignalRO, ':STATUS_RBV', kind='normal')
+    statuscodecl = Cpt(EpicsSignalRO, ':STATUSCODECL_RBV', kind='omitted')
+    statuscode = Cpt(EpicsSignalRO, ':STATUSCODE_RBV', kind='omitted')
+    pumpsizedes = Cpt(EpicsSignal, ':PUMPSIZEDES', kind='omitted')
+    pumpsize = Cpt(EpicsSignal, ':PUMPSIZE', kind='omitted')
+    calfactordes = Cpt(EpicsSignal, ':CALFACTORDES', kind='omitted')
+    calfactor = Cpt(EpicsSignal, ':CALFACTOR', kind='omitted')
+    aomodedes = Cpt(EpicsSignal, ':AOMODEDES', kind='omitted')
+    aomode = Cpt(EpicsSignal, ':AOMODE', kind='omitted')
+    statedes = Cpt(EpicsSignal, ':STATEDES', kind='omitted')
+    statemon = Cpt(EpicsSignalRO, ':STATEMON_RBV', kind='normal')
+    dispdes = Cpt(EpicsSignal, ':DISPDES', kind='omitted')
+    pname = Cpt(EpicsSignalRO, ':PNAME_RBV', kind='normal')
+    pnamedes = Cpt(EpicsSignal, ':PNAMEDES', kind='omitted')
+    vpcname = Cpt(EpicsSignal, ':VPCNAME', kind='omitted')
 
 
 # factory function for IonPumps

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -179,16 +179,15 @@ class PTMPLC(Device):
     switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted')
     reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='normal')
     run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal')
-    run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV', kind='omitted')
     pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='omitted')
     pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV', kind='normal')
     pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV', kind='normal')
     fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal')
     warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal')
-    alarm = Cpt(EpicsSignalWithRBV, ':ALARM', kind='normal')
+    alarm = Cpt(EpicsSignalRO, ':ALARM_RBV', kind='normal')
     bp_sp = Cpt(EpicsSignalWithRBV, ':BP_SP', kind='omitted')
     ip_sp = Cpt(EpicsSignalWithRBV, ':IP_SP', kind='omitted')
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+    interlock_status = Cpt(EpicsSignalRO, ':ILK_STATUS_RBV', kind='normal',
                        doc='interlock  is ok when true')
 
 

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -158,17 +158,17 @@ class PIPPLC(Device):
     Still need to work out replacement of old classes.
     """
     pressure = Cpt(EpicsSignalRO, ':PRESS_RBV', kind='hinted',
-        doc='pressure reading')
+                   doc='pressure reading')
     high_voltage_do = Cpt(EpicsSignalRO, ':HV_DO_RBV', kind='normal',
-        doc='high voltage digital output')
+                          doc='high voltage digital output')
     high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='omitted',
-        doc='epics command to witch on the high voltage')
+                              doc='epics command to witch on the high voltage')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
-        doc='interlock  is ok when true')
+                       doc='interlock  is ok when true')
     at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
-        doc='at vacuum set point')
+                    doc='at vacuum set point')
     set_point_relay = Cpt(EpicsSignalRO, ':SP_DI_RBV', kind='normal',
-        doc='set point digital input relay')
+                          doc='set point digital input relay')
 
 
 class PTMPLC(Device):
@@ -177,24 +177,24 @@ class PTMPLC(Device):
 
     """
     switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted',
-        doc='')
+                         doc='')
     reset_fault = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='normal', doc='')
     run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal', doc='')
     run_ok = Cpt(EpicsSignalRO, ':RUN_OK_RBV', kind='omitted', doc='')
     pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='omitted',
-        doc='')
+                        doc='')
     pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV', kind='normal',
-        doc='')
+                            doc='')
     pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV', kind='normal', doc='')
     fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal', doc='')
     warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
     alarm = Cpt(EpicsSignalWithRBV, ':ALARM', kind='normal', doc='')
     backing_pressure_sp = Cpt(EpicsSignalWithRBV, ':BackingPressureSP',
-        kind='omitted', doc='')
+                              kind='omitted', doc='')
     inlet_pressure_sp = Cpt(EpicsSignalWithRBV, ':InletPressureSP',
-        kind='omitted', doc='')
+                            kind='omitted', doc='')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
-        doc='interlock  is ok when true')
+                       doc='interlock  is ok when true')
 
 
 class PROPLC(Device):
@@ -203,9 +203,9 @@ class PROPLC(Device):
 
     """
     switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted',
-        doc='')
+                         doc='')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
-        doc='interlock is ok when true')
+                       doc='interlock is ok when true')
     run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal', doc='')
     error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal', doc='')
     warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal', doc='')
@@ -232,23 +232,24 @@ class AgilentSerial(Device):
     sp_hys = Cpt(EpicsSignal, ':SP_HYS', kind='omitted', doc='')
     water_cooling = Cpt(EpicsSignal, ':WATER_COOLING', kind='normal', doc='')
     active_stop = Cpt(EpicsSignal, ':ACTIVE_STOP', kind='normal', doc='')
-    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE', kind='omitted', doc='')
+    interlock_type = Cpt(EpicsSignal, ':INTERLOCK_TYPE', kind='omitted',
+                         doc='')
     ao_type = Cpt(EpicsSignal, ':AO_TYPE', kind='omitted', doc='')
     rot_freq = Cpt(EpicsSignal, ':ROT_FREQ', kind='normal', doc='')
     vent_valve = Cpt(EpicsSignal, ':VENT_VALVE', kind='omitted', doc='')
     vent_valve_operation = Cpt(EpicsSignal, ':VENT_VALVE_OPERATION',
-        kind='omitted', doc='')
+                               kind='omitted', doc='')
     vent_valve_delay = Cpt(EpicsSignal, ':VENT_VALVE_DELAY', kind='omitted',
-        doc='')
+                           doc='')
     vent_valve_raw = Cpt(EpicsSignal, ':VENT_VALVE_RAW', kind='omitted',
-        doc='')
+                         doc='')
     pump_current = Cpt(EpicsSignalRO, ':PUMP_CURRENT', kind='omitted',
-        doc='')
+                       doc='')
     pump_voltage = Cpt(EpicsSignalRO, ':PUMP_VOLTAGE', kind='normal',
-        doc='')
+                       doc='')
     pump_power = Cpt(EpicsSignalRO, ':PUMP_POWER', kind='normal', doc='')
     pump_drive_freq = Cpt(EpicsSignalRO, ':PUMP_DRIVE_FREQ', kind='normal',
-        doc='')
+                          doc='')
     pump_temp = Cpt(EpicsSignalRO, ':PUMP_TEMP', kind='normal', doc='')
     pump_status = Cpt(EpicsSignalRO, ':PUMP_STATUS', kind='normal', doc='')
     pump_error = Cpt(EpicsSignalRO, ':PUMP_ERROR', kind='normal', doc='')
@@ -261,30 +262,30 @@ class Navigator(AgilentSerial):
     """
     low_speed = Cpt(EpicsSignalRO, ':LOW_SPEED', kind='omitted', doc='')
     low_speed_freq = Cpt(EpicsSignalRO, ':LOW_SPEED_FREQ', kind='omitted',
-        doc='')
+                         doc='')
     sp_power = Cpt(EpicsSignalRO, ':SP_POWER', kind='omitted', doc='')
     sp_time = Cpt(EpicsSignalRO, ':SP_TIME', kind='omitted', doc='')
     sp_normal = Cpt(EpicsSignalRO, ':SP_NORMAL', kind='omitted', doc='')
     sp_pressure = Cpt(EpicsSignalRO, ':SP_PRESSURE', kind='omitted', doc='')
     vent_open_time = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME', kind='omitted',
-        doc='')
+                         doc='')
     vent_open_time_raw = Cpt(EpicsSignalRO, ':VENT_OPEN_TIME_RAW',
-        kind='omitted', doc='')
+                             kind='omitted', doc='')
     power_limit = Cpt(EpicsSignalRO, ':POWER_LIMIT', kind='omitted', doc='')
     gas_load_type = Cpt(EpicsSignalRO, ':GAS_LOAD_TYPE', kind='omitted',
-        doc='')
+                        doc='')
     press_read_corr = Cpt(EpicsSignalRO, ':PRESS_READ_CORR', kind='omitted',
-        doc='')
+                          doc='')
     sp_press_unit = Cpt(EpicsSignalRO, ':SP_PRESS_UNIT', kind='omitted',
-        doc='')
+                        doc='')
     sp_write_press_unit = Cpt(EpicsSignalRO, ':SP_WRITE_PRESS_UNIT',
-        kind='omitted', doc='')
+                              kind='omitted', doc='')
     stop_speed_reading = Cpt(EpicsSignalRO, ':STOP_SPEED_READING',
-        kind='omitted', doc='')
+                             kind='omitted', doc='')
     ctrl_heatsink_temp = Cpt(EpicsSignalRO, ':CTRL_HEATSINK_TEMP',
-        kind='omitted', doc='')
+                             kind='omitted', doc='')
     ctrl_air_temp = Cpt(EpicsSignalRO, ':CTRL_AIR_TEMP', kind='omitted',
-        doc='')
+                        doc='')
 
 
 class GammaPCT(Device):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -270,7 +270,5 @@ class VCN(Device):
                        doc='interlock ok status')
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
                        doc='Epics command to Open valve')
-    position_output = Cpt(EpicsSignalRO, ':POS_DES_RBV', kind='omitted',
-                          doc='requested position set to output channel')
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted', doc='Valve state')
     pos_ao = Cpt(EpicsSignalRO, ':POS_AO_RBV', kind='hinted')

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -185,8 +185,8 @@ class VVC(Valve_base):
     Vent Valve Controlled
 
     """
-    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON' , kind='ommitted', doc='Epics Command to set/reset Override mode')
-    open_override = Cpt(EpicsSignalWithRBV, ':FORCE_OPN' , kind='ommitted', doc='Epics Command for open the valve in override mode')
+    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON' , kind='omitted', doc='Epics Command to set/reset Override mode')
+    open_override = Cpt(EpicsSignalWithRBV, ':FORCE_OPN' , kind='omitted', doc='Epics Command for open the valve in override mode')
 
 class VGC_legacy(Valve_base):
     """
@@ -224,8 +224,8 @@ class VVC_NO(Device):
 
     """
     close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW' , kind='normal', doc='Epics command to close valve')
-    close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS' , kind='ommitted', doc='Epics Command for open the valve in override mode')
-    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON' , kind='ommitted', doc='Epics Command to set/reset Override mode')
+    close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS' , kind='omitted', doc='Epics Command for open the valve in override mode')
+    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON' , kind='omitted', doc='Epics Command to set/reset Override mode')
     close_ok = Cpt(EpicsSignalRO, ':CLS_OK' , kind='normal', doc='used for normally open valves')
     close_do = Cpt(EpicsSignalRO, ':CLS_DO' , kind='normal', doc='PLC Output to close valve')
 
@@ -238,6 +238,6 @@ class VCN(Device):
     position_control = Cpt(EpicsSignalWithRBV, ':POS_REQ' , kind='normal', doc='requested positition to control the valve 0-100%')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK' , kind='normal', doc='interlock ok status')
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW' , kind='normal', doc='Epics command to Open valve')
-    position_output = Cpt(EpicsSignalRO, ':POS_DES' , kind='ommitted', doc='requested position set to output channel')
+    position_output = Cpt(EpicsSignalRO, ':POS_DES' , kind='omitted', doc='requested position set to output channel')
     state = Cpt(EpicsSignalRO, ':STATE' , kind='hinted', doc='Valve state')
     pos_ao = Cpt(EpicsSignalRO, ':POS_AO' , kind='hinted', doc='')

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -176,11 +176,11 @@ class ValveBase(Device):
     Still need to work out replacement of old classes.
     """
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
-        doc='Epics command to Open valve')
+                       doc='Epics command to Open valve')
     interlock_ok = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal',
-        doc='Valve is OK to Open interlock ')
+                       doc='Valve is OK to Open interlock ')
     open_do = Cpt(EpicsSignalRO, ':OPN_DO', kind='normal',
-        doc='PLC Output to Open valve, 1 means 24V on command cable')
+                  doc='PLC Output to Open valve, 1 means 24V on command cable')
 
 
 class VVC(ValveBase):
@@ -189,9 +189,10 @@ class VVC(ValveBase):
 
     """
     override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
-        doc='Epics Command to set/reset Override mode')
+                      doc='Epics Command to set/reset Override mode')
     open_override = Cpt(EpicsSignalWithRBV, ':FORCE_OPN', kind='omitted',
-        doc='Epics Command for open the valve in override mode')
+                        doc=('Epics Command for open the valve in override '
+                             'mode'))
 
 
 class VGCLegacy(ValveBase):
@@ -201,9 +202,9 @@ class VGCLegacy(ValveBase):
     Replaces the GateValve class
     """
     open_limit = Cpt(EpicsSignalRO, ':OPN_DI', kind='hinted',
-        doc='Open limit switch digital input')
+                     doc='Open limit switch digital input')
     closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='hinted',
-        doc='Closed limit switch digital input')
+                       doc='Closed limit switch digital input')
 
 
 class VRC(VVC):
@@ -213,9 +214,9 @@ class VRC(VVC):
     """
     state = Cpt(EpicsSignalRO, ':STATE', kind='normal', doc='Valve state')
     open_limit = Cpt(EpicsSignalRO, ':OPN_DI', kind='hinted',
-        doc='Open limit switch digital input')
+                     doc='Open limit switch digital input')
     closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='hinted',
-        doc='Closed limit switch digital input')
+                       doc='Closed limit switch digital input')
 
 
 class VGC(VRC):
@@ -224,15 +225,15 @@ class VGC(VRC):
 
     """
     diff_press_ok = Cpt(EpicsSignalRO, ':DP_OK_RBV', kind='normal',
-        doc='Differential pressure interlock ok')
+                        doc='Differential pressure interlock ok')
     ext_ilk_ok = Cpt(EpicsSignalRO, ':Ext_ILK_OK', kind='normal',
-        doc='External interlock ok')
+                     doc='External interlock ok')
     at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
-        doc='AT VAC Set point value')
+                    doc='AT VAC Set point value')
     at_vac_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS', kind='config',
-        doc='AT VAC Hysterisis')
+                            doc='AT VAC Hysterisis')
     at_vac = Cpt(EpicsSignalRO, ':AT_VAC', kind='normal',
-        doc='at vacuum sp is reached')
+                 doc='at vacuum sp is reached')
     error = Cpt(EpicsSignalRO, ':Error', kind='normal', doc='Error Present')
 
 
@@ -242,15 +243,16 @@ class VVCNO(Device):
 
     """
     close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',
-        doc='Epics command to close valve')
+                        doc='Epics command to close valve')
     close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS', kind='omitted',
-        doc='Epics Command for open the valve in override mode')
+                         doc=('Epics Command for open the valve in override '
+                              'mode'))
     override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
-        doc='Epics Command to set/reset Override mode')
+                      doc='Epics Command to set/reset Override mode')
     close_ok = Cpt(EpicsSignalRO, ':CLS_OK', kind='normal',
-        doc='used for normally open valves')
+                   doc='used for normally open valves')
     close_do = Cpt(EpicsSignalRO, ':CLS_DO', kind='normal',
-        doc='PLC Output to close valve')
+                   doc='PLC Output to close valve')
 
 
 class VCN(Device):
@@ -259,14 +261,15 @@ class VCN(Device):
 
     """
     position_readback = Cpt(EpicsSignalRO, ':POS_RDBK', kind='hinted',
-        doc='valve position readback')
+                            doc='valve position readback')
     position_control = Cpt(EpicsSignalWithRBV, ':POS_REQ', kind='normal',
-        doc='requested positition to control the valve 0-100%')
+                           doc=('requested positition to control the valve '
+                                '0-100%'))
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK', kind='normal',
-        doc='interlock ok status')
+                       doc='interlock ok status')
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
-        doc='Epics command to Open valve')
+                       doc='Epics command to Open valve')
     position_output = Cpt(EpicsSignalRO, ':POS_DES', kind='omitted',
-        doc='requested position set to output channel')
+                          doc='requested position set to output channel')
     state = Cpt(EpicsSignalRO, ':STATE', kind='hinted', doc='Valve state')
     pos_ao = Cpt(EpicsSignalRO, ':POS_AO', kind='hinted', doc='')

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -234,7 +234,8 @@ class VGC(VRC):
                             doc='AT VAC Hysterisis')
     at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV', kind='normal',
                  doc='at vacuum sp is reached')
-    error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal', doc='Error Present')
+    error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal',
+                doc='Error Present')
 
 
 class VVCNO(Device):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -272,4 +272,4 @@ class VCN(Device):
     position_output = Cpt(EpicsSignalRO, ':POS_DES_RBV', kind='omitted',
                           doc='requested position set to output channel')
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted', doc='Valve state')
-    pos_ao = Cpt(EpicsSignalRO, ':POS_AO_RBV', kind='hinted', doc='')
+    pos_ao = Cpt(EpicsSignalRO, ':POS_AO_RBV', kind='hinted')

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -92,7 +92,7 @@ class GateValve(Stopper):
     check the state of the interlock before requesting motion. This is not a
     safety feature, just a notice to the operator.
 
-    This class has been replaced by VGC_legacy but has not been removed as some
+    This class has been replaced by VGCLegacy but has not been removed as some
     elements still need to be carried over.
     """
     # Limit based states
@@ -100,7 +100,7 @@ class GateValve(Stopper):
     closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='normal')
 
     # Commands and Interlock information
-    command = Cpt(EpicsSignal,   ':OPN_SW', kind='omitted')
+    command = Cpt(EpicsSignal, ':OPN_SW', kind='omitted')
     interlock = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal')
 
     # QIcon for UX
@@ -168,76 +168,105 @@ class PPSStopper(InOutPositioner):
         raise PermissionError("PPSStopper can not be commanded via EPICS")
 
 
-
-class Valve_base(Device):
+class ValveBase(Device):
     """
     Base class for valves
 
     Newer class. This and below are still missing some functionality.
     Still need to work out replacement of old classes.
     """
-    open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW' , kind='normal', doc='Epics command to Open valve')
-    interlock_ok = Cpt(EpicsSignalRO, ':OPN_OK' , kind='normal', doc='Valve is OK to Open interlock ')
-    open_do = Cpt(EpicsSignalRO, ':OPN_DO' , kind='normal', doc='PLC Output to Open valve, 1 means 24V on command cable')
+    open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
+        doc='Epics command to Open valve')
+    interlock_ok = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal',
+        doc='Valve is OK to Open interlock ')
+    open_do = Cpt(EpicsSignalRO, ':OPN_DO', kind='normal',
+        doc='PLC Output to Open valve, 1 means 24V on command cable')
 
-class VVC(Valve_base):
+
+class VVC(ValveBase):
     """
     Vent Valve Controlled
 
     """
-    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON' , kind='omitted', doc='Epics Command to set/reset Override mode')
-    open_override = Cpt(EpicsSignalWithRBV, ':FORCE_OPN' , kind='omitted', doc='Epics Command for open the valve in override mode')
+    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
+        doc='Epics Command to set/reset Override mode')
+    open_override = Cpt(EpicsSignalWithRBV, ':FORCE_OPN', kind='omitted',
+        doc='Epics Command for open the valve in override mode')
 
-class VGC_legacy(Valve_base):
+
+class VGCLegacy(ValveBase):
     """
     Class for Basic Vacuum Valve
 
     Replaces the GateValve class
     """
-    open_limit = Cpt(EpicsSignalRO, ':OPN_DI' , kind='hinted', doc='Open limit switch digital input')
-    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI' , kind='hinted', doc='Closed limit switch digital input')
+    open_limit = Cpt(EpicsSignalRO, ':OPN_DI', kind='hinted',
+        doc='Open limit switch digital input')
+    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='hinted',
+        doc='Closed limit switch digital input')
+
 
 class VRC(VVC):
     """
     Class for Gate Valves with Control and readback
 
     """
-    state = Cpt(EpicsSignalRO, ':STATE' , kind='normal', doc='Valve state')
-    open_limit = Cpt(EpicsSignalRO, ':OPN_DI' , kind='hinted', doc='Open limit switch digital input')
-    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI' , kind='hinted', doc='Closed limit switch digital input')
+    state = Cpt(EpicsSignalRO, ':STATE', kind='normal', doc='Valve state')
+    open_limit = Cpt(EpicsSignalRO, ':OPN_DI', kind='hinted',
+        doc='Open limit switch digital input')
+    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='hinted',
+        doc='Closed limit switch digital input')
+
 
 class VGC(VRC):
     """
     Class for Controlled Gate Valves
 
     """
-    diff_press_ok = Cpt(EpicsSignalRO, ':DP_OK_RBV' , kind='normal', doc='Differential pressure interlock ok')
-    ext_ilk_ok = Cpt(EpicsSignalRO, ':Ext_ILK_OK' , kind='normal', doc='External interlock ok')
-    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP' , kind='config', doc='AT VAC Set point value')
-    at_vac_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS' , kind='config', doc='AT VAC Hysterisis')
-    at_vac = Cpt(EpicsSignalRO, ':AT_VAC' , kind='normal', doc='at vacuum sp is reached')
-    error = Cpt(EpicsSignalRO, ':Error' , kind='normal', doc='Error Present')
+    diff_press_ok = Cpt(EpicsSignalRO, ':DP_OK_RBV', kind='normal',
+        doc='Differential pressure interlock ok')
+    ext_ilk_ok = Cpt(EpicsSignalRO, ':Ext_ILK_OK', kind='normal',
+        doc='External interlock ok')
+    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
+        doc='AT VAC Set point value')
+    at_vac_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS', kind='config',
+        doc='AT VAC Hysterisis')
+    at_vac = Cpt(EpicsSignalRO, ':AT_VAC', kind='normal',
+        doc='at vacuum sp is reached')
+    error = Cpt(EpicsSignalRO, ':Error', kind='normal', doc='Error Present')
 
-class VVC_NO(Device):
+
+class VVCNO(Device):
     """
     Vent Valve Controlled, Normally Open
 
     """
-    close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW' , kind='normal', doc='Epics command to close valve')
-    close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS' , kind='omitted', doc='Epics Command for open the valve in override mode')
-    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON' , kind='omitted', doc='Epics Command to set/reset Override mode')
-    close_ok = Cpt(EpicsSignalRO, ':CLS_OK' , kind='normal', doc='used for normally open valves')
-    close_do = Cpt(EpicsSignalRO, ':CLS_DO' , kind='normal', doc='PLC Output to close valve')
+    close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',
+        doc='Epics command to close valve')
+    close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS', kind='omitted',
+        doc='Epics Command for open the valve in override mode')
+    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
+        doc='Epics Command to set/reset Override mode')
+    close_ok = Cpt(EpicsSignalRO, ':CLS_OK', kind='normal',
+        doc='used for normally open valves')
+    close_do = Cpt(EpicsSignalRO, ':CLS_DO', kind='normal',
+        doc='PLC Output to close valve')
+
 
 class VCN(Device):
     """
     Class for Variable Controlled Needle Valves
 
     """
-    position_readback = Cpt(EpicsSignalRO, ':POS_RDBK' , kind='hinted', doc='valve position readback')
-    position_control = Cpt(EpicsSignalWithRBV, ':POS_REQ' , kind='normal', doc='requested positition to control the valve 0-100%')
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK' , kind='normal', doc='interlock ok status')
-    open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW' , kind='normal', doc='Epics command to Open valve')
-    position_output = Cpt(EpicsSignalRO, ':POS_DES' , kind='omitted', doc='requested position set to output channel')
-    state = Cpt(EpicsSignalRO, ':STATE' , kind='hinted', doc='Valve state')
-    pos_ao = Cpt(EpicsSignalRO, ':POS_AO' , kind='hinted', doc='')
+    position_readback = Cpt(EpicsSignalRO, ':POS_RDBK', kind='hinted',
+        doc='valve position readback')
+    position_control = Cpt(EpicsSignalWithRBV, ':POS_REQ', kind='normal',
+        doc='requested positition to control the valve 0-100%')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK', kind='normal',
+        doc='interlock ok status')
+    open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
+        doc='Epics command to Open valve')
+    position_output = Cpt(EpicsSignalRO, ':POS_DES', kind='omitted',
+        doc='requested position set to output channel')
+    state = Cpt(EpicsSignalRO, ':STATE', kind='hinted', doc='Valve state')
+    pos_ao = Cpt(EpicsSignalRO, ':POS_AO', kind='hinted', doc='')

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -177,9 +177,9 @@ class ValveBase(Device):
     """
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
                        doc='Epics command to Open valve')
-    interlock_ok = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal',
+    interlock_ok = Cpt(EpicsSignalRO, ':OPN_OK_RBV', kind='normal',
                        doc='Valve is OK to Open interlock ')
-    open_do = Cpt(EpicsSignalRO, ':OPN_DO', kind='normal',
+    open_do = Cpt(EpicsSignalRO, ':OPN_DO_RBV', kind='normal',
                   doc='PLC Output to Open valve, 1 means 24V on command cable')
 
 
@@ -201,9 +201,9 @@ class VGCLegacy(ValveBase):
 
     Replaces the GateValve class
     """
-    open_limit = Cpt(EpicsSignalRO, ':OPN_DI', kind='hinted',
+    open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
                      doc='Open limit switch digital input')
-    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='hinted',
+    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',
                        doc='Closed limit switch digital input')
 
 
@@ -212,10 +212,10 @@ class VRC(VVC):
     Class for Gate Valves with Control and readback
 
     """
-    state = Cpt(EpicsSignalRO, ':STATE', kind='normal', doc='Valve state')
-    open_limit = Cpt(EpicsSignalRO, ':OPN_DI', kind='hinted',
+    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal', doc='Valve state')
+    open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
                      doc='Open limit switch digital input')
-    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI', kind='hinted',
+    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',
                        doc='Closed limit switch digital input')
 
 
@@ -226,15 +226,15 @@ class VGC(VRC):
     """
     diff_press_ok = Cpt(EpicsSignalRO, ':DP_OK_RBV', kind='normal',
                         doc='Differential pressure interlock ok')
-    ext_ilk_ok = Cpt(EpicsSignalRO, ':Ext_ILK_OK', kind='normal',
+    ext_ilk_ok = Cpt(EpicsSignalRO, ':EXT_ILK_OK_RBV', kind='normal',
                      doc='External interlock ok')
     at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
                     doc='AT VAC Set point value')
     at_vac_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS', kind='config',
                             doc='AT VAC Hysterisis')
-    at_vac = Cpt(EpicsSignalRO, ':AT_VAC', kind='normal',
+    at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV', kind='normal',
                  doc='at vacuum sp is reached')
-    error = Cpt(EpicsSignalRO, ':Error', kind='normal', doc='Error Present')
+    error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal', doc='Error Present')
 
 
 class VVCNO(Device):
@@ -249,9 +249,9 @@ class VVCNO(Device):
                               'mode'))
     override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
                       doc='Epics Command to set/reset Override mode')
-    close_ok = Cpt(EpicsSignalRO, ':CLS_OK', kind='normal',
+    close_ok = Cpt(EpicsSignalRO, ':CLS_OK_RBV', kind='normal',
                    doc='used for normally open valves')
-    close_do = Cpt(EpicsSignalRO, ':CLS_DO', kind='normal',
+    close_do = Cpt(EpicsSignalRO, ':CLS_DO_RBV', kind='normal',
                    doc='PLC Output to close valve')
 
 
@@ -260,16 +260,16 @@ class VCN(Device):
     Class for Variable Controlled Needle Valves
 
     """
-    position_readback = Cpt(EpicsSignalRO, ':POS_RDBK', kind='hinted',
+    position_readback = Cpt(EpicsSignalRO, ':POS_RDBK_RBV', kind='hinted',
                             doc='valve position readback')
     position_control = Cpt(EpicsSignalWithRBV, ':POS_REQ', kind='normal',
                            doc=('requested positition to control the valve '
                                 '0-100%'))
-    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK', kind='normal',
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock ok status')
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
                        doc='Epics command to Open valve')
-    position_output = Cpt(EpicsSignalRO, ':POS_DES', kind='omitted',
+    position_output = Cpt(EpicsSignalRO, ':POS_DES_RBV', kind='omitted',
                           doc='requested position set to output channel')
-    state = Cpt(EpicsSignalRO, ':STATE', kind='hinted', doc='Valve state')
-    pos_ao = Cpt(EpicsSignalRO, ':POS_AO', kind='hinted', doc='')
+    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted', doc='Valve state')
+    pos_ao = Cpt(EpicsSignalRO, ':POS_AO_RBV', kind='hinted', doc='')


### PR DESCRIPTION
## Description
Added new ophyd devices for vacuum gauges, pumps, and valves.
New classes have been made for various devices. Some overlap with existing classes and will need to be merged. The new classes are also missing some features such as getter functions for interlock and tab_whitelist.

## Motivation and Context
Allows us to accommodate new devices on the beamline and use them in python & typhos.

## How Has This Been Tested?
I was able to create instances of all of the PLC classes and tested that they work on Maggie's tst IOC, including the ability to create a typhos screen with the device object. Will test the non-PLC devices later and create a new pull request from any necessary fixes.

## Where Has This Been Documented?
Each class has a simple docstring which needs to be expanded with more information.