### PR TITLE
BLD: Incompatibility with python 3.7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
+  # Paranoid check of what version we're using
+  - echo $TRAVIS_PYTHON_VERSION
   # Test conda build and create test environment
   - |
     if [[ $UNIT_TEST || $BUILD_DOCS ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,11 @@ install:
   - |
     if [[ $UNIT_TEST || $BUILD_DOCS ]]; then
       echo "Building full environment"
+      set -e
       conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
       conda config --add channels "file://`pwd`/bld-dir"
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdevices --file dev-requirements.txt
+      set +e
     elif [[ $STYLE ]]; then
       echo "Building minimal flake8 environment"
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - setuptools
 
   run:
-    - python >=3.6
+    - python >=3.6,<3.7.6
     - ophyd >=1.3.1
     - bluesky >=1.2.0
     - pyepics


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Pin run version to before 3.7.6
Fix CI to fail on bad build

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
import epics
Traceback (most recent call last):
  File "/u1/zlentz/conda/envs/test/lib/python3.7/ctypes/__init__.py", line 97, in CFUNCTYPE
    return _c_functype_cache[(restype, argtypes, flags)]
KeyError: (None, (<class 'epics.dbr.access_rights_handler_args'>,), 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/afs/slac.stanford.edu/u/lu/zlentz/pyepics/epics/__init__.py", line 29, in <module>
    from . import ca
  File "/afs/slac.stanford.edu/u/lu/zlentz/pyepics/epics/ca.py", line 761, in <module>
    dbr.access_rights_handler_args)
  File "/afs/slac.stanford.edu/u/lu/zlentz/pyepics/epics/dbr.py", line 339, in make_callback
    return ctypes.CFUNCTYPE(None, args)(func)
  File "/u1/zlentz/conda/envs/test/lib/python3.7/ctypes/__init__.py", line 99, in CFUNCTYPE
    class CFunctionType(_CFuncPtr):
TypeError: item 1 in _argtypes_ passes a struct/union with a bitfield by value, which is unsupported.
```
