### PR TITLE
CI: Cleanup and BLD: noarch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,12 @@ install:
   # Test conda build and create test environment
   - |
     if [[ $UNIT_TEST || $BUILD_DOCS ]]; then
+      echo "Building full environment"
       conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
       conda config --add channels "file://`pwd`/bld-dir"
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
     elif [[ $STYLE ]]; then
+      echo "Building minimal flake8 environment"
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8
     fi
   # Launch Conda environment
@@ -50,6 +52,7 @@ install:
   # Add the docs packages
   - |
     if [[ $BUILD_DOCS ]]; then
+      echo "Adding docs requirements"
       conda install --file docs-requirements.txt
     fi
 
@@ -57,18 +60,21 @@ script:
   # Run tests
   - |
     if [[ $UNIT_TEST ]]; then
+      echo "Running tests"
       coverage run run_tests.py
       coverage report -m
     fi
   # Check style
   - |
     if [[ $STYLE ]]; then
+      echo "Checking style"
       flake8 pcdsdevices/*.py
       flake8 tests/*.py
     fi
   # Build docs
   - |
     if [[ $BUILD_DOCS ]]; then
+      echo "Building docs"
       set -e
       conda install --file docs-requirements.txt
       pushd docs
@@ -78,18 +84,25 @@ script:
   # Upload docs
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_PCDSDEVICES" && $BUILD_DOCS ]]; then
+      echo "Deploying docs"
       doctr deploy . --built-docs docs/build/html --deploy-branch-name gh-pages
     fi
 
 after_success:
-  - codecov
+  - |
+    if [[ $UNIT_TEST ]]; then
+      echo "Uploading to codecov"
+      codecov
+    fi
   - |
     if [[ $UNIT_TEST && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
+      echo "Uploading to pcds_tag channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
       anaconda upload bld-dir/noarch/*.tar.bz2
     fi
   - |
     if [[ $UNIT_TEST && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+      echo "Uploading to pcds_dev channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
       anaconda upload bld-dir/noarch/*.tar.bz2
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       python: 3.6
       env:
         - UNIT_TEST=1
-        - ANACONDA_UPLOAD=1
+        - UPLOAD=1
     - name: "Python 3.7 Unit Tests"
       python: 3.7
       env: UNIT_TEST=1
@@ -97,18 +97,18 @@ script:
 
 after_success:
   - |
-    if [[ $UNIT_TEST ]]; then
+    if [[ $UPLOAD ]]; then
       echo "Uploading to codecov"
       codecov
     fi
   - |
-    if [[ $ANACONDA_UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
+    if [[ $UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
       echo "Uploading to pcds_tag channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
       anaconda upload bld-dir/noarch/*.tar.bz2
     fi
   - |
-    if [[ $ANACONDA_UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+    if [[ $UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
       echo "Uploading to pcds_dev channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
       anaconda upload bld-dir/noarch/*.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ matrix:
   include:
     - name: "Python 3.6 Unit Tests"
       python: 3.6
-      env: UNIT_TEST=1
+      env:
+        - UNIT_TEST=1
+        - ANACONDA_UPLOAD=1
     - name: "Python 3.7 Unit Tests"
       python: 3.7
       env: UNIT_TEST=1
@@ -45,8 +47,7 @@ install:
   - |
     if [[ $UNIT_TEST || $BUILD_DOCS ]]; then
       echo "Building full environment"
-      # Drop early if the dependencies are not satisfiable
-      timeout 5m conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
+      conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
       conda config --add channels "file://`pwd`/bld-dir"
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
     elif [[ $STYLE ]]; then
@@ -101,13 +102,13 @@ after_success:
       codecov
     fi
   - |
-    if [[ $UNIT_TEST && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
+    if [[ $ANACONDA_UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
       echo "Uploading to pcds_tag channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
       anaconda upload bld-dir/noarch/*.tar.bz2
     fi
   - |
-    if [[ $UNIT_TEST && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+    if [[ $ANACONDA_UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
       echo "Uploading to pcds_dev channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
       anaconda upload bld-dir/noarch/*.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - OFFICIAL_REPO="pcdshub/pcdsdevices"
     - secure: "r193Awf/D5CEelI4xRDPsgcJQbbrgrhZNLUtPaHeK1H17yZIRkCPjDUfU7JZuA72JRbFNVaDSIVCJiTfKMbD4QwclVaHsBunWyJ+S6L9BrKzL7Fo2RvUsJ675gpSnY071ibVmY7Q4iI5vt1Hn3WKracgH6VaMZzWC7GbPJd0E/hYygR1zXXzGtowOv1W4n9U1Tj2AuL6qdF6/l4qgVfaMe0Lr6JvdmFdqv8bWD4Cm3y78yi3cadHy5YAf2IkHqAEghgvrf3qJYFx4ZJcKMTjMqvyPSqWQ2J9xntoj4aHKWFvg/uLHU7GLttAOtoabjf/2mYnjnMpN8WI2h2Nsi4Q16ELKlKUY5zdz7/v4JvO9lKn2dP3LtOoI/j0gqMtZqXQ85tVndvvln40x7QwXo14T5sZU5y0IwI8OZXBVEk+cimbVQggtsm7MJoIWwopjdmbq0R5n39+Q6Xfgt5GJJf8EDvAI0uYK7PNIgDTEEqxMChj+R8/ArEyfcDPrgODVAuLpwvkFft3wKFAH8O3Ms2Dc5jeunqYmf2kEYkyr/pSuukVLKVe0HIi75CfMEguuCPHoCN+p/nESRrach2ItCHBqHIjggCYPzmAYueIF11ecbkok8k2sweC6DKDm9yP/wfq01fHpvhTTsBMMexXVqLpj1HYybonxGGw448EHTZKT2k="
 matrix: 
+  fast_finish: true
   include:
     - name: "Python 3.6 Unit Tests"
       python: 3.6
@@ -22,6 +23,10 @@ matrix:
     - name: "Style Check"
       python: 3.6
       env: STYLE=1
+  allow_failures:
+    - name: "Python 3.8 Unit Tests"
+      python: 3.8
+      env: UNIT_TEST=1
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -40,7 +45,8 @@ install:
   - |
     if [[ $UNIT_TEST || $BUILD_DOCS ]]; then
       echo "Building full environment"
-      conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
+      # Drop early if the dependencies are not satisfiable
+      timeout 5m conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
       conda config --add channels "file://`pwd`/bld-dir"
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
     elif [[ $STYLE ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,27 @@ env:
     - secure: "r193Awf/D5CEelI4xRDPsgcJQbbrgrhZNLUtPaHeK1H17yZIRkCPjDUfU7JZuA72JRbFNVaDSIVCJiTfKMbD4QwclVaHsBunWyJ+S6L9BrKzL7Fo2RvUsJ675gpSnY071ibVmY7Q4iI5vt1Hn3WKracgH6VaMZzWC7GbPJd0E/hYygR1zXXzGtowOv1W4n9U1Tj2AuL6qdF6/l4qgVfaMe0Lr6JvdmFdqv8bWD4Cm3y78yi3cadHy5YAf2IkHqAEghgvrf3qJYFx4ZJcKMTjMqvyPSqWQ2J9xntoj4aHKWFvg/uLHU7GLttAOtoabjf/2mYnjnMpN8WI2h2Nsi4Q16ELKlKUY5zdz7/v4JvO9lKn2dP3LtOoI/j0gqMtZqXQ85tVndvvln40x7QwXo14T5sZU5y0IwI8OZXBVEk+cimbVQggtsm7MJoIWwopjdmbq0R5n39+Q6Xfgt5GJJf8EDvAI0uYK7PNIgDTEEqxMChj+R8/ArEyfcDPrgODVAuLpwvkFft3wKFAH8O3Ms2Dc5jeunqYmf2kEYkyr/pSuukVLKVe0HIi75CfMEguuCPHoCN+p/nESRrach2ItCHBqHIjggCYPzmAYueIF11ecbkok8k2sweC6DKDm9yP/wfq01fHpvhTTsBMMexXVqLpj1HYybonxGGw448EHTZKT2k="
 matrix: 
   include:
-    - python: 3.6
+    - name: "Python 3.6 Unit Tests"
+      python: 3.6
+      env: UNIT_TEST=1
+    - name: "Python 3.7 Unit Tests"
+      python: 3.7
+      env: UNIT_TEST=1
+    - name: "Python 3.8 Unit Tests"
+      python: 3.8
+      env: UNIT_TEST=1
+    - name: "Build Docs"
+      python: 3.6
       env: BUILD_DOCS=1
-    - python: 3.7
-      dist: xenial
-      sudo: true
+    - name: "Style Check"
+      python: 3.6
+      env: STYLE=1
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - source $HOME/miniconda/etc/profile.d/conda.sh
+  - conda activate base
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install conda-build anaconda-client
@@ -25,25 +36,45 @@ install:
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  # Test conda build
-  - conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
-  - conda config --add channels "file://`pwd`/bld-dir"
-  #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
-  #Launch Conda environment
-  - source activate test-environment
+  # Test conda build and create test environment
+  - |
+    if [[ $UNIT_TEST || $BUILD_DOCS ]]; then
+      conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
+      conda config --add channels "file://`pwd`/bld-dir"
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
+    elif [[ $STYLE ]]; then
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8
+    fi
+  # Launch Conda environment
+  - conda activate test-environment
+  # Add the docs packages
+  - |
+    if [[ $BUILD_DOCS ]]; then
+      conda install --file docs-requirements.txt
+    fi
 
 script:
-  - coverage run run_tests.py
-  - coverage report -m
-  - flake8 pcdsdevices/*.py
-  - flake8 tests/*.py
-  - set -e
+  # Run tests
+  - |
+    if [[ $UNIT_TEST ]]; then
+      coverage run run_tests.py
+      coverage report -m
+    fi
+  # Check style
+  - |
+    if [[ $STYLE ]]; then
+      flake8 pcdsdevices/*.py
+      flake8 tests/*.py
+    fi
   # Build docs
-  - conda install --file docs-requirements.txt
-  - pushd docs
-  - make html
-  - popd
+  - |
+    if [[ $BUILD_DOCS ]]; then
+      set -e
+      conda install --file docs-requirements.txt
+      pushd docs
+      make html
+      popd
+    fi
   # Upload docs
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_PCDSDEVICES" && $BUILD_DOCS ]]; then
@@ -53,13 +84,13 @@ script:
 after_success:
   - codecov
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
+    if [[ $UNIT_TEST && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
-      anaconda upload bld-dir/linux-64/*.tar.bz2
+      anaconda upload bld-dir/noarch/*.tar.bz2
     fi
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+    if [[ $UNIT_TEST && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
-      anaconda upload bld-dir/linux-64/*.tar.bz2
+      anaconda upload bld-dir/noarch/*.tar.bz2
     fi
     

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 1
+  noarch: python
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,11 +13,11 @@ build:
 
 requirements:
   build:
-    - python {{PY_VER}}*,>=3
+    - python >=3.6
     - setuptools
 
   run:
-    - python {{PY_VER}}*,>=3
+    - python >=3.6
     - ophyd >=1.3.1
     - bluesky >=1.2.0
     - pyepics

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-timeout
 codecov
-flake8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I want to make one package noarch and py3.8 each day until we catch em all
I put the style checks and the docs build into their own jobs, and I also cleaned up the CI a bit, unfortunately working on a parallel path from @klauer and @n-wbrown on the ci-helpers stuff. Possibly going to contribute to that effort and then redirect this code to call stuff from there.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
noarch is more efficient and portable
doing docs build and style checks in their own jobs lets us easily see which is failing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is tests