### PR TITLE
CI: Fix cases where failed tests marked as passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ script:
     if [[ $UNIT_TEST ]]; then
       echo "Running tests"
       coverage run run_tests.py
+    fi
+  - |
+    if [[ $UNIT_TEST ]]; then
       coverage report -m
     fi
   # Check style

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,7 @@ script:
   - |
     if [[ $STYLE ]]; then
       echo "Checking style"
-      flake8 pcdsdevices/*.py
-      flake8 tests/*.py
+      flake8
     fi
   # Build docs
   - |

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,6 @@ versionfile_source = pcdsdevices/_version.py
 versionfile_build  = pcdsdevices/_version.py
 tag_prefix = v
 [flake8]
-exclude = pcdsdevices/areadetector/*,docs/*
+exclude = pcdsdevices/areadetector/*,docs/*,versioneer.py
 per-file-ignores =
     pcdsdevices/signal.py:E402


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make sure the tests are the last command run in the `if` blocks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Only the last command in the `if` block has a return code that is elevated to the main test script. This means in the previous setup we could fail the run_tests and succeed on coverage report and the whole thing would be marked as good.
