### PR TITLE
BLD: Update to ophyd=1.4.0rc4 and FIX: initialization bugs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
 
   run:
     - python >=3.6
-    - ophyd >=1.3.1
+    - ophyd 1.4.0rc4|>=1.4.0
     - bluesky >=1.2.0
     - pyepics >=3.4.1
     - pyyaml

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -61,8 +61,10 @@ class AttBase(FltMvInterface, PVPositioner):
     `Attenuator` factory function.
     """
     # Positioner Signals
-    setpoint = Cpt(EpicsSignal, ':COM:R_DES', kind='normal')
-    readback = Cpt(EpicsSignalRO, ':COM:R_CUR', kind='hinted')
+    setpoint = Cpt(EpicsSignal, ':COM:R_DES', auto_monitor=True,
+                   kind='normal')
+    readback = Cpt(EpicsSignalRO, ':COM:R_CUR', auto_monitor=True,
+                   kind='hinted')
     actuate = Cpt(EpicsSignal, ':COM:GO', kind='omitted')
     done = Cpt(EpicsSignalRO, ':COM:STATUS', kind='omitted')
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -66,7 +66,8 @@ class AttBase(FltMvInterface, PVPositioner):
     readback = Cpt(EpicsSignalRO, ':COM:R_CUR', auto_monitor=True,
                    kind='hinted')
     actuate = Cpt(EpicsSignal, ':COM:GO', kind='omitted')
-    done = Cpt(EpicsSignalRO, ':COM:STATUS', kind='omitted')
+    done = Cpt(EpicsSignalRO, ':COM:STATUS', auto_monitor=True,
+               kind='omitted')
 
     # Attenuator Signals
     energy = Cpt(EpicsSignalRO, ':COM:T_CALC.VALE', kind='normal')

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -32,8 +32,9 @@ class CCMMotor(PVPositionerPC, FltMvInterface):
     TODO: switch to PVPositioner subclass and override code that prevents
     loading, and make the wait for done just compare the values.
     """
-    setpoint = Cpt(EpicsSignal, ":POSITIONSET")
-    readback = Cpt(EpicsSignalRO, ":POSITIONGET", kind='hinted')
+    setpoint = Cpt(EpicsSignal, ":POSITIONSET", auto_monitor=True)
+    readback = Cpt(EpicsSignalRO, ":POSITIONGET", auto_monitor=True,
+                   kind='hinted')
 
     limits = None
 

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -105,7 +105,7 @@ class GaugeSetBase(Device, BaseInterface):
 
     def __init__(self, prefix, *, name, index, **kwargs):
         if isinstance(index, int):
-            self.index = '%02d' % self.index
+            self.index = '%02d' % index
         else:
             self.index = index
         super().__init__(prefix, name=name, **kwargs)

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -385,7 +385,7 @@ class Presets:
         logger.debug('read presets for %s', self._device.name)
         with self._file_open_rlock(preset_type) as f:
             f.seek(0)
-            return yaml.load(f) or {}
+            return yaml.full_load(f) or {}
 
     def _write(self, preset_type, data):
         """

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -53,16 +53,17 @@ class BaseInterface:
                      Positioner_whitelist)
     _filtered_dir_cache = None
 
-    def __init_subclass__(self):
+    def __init_subclass__(cls, **kwargs):
+        super.__init_subclass__(**kwargs)
         string_whitelist = []
-        for cls in self.mro():
-            if hasattr(cls, "tab_whitelist"):
-                string_whitelist.extend(cls.tab_whitelist)
-            if getattr(cls, "tab_component_names", False):
-                for cpt_name in cls.component_names:
-                    if getattr(cls, cpt_name).kind != Kind.omitted:
+        for parent in cls.mro():
+            if hasattr(parent, "tab_whitelist"):
+                string_whitelist.extend(parent.tab_whitelist)
+            if getattr(parent, "tab_component_names", False):
+                for cpt_name in parent.component_names:
+                    if getattr(parent, cpt_name).kind != Kind.omitted:
                         string_whitelist.append(cpt_name)
-        self._tab_regex = re.compile("|".join(string_whitelist))
+        cls._tab_regex = re.compile("|".join(string_whitelist))
 
     def __dir__(self):
         if get_engineering_mode():

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -54,7 +54,7 @@ class BaseInterface:
     _filtered_dir_cache = None
 
     def __init_subclass__(cls, **kwargs):
-        super.__init_subclass__(**kwargs)
+        super().__init_subclass__(**kwargs)
         string_whitelist = []
         for parent in cls.mro():
             if hasattr(parent, "tab_whitelist"):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -27,7 +27,8 @@ class OMMotor(FltMvInterface, PVPositioner):
 
     # position
     readback = Cpt(EpicsSignalRO, ':RBV', auto_monitor=True, kind='hinted')
-    setpoint = Cpt(EpicsSignal, ':VAL', limits=True, kind='normal')
+    setpoint = Cpt(EpicsSignal, ':VAL', auto_monitor=True, limits=True,
+                   kind='normal')
     done = Cpt(EpicsSignalRO, ':DMOV', auto_monitor=True, kind='omitted')
     motor_egu = Cpt(EpicsSignal, ':RBV.EGU', kind='omitted')
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -59,7 +59,7 @@ class SlitPositioner(FltMvInterface, PVPositioner, Device):
                     auto_monitor=True, kind='hinted')
     setpoint = FCpt(EpicsSignal, "{self.prefix}:{self._dirshort}_REQ",
                     auto_monitor=True, kind='normal')
-    done = Cpt(EpicsSignalRO, ":DMOV", kind='omitted')
+    done = Cpt(EpicsSignalRO, ":DMOV", auto_monitor=True, kind='omitted')
 
     def __init__(self, prefix, *, slit_type="", name=None,
                  limits=None, **kwargs):

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -56,9 +56,9 @@ class SlitPositioner(FltMvInterface, PVPositioner, Device):
         ``SlitPositioner`` inherits directly from ``PVPositioner``.
     """
     readback = FCpt(EpicsSignalRO, "{self.prefix}:ACTUAL_{self._dirlong}",
-                    kind='hinted')
+                    auto_monitor=True, kind='hinted')
     setpoint = FCpt(EpicsSignal, "{self.prefix}:{self._dirshort}_REQ",
-                    kind='normal')
+                    auto_monitor=True, kind='normal')
     done = Cpt(EpicsSignalRO, ":DMOV", kind='omitted')
 
     def __init__(self, prefix, *, slit_type="", name=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,14 @@ from pcdsdevices.interface import setup_preset_paths
 import os
 import pytest
 import shutil
+import warnings
 
+
+# Signal.put warning is a testing artifact.
+# FakeEpicsSignal needs an update, but I don't have time today
+# Needs to not pass tons of kwargs up to Signal.put
+warnings.filterwarnings('ignore',
+                        message='Signal.put no longer takes keyword arguments')
 
 @pytest.fixture(scope='function')
 def presets():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import warnings
 warnings.filterwarnings('ignore',
                         message='Signal.put no longer takes keyword arguments')
 
+
 @pytest.fixture(scope='function')
 def presets():
     folder_obj = Path(__file__).parent / 'test_presets'

--- a/tests/test_analog_signals.py
+++ b/tests/test_analog_signals.py
@@ -101,9 +101,9 @@ def test_tweak_mesh_voltage(fake_mesh, monkeypatch):
 
 @pytest.mark.timeout(5)
 def test_acromag_disconnected():
-    acromag = Acromag('Test:Acromag', name='test_acromag')
+    Acromag('Test:Acromag', name='test_acromag')
 
 
 @pytest.mark.timeout(5)
 def test_mesh_disconnected():
-    mesh = Mesh('Test:Mesh', 1, 2)
+    Mesh('Test:Mesh', 1, 2)

--- a/tests/test_analog_signals.py
+++ b/tests/test_analog_signals.py
@@ -97,3 +97,13 @@ def test_tweak_mesh_voltage(fake_mesh, monkeypatch):
     monkeypatch.setattr(key_press, 'get_input', mock_tweak_down)
     fake_mesh.tweak_mesh_voltage(500.0, test_flag=True)
     assert fake_mesh.write_sig.get() == 1.0
+
+
+@pytest.mark.timeout(5)
+def test_acromag_disconnected():
+    acromag = Acromag('Test:Acromag', name='test_acromag')
+
+
+@pytest.mark.timeout(5)
+def test_mesh_disconnected():
+    mesh = Mesh('Test:Mesh', 1, 2)

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -8,7 +8,8 @@ from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
 
 from pcdsdevices.attenuator import (Attenuator, MAX_FILTERS,
-                                    _att_classes, _att3_classes)
+                                    _att_classes, _att3_classes,
+                                    AttBase)
 
 logger = logging.getLogger(__name__)
 
@@ -169,3 +170,8 @@ def test_attenuator_third_harmonic():
     logger.debug('test_attenuator_third_harmonic')
     att = Attenuator('TRD:ATT', MAX_FILTERS-1, name='third', use_3rd=True)
     att.wait_for_connection()
+
+
+@pytest.mark.timeout(5)
+def test_attenuator_disconnected():
+    att = AttBase('TST:ATT', name='test_att')

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -174,4 +174,4 @@ def test_attenuator_third_harmonic():
 
 @pytest.mark.timeout(5)
 def test_attenuator_disconnected():
-    att = AttBase('TST:ATT', name='test_att')
+    AttBase('TST:ATT', name='test_att')

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -40,3 +40,8 @@ def test_beam_stats_avg(fake_beam_stats):
     cfg = stats.read_configuration()
 
     assert cfg['beam_stats_mj_buffersize']['value'] == 20
+
+
+@pytest.mark.timeout(5)
+def test_beam_stats_disconnected():
+    stats = BeamStats()

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -44,4 +44,4 @@ def test_beam_stats_avg(fake_beam_stats):
 
 @pytest.mark.timeout(5)
 def test_beam_stats_disconnected():
-    stats = BeamStats()
+    BeamStats()

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -27,7 +27,7 @@ def test_beam_stats_avg(fake_beam_stats):
     logger.debug('test_beam_stats_avg')
     stats = fake_beam_stats
 
-    assert stats.mj_buffersize.value == 120
+    assert stats.mj_buffersize.get() == 120
 
     stats.mj_buffersize.put(10)
 

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -150,8 +150,8 @@ def test_ccm_main(fake_ccm):
 
 @pytest.mark.timeout(5)
 def test_disconnected_ccm():
-    dc_ccm = ccm.CCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
-                     x_down_prefix='X:DOWN', x_up_prefix='X:UP',
-                     y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
-                     y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,
-                     name='ccm')
+    ccm.CCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
+            x_down_prefix='X:DOWN', x_up_prefix='X:UP',
+            y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
+            y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,
+            name='ccm')

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -146,3 +146,12 @@ def test_ccm_main(fake_ccm):
     fake_ccm.remove(wait=False)
     assert fake_ccm.x.down.user_setpoint.get() == 0
     assert fake_ccm.x.up.user_setpoint.get() == 0
+
+
+@pytest.mark.timeout(5)
+def test_disconnected_ccm():
+    dc_ccm = ccm.CCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
+                     x_down_prefix='X:DOWN', x_up_prefix='X:UP',
+                     y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
+                     y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,
+                     name='ccm')

--- a/tests/test_dc_devices.py
+++ b/tests/test_dc_devices.py
@@ -23,3 +23,8 @@ def test_PDU_status(fake_ICT):
     assert PDU.ch_1A.ch_status.get() == 'DISABLED'
     PDU.ch_1A.on()
     assert PDU.ch_1A.ch_status.get() == 'ENABLED'
+
+
+@pytest.mark.timeout(5)
+def test_disconnected_ict():
+    pdu = ICT('TST:PDU:ICT', name='test')

--- a/tests/test_dc_devices.py
+++ b/tests/test_dc_devices.py
@@ -27,4 +27,4 @@ def test_PDU_status(fake_ICT):
 
 @pytest.mark.timeout(5)
 def test_disconnected_ict():
-    pdu = ICT('TST:PDU:ICT', name='test')
+    ICT('TST:PDU:ICT', name='test')

--- a/tests/test_disconnected.py
+++ b/tests/test_disconnected.py
@@ -29,4 +29,4 @@ class Disconnected(Device):
 @pytest.mark.timeout(5)
 def test_instantiate_disconnected():
     """Check if environment handles disconnected devices gracefully"""
-    disc = Disconnected('NO:CONN:', name='no_conn')
+    Disconnected('NO:CONN:', name='no_conn')

--- a/tests/test_disconnected.py
+++ b/tests/test_disconnected.py
@@ -1,0 +1,32 @@
+from ophyd.device import Device, Component as Cpt
+from ophyd.signal import EpicsSignal
+import pytest
+
+
+class Disconnected(Device):
+    sig01 = Cpt(EpicsSignal, '01')
+    sig02 = Cpt(EpicsSignal, '02')
+    sig03 = Cpt(EpicsSignal, '03')
+    sig04 = Cpt(EpicsSignal, '04')
+    sig05 = Cpt(EpicsSignal, '05')
+    sig06 = Cpt(EpicsSignal, '06')
+    sig07 = Cpt(EpicsSignal, '07')
+    sig08 = Cpt(EpicsSignal, '08')
+    sig09 = Cpt(EpicsSignal, '09')
+    sig10 = Cpt(EpicsSignal, '10')
+    sig11 = Cpt(EpicsSignal, '11')
+    sig12 = Cpt(EpicsSignal, '12')
+    sig13 = Cpt(EpicsSignal, '13')
+    sig14 = Cpt(EpicsSignal, '14')
+    sig15 = Cpt(EpicsSignal, '15')
+    sig16 = Cpt(EpicsSignal, '16')
+    sig17 = Cpt(EpicsSignal, '17')
+    sig18 = Cpt(EpicsSignal, '18')
+    sig19 = Cpt(EpicsSignal, '19')
+    sig20 = Cpt(EpicsSignal, '20')
+
+
+@pytest.mark.timeout(5)
+def test_instantiate_disconnected():
+    """Check if environment handles disconnected devices gracefully"""
+    disc = Disconnected('NO:CONN:', name='no_conn')

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -210,9 +210,8 @@ def test_motor_factory():
     assert isinstance(m, EpicsMotor)
 
 
-
 @pytest.mark.parametrize("cls", [PCDSMotorBase, IMS, Newport, PMC100,
                                  BeckhoffAxis, EpicsMotor])
 @pytest.mark.timeout(5)
 def test_disconnected_motors(cls):
-    mot = cls('MOTOR', name='motor')
+    cls('MOTOR', name='motor')

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -208,3 +208,11 @@ def test_motor_factory():
     assert isinstance(m, IMS)
     m = Motor('TST:RANDOM:MTR:01', name='test_motor')
     assert isinstance(m, EpicsMotor)
+
+
+
+@pytest.mark.parametrize("cls", [PCDSMotorBase, IMS, Newport, PMC100,
+                                 BeckhoffAxis, EpicsMotor])
+@pytest.mark.timeout(5)
+def test_disconnected_motors(cls):
+    mot = cls('MOTOR', name='motor')

--- a/tests/test_evr.py
+++ b/tests/test_evr.py
@@ -19,4 +19,4 @@ def test_enable(fake_trigger):
 
 @pytest.mark.timeout(5)
 def test_disconnected_trigger():
-    trig = Trigger('TST', name='test')
+    Trigger('TST', name='test')

--- a/tests/test_evr.py
+++ b/tests/test_evr.py
@@ -15,3 +15,8 @@ def test_enable(fake_trigger):
     assert fake_trigger.enable_cmd.get() == 1
     fake_trigger.disable()
     assert fake_trigger.enable_cmd.get() == 0
+
+
+@pytest.mark.timeout(5)
+def test_disconnected_trigger():
+    trig = Trigger('TST', name='test')

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
+import inspect
 
+import pytest
 from ophyd.sim import make_fake_device
 from pcdsdevices.gauge import GaugeSet, GaugeSetPirani, GaugeSetBase
 from pcdsdevices.gauge import GaugeSetMks, GaugeSetPiraniMks
@@ -40,8 +41,16 @@ def test_gauge_factory():
     assert isinstance(m, GaugeSetMks)
 
 
+kw_defaults = {'name': 'gauge',
+               'index': 1,
+               'prefix_controller': 'CONTROLLER'}
 @pytest.mark.parametrize('cls', [GaugeSetPirani, GaugeSetBase, GaugeSetMks,
                                  GaugeSetPiraniMks])
 @pytest.mark.timeout(5)
-def test_gauge_set_disconnected(cls):
-    gauge = cls('TST', name='gauge', index=1)
+def test_gauge_disconnected(cls):
+    kwargs = {}
+    sig = inspect.signature(cls.__init__)
+    for key, value in kw_defaults.items():
+        if key in sig.parameters:
+            kwargs[key] = value
+    gauge = cls('TST', **kwargs)

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -38,3 +38,10 @@ def test_gauge_factory():
     m = GaugeSet('TST:MY', name='test_gauge', index='99',
                  prefix_controller='TST:R99:GCT:99:A', onlyGCC=True)
     assert isinstance(m, GaugeSetMks)
+
+
+@pytest.mark.parametrize('cls', [GaugeSetPirani, GaugeSetBase, GaugeSetMks,
+                                 GaugeSetPiraniMks])
+@pytest.mark.timeout(5)
+def test_gauge_disconnected(cls):
+    gauge = cls('TST', name='gauge')

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -43,5 +43,5 @@ def test_gauge_factory():
 @pytest.mark.parametrize('cls', [GaugeSetPirani, GaugeSetBase, GaugeSetMks,
                                  GaugeSetPiraniMks])
 @pytest.mark.timeout(5)
-def test_gauge_disconnected(cls):
-    gauge = cls('TST', name='gauge')
+def test_gauge_set_disconnected(cls):
+    gauge = cls('TST', name='gauge', index=1)

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -53,4 +53,4 @@ def test_gauge_disconnected(cls):
     for key, value in kw_defaults.items():
         if key in sig.parameters:
             kwargs[key] = value
-    gauge = cls('TST', **kwargs)
+    cls('TST', **kwargs)

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -63,4 +63,4 @@ def test_ipm_subscriptions(fake_ipm):
 
 @pytest.mark.timeout(5)
 def test_ipm_disconnected():
-    ipm = IPM('IPM', name='ipm')
+    IPM('IPM', name='ipm')

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -59,3 +59,8 @@ def test_ipm_subscriptions(fake_ipm):
     # Change the target state
     ipm.target.state.put(2)
     assert cb.called
+
+
+@pytest.mark.timeout(5)
+def test_ipm_disconnected():
+    ipm = IPM('IPM', name='ipm')

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -67,3 +67,16 @@ def test_LensStack_align(presets, monkeypatch):
     assert lens.z.position == 0
     assert lens.x.position == 1.5
     assert lens.y.position == 1.5
+
+
+@pytest.mark.timeout(5)
+def test_xfls_disconnected():
+    xfls = XFLS('TST', name='tst')
+
+
+@pytest.mark.timeout(5)
+def test_lens_stack_disconnected():
+    lens = SimLensStack(name='test',
+                        x_prefix='x_motor',
+                        y_prefix='y_motor',
+                        z_prefix='z_motor')

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -71,12 +71,12 @@ def test_LensStack_align(presets, monkeypatch):
 
 @pytest.mark.timeout(5)
 def test_xfls_disconnected():
-    xfls = XFLS('TST', name='tst')
+    XFLS('TST', name='tst')
 
 
 @pytest.mark.timeout(5)
 def test_lens_stack_disconnected():
-    lens = SimLensStack(name='test',
-                        x_prefix='x_motor',
-                        y_prefix='y_motor',
-                        z_prefix='z_motor')
+    SimLensStack(name='test',
+                 x_prefix='x_motor',
+                 y_prefix='y_motor',
+                 z_prefix='z_motor')

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -78,4 +78,4 @@ def test_hutch_foils():
 
 @pytest.mark.timeout(5)
 def test_lodcm_disconnected():
-    lodcm = LODCM('TST:LOM', name='test_lom')
+    LODCM('TST:LOM', name='test_lom')

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -74,3 +74,8 @@ def test_hutch_foils():
     FakeFoil = make_fake_device(Foil)
     assert 'Zn' in FakeFoil('XPP', name='foil').in_states
     assert 'Ge' in FakeFoil('XCS', name='foil').in_states
+
+
+@pytest.mark.timeout(5)
+def test_lodcm_disconnected():
+    lodcm = LODCM('TST:LOM', name='test_lom')

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -119,6 +119,6 @@ def test_epics_mirror_subscription(fake_branching_mirror):
 
 @pytest.mark.timeout(5)
 def test_mirror_disconnected():
-    m = PointingMirror("TST:M1H", prefix_xy="STEP:TST:M1H",
-                       xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
-                       in_lines=['MFX', 'MEC'], out_lines=['CXI'])
+    PointingMirror("TST:M1H", prefix_xy="STEP:TST:M1H",
+                   xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
+                   in_lines=['MFX', 'MEC'], out_lines=['CXI'])

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -115,3 +115,10 @@ def test_epics_mirror_subscription(fake_branching_mirror):
     # Change the target state
     branching_mirror.state.put('IN')
     assert cb.called
+
+
+@pytest.mark.timeout(5)
+def test_mirror_disconnected():
+    m = PointingMirror("TST:M1H", prefix_xy="STEP:TST:M1H",
+                       xgantry_prefix="GANTRY:M1H:X", name='Test Mirror',
+                       in_lines=['MFX', 'MEC'], out_lines=['CXI'])

--- a/tests/test_movablestand.py
+++ b/tests/test_movablestand.py
@@ -19,3 +19,8 @@ def test_movablestand_sanity(fake_stand):
     logger.debug('test_movablestand_sanity')
     with pytest.raises(NotImplementedError):
         fake_stand.move('OUT')
+
+
+@pytest.mark.timeout(5)
+def test_movablestand_disconnected():
+    stand = MovableStand('TST', name='tst')

--- a/tests/test_movablestand.py
+++ b/tests/test_movablestand.py
@@ -23,4 +23,4 @@ def test_movablestand_sanity(fake_stand):
 
 @pytest.mark.timeout(5)
 def test_movablestand_disconnected():
-    stand = MovableStand('TST', name='tst')
+    MovableStand('TST', name='tst')

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -108,3 +108,13 @@ def test_mpslimit_subscriptions(fake_mps_limits):
     # Cause a fault
     mps.out_limit.fault.sim_put(1)
     assert cb.called
+
+
+@pytest.mark.timeout(5)
+def test_mps_disconnected():
+    mps = MPS("TST:MPS", name='MPS Bit')
+
+
+@pytest.mark.timeout(5)
+def test_mps_limit_disconnected():
+    mps = MPSLimits("Tst:Mps:Lim", logic=lambda x, y: x, name='MPS Limits')

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -112,9 +112,9 @@ def test_mpslimit_subscriptions(fake_mps_limits):
 
 @pytest.mark.timeout(5)
 def test_mps_disconnected():
-    mps = MPS("TST:MPS", name='MPS Bit')
+    MPS("TST:MPS", name='MPS Bit')
 
 
 @pytest.mark.timeout(5)
 def test_mps_limit_disconnected():
-    mps = MPSLimits("Tst:Mps:Lim", logic=lambda x, y: x, name='MPS Limits')
+    MPSLimits("Tst:Mps:Lim", logic=lambda x, y: x, name='MPS Limits')

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -1,12 +1,10 @@
 import logging
+
 import pytest
 from unittest.mock import Mock
 
-from ophyd.device import Component as Cpt
-from ophyd.signal import Signal
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.areadetector.detectors import PCDSAreaDetector
 from pcdsdevices.pim import PIM, PIMMotor
 
 logger = logging.getLogger(__name__)
@@ -65,4 +63,4 @@ def test_pim_subscription(fake_pim):
 
 @pytest.mark.timeout(5)
 def test_pim_disconnected():
-    pim = PIM('TST:YAG', name='tst', prefix_det='tstst')
+    PIM('TST:YAG', name='tst', prefix_det='tstst')

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -69,3 +69,8 @@ def test_pim_subscription(fake_pim):
     pim.subscribe(cb, event_type=pim.SUB_STATE, run=False)
     pim.state.sim_put(2)
     assert cb.called
+
+
+@pytest.mark.timeout(5)
+def test_pim_disconnected():
+    pim = PIM('TST:YAG', name='tst', prefix_Det='tstst')

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -12,14 +12,6 @@ from pcdsdevices.pim import PIM, PIMMotor
 logger = logging.getLogger(__name__)
 
 
-# OK, we have to screw with the class def here. I'm sorry. It's ophyd's fault
-# for checking an epics signal value in the __init__ statement.
-for attr in PCDSAreaDetector._sub_devices:
-    plugin_class = getattr(PCDSAreaDetector, attr).cls
-    if hasattr(plugin_class, 'plugin_type'):
-        plugin_class.plugin_type = Cpt(Signal, value=plugin_class._plugin_type)
-
-
 @pytest.fixture(scope='function')
 def fake_pim():
     FakePIM = make_fake_device(PIMMotor)

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -73,4 +73,4 @@ def test_pim_subscription(fake_pim):
 
 @pytest.mark.timeout(5)
 def test_pim_disconnected():
-    pim = PIM('TST:YAG', name='tst', prefix_Det='tstst')
+    pim = PIM('TST:YAG', name='tst', prefix_det='tstst')

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -156,4 +156,4 @@ def test_picker_subs(fake_picker):
 
 @pytest.mark.timeout(5)
 def test_picker_disconnected():
-    picker = Picker('TST:SB1:MMS:35', name='picker')
+    picker = PulsePickerInOut('TST:SB1:MMS:35', name='picker')

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -152,3 +152,8 @@ def test_picker_subs(fake_picker):
     # Change the target state
     picker.insert()
     assert cb.called
+
+
+@pytest.mark.timeout(5)
+def test_picker_disconnected():
+    picker = Picker('TST:SB1:MMS:35', name='picker')

--- a/tests/test_pulsepicker.py
+++ b/tests/test_pulsepicker.py
@@ -156,4 +156,4 @@ def test_picker_subs(fake_picker):
 
 @pytest.mark.timeout(5)
 def test_picker_disconnected():
-    picker = PulsePickerInOut('TST:SB1:MMS:35', name='picker')
+    PulsePickerInOut('TST:SB1:MMS:35', name='picker')

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -37,4 +37,4 @@ def test_ionpump_factory():
 
 @pytest.mark.timeout(5)
 def test_ionpump_disconnected():
-    pump = IonPumpWithController('tst', name='tst')
+    pump = IonPumpWithController('tst', name='tst', prefix_controller='gamma')

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -37,4 +37,4 @@ def test_ionpump_factory():
 
 @pytest.mark.timeout(5)
 def test_ionpump_disconnected():
-    pump = IonPumpWithController('tst', name='tst', prefix_controller='gamma')
+    IonPumpWithController('tst', name='tst', prefix_controller='gamma')

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -33,3 +33,8 @@ def test_ionpump_factory():
     assert isinstance(m, IonPumpWithController)
     m = IonPump('TST:MY:PIP:01', name='test_pump')
     assert isinstance(m, IonPumpBase)
+
+
+@pytest.mark.timeout(5)
+def test_ionpump_disconnected():
+    pump = IonPumpWithController('tst', name='tst')

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -172,3 +172,8 @@ def test_sequence_get_put():
     curr_seq = seq.sequence.get_seq()
 
     assert curr_seq == dummy_sequence
+
+
+@pytest.mark.timeout(5)
+def test_seq_disconnected():
+    seq = EventSequencer('ECS:TST:100', name='seq')

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -176,4 +176,4 @@ def test_sequence_get_put():
 
 @pytest.mark.timeout(5)
 def test_seq_disconnected():
-    seq = EventSequencer('ECS:TST:100', name='seq')
+    EventSequencer('ECS:TST:100', name='seq')

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -98,3 +98,8 @@ def test_slit_staging(fake_slits):
     slits.unstage()
     assert slits.xwidth.setpoint.get() == 2.5
     assert slits.ywidth.setpoint.get() == 2.5
+
+
+@pytest.mark.timeout(5)
+def test_slits_disconnected():
+    slits = Slits("TST:JAWS:", name='Test Slits')

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -102,4 +102,4 @@ def test_slit_staging(fake_slits):
 
 @pytest.mark.timeout(5)
 def test_slits_disconnected():
-    slits = Slits("TST:JAWS:", name='Test Slits')
+    Slits("TST:JAWS:", name='Test Slits')

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -116,3 +116,9 @@ def test_valve_motion(fake_valve):
     assert valve.interlocked
     with pytest.raises(InterlockError):
         valve.open()
+
+
+@pytest.mark.parametrize('cls', [GateValve, PPSStopper, Stopper])
+@pytest.mark.timeout(5)
+def test_valve_disconnected(cls):
+    valve = cls('TST', name='tst')

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -121,4 +121,4 @@ def test_valve_motion(fake_valve):
 @pytest.mark.parametrize('cls', [GateValve, PPSStopper, Stopper])
 @pytest.mark.timeout(5)
 def test_valve_disconnected(cls):
-    valve = cls('TST', name='tst')
+    cls('TST', name='tst')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Upgrade to new `ophyd` land a little early.

Correct the arguments on our tab completion `__init_subclass__` and properly pass them through so that new `ophyd` land works properly.

Set up extra tests with timeouts for instantiation of all epics devices. Fix devices so that they pass these tests (every device should instantiate quickly even with no connected PVs). In most cases the issue is that calls to `Signal.subscribe` halt/time out if we don't specify `auto_monitor=True` in the component definition, since `ophyd` tries to force these into `auto_monitor` state if not already there. We have control over our device definitions and know that these should always be monitored because a subscription is planned during init, so we do this in the class definition now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New `ophyd` land is a glorious place.

We had a blocking `__init_subclass__` that wasn't passing through to `ophyd.Device`, so no components defined in our ophyd subclasses were getting created.

Some applications are being slowed to a slog by misbehaving device initialization.

closes #358 

## Follow-ups
Investigate a possible patch to `pyepics` to make sure the `PV.auto_monitor` setter never times out. This can be likely be accomplished with a connection check and some threading locks, either applying the `auto_monitor` if connected or just setting `_auto_monitor` if not.