### PR TITLE
Gas Detector Digitizer Objects

### DIFF
--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -10,77 +10,54 @@ from .interface import BaseInterface
 logger = logging.getLogger(__name__)
 
 
-class acqiris_channel(Device):
+class AcqirisChannel(Device):
     """
     Class to define a single acqiris channel.
     """
+
     waveform = Cpt(
-        EpicsSignalRO,
-        ':Data',
-        kind='hinted'
+        EpicsSignalRO, ":Data", kind="hinted"
     )
     v_max = Cpt(
-        EpicsSignal,
-        ':CMaxVert',
-        kind='normal'
+        EpicsSignal, ":CMaxVert", kind="normal"
     )
     v_cent = Cpt(
-        EpicsSignal,
-        ':CCenter',
-        kind='normal'
+        EpicsSignal, ":CCenter", kind="normal"
     )
     v_in = Cpt(
-        EpicsSignal,
-        ':CMinVert',
-        kind='normal'
+        EpicsSignal, ":CMinVert", kind="normal"
     )
     v_scale = Cpt(
-        EpicsSignal,
-        ':CVPerDiv',
-        kind='normal'
+        EpicsSignal, ":CVPerDiv", kind="normal"
     )
     bandwidth = Cpt(
-        EpicsSignal,
-        ':CBandwidth',
-        kind='config',
+        EpicsSignal, ":CBandwidth", kind="config",
         string=True
     )
     full_scale = Cpt(
-        EpicsSignal,
-        ':CFullScale',
-        kind='config'
+        EpicsSignal, ":CFullScale", kind="config"
     )
     coupling = Cpt(
-        EpicsSignal,
-        ':CCoupling',
-        kind='config',
+        EpicsSignal, ":CCoupling", kind="config",
         string=True
     )
     offset = Cpt(
-        EpicsSignal,
-        ':COffset',
-        kind='config'
+        EpicsSignal, ":COffset", kind="config"
     )
     trig_coupling = Cpt(
-        EpicsSignal,
-        'CTrigCoupling',
-        kind='config',
+        EpicsSignal, "CTrigCoupling", kind="config",
         string=True
     )
     trig_slope = Cpt(
-        EpicsSignal,
-        'CTrigSlope',
-        kind='config',
+        EpicsSignal, "CTrigSlope", kind="config",
         string=True
     )
     trig_level = Cpt(
-        EpicsSignal,
-        ':CTrigLevel1',
-        kind='config'
+        EpicsSignal, ":CTrigLevel1", kind="config"
     )
 
 
-class acqiris(Device, BaseInterface):
+class Acqiris(Device, BaseInterface):
     """
     Class to define an acqiris digitizer board as constructed by the
     'GasDetDAQ' EPICS IOC. This device is used to access specific
@@ -98,146 +75,122 @@ class acqiris(Device, BaseInterface):
         e.g. '240', '360'.
 
     """
-    ch1 = FCpt(
-        acqiris_channel,
-        '{self.prefix}:{self._mod_pref}1',
-        kind='hinted'
-    )
-    ch2 = FCpt(
-        acqiris_channel,
-        '{self.prefix}:{self._mod_pref}2',
-        kind='hinted')
-    ch3 = FCpt(
-        acqiris_channel,
-        '{self.prefix}:{self._mod_pref}3',
-        kind='hinted')
-    ch4 = FCpt(
-        acqiris_channel,
-        '{self.prefix}:{self._mod_pref}4',
-        kind='hinted')
 
     tab_component_names = True
     tab_whitelist = ["ch1", "ch2", "ch3", "ch4"]
 
+    ch1 = FCpt(
+        AcqirisChannel, "{self.prefix}:{self._mod_pref}1",
+        kind="hinted"
+    )
+    ch2 = FCpt(
+        AcqirisChannel, "{self.prefix}:{self._mod_pref}2",
+        kind="hinted"
+    )
+    ch3 = FCpt(
+        AcqirisChannel, "{self.prefix}:{self._mod_pref}3",
+        kind="hinted"
+    )
+    ch4 = FCpt(
+        AcqirisChannel, "{self.prefix}:{self._mod_pref}4",
+        kind="hinted"
+    )
+
     run_state = FCpt(
-        EpicsSignal,
-        '{self.prefix}:{self.module}:MDAQStatus',
-        kind='config',
-        string=True
+        EpicsSignal, "{self.prefix}:{self.module}:MDAQStatus",
+        kind="config",
+        string=True,
     )
     sample_interval = FCpt(
-        EpicsSignal,
-        '{self.prefix}:{self.module}:MSampInterval',
-        kind='config'
+        EpicsSignal, "{self.prefix}:{self.module}:MSampInterval",
+        kind="config"
     )
     delay_time = FCpt(
-        EpicsSignal,
-        '{self.prefix}:{self.module}:MDelayTime',
-        kind='config'
+        EpicsSignal, "{self.prefix}:{self.module}:MDelayTime",
+        kind="config"
     )
     num_samples = FCpt(
-        EpicsSignal,
-        '{self.prefix}:{self.module}:MNbrSamples',
-        kind='config'
+        EpicsSignal, "{self.prefix}:{self.module}:MNbrSamples",
+        kind="config"
     )
     trig_source = FCpt(
         EpicsSignal,
-        '{self.prefix}:{self.module}:MTriggerSource',
-        kind='config', string=True)
+        "{self.prefix}:{self.module}:MTriggerSource",
+        kind="config",
+        string=True,
+    )
     trig_class = FCpt(
         EpicsSignal,
-        '{self.prefix}:{self.module}:MTrigClass',
-        kind='config',
-        string=True
+        "{self.prefix}:{self.module}:MTrigClass", kind="config",
+        string=True,
     )
     samples_freq = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MSampFrequency',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MSampFrequency",
+        kind="config"
     )
     rate = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MEventRate',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MEventRate",
+        kind="config"
     )
     num_events = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MEventCount',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MEventCount",
+        kind="config"
     )
     num_trig_timeouts = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MTriggerTimeouts',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MTriggerTimeouts",
+        kind="config"
     )
     num_truncated = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MTruncated',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MTruncated",
+        kind="config"
     )
     acq_type = FCpt(
-        EpicsSignal,
-        '{self.prefix}:{self.module}:MType',
-        kind='config',
-        string=True
+        EpicsSignal, "{self.prefix}:{self.module}:MType",
+        kind="config", string=True
     )
     acq_mode = FCpt(
-        EpicsSignal,
-        '{self.prefix}:{self.module}:MMode',
-        kind='config',
-        string=True
+        EpicsSignal, "{self.prefix}:{self.module}:MMode",
+        kind="config", string=True
     )
     acq_mode_flags = FCpt(
         EpicsSignal,
-        '{self.prefix}:{self.module}:MModeFlags',
-        kind='config',
-        string=True
+        "{self.prefix}:{self.module}:MModeFlags", kind="config",
+        string=True,
     )
     clock_type = FCpt(
         EpicsSignalRO,
-        '{self.prefix}:{self.module}:MClockType',
-        kind='config',
-        string=True
+        "{self.prefix}:{self.module}:MClockType", kind="config",
+        string=True,
     )
     crate_number = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MCrateNb',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MCrateNb", kind="config"
     )
-    nADC_bits = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MNbrADCBits',
-        kind='config'
+    n_adc_bits = FCpt(
+        EpicsSignalRO, "{self.prefix}:{self.module}:MNbrADCBits", kind="config"
     )
     crate_slot = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MPosInCrate',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MPosInCrate", kind="config"
     )
     temp = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MTemperature_m',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MTemperature_m",
+        kind="config"
     )
     input_freq = FCpt(
-        EpicsSignalRO,
-        '{self.prefix}:{self.module}:MInputFrequency',
-        kind='config'
+        EpicsSignalRO, "{self.prefix}:{self.module}:MInputFrequency",
+        kind="config"
     )
 
-    def __init__(self,
-                 prefix,
-                 module,
-                 platform=None,
-                 name='acqiris_module',
-                 **kwargs):
+    def __init__(self, prefix, module, platform=None,
+                 name="Acqiris", **kwargs):
         self.module = module
         self.prefix = prefix
         self.platform = platform
         if len(self.module) != 3:
-            raise ValueError("acqiris 'module'"
-                             + " expects a 3-digit module identifier,"
-                             + " e.g. '240'")
+            raise ValueError(
+                "Acqiris 'module'"
+                + " expects a 3-digit module identifier,"
+                + " e.g. '240'"
+            )
         self._mod_pref = self.module[:2]
         super().__init__(prefix, name=name, **kwargs)
 
@@ -254,7 +207,7 @@ class acqiris(Device, BaseInterface):
         self.run_state.put(1)
 
 
-class gasdet(Device):
+class GasDet(Device):
     """
     Class to read out pulse energy from a PMT/diode as digitized
     by an acqiris in the GasDetDAQ EPICS IOC.
@@ -273,72 +226,29 @@ class gasdet(Device):
         The digitizer channel.
 
     """
-    mJ = Cpt(
-        EpicsSignalRO,
-        ':ENRC',
-        kind='hinted'
-    )
-    time = Cpt(
-        EpicsSignalRO,
-        ':TIME',
-        kind='hinted'
-    )
-    cal = Cpt(
-        EpicsSignalRO,
-        ':CALI',
-        kind='hinted'
-    )
-    offset = Cpt(
-        EpicsSignalRO,
-        ':OFFS',
-        kind='hinted'
-    )
-    BG_start_index = Cpt(
-        EpicsSignalRO,
-        ':BSTR',
-        kind='hinted'
-    )
-    BG_stop_index = Cpt(
-        EpicsSignalRO,
-        ':BSTP',
-        kind='hinted'
-    )
-    BG_sum = Cpt(
-        EpicsSignalRO,
-        ':BSUM',
-        kind='hinted'
-    )
-    pulse_start_index = Cpt(
-        EpicsSignalRO,
-        ':STRT',
-        kind='hinted'
-    )
-    pulse_stop_index = Cpt(
-        EpicsSignalRO,
-        ':STOP',
-        kind='hinted'
-    )
-    pulse_sum = Cpt(
-        EpicsSignalRO,
-        ':PSUM',
-        kind='hinted'
-    )
 
-    def __init__(self,
-                 prefix,
-                 *,
-                 platform=None,
-                 module=None,
-                 channel=None,
-                 name='gasdet',
-                 **kwargs):
+    mj = Cpt(EpicsSignalRO, ":ENRC", kind="hinted")
+    time = Cpt(EpicsSignalRO, ":TIME", kind="hinted")
+    cal = Cpt(EpicsSignalRO, ":CALI", kind="hinted")
+    offset = Cpt(EpicsSignalRO, ":OFFS", kind="hinted")
+    bg_start_index = Cpt(EpicsSignalRO, ":BSTR", kind="hinted")
+    bg_stop_index = Cpt(EpicsSignalRO, ":BSTP", kind="hinted")
+    bg_sum = Cpt(EpicsSignalRO, ":BSUM", kind="hinted")
+    pulse_start_index = Cpt(EpicsSignalRO, ":STRT", kind="hinted")
+    pulse_stop_index = Cpt(EpicsSignalRO, ":STOP", kind="hinted")
+    pulse_sum = Cpt(EpicsSignalRO, ":PSUM", kind="hinted")
+
+    def __init__(self, prefix, *, platform=None,
+                 module=None, channel=None, name="GasDet", **kwargs):
         self.module = module
         self.prefix = prefix
         self.platform = platform
         if self.module and len(self.module) != 3:
-            raise ValueError("acqiris 'module'"
-                             + " expects a 3-digit module identifier,"
-                             + " e.g. '240'")
+            raise ValueError(
+                "acqiris 'module'"
+                + " expects a 3-digit module identifier,"
+                + " e.g. '240'"
+            )
         else:
             if self.module:
                 self._mod_pref = self.module[:2]

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -1,5 +1,5 @@
 """
-Ophyd device for the Hard X-ray Gas Energy Monitor
+Ophyd devices for the Hard X-ray Gas Energy Monitor
 """
 import logging
 from ophyd import EpicsSignal, EpicsSignalRO, Device
@@ -23,13 +23,8 @@ class acqiris_channel(Device):
     board : ``str``
         3-digit ID of the board the channel belongs to, e.g. '241'
     """
-    waveform = Cpt(EpicsSignalRO, ':Data',kind='hinted')
-
-    def __init__(self, prefix, board, channel, name='acqiris_channel', **kwargs):
-        self.prefix = prefix
-        self.channel = channel
-        super().__init__(prefix, name=name, **kwargs)
-
+    waveform = Cpt(EpicsSignalRO, ':Data', kind='hinted')
+    
 
 class acqiris_board(Device):
     """
@@ -43,44 +38,47 @@ class acqiris_board(Device):
         3-digit number representing the digitizer board, e.g. '240', '360'.
 
     """
-    ch1 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}1', channel='1', board='{self.board}',kind='hinted')
-    ch2 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}2', channel='2', board='{self.board}',kind='hinted')
-    ch3 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}3', channel='3', board='{self.board}',kind='hinted')
-    ch4 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}4', channel='4', board='{self.board}',kind='hinted')
+
+    ch1 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}1',kind='hinted')
+    ch2 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}2',kind='hinted')
+    ch3 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}3',kind='hinted')
+    ch4 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}4',kind='hinted')
+
 
     tab_component_names = True
 
-    run_state = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MDAQStatus',kind='hinted')
-    sample_interval = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MSampInterval',kind='hinted')
-    delay_time = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MDelayTime',kind='hinted')
-    num_samples = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MNbrSamples',kind='hinted')
-    trig_source = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MTriggerSource',kind='hinted')
-    trig_class = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MTrigClass',kind='hinted')
-    samples_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MSampFrequency',kind='hinted')
-    rate =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MEventRate',kind='hinted')
-    num_events =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MEventCount',kind='hinted')
-    num_trig_timeouts = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTriggerTimeouts',kind='hinted')
-    num_truncated = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTruncated',kind='hinted')
+    run_state = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MDAQStatus',kind='config', string=True)
+    sample_interval = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MSampInterval',kind='config')
+    delay_time = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MDelayTime',kind='config')
+    num_samples = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MNbrSamples',kind='config')
+    trig_source = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MTriggerSource',kind='config', string=True)
+    trig_class = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MTrigClass',kind='config', string=True)
+    samples_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MSampFrequency',kind='config')
+    rate =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MEventRate',kind='config')
+    num_events =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MEventCount',kind='config')
+    num_trig_timeouts = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTriggerTimeouts',kind='config')
+    num_truncated = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTruncated',kind='config')
 
-    # Extras
-    acq_type = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MType',kind='hinted')
-    acq_mode = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MMode',kind='hinted')
-    acq_mode_flags = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MModeFlags',kind='hinted')
-    clock_type = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MClockType',kind='hinted')
-    crate_number =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MCrateNb',kind='hinted')
-    nADC_bits =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MNbrADCBits',kind='hinted')
-    crate_slot = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MPosInCrate',kind='hinted')
-    temp = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTemperature_m',kind='hinted')
-    input_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MInputFrequency',kind='hinted')
+    # "Extras"
+    acq_type = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MType',kind='config', string=True)
+    acq_mode = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MMode',kind='config', string=True)
+    acq_mode_flags = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MModeFlags',kind='config', string=True)
+    clock_type = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MClockType',kind='config', string=True)
+    crate_number =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MCrateNb',kind='config')
+    nADC_bits =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MNbrADCBits',kind='config')
+    crate_slot = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MPosInCrate',kind='config')
+    temp = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTemperature_m',kind='config')
+    input_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MInputFrequency',kind='config')
     
-    def __init__(self, prefix, platform=None, board=None, name='acqiris_board', *args, **kwargs):
+    def __init__(self, prefix, *, platform, board, name='acqiris_board', **kwargs):
         self.board = board
         self.prefix = prefix
+        self.platform = platform
         if len(self.board) != 3:
             raise ValueError("acqiris 'board' expects a 3-digit board identifier, e.g. '240'")
         self._board_pref = self.board[:2]
         super().__init__(prefix, name=name, **kwargs)
-    
+
     def start(self):
         """
         Start the acqiris DAQ
@@ -93,31 +91,36 @@ class acqiris_board(Device):
         """
         self.run_state.put(0)
 
-class gasdet(Device, BaseInterface):
-    """
-    Class to create complete gas detector with all acqiris boards.
+# class gasdet(Device, BaseInterface):
+#     """
+#     Class to create complete gas detector with all acqiris boards.
 
-    Parameters
-    ----------
-    prefix : ``str``
-        The PV base of the digitizer.
-    platform : ``str``
-        This a legacy PV segment found in the GasDetDAQ IOC. The default '202' applies to
-        the HXR gas detector system.
-    acq1_board : ``str``
-        3-digit number representing the first digitizer board, e.g. '240', '360'.
-    acq2_board : ``str``
-        3-digit number representing the second digitizer board, e.g. '240', '360'.
+#     Parameters
+#     ----------
+#     prefix : ``str``
+#         The PV base of the digitizer.
+#     platform : ``str``
+#         This a legacy PV segment found in the GasDetDAQ IOC. The default '202' applies to
+#         the HXR gas detector system.
+#     board1 : ``str``
+#         3-digit number representing the first digitizer board, e.g. '240', '360'.
+#     board2 : ``str``
+#         3-digit number representing the second digitizer board, e.g. '240', '360'.
 
-    """
-    acq1 = FCpt(acqiris_board, '{self.prefix}:DIAG:202', platform='{self.platform}',board='{self.acq1_board}', kind='hinted')
+#     """
+#     ###
+#     # At the moment I cannot get the self.board and self.platfrom arguments to be interpreted by component 
+#     # (they just pass the literal string "{self.board}" etc.
+#     ##
+#     acq1 = FCpt(acqiris_board, '{self.prefix}:DIAG:{self.platform}', platform='{self.platform}',board='{self.board1}', kind='hinted')
+#     acq2 = FCpt(acqiris_board, '{self.prefix}:DIAG:{self.platform}', platform='{self.platform}',board='{self.board2}.', kind='hinted')
 
-    tab_component_names = True
+#     tab_component_names = True
+#     tab_whitelist = ['acq1', 'acq2']
 
-    def __init__(self, prefix, platform='202', acq1_board=None, acq2_board=None, name='gasdet', *args, **kwargs):
-        self.acq1_board = acq1_board
-        super().__init__(prefix, name=name, **kwargs)
-
-
-
+#     def __init__(self, prefix, *, platform, board1, board2, name='gasdet', **kwargs):
+#         self.platform = platform
+#         self.board1 = board1
+#         self.board2 = board2
+#         super().__init__(prefix, name=name, **kwargs)
 

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -237,19 +237,3 @@ class GasDet(Device):
     pulse_start_index = Cpt(EpicsSignalRO, ":STRT", kind="hinted")
     pulse_stop_index = Cpt(EpicsSignalRO, ":STOP", kind="hinted")
     pulse_sum = Cpt(EpicsSignalRO, ":PSUM", kind="hinted")
-
-    def __init__(self, prefix, *, platform=None,
-                 module=None, channel=None, name="GasDet", **kwargs):
-        self.module = module
-        self.prefix = prefix
-        self.platform = platform
-        if self.module and len(self.module) != 3:
-            raise ValueError(
-                "acqiris 'module'"
-                + " expects a 3-digit module identifier,"
-                + " e.g. '240'"
-            )
-        else:
-            if self.module:
-                self._mod_pref = self.module[:2]
-        super().__init__(prefix, name=name, **kwargs)

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -9,77 +9,234 @@ from .interface import BaseInterface
 
 logger = logging.getLogger(__name__)
 
+
 class acqiris_channel(Device):
     """
     Class to define a single acqiris channel.
-
     """
-    waveform = Cpt(EpicsSignalRO, ':Data', kind='hinted')
-    v_max = Cpt(EpicsSignal, ':CMaxVert', kind='normal')
-    v_cent = Cpt(EpicsSignal, ':CCenter', kind='normal')
-    v_in = Cpt(EpicsSignal, ':CMinVert', kind='normal')
-    v_scale = Cpt(EpicsSignal, ':CVPerDiv', kind='normal')
-    bandwidth = Cpt(EpicsSignal, ':CBandwidth', kind='config', string=True)
-    full_scale = Cpt(EpicsSignal, ':CFullScale', kind='config')
-    coupling = Cpt(EpicsSignal, ':CCoupling', kind='config', string=True)
-    offset = Cpt(EpicsSignal, ':COffset', kind='config')
-    trig_coupling = Cpt(EpicsSignal, 'CTrigCoupling', kind='config', string=True)
-    trig_slope = Cpt(EpicsSignal, 'CTrigSlope', kind='config', string=True)
-    trig_level = Cpt(EpicsSignal, ':CTrigLevel1', kind='config')
+    waveform = Cpt(
+        EpicsSignalRO,
+        ':Data',
+        kind='hinted'
+    )
+    v_max = Cpt(
+        EpicsSignal,
+        ':CMaxVert',
+        kind='normal'
+    )
+    v_cent = Cpt(
+        EpicsSignal,
+        ':CCenter',
+        kind='normal'
+    )
+    v_in = Cpt(
+        EpicsSignal,
+        ':CMinVert',
+        kind='normal'
+    )
+    v_scale = Cpt(
+        EpicsSignal,
+        ':CVPerDiv',
+        kind='normal'
+    )
+    bandwidth = Cpt(
+        EpicsSignal,
+        ':CBandwidth',
+        kind='config',
+        string=True
+    )
+    full_scale = Cpt(
+        EpicsSignal,
+        ':CFullScale',
+        kind='config'
+    )
+    coupling = Cpt(
+        EpicsSignal,
+        ':CCoupling',
+        kind='config',
+        string=True
+    )
+    offset = Cpt(
+        EpicsSignal,
+        ':COffset',
+        kind='config'
+    )
+    trig_coupling = Cpt(
+        EpicsSignal,
+        'CTrigCoupling',
+        kind='config',
+        string=True
+    )
+    trig_slope = Cpt(
+        EpicsSignal,
+        'CTrigSlope',
+        kind='config',
+        string=True
+    )
+    trig_level = Cpt(
+        EpicsSignal,
+        ':CTrigLevel1',
+        kind='config'
+    )
+
 
 class acqiris(Device, BaseInterface):
     """
-    Class to define an acqiris digitizer board as constructed by the 'GasDetDAQ' EPICS IOC. 
-    This device is used to access specific acqiris channels as subcomponents.
-    
+    Class to define an acqiris digitizer board as constructed by the
+    'GasDetDAQ' EPICS IOC. This device is used to access specific
+    acqiris channels as subcomponents.
+
     Parameters
     ----------
     prefix : ``str``
         The PV base of the digitizer.
     platform : ``str``
-        This a legacy PV segment found in the GasDetDAQ IOC. The default '202' applies to
-        the HXR gas detector system.
+        This a legacy PV segment found in the GasDetDAQ IOC.
+        The default '202' applies to the HXR gas detector system.
     module : ``str``
-        3-digit number representing the digitizer board, e.g. '240', '360'.
+        3-digit number representing the digitizer board,
+        e.g. '240', '360'.
 
     """
-    ch1 = FCpt(acqiris_channel, '{self.prefix}:{self._mod_pref}1',kind='hinted')
-    ch2 = FCpt(acqiris_channel, '{self.prefix}:{self._mod_pref}2',kind='hinted')
-    ch3 = FCpt(acqiris_channel, '{self.prefix}:{self._mod_pref}3',kind='hinted')
-    ch4 = FCpt(acqiris_channel, '{self.prefix}:{self._mod_pref}4',kind='hinted')
-    
+    ch1 = FCpt(
+        acqiris_channel,
+        '{self.prefix}:{self._mod_pref}1',
+        kind='hinted'
+    )
+    ch2 = FCpt(
+        acqiris_channel,
+        '{self.prefix}:{self._mod_pref}2',
+        kind='hinted')
+    ch3 = FCpt(
+        acqiris_channel,
+        '{self.prefix}:{self._mod_pref}3',
+        kind='hinted')
+    ch4 = FCpt(
+        acqiris_channel,
+        '{self.prefix}:{self._mod_pref}4',
+        kind='hinted')
+
     tab_component_names = True
     tab_whitelist = ["ch1", "ch2", "ch3", "ch4"]
 
-    run_state = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MDAQStatus',kind='config', string=True)
-    sample_interval = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MSampInterval',kind='config')
-    delay_time = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MDelayTime',kind='config')
-    num_samples = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MNbrSamples',kind='config')
-    trig_source = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MTriggerSource',kind='config', string=True)
-    trig_class = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MTrigClass',kind='config', string=True)
-    samples_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MSampFrequency',kind='config')
-    rate =  FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MEventRate',kind='config')
-    num_events =  FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MEventCount',kind='config')
-    num_trig_timeouts = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MTriggerTimeouts',kind='config')
-    num_truncated = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MTruncated',kind='config')
+    run_state = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MDAQStatus',
+        kind='config',
+        string=True
+    )
+    sample_interval = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MSampInterval',
+        kind='config'
+    )
+    delay_time = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MDelayTime',
+        kind='config'
+    )
+    num_samples = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MNbrSamples',
+        kind='config'
+    )
+    trig_source = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MTriggerSource',
+        kind='config', string=True)
+    trig_class = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MTrigClass',
+        kind='config',
+        string=True
+    )
+    samples_freq = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MSampFrequency',
+        kind='config'
+    )
+    rate = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MEventRate',
+        kind='config'
+    )
+    num_events = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MEventCount',
+        kind='config')
+    num_trig_timeouts = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MTriggerTimeouts',
+        kind='config'
+    )
+    num_truncated = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MTruncated',
+        kind='config'
+    )
+    acq_type = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MType',
+        kind='config',
+        string=True
+    )
+    acq_mode = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MMode',
+        kind='config',
+        string=True
+    )
+    acq_mode_flags = FCpt(
+        EpicsSignal,
+        '{self.prefix}:{self.module}:MModeFlags',
+        kind='config',
+        string=True
+    )
+    clock_type = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MClockType',
+        kind='config',
+        string=True
+    )
+    crate_number = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MCrateNb',
+        kind='config'
+    )
+    nADC_bits = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MNbrADCBits',
+        kind='config'
+    )
+    crate_slot = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MPosInCrate',
+        kind='config'
+    )
+    temp = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MTemperature_m',
+        kind='config'
+    )
+    input_freq = FCpt(
+        EpicsSignalRO,
+        '{self.prefix}:{self.module}:MInputFrequency',
+        kind='config'
+    )
 
-    # "Extras"
-    acq_type = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MType',kind='config', string=True)
-    acq_mode = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MMode',kind='config', string=True)
-    acq_mode_flags = FCpt(EpicsSignal, '{self.prefix}:{self.module}:MModeFlags',kind='config', string=True)
-    clock_type = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MClockType',kind='config', string=True)
-    crate_number =  FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MCrateNb',kind='config')
-    nADC_bits =  FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MNbrADCBits',kind='config')
-    crate_slot = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MPosInCrate',kind='config')
-    temp = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MTemperature_m',kind='config')
-    input_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.module}:MInputFrequency',kind='config')
-    
-    def __init__(self, prefix, module, platform=None, name='acqiris_module', **kwargs):
+    def __init__(self,
+                 prefix,
+                 module,
+                 platform=None,
+                 name='acqiris_module',
+                 **kwargs):
         self.module = module
         self.prefix = prefix
         self.platform = platform
         if len(self.module) != 3:
-            raise ValueError("acqiris 'module' expects a 3-digit module identifier, e.g. '240'")
+            raise ValueError("acqiris 'module'"
+                             + "expects a 3-digit module identifier, "
+                             + "e.g. '240'")
         self._mod_pref = self.module[:2]
         super().__init__(prefix, name=name, **kwargs)
 
@@ -95,16 +252,19 @@ class acqiris(Device, BaseInterface):
         """
         self.run_state.put(1)
 
+
 class gasdet(Device):
     """
-    Class to read out pulse energy from a PMT/diode as digitized by an acqiris in the GasDetDAQ EPICS IOC.
+    Class to read out pulse energy from a PMT/diode as digitized
+    by an acqiris in the GasDetDAQ EPICS IOC.
 
     Parameters
     ----------
     prefix : ``str``
         The PV base of the digitizer.
     platform : ``str``
-        This a legacy PV segment found in the GasDetDAQ IOC. For example, '202' applies to
+        This a legacy PV segment found in the GasDetDAQ IOC.
+        For example, '202' applies to
         the HXR gas detector system... for some reason.
     module : ``str``
         3-digit number representing the digitizer board, e.g. '240', '360'.
@@ -112,23 +272,72 @@ class gasdet(Device):
         The digitizer channel.
 
     """
-    mJ = Cpt(EpicsSignalRO, ':ENRC', kind='hinted')
-    time = Cpt(EpicsSignalRO, ':TIME', kind='hinted')
-    cal = Cpt(EpicsSignalRO, ':CALI', kind='hinted')
-    offset = Cpt(EpicsSignalRO, ':OFFS', kind='hinted')
-    BG_start_index = Cpt(EpicsSignalRO, ':BSTR', kind='hinted')
-    BG_stop_index = Cpt(EpicsSignalRO, ':BSTP', kind='hinted')
-    BG_sum = Cpt(EpicsSignalRO, ':BSUM', kind='hinted')
-    pulse_start_index = Cpt(EpicsSignalRO, ':STRT', kind='hinted')
-    pulse_stop_index = Cpt(EpicsSignalRO, ':STOP', kind='hinted')
-    pulse_sum = Cpt(EpicsSignalRO, ':PSUM', kind='hinted')
+    mJ = Cpt(
+        EpicsSignalRO,
+        ':ENRC',
+        kind='hinted'
+    )
+    time = Cpt(
+        EpicsSignalRO,
+        ':TIME',
+        kind='hinted'
+    )
+    cal = Cpt(
+        EpicsSignalRO,
+        ':CALI',
+        kind='hinted'
+    )
+    offset = Cpt(
+        EpicsSignalRO,
+        ':OFFS',
+        kind='hinted'
+    )
+    BG_start_index = Cpt(
+        EpicsSignalRO,
+        ':BSTR',
+        kind='hinted'
+    )
+    BG_stop_index = Cpt(
+        EpicsSignalRO,
+        ':BSTP',
+        kind='hinted'
+    )
+    BG_sum = Cpt(
+        EpicsSignalRO,
+        ':BSUM',
+        kind='hinted'
+    )
+    pulse_start_index = Cpt(
+        EpicsSignalRO,
+        ':STRT',
+        kind='hinted'
+    )
+    pulse_stop_index = Cpt(
+        EpicsSignalRO,
+        ':STOP',
+        kind='hinted'
+    )
+    pulse_sum = Cpt(
+        EpicsSignalRO,
+        ':PSUM',
+        kind='hinted'
+    )
 
-    def __init__(self, prefix, *, platform=None, module=None, channel=None, name='gasdet', **kwargs):
+    def __init__(self,
+                 prefix,
+                 *,
+                 platform=None,
+                 module=None,
+                 channel=None,
+                 name='gasdet',
+                 **kwargs):
         self.module = module
         self.prefix = prefix
         self.platform = platform
         if self.module and len(self.module) != 3:
-            raise ValueError("acqiris 'module' expects a 3-digit module identifier, e.g. '240'")
+            raise ValueError("acqiris 'module'"
+                             + "expects a 3-digit module identifier,"
+                             + "e.g. '240'")
         else:
             if self.module:
                 self._mod_pref = self.module[:2]

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -1,0 +1,123 @@
+"""
+Ophyd device for the Hard X-ray Gas Energy Monitor
+"""
+import logging
+from ophyd import EpicsSignal, EpicsSignalRO, Device
+from ophyd import Component as Cpt
+from ophyd import FormattedComponent as FCpt
+
+from pcdsdevices.interface import BaseInterface
+
+logger = logging.getLogger(__name__)
+
+class acqiris_channel(Device):
+    """
+    Class to define a single acqiris channel and its data.
+
+    Parameters
+    ----------
+    prefix : ``str``
+        The PV base of the digitizer.
+    channel : ``str``
+        The channel number, e.g. '1',..,'4'
+    board : ``str``
+        3-digit ID of the board the channel belongs to, e.g. '241'
+    """
+    waveform = Cpt(EpicsSignalRO, ':Data',kind='hinted')
+
+    def __init__(self, prefix, board, channel, name='acqiris_channel', **kwargs):
+        self.prefix = prefix
+        self.channel = channel
+        super().__init__(prefix, name=name, **kwargs)
+
+
+class acqiris_board(Device):
+    """
+    Class to define an acqiris digitizer board in the HXR gas detector.
+    
+    Parameters
+    ----------
+    prefix : ``str``
+        The PV base of the digitizer.
+    board : ``str``
+        3-digit number representing the digitizer board, e.g. '240', '360'.
+
+    """
+    ch1 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}1', channel='1', board='{self.board}',kind='hinted')
+    ch2 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}2', channel='2', board='{self.board}',kind='hinted')
+    ch3 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}3', channel='3', board='{self.board}',kind='hinted')
+    ch4 = FCpt(acqiris_channel, '{self.prefix}:{self._board_pref}4', channel='4', board='{self.board}',kind='hinted')
+
+    tab_component_names = True
+
+    run_state = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MDAQStatus',kind='hinted')
+    sample_interval = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MSampInterval',kind='hinted')
+    delay_time = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MDelayTime',kind='hinted')
+    num_samples = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MNbrSamples',kind='hinted')
+    trig_source = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MTriggerSource',kind='hinted')
+    trig_class = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MTrigClass',kind='hinted')
+    samples_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MSampFrequency',kind='hinted')
+    rate =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MEventRate',kind='hinted')
+    num_events =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MEventCount',kind='hinted')
+    num_trig_timeouts = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTriggerTimeouts',kind='hinted')
+    num_truncated = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTruncated',kind='hinted')
+
+    # Extras
+    acq_type = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MType',kind='hinted')
+    acq_mode = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MMode',kind='hinted')
+    acq_mode_flags = FCpt(EpicsSignal, '{self.prefix}:{self.board}:MModeFlags',kind='hinted')
+    clock_type = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MClockType',kind='hinted')
+    crate_number =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MCrateNb',kind='hinted')
+    nADC_bits =  FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MNbrADCBits',kind='hinted')
+    crate_slot = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MPosInCrate',kind='hinted')
+    temp = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MTemperature_m',kind='hinted')
+    input_freq = FCpt(EpicsSignalRO, '{self.prefix}:{self.board}:MInputFrequency',kind='hinted')
+    
+    def __init__(self, prefix, platform=None, board=None, name='acqiris_board', *args, **kwargs):
+        self.board = board
+        self.prefix = prefix
+        if len(self.board) != 3:
+            raise ValueError("acqiris 'board' expects a 3-digit board identifier, e.g. '240'")
+        self._board_pref = self.board[:2]
+        super().__init__(prefix, name=name, **kwargs)
+    
+    def start(self):
+        """
+        Start the acqiris DAQ
+        """
+        self.run_state.put(1)
+
+    def stop(self):
+        """
+        Stop the acqiris DAQ
+        """
+        self.run_state.put(0)
+
+class gasdet(Device, BaseInterface):
+    """
+    Class to create complete gas detector with all acqiris boards.
+
+    Parameters
+    ----------
+    prefix : ``str``
+        The PV base of the digitizer.
+    platform : ``str``
+        This a legacy PV segment found in the GasDetDAQ IOC. The default '202' applies to
+        the HXR gas detector system.
+    acq1_board : ``str``
+        3-digit number representing the first digitizer board, e.g. '240', '360'.
+    acq2_board : ``str``
+        3-digit number representing the second digitizer board, e.g. '240', '360'.
+
+    """
+    acq1 = FCpt(acqiris_board, '{self.prefix}:DIAG:202', platform='{self.platform}',board='{self.acq1_board}', kind='hinted')
+
+    tab_component_names = True
+
+    def __init__(self, prefix, platform='202', acq1_board=None, acq2_board=None, name='gasdet', *args, **kwargs):
+        self.acq1_board = acq1_board
+        super().__init__(prefix, name=name, **kwargs)
+
+
+
+

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -163,7 +163,8 @@ class acqiris(Device, BaseInterface):
     num_events = FCpt(
         EpicsSignalRO,
         '{self.prefix}:{self.module}:MEventCount',
-        kind='config')
+        kind='config'
+    )
     num_trig_timeouts = FCpt(
         EpicsSignalRO,
         '{self.prefix}:{self.module}:MTriggerTimeouts',
@@ -235,8 +236,8 @@ class acqiris(Device, BaseInterface):
         self.platform = platform
         if len(self.module) != 3:
             raise ValueError("acqiris 'module'"
-                             + "expects a 3-digit module identifier, "
-                             + "e.g. '240'")
+                             + " expects a 3-digit module identifier,"
+                             + " e.g. '240'")
         self._mod_pref = self.module[:2]
         super().__init__(prefix, name=name, **kwargs)
 
@@ -336,8 +337,8 @@ class gasdet(Device):
         self.platform = platform
         if self.module and len(self.module) != 3:
             raise ValueError("acqiris 'module'"
-                             + "expects a 3-digit module identifier,"
-                             + "e.g. '240'")
+                             + " expects a 3-digit module identifier,"
+                             + " e.g. '240'")
         else:
             if self.module:
                 self._mod_pref = self.module[:2]

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -15,46 +15,19 @@ class AcqirisChannel(Device):
     Class to define a single acqiris channel.
     """
 
-    waveform = Cpt(
-        EpicsSignalRO, ":Data", kind="hinted"
-    )
-    v_max = Cpt(
-        EpicsSignal, ":CMaxVert", kind="normal"
-    )
-    v_cent = Cpt(
-        EpicsSignal, ":CCenter", kind="normal"
-    )
-    v_in = Cpt(
-        EpicsSignal, ":CMinVert", kind="normal"
-    )
-    v_scale = Cpt(
-        EpicsSignal, ":CVPerDiv", kind="normal"
-    )
-    bandwidth = Cpt(
-        EpicsSignal, ":CBandwidth", kind="config",
-        string=True
-    )
-    full_scale = Cpt(
-        EpicsSignal, ":CFullScale", kind="config"
-    )
-    coupling = Cpt(
-        EpicsSignal, ":CCoupling", kind="config",
-        string=True
-    )
-    offset = Cpt(
-        EpicsSignal, ":COffset", kind="config"
-    )
-    trig_coupling = Cpt(
-        EpicsSignal, "CTrigCoupling", kind="config",
-        string=True
-    )
-    trig_slope = Cpt(
-        EpicsSignal, "CTrigSlope", kind="config",
-        string=True
-    )
-    trig_level = Cpt(
-        EpicsSignal, ":CTrigLevel1", kind="config"
-    )
+    waveform = Cpt(EpicsSignalRO, ":Data", kind="hinted")
+    v_max = Cpt(EpicsSignal, ":CMaxVert", kind="normal")
+    v_cent = Cpt(EpicsSignal, ":CCenter", kind="normal")
+    v_in = Cpt(EpicsSignal, ":CMinVert", kind="normal")
+    v_scale = Cpt(EpicsSignal, ":CVPerDiv", kind="normal")
+    bandwidth = Cpt(EpicsSignal, ":CBandwidth", kind="config", string=True)
+    full_scale = Cpt(EpicsSignal, ":CFullScale", kind="config")
+    coupling = Cpt(EpicsSignal, ":CCoupling", kind="config", string=True)
+    offset = Cpt(EpicsSignal, ":COffset", kind="config")
+    trig_coupling = Cpt(EpicsSignal, ":CTrigCoupling", kind="config",
+                        string=True)
+    trig_slope = Cpt(EpicsSignal, "CTrigSlope", kind="config", string=True)
+    trig_level = Cpt(EpicsSignal, ":CTrigLevel1", kind="config")
 
 
 class Acqiris(Device, BaseInterface):
@@ -79,109 +52,54 @@ class Acqiris(Device, BaseInterface):
     tab_component_names = True
     tab_whitelist = ["ch1", "ch2", "ch3", "ch4"]
 
-    ch1 = FCpt(
-        AcqirisChannel, "{self.prefix}:{self._mod_pref}1",
-        kind="hinted"
-    )
-    ch2 = FCpt(
-        AcqirisChannel, "{self.prefix}:{self._mod_pref}2",
-        kind="hinted"
-    )
-    ch3 = FCpt(
-        AcqirisChannel, "{self.prefix}:{self._mod_pref}3",
-        kind="hinted"
-    )
-    ch4 = FCpt(
-        AcqirisChannel, "{self.prefix}:{self._mod_pref}4",
-        kind="hinted"
-    )
+    ch1 = FCpt(AcqirisChannel, "{_mod_pref}1", kind="hinted")
+    ch2 = FCpt(AcqirisChannel, "{_mod_pref}2", kind="hinted")
+    ch3 = FCpt(AcqirisChannel, "{_mod_pref}3", kind="hinted")
+    ch4 = FCpt(AcqirisChannel, "{_mod_pref}4", kind="hinted")
 
-    run_state = FCpt(
-        EpicsSignal, "{self.prefix}:{self.module}:MDAQStatus",
-        kind="config",
-        string=True,
-    )
-    sample_interval = FCpt(
-        EpicsSignal, "{self.prefix}:{self.module}:MSampInterval",
-        kind="config"
-    )
-    delay_time = FCpt(
-        EpicsSignal, "{self.prefix}:{self.module}:MDelayTime",
-        kind="config"
-    )
-    num_samples = FCpt(
-        EpicsSignal, "{self.prefix}:{self.module}:MNbrSamples",
-        kind="config"
-    )
-    trig_source = FCpt(
-        EpicsSignal,
-        "{self.prefix}:{self.module}:MTriggerSource",
-        kind="config",
-        string=True,
-    )
-    trig_class = FCpt(
-        EpicsSignal,
-        "{self.prefix}:{self.module}:MTrigClass", kind="config",
-        string=True,
-    )
-    samples_freq = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MSampFrequency",
-        kind="config"
-    )
-    rate = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MEventRate",
-        kind="config"
-    )
-    num_events = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MEventCount",
-        kind="config"
-    )
-    num_trig_timeouts = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MTriggerTimeouts",
-        kind="config"
-    )
-    num_truncated = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MTruncated",
-        kind="config"
-    )
-    acq_type = FCpt(
-        EpicsSignal, "{self.prefix}:{self.module}:MType",
-        kind="config", string=True
-    )
-    acq_mode = FCpt(
-        EpicsSignal, "{self.prefix}:{self.module}:MMode",
-        kind="config", string=True
-    )
-    acq_mode_flags = FCpt(
-        EpicsSignal,
-        "{self.prefix}:{self.module}:MModeFlags", kind="config",
-        string=True,
-    )
-    clock_type = FCpt(
-        EpicsSignalRO,
-        "{self.prefix}:{self.module}:MClockType", kind="config",
-        string=True,
-    )
-    crate_number = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MCrateNb", kind="config"
-    )
-    n_adc_bits = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MNbrADCBits", kind="config"
-    )
-    crate_slot = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MPosInCrate", kind="config"
-    )
-    temp = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MTemperature_m",
-        kind="config"
-    )
-    input_freq = FCpt(
-        EpicsSignalRO, "{self.prefix}:{self.module}:MInputFrequency",
-        kind="config"
-    )
+    run_state = FCpt(EpicsSignal, "{prefix}:{module}:MDAQStatus",
+                     kind="config", string=True)
+    sample_interval = FCpt(EpicsSignal, "{prefix}:{module}:MSampInterval",
+                           kind="config")
+    delay_time = FCpt(EpicsSignal, "{prefix}:{module}:MDelayTime",
+                      kind="config")
+    num_samples = FCpt(EpicsSignal, "{prefix}:{module}:MNbrSamples",
+                       kind="config")
+    trig_source = FCpt(EpicsSignal, "{prefix}:{module}:MTriggerSource",
+                       kind="config", string=True)
+    trig_class = FCpt(EpicsSignal, "{prefix}:{module}:MTrigClass",
+                      kind="config", string=True)
+    samples_freq = FCpt(EpicsSignalRO, "{prefix}:{module}:MSampFrequency",
+                        kind="config")
+    rate = FCpt(EpicsSignalRO, "{prefix}:{module}:MEventRate", kind="config")
+    num_events = FCpt(EpicsSignalRO, "{prefix}:{module}:MEventCount",
+                      kind="config")
+    num_trig_timeouts = FCpt(EpicsSignalRO,
+                             "{prefix}:{module}:MTriggerTimeouts",
+                             kind="config")
+    num_truncated = FCpt(EpicsSignalRO, "{prefix}:{module}:MTruncated",
+                         kind="config")
+    acq_type = FCpt(EpicsSignal, "{prefix}:{module}:MType", kind="config",
+                    string=True)
+    acq_mode = FCpt(EpicsSignal, "{prefix}:{module}:MMode", kind="config",
+                    string=True)
+    acq_mode_flags = FCpt(EpicsSignal, "{prefix}:{module}:MModeFlags",
+                          kind="config", string=True)
+    clock_type = FCpt(EpicsSignalRO, "{prefix}:{module}:MClockType",
+                      kind="config", string=True)
+    crate_number = FCpt(EpicsSignalRO, "{prefix}:{module}:MCrateNb",
+                        kind="config")
+    n_adc_bits = FCpt(EpicsSignalRO, "{prefix}:{module}:MNbrADCBits",
+                      kind="config")
+    crate_slot = FCpt(EpicsSignalRO, "{prefix}:{module}:MPosInCrate",
+                      kind="config")
+    temp = FCpt(EpicsSignalRO, "{prefix}:{module}:MTemperature_m",
+                kind="config")
+    input_freq = FCpt(EpicsSignalRO, "{prefix}:{module}:MInputFrequency",
+                      kind="config")
 
-    def __init__(self, prefix, module, platform=None,
-                 name="Acqiris", **kwargs):
+    def __init__(self, prefix, module, platform=None, name="Acqiris",
+                 **kwargs):
         self.module = module
         self.prefix = prefix
         self.platform = platform
@@ -191,7 +109,7 @@ class Acqiris(Device, BaseInterface):
                 + " expects a 3-digit module identifier,"
                 + " e.g. '240'"
             )
-        self._mod_pref = self.module[:2]
+        self._mod_pref = f'{prefix}:{self.module[:2]}'
         super().__init__(prefix, name=name, **kwargs)
 
     def start(self):

--- a/pcdsdevices/gasdet.py
+++ b/pcdsdevices/gasdet.py
@@ -5,7 +5,7 @@ import logging
 from ophyd import EpicsSignal, EpicsSignalRO, Device
 from ophyd import Component as Cpt
 from ophyd import FormattedComponent as FCpt
-from pcdsdevices.interface import BaseInterface
+from .interface import BaseInterface
 
 logger = logging.getLogger(__name__)
 
@@ -87,13 +87,13 @@ class acqiris(Device, BaseInterface):
         """
         Start the acqiris DAQ
         """
-        self.run_state.put(1)
+        self.run_state.put(0)
 
     def stop(self):
         """
         Stop the acqiris DAQ
         """
-        self.run_state.put(0)
+        self.run_state.put(1)
 
 class gasdet(Device):
     """

--- a/tests/test_gasdet.py
+++ b/tests/test_gasdet.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 from ophyd.sim import make_fake_device
-from pcdsdevices.gasdet import acqiris, acqiris_channel, gasdet
+from pcdsdevices.gasdet import Acqiris, AcqirisChannel, GasDet
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope='function')
 def fake_acq():
     logger.debug('test_acqiris')
-    FakeAcq = make_fake_device(acqiris)
+    FakeAcq = make_fake_device(Acqiris)
     acq = FakeAcq('TEST:ACQ', '000')
     acq.run_state.sim_set_enum_strs(['RUNNING', 'STOPPED'])
     acq.run_state.sim_put('RUNNING')
@@ -24,22 +24,22 @@ def fake_acq():
 @pytest.mark.timout(5)
 def test_acqiris_channel():
     logger.debug('test_acqiris_channel')
-    FakeAcq = make_fake_device(acqiris_channel)
+    FakeAcq = make_fake_device(AcqirisChannel)
     FakeAcq('TEST:ACQ', name='test')
 
 
 @pytest.mark.timeout(5)
 def test_gasdet():
     logger.debug('test_gasdet')
-    FakeGasDet = make_fake_device(gasdet)
+    FakeGasDet = make_fake_device(GasDet)
     FakeGasDet('TEST:GASDET', name='gasdet')
 
 
 @pytest.mark.timeout(5)
 def test_gasdet_disconnected():
-    gasdet('TRO:LOL:LOL', name='tst')
+    GasDet('TRO:LOL:LOL', name='tst')
 
 
 @pytest.mark.timeout(5)
 def test_acq_disconnected():
-    acqiris('ECS:RULEZ', '666', name='tst')
+    Acqiris('ECS:RULEZ', '666', name='tst')

--- a/tests/test_gasdet.py
+++ b/tests/test_gasdet.py
@@ -8,12 +8,16 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='function')
 def fake_acq():
+    logger.debug('test_acqiris')
     FakeAcq = make_fake_device(acqiris)
     acq = FakeAcq('TEST:ACQ', '000')
+    acq.run_state.sim_set_enum_strs(['RUNNING','STOPPED'])
+    acq.run_state.sim_put('RUNNING')
+    assert acq.run_state.get() == 'RUNNING'
     acq.stop()
-    assert acq.run_state == 1
+    assert acq.run_state.get() == 'STOPPED'
     acq.start()
-    assert acq.run_state == 0
+    assert acq.run_state.get() == 'RUNNING'
     return acq
 
 @pytest.mark.timout(5)
@@ -29,14 +33,9 @@ def test_gasdet():
     FakeGasDet('TEST:GASDET', name='gasdet')
 
 @pytest.mark.timeout(5)
-def test_acq_subscription(fake_acq):
-    logger.debug('test_acqiris_subscriptions')
-    acq = fake_acq
-    cb = Mock()
-    acq.subscribe(cb, event_type=acq.SUB_STATE, run=False)
-    acq.run_state.sim_put(0)
-    assert cb.called
-
+def test_gasdet_disconnected():
+    gasdet('TRO:LOL:LOL', name='tst')
+    
 @pytest.mark.timeout(5)
 def test_acq_disconnected():
-    acqiris('ECS:RLZ', '666', name='tst')
+    acqiris('ECS:RULEZ', '666', name='tst')

--- a/tests/test_gasdet.py
+++ b/tests/test_gasdet.py
@@ -1,0 +1,43 @@
+import logging
+import pytest
+from unittest.mock import Mock
+from ophyd.sim import make_fake_device
+from pcdsdevices.gasdet import acqiris, acqiris_channel, gasdet
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def fake_acq():
+    FakeAcq = make_fake_device(acqiris)
+    acq = FakeAcq('TEST:ACQ', '000')
+    acq.stop()
+    assert acq.run_state == 1
+    acq.start()
+    assert acq.run_state == 0
+    return acq
+
+@pytest.mark.timout(5)
+def test_acqiris_channel():
+    logger.debug('test_acqiris_channel')
+    FakeAcq = make_fake_device(acqiris_channel)
+    FakeAcq('TEST:ACQ', name='test')
+
+@pytest.mark.timeout(5)
+def test_gasdet():
+    logger.debug('test_gasdet')
+    FakeGasDet = make_fake_device(gasdet)
+    FakeGasDet('TEST:GASDET', name='gasdet')
+
+@pytest.mark.timeout(5)
+def test_acq_subscription(fake_acq):
+    logger.debug('test_acqiris_subscriptions')
+    acq = fake_acq
+    cb = Mock()
+    acq.subscribe(cb, event_type=acq.SUB_STATE, run=False)
+    acq.run_state.sim_put(0)
+    assert cb.called
+
+@pytest.mark.timeout(5)
+def test_acq_disconnected():
+    acqiris('ECS:RLZ', name='tst', '666')

--- a/tests/test_gasdet.py
+++ b/tests/test_gasdet.py
@@ -1,17 +1,17 @@
 import logging
 import pytest
-from unittest.mock import Mock
 from ophyd.sim import make_fake_device
 from pcdsdevices.gasdet import acqiris, acqiris_channel, gasdet
 
 logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope='function')
 def fake_acq():
     logger.debug('test_acqiris')
     FakeAcq = make_fake_device(acqiris)
     acq = FakeAcq('TEST:ACQ', '000')
-    acq.run_state.sim_set_enum_strs(['RUNNING','STOPPED'])
+    acq.run_state.sim_set_enum_strs(['RUNNING', 'STOPPED'])
     acq.run_state.sim_put('RUNNING')
     assert acq.run_state.get() == 'RUNNING'
     acq.stop()
@@ -20,11 +20,13 @@ def fake_acq():
     assert acq.run_state.get() == 'RUNNING'
     return acq
 
+
 @pytest.mark.timout(5)
 def test_acqiris_channel():
     logger.debug('test_acqiris_channel')
     FakeAcq = make_fake_device(acqiris_channel)
     FakeAcq('TEST:ACQ', name='test')
+
 
 @pytest.mark.timeout(5)
 def test_gasdet():
@@ -32,10 +34,12 @@ def test_gasdet():
     FakeGasDet = make_fake_device(gasdet)
     FakeGasDet('TEST:GASDET', name='gasdet')
 
+
 @pytest.mark.timeout(5)
 def test_gasdet_disconnected():
     gasdet('TRO:LOL:LOL', name='tst')
-    
+
+
 @pytest.mark.timeout(5)
 def test_acq_disconnected():
     acqiris('ECS:RULEZ', '666', name='tst')

--- a/tests/test_gasdet.py
+++ b/tests/test_gasdet.py
@@ -6,7 +6,6 @@ from pcdsdevices.gasdet import acqiris, acqiris_channel, gasdet
 
 logger = logging.getLogger(__name__)
 
-
 @pytest.fixture(scope='function')
 def fake_acq():
     FakeAcq = make_fake_device(acqiris)
@@ -40,4 +39,4 @@ def test_acq_subscription(fake_acq):
 
 @pytest.mark.timeout(5)
 def test_acq_disconnected():
-    acqiris('ECS:RLZ', name='tst', '666')
+    acqiris('ECS:RLZ', '666', name='tst')


### PR DESCRIPTION
###  Description
I have created some objects for capturing the readback and configuration of several of the digitzer elements involved in gas detector / energy monitor systems.  These are based on the PV structure of the GasDetDAQ EPICS IOC -- which is pretty loopy (for a number of pretty logical and pretty illogical legacy reasons).  I would appreciate suggestions of how to best layer these objects (or even retemplate the IOC) so that prefixing isn't so weird/difficult.

Full PV list can be browsed at `/reg/d/iocData/ioc-lfe-gasdet-daq/iocInfo/IOC.pvlist`

The general way I am doing this now is to configure channels via the `acqiris_channel` object.  The digitizer waveform (volts) is also read out through here. 

More 'physical' measurements i.e. energy in mJ is available in the `gasdet` object, which has a different PV base unfortunately... it would be nice to capture the digitizer channel and its energy measurements in the same object. 

All 4 digitizer channels are coalesced in the `acqiris` object, which represents one complete module. 

I experimented with creating a larger "gas detector system"-like object that had the aforementioned objects as subcomponents and would be a used as a `baseinterface` representing the entire system, but the PV bases are so bizarre that I gave up and broke it all out for now. 

I was pretty generous with 'hinting' a lot of signals for now since I haven't dived into the screens yet.

I have no idea if I wrote the tests right lol. 

## Motivation and Context
Screens will be needed very soon and a beamline python interface is desirable.

## How Has This Been Tested?
I am testing this on the GasDetDAQ IOC running on ioc-lfe-gasdet-daq in the XCS hutch. 

## Where Has This Been Documented?
Formatted docstrings.
