### PR TITLE
CI: Fix issue where package was not uploaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - conda activate base
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install conda-build anaconda-client
+  - conda install conda-build
   - conda update -q conda conda-build
   - conda config --add channels pcds-tag
   - conda config --append channels conda-forge
@@ -109,14 +109,19 @@ after_success:
     fi
   - |
     if [[ $UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
-      echo "Uploading to pcds_tag channel"
+      echo "Installing anaconda-client"
+      conda activate base
+      conda install anaconda-client
+      echo "Uploading to pcds-tag channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
       anaconda upload bld-dir/noarch/*.tar.bz2
     fi
   - |
     if [[ $UPLOAD && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
-      echo "Uploading to pcds_dev channel"
+      echo "Installing anaconda-client"
+      conda activate base
+      conda install anaconda-client
+      echo "Uploading to pcds-dev channel"
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
       anaconda upload bld-dir/noarch/*.tar.bz2
     fi
-    


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In the test environment, we didn't have anaconda-client installed. This meant that at the end of the tests we were unable to upload to anaconda. This commit makes sure we're in the correct conda env (base) and defers the install of anaconda-client until the very end since it's only needed if we are uploading.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
v2.1.0 is not on anaconda despite being tagged

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I don't think I can actually test this, beyond that it doesn't break the rest of the CI. If it doesn't work I'll try again. If it gets uploaded to `pcds-dev` then I'll feel confident that the re-tag will be uploaded too.
