### PR TITLE
DOC: add release notes for v2.3.0

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,14 @@
 Release History
 ###############
 
+v2.3.0 (2020-02-05)
+===================
+
+Features
+--------
+- Make everything compatible with the upcoming ``ophyd`` ``v1.4.0``
+- Add be lens calculations port from old python system
+
 v2.2.0 (2020-01-22)
 ===================
 


### PR DESCRIPTION
This release probably won't be the newest for too long, but the fact that we're upgrading ophyd versions is enough to warrant a tag