### PR TITLE
ENH: add PytmcSignal class

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - ophyd 1.4.0rc4|>=1.4.0
     - bluesky >=1.2.0
     - pyepics >=3.4.1
+    - pytmc >=2.4.0
     - pyyaml
     - cf_units >=2.0.1
     - scipy

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -19,7 +19,7 @@ from pytmc.pragmas import normalize_io
 logger = logging.getLogger(__name__)
 
 
-class PytmcEpicsSignal(EpicsSignalBase):
+class PytmcSignal(EpicsSignalBase):
     """
     Class for a connection to a pytmc-generated EPICS record.
 
@@ -34,9 +34,9 @@ class PytmcEpicsSignal(EpicsSignalBase):
     def __new__(cls, prefix, *, io, **kwargs):
         norm = normalize_io(io)
         if norm == 'output':
-            return super().__new__(PytmcEpicsSignalRW)
+            return super().__new__(PytmcSignalRW)
         elif norm == 'input':
-            return super().__new__(PytmcEpicsSignalRO)
+            return super().__new__(PytmcSignalRO)
         else:
             # Should never get here unless pytmc's API changes
             raise ValueError(f'Invalid io specifier {io}')
@@ -47,7 +47,7 @@ class PytmcEpicsSignal(EpicsSignalBase):
         super().__init__(prefix + '_RBV', **kwargs)
 
 
-class PytmcEpicsSignalRW(PytmcEpicsSignal, EpicsSignal):
+class PytmcSignalRW(PytmcSignal, EpicsSignal):
     """
     Read-write connection to a pytmc-generated EPICS record
     """
@@ -55,7 +55,7 @@ class PytmcEpicsSignalRW(PytmcEpicsSignal, EpicsSignal):
         super().__init__(prefix, write_pv=prefix, **kwargs)
 
 
-class PytmcEpicsSignalRO(PytmcEpicsSignal, EpicsSignalRO):
+class PytmcSignalRO(PytmcSignal, EpicsSignalRO):
     """
     Read-only connection to a pytmc-generated EPICS record
     """

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -14,6 +14,7 @@ from threading import RLock, Thread
 
 import numpy as np
 from ophyd.signal import Signal, EpicsSignalBase, EpicsSignal, EpicsSignalRO
+from pytmc.pragmas import normalize_io
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +32,14 @@ class PytmcEpicsSignal(EpicsSignalBase):
     depending on your io argument.
     """
     def __new__(cls, prefix, *, io, **kwargs):
-        # Same exact check done in pytmc
-        if 'o' in io:
+        norm = normalize_io(io)
+        if norm == 'output':
             return super().__new__(PytmcEpicsSignalRW)
-        else:
+        elif norm == 'input':
             return super().__new__(PytmcEpicsSignalRO)
+        else:
+            # Should never get here unless pytmc's API changes
+            raise ValueError(f'Invalid io specifier {io}')
 
     def __init__(self, prefix, *, io, **kwargs):
         self.pytmc_pv = prefix

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,11 +1,22 @@
 import logging
 from unittest.mock import Mock
 
-from ophyd.signal import Signal
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 
-from pcdsdevices.signal import AvgSignal
+from pcdsdevices.signal import PytmcSignal, AvgSignal
 
 logger = logging.getLogger(__name__)
+
+
+def test_pytmc_signal():
+    logger.debug('test_pytmc_signal')
+    # Just make sure the normal use cases aren't super broken
+    rwsig = PytmcEpicsSignal('PREFIX', io='io')
+    rosig = PytmcEpicsSignal('PREFIX', io='i')
+    assert isinstance(rwsig, EpicsSignal)
+    assert isinstance(rwsig, PytmcSignal)
+    assert isinstance(rosig, EpicsSignalRO)
+    assert isinstance(rosig, PytmcSignal)
 
 
 def test_avg_signal():

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 def test_pytmc_signal():
     logger.debug('test_pytmc_signal')
     # Just make sure the normal use cases aren't super broken
-    rwsig = PytmcEpicsSignal('PREFIX', io='io')
-    rosig = PytmcEpicsSignal('PREFIX', io='i')
+    rwsig = PytmcSignal('PREFIX', io='io')
+    rosig = PytmcSignal('PREFIX', io='i')
     assert isinstance(rwsig, EpicsSignal)
     assert isinstance(rwsig, PytmcSignal)
     assert isinstance(rosig, EpicsSignalRO)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `PytmcSignal` to connect to the PVs created by `pytmc` using the same arg as in the `pytmc` pragma.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should be really straightforward to make these pytmc pvs without picking between classes and typing _RBV in the right places

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added basic tests, checked that the read and write PVs are what I expected, and connected to sample PVs in a live IOC

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Included in the autodocs by default

<!--
## Screenshots (if appropriate):
-->
