### PR TITLE
ENH: Add PPM, XPIM, and supporting classes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,6 +8,9 @@ Full API
    ~pcdsdevices.attenuator
    ~pcdsdevices.beam_stats
    ~pcdsdevices.ccm
+   ~pcdsdevices.dc_devices
+   ~pcdsdevices.device_types
+   ~pcdsdeviecs.doc_stubs
    ~pcdsdevices.epics_motor
    ~pcdsdevices.evr
    ~pcdsdevices.gauge
@@ -19,10 +22,12 @@ Full API
    ~pcdsdevices.mirror
    ~pcdsdevices.movablestand
    ~pcdsdevices.mps
+   ~pcdsdevices.mv_interface
    ~pcdsdevices.pim
    ~pcdsdevices.pseudopos
    ~pcdsdevices.pulsepicker
    ~pcdsdevices.pump
+   ~pcdsdevices.sensors
    ~pcdsdevices.sequencer
    ~pcdsdevices.signal
    ~pcdsdevices.sim

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,7 +10,7 @@ Full API
    ~pcdsdevices.ccm
    ~pcdsdevices.dc_devices
    ~pcdsdevices.device_types
-   ~pcdsdeviecs.doc_stubs
+   ~pcdsdevices.doc_stubs
    ~pcdsdevices.epics_motor
    ~pcdsdevices.evr
    ~pcdsdevices.gauge

--- a/docs/source/epics_types.rst
+++ b/docs/source/epics_types.rst
@@ -27,6 +27,7 @@ Common EPICS Devices
     PIM
     PMC100
     PointingMirror
+    PPM
     PulsePicker
     Reflaser
     Slits
@@ -34,3 +35,4 @@ Common EPICS Devices
     Trigger
     TTReflaser
     XFLS
+    XPIM

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -13,7 +13,7 @@ from .lens import XFLS
 from .lodcm import LODCM
 from .mirror import OffsetMirror, PointingMirror
 from .movablestand import MovableStand
-from .pim import PIM
+from .pim import PIM, PPM, XPIM
 from .pulsepicker import PulsePicker
 from .pump import IonPump
 from .sequencer import EventSequencer

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -4,7 +4,7 @@ Module for LCLS's special motor records.
 import logging
 import shutil
 import os
-from ophyd.device import Component as Cpt
+from ophyd.device import Device, Component as Cpt
 from ophyd.epics_motor import EpicsMotor
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 from ophyd.status import DeviceStatus, SubscriptionStatus, wait as status_wait
@@ -434,25 +434,34 @@ class PMC100(PCDSMotorBase):
         raise NotImplementedError("PMC100 motors have no homing procedure")
 
 
+class BeckhoffAxisPLC(Device):
+    """
+    Debug PVs from the Beckhoff Axis PLC code
+    """
+    status = Cpt(EpicsSignalRO, 'sErrorMessage', kind='normal', string=True)
+    err_code = Cpt(EpicsSignalRO, 'sErrorId', kind='normal')
+    cmd_err_reset = Cpt(EpicsSignal, 'bReset', kind='omitted')
+
+
 class BeckhoffAxis(EpicsMotorInterface):
     """
     Beckhoff Axis motor record as implemented by ESS.
 
-    This class simply adds a convenience `clear_error` method, and makes
+    This class adds a convenience `clear_error` method, and makes
     sure to call it on stage.
+
+    It also exposes the PLC debug PVs.
     """
     __doc__ += basic_positioner_init
-
-    status = Cpt(EpicsSignalRO, '-MsgTxt', kind='normal', string=True)
-    cmd_err_reset = Cpt(EpicsSignal, '-ErrRst', kind='omitted')
-
     tab_whitelist = ['clear_error']
+
+    plc = Cpt(BeckhoffAxisPLC, ':PLC:', kind='normal')
 
     def clear_error(self):
         """
         Clear any active motion errors on this axis.
         """
-        self.cmd_err_reset.put(1)
+        self.plc.cmd_err_reset.put(1)
 
     def stage(self):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -445,7 +445,7 @@ class BeckhoffAxisPLC(Device):
 
 class BeckhoffAxis(EpicsMotorInterface):
     """
-    Beckhoff Axis motor record as implemented by ESS.
+    Beckhoff Axis motor record as implemented by ESS and extended by us
 
     This class adds a convenience `clear_error` method, and makes
     sure to call it on stage.

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -13,6 +13,7 @@ from ophyd.utils import LimitError
 from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import DelayBase
+from .signal import PytmcSignal
 
 
 logger = logging.getLogger(__name__)
@@ -438,9 +439,10 @@ class BeckhoffAxisPLC(Device):
     """
     Debug PVs from the Beckhoff Axis PLC code
     """
-    status = Cpt(EpicsSignalRO, 'sErrorMessage', kind='normal', string=True)
-    err_code = Cpt(EpicsSignalRO, 'sErrorId', kind='normal')
-    cmd_err_reset = Cpt(EpicsSignal, 'bReset', kind='omitted')
+    status = Cpt(PytmcSignal, 'sErrorMessage', io='i', kind='normal',
+                 string=True)
+    err_code = Cpt(PytmcSignal, 'nErrorId', io='i', kind='normal')
+    cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='o', kind='omitted')
 
 
 class BeckhoffAxis(EpicsMotorInterface):

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -40,6 +40,10 @@ class InOutPositioner(StatePositioner):
         number from 0 to 1. Default values will be 1 (full transmission) for
         ``out_states``, 0 (full block) for ``in_states``, and nan (no idea!)
         for unaccounted states.
+
+    _in_if_not_out: ``bool``
+        If True, shorthand for saying "all the states not in out_states or
+        unknown belong in the in_states list"
     """
     __doc__ = __doc__ % basic_positioner_init
 
@@ -182,8 +186,28 @@ class TwinCATInOutPositioner(TwinCATStatePositioner, InOutPositioner):
     any function block that follows the pattern set up by
     FB_EpicsInOut.
 
-    `states_list` does not have to be provided
+    Use `TwinCATStatePositioner` instead if the device does not have clear
+    inserted and removed states.
+
+    Does not need to be subclassed to be used
+    ``states_list`` does not have to be provided in a subclass
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The EPICS PV prefix for this motor.
+
+    name: ``str``, required keyword
+        An identifying name for this motor.
+
+    settle_time: ``float``, optional
+        The amount of extra time to wait before interpreting a move as done
+
+    timeout ``float``, optional
+        The amount of time to wait before automatically marking a long
+        in-progress move as failed.
     """
-    __doc__ += basic_positioner_init
+    # Clear the default in/out state list
     states_list = []
+    # In should be everything except state 0 (Unknown) and state 1 (Out)
     _in_if_not_out = True

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -209,5 +209,7 @@ class TwinCATInOutPositioner(TwinCATStatePositioner, InOutPositioner):
     """
     # Clear the default in/out state list
     states_list = []
+    # Override the default out name
+    out_states = ['Out']
     # In should be everything except state 0 (Unknown) and state 1 (Out)
     _in_if_not_out = True

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -16,6 +16,7 @@ from weakref import WeakSet
 import yaml
 from bluesky.utils import ProgressBar
 from ophyd.device import Kind
+from ophyd.ophydobj import OphydObject
 from ophyd.status import wait as status_wait
 
 from . import utils as util
@@ -33,7 +34,7 @@ Positioner_whitelist = ["settle_time", "timeout", "egu", "limits", "move",
                         "position", "moving"]
 
 
-class BaseInterface:
+class BaseInterface(OphydObject):
     """
     Interface layer to attach to any Device for SLAC features.
 
@@ -79,6 +80,14 @@ class BaseInterface:
         return [elem
                 for elem in super().__dir__()
                 if self._tab_regex.fullmatch(elem)]
+
+    def __repr__(self):
+        """
+        Simplify the ophydobject repr to avoid crazy long represenations
+        """
+        prefix = getattr(self, 'prefix', None)
+        name = getattr(self, 'name', None)
+        return f"{self.__class__.__name__}({prefix}, name={name})"
 
 
 def set_engineering_mode(expert):

--- a/pcdsdevices/mps.py
+++ b/pcdsdevices/mps.py
@@ -7,7 +7,6 @@ interpreted by :class:`.MPS`.
 """
 import logging
 
-from ophyd.ophydobj import OphydObject
 from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as Cpt,
                    FormattedComponent as FCpt)
 
@@ -16,7 +15,7 @@ from .interface import BaseInterface
 logger = logging.getLogger(__name__)
 
 
-class MPSBase(OphydObject, BaseInterface):
+class MPSBase(BaseInterface):
     """
     Base MPS class
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -75,6 +75,12 @@ class PIM(PIMMotor):
 
 
 class LCLS2ImagerBase(Device, BaseInterface):
+    """
+    Shared PVs and components from the LCLS2 imagers
+
+    All LCLS2 imagers are guaranteed to have the following components that
+    behave essentially the same
+    """
     tab_component_names = True
 
     y_states = Cpt(TwinCATInOutPositioner, ':STATE', kind='hinted')
@@ -84,6 +90,19 @@ class LCLS2ImagerBase(Device, BaseInterface):
 
 
 class PPMPowerMeter(Device, BaseInterface):
+    """
+    Analog measurement tool for beam energy as part of the PPM assembly.
+
+    When inserted into the beam, the ``raw_voltage`` signal value should
+    increase proportional to the beam energy. The equivalent calibrated
+    readings are ``dimensionless``, which is a unitless number that
+    represents the relative calibration of every power meter, and
+    ``calibrated_mj``, which is the real engineering unit of the beam
+    power. These are calibrated using the other signals in the following way:
+
+    ``dimensionless`` = (``raw_voltage`` + ``calib_offset``) * ``calib_ratio``
+    ``calibrated_mj`` = ``dimensionless`` * ``calib_mj_ratio``
+    """
     tab_component_names = True
 
     raw_voltage = Cpt(PytmcSignal, 'VOLT', io='i', kind='normal')
@@ -104,6 +123,21 @@ class PPMPowerMeter(Device, BaseInterface):
 
 
 class PPM(LCLS2ImagerBase):
+    """
+    L2SI's Power and Profile Monitor design.
+
+    Unlike the `XPIM`, this includes a power meter and two thermocouples, one
+    on the power meter itself and one on the yag holder. The LED on this unit
+    has been outfitted with a dimmable control in units of percentage.
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The EPICS PV prefix for this imager, e.g. ``IM3L0:PPM``.
+
+    name: ``str``, required keyword
+        An identifying name for this motor, e.g. ``im3l0``
+    """
     power_meter = Cpt(PPMPowerMeter, ':SPM:', kind='normal')
     yag_thermocouple = Cpt(TwinCATThermoCouple, ':YAG:', kind='normal')
 
@@ -111,6 +145,13 @@ class PPM(LCLS2ImagerBase):
 
 
 class XPIMFilterWheel(StatePositioner):
+    """
+    Controllable optical filters to prevent camera saturation.
+
+    There are six filter slots, five with filters of varying optical densities
+    and one that is empty. The enum strings here are T100, T50, etc. which
+    represent the transmission percentage of the associated filter.
+    """
     tab_component_names = True
 
     state = Cpt(EpicsSignal, 'GET_RBV', write_pv='SET', kind='normal')
@@ -120,6 +161,21 @@ class XPIMFilterWheel(StatePositioner):
 
 
 class XPIM(LCLS2ImagerBase):
+    """
+    XTES's Imager design.
+
+    Unlike the `PPM`, this includes a relative encoder zoom and focus dc motor
+    stack and a controllable optical filter wheel. The LED on this unit has
+    only been outfitted with binary control, on/off.
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The EPICS PV prefix for this imager, e.g. ``IM3L0:PPM``.
+
+    name: ``str``, required keyword
+        An identifying name for this motor, e.g. ``im3l0``
+    """
     zoom_motor = Cpt(BeckhoffAxis, ':CLZ', kind='normal')
     focus_motor = Cpt(BeckhoffAxis, ':CLF', kind='normal')
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -105,20 +105,20 @@ class PPMPowerMeter(Device, BaseInterface):
     """
     tab_component_names = True
 
-    raw_voltage = Cpt(PytmcSignal, 'VOLT', io='i', kind='normal')
-    dimensionless = Cpt(PytmcSignal, 'CALIB', io='i', kind='normal')
-    calibrated_mj = Cpt(PytmcSignal, 'MJ', io='i', kind='normal')
+    raw_voltage = Cpt(PytmcSignal, ':VOLT', io='i', kind='normal')
+    dimensionless = Cpt(PytmcSignal, ':CALIB', io='i', kind='normal')
+    calibrated_mj = Cpt(PytmcSignal, ':MJ', io='i', kind='normal')
     thermocouple = Cpt(TwinCATThermoCouple, '', kind='normal')
 
-    calib_offset = Cpt(PytmcSignal, 'CALIB:OFFSET', io='io', kind='config')
-    calib_ratio = Cpt(PytmcSignal, 'CALIB:RATIO', io='io', kind='config')
-    calib_mj_ratio = Cpt(PytmcSignal, 'CALIB:MJ_RATIO', io='io', kind='config')
+    calib_offset = Cpt(PytmcSignal, ':CALIB:OFFSET', io='io', kind='config')
+    calib_ratio = Cpt(PytmcSignal, ':CALIB:RATIO', io='io', kind='config')
+    calib_mj_ratio = Cpt(PytmcSignal, ':CALIB:MJ_RATIO', io='io', kind='config')
 
-    raw_voltage_buffer = Cpt(PytmcSignal, 'VOLT_BUFFER', io='i',
+    raw_voltage_buffer = Cpt(PytmcSignal, ':VOLT_BUFFER', io='i',
                              kind='omitted')
-    dimensionless_buffer = Cpt(PytmcSignal, 'CALIB_BUFFER', io='i',
+    dimensionless_buffer = Cpt(PytmcSignal, ':CALIB_BUFFER', io='i',
                                kind='omitted')
-    calibrated_mj_buffer = Cpt(PytmcSignal, 'MJ_BUFFER', io='i',
+    calibrated_mj_buffer = Cpt(PytmcSignal, ':MJ_BUFFER', io='i',
                                kind='omitted')
 
 
@@ -138,8 +138,8 @@ class PPM(LCLS2ImagerBase):
     name: ``str``, required keyword
         An identifying name for this motor, e.g. ``im3l0``
     """
-    power_meter = Cpt(PPMPowerMeter, ':SPM:', kind='normal')
-    yag_thermocouple = Cpt(TwinCATThermoCouple, ':YAG:', kind='normal')
+    power_meter = Cpt(PPMPowerMeter, ':SPM', kind='normal')
+    yag_thermocouple = Cpt(TwinCATThermoCouple, ':YAG', kind='normal')
 
     led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config')
 
@@ -154,10 +154,10 @@ class XPIMFilterWheel(StatePositioner):
     """
     tab_component_names = True
 
-    state = Cpt(EpicsSignal, 'GET_RBV', write_pv='SET', kind='normal')
+    state = Cpt(EpicsSignal, ':GET_RBV', write_pv='SET', kind='normal')
 
-    reset_cmd = Cpt(PytmcSignal, 'ERR:RESET', io='i', kind='omitted')
-    error_message = Cpt(PytmcSignal, 'ERR:MSG', io='i', kind='omitted')
+    reset_cmd = Cpt(PytmcSignal, ':ERR:RESET', io='i', kind='omitted')
+    error_message = Cpt(PytmcSignal, ':ERR:MSG', io='i', kind='omitted')
 
 
 class XPIM(LCLS2ImagerBase):
@@ -180,4 +180,4 @@ class XPIM(LCLS2ImagerBase):
     focus_motor = Cpt(BeckhoffAxis, ':CLF', kind='normal')
 
     led = Cpt(PytmcSignal, ':CAM:CIL:PWR', io='io', kind='config')
-    filter_wheel = Cpt(XPIMFilterWheel, ':MFW:', kind='config')
+    filter_wheel = Cpt(XPIMFilterWheel, ':MFW', kind='config')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -83,7 +83,7 @@ class LCLS2ImagerBase(Device, BaseInterface):
     """
     tab_component_names = True
 
-    y_states = Cpt(TwinCATInOutPositioner, ':STATE', kind='hinted')
+    y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted')
     y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal')
     detector = Cpt(PCDSAreaDetector, ':CAM:', kind='normal')
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -112,7 +112,8 @@ class PPMPowerMeter(Device, BaseInterface):
 
     calib_offset = Cpt(PytmcSignal, ':CALIB:OFFSET', io='io', kind='config')
     calib_ratio = Cpt(PytmcSignal, ':CALIB:RATIO', io='io', kind='config')
-    calib_mj_ratio = Cpt(PytmcSignal, ':CALIB:MJ_RATIO', io='io', kind='config')
+    calib_mj_ratio = Cpt(PytmcSignal, ':CALIB:MJ_RATIO', io='io',
+                         kind='config')
 
     raw_voltage_buffer = Cpt(PytmcSignal, ':VOLT_BUFFER', io='i',
                              kind='omitted')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -155,7 +155,7 @@ class XPIMFilterWheel(StatePositioner):
     """
     tab_component_names = True
 
-    state = Cpt(EpicsSignal, ':GET_RBV', write_pv='SET', kind='normal')
+    state = Cpt(EpicsSignal, ':GET_RBV', write_pv=':SET', kind='normal')
 
     reset_cmd = Cpt(PytmcSignal, ':ERR:RESET', io='i', kind='omitted')
     error_message = Cpt(PytmcSignal, ':ERR:MSG', io='i', kind='omitted')

--- a/pcdsdevices/sensors.py
+++ b/pcdsdevices/sensors.py
@@ -16,6 +16,6 @@ class TwinCATThermoCouple(Device, BaseInterface):
     Assumes we're using the FB_ThermoCouple function block from
     lcls-twincat-general
     """
-    temperature = Cpt(PytmcSignal, 'STC:TEMP', io='i', kind='normal')
-    sensor_connected = Cpt(PytmcSignal, 'STC:CONN', io='i', kind='normal')
-    error = Cpt(PytmcSignal, 'STC:ERR', io='i', kind='normal')
+    temperature = Cpt(PytmcSignal, ':STC:TEMP', io='i', kind='normal')
+    sensor_connected = Cpt(PytmcSignal, ':STC:CONN', io='i', kind='normal')
+    error = Cpt(PytmcSignal, ':STC:ERR', io='i', kind='normal')

--- a/pcdsdevices/sensors.py
+++ b/pcdsdevices/sensors.py
@@ -1,0 +1,21 @@
+"""
+Sensor classes
+
+Classes for the various thermocouples, rtds, flow meters, O2 sensors, etc.
+"""
+from ophyd import Device, Component as Cpt
+
+from .interface import BaseInterface
+from .signal import PytmcSignal
+
+
+class TwinCATThermoCouple(Device, BaseInterface):
+    """
+    Basic twincat temperature sensor class
+
+    Assumes we're using the FB_ThermoCouple function block from
+    lcls-twincat-general
+    """
+    temperature = Cpt(PytmcSignal, 'STC:TEMP', io='i', kind='normal')
+    sensor_connected = Cpt(PytmcSignal, 'STC:CONN', io='i', kind='normal')
+    error = Cpt(PytmcSignal, 'STC:ERR', io='i', kind='normal')

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -31,7 +31,13 @@ class PytmcSignal(EpicsSignalBase):
     Under the hood this actually gives you the RW or RO version of the signal
     depending on your io argument.
     """
-    def __new__(cls, prefix, *, io, **kwargs):
+    def __new__(cls, prefix, io=None, **kwargs):
+        if io is None:
+            # Provide a better error here than "__new__ missing an arg"
+            raise ValueError('Must provide an "io" argument to PytmcSignal. '
+                             f'This is missing for signal with pv {prefix}. '
+                             'Feel free to copy the io field from the '
+                             'pytmc pragma.')
         norm = normalize_io(io)
         if norm == 'output':
             return super().__new__(PytmcSignalRW)

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -99,7 +99,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
     def _late_state_init(self, *args, enum_strs=None, **kwargs):
         if enum_strs is not None and not self.states_list:
             self.states_list = list(enum_strs)
-            # Unknown state is reserved for slot zero, automatically added later
+            # Unknown state reserved for slot zero, automatically added later
             # Removing and auto re-adding *feels* silly, but it was easy to do
             if self._unknown:
                 self.states_list.pop(0)

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -293,19 +293,6 @@ class StatePositioner(Device, PositionerBase, MvInterface):
                               ''.format(self.states_list, self._states_alias)))
         return enum
 
-    @property
-    def unknown(self):
-        """
-        True if we're in an unknown state, False otherwise
-        """
-        if self._unknown:
-            if self.position.name == self._unknown:
-                return True
-            else:
-                return False
-        else:
-            return False
-
 
 class PVStateSignal(AggregateSignal):
     """

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -507,7 +507,26 @@ class TwinCATStatePositioner(StatePositioner):
     any function block that follows the pattern set up by
     FB_EpicsInOut.
 
-    `states_list` does not have to be provided
+    Use `TwinCATInOutPositioner` instead if the device has clear inserted and
+    removed states.
+
+    Does not need to be subclassed to be used
+    ``states_list`` does not have to be provided in a subclass
+
+    Parameters
+    ----------
+    prefix: ``str``
+        The EPICS PV prefix for this motor.
+
+    name: ``str``, required keyword
+        An identifying name for this motor.
+
+    settle_time: ``float``, optional
+        The amount of extra time to wait before interpreting a move as done
+
+    timeout ``float``, optional
+        The amount of time to wait before automatically marking a long
+        in-progress move as failed.
     """
     state = Cpt(EpicsSignal, ':GET_RBV', write_pv='SET', kind='hinted')
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -463,15 +463,15 @@ class TwinCATStateConfigOne(Device):
     Designed to be used with the records from lcls-twincat-motion.
     Corresponds with DUT_PositionState
     """
-    state_name = Cpt(PytmcSignal, 'NAME', io='i', kind='config')
-    setpoint = Cpt(PytmcSignal, 'SETPOINT', io='io', kind='config')
-    delta = Cpt(PytmcSignal, 'DELTA', io='io', kind='config')
-    velo = Cpt(PytmcSignal, 'VELO', io='io', kind='config')
-    accl = Cpt(PytmcSignal, 'ACCL', io='io', kind='config')
-    dccl = Cpt(PytmcSignal, 'DCCL', io='io', kind='config')
-    move_ok = Cpt(PytmcSignal, 'MOVE_OK', io='i', kind='config')
-    locked = Cpt(PytmcSignal, 'LOCKED', io='i', kind='config')
-    valid = Cpt(PytmcSignal, 'VALID', io='i', kind='config')
+    state_name = Cpt(PytmcSignal, ':NAME', io='i', kind='config')
+    setpoint = Cpt(PytmcSignal, ':SETPOINT', io='io', kind='config')
+    delta = Cpt(PytmcSignal, ':DELTA', io='io', kind='config')
+    velo = Cpt(PytmcSignal, ':VELO', io='io', kind='config')
+    accl = Cpt(PytmcSignal, ':ACCL', io='io', kind='config')
+    dccl = Cpt(PytmcSignal, ':DCCL', io='io', kind='config')
+    move_ok = Cpt(PytmcSignal, ':MOVE_OK', io='i', kind='config')
+    locked = Cpt(PytmcSignal, ':LOCKED', io='i', kind='config')
+    valid = Cpt(PytmcSignal, ':VALID', io='i', kind='config')
 
 
 class TwinCATStateConfigAll(Device):
@@ -481,21 +481,21 @@ class TwinCATStateConfigAll(Device):
     Designed to be used with the array of DUT_PositionState from
     FB_PositionStateManager
     """
-    state01 = Cpt(TwinCATStateConfigOne, ':01:', kind='config')
-    state02 = Cpt(TwinCATStateConfigOne, ':02:', kind='config')
-    state03 = Cpt(TwinCATStateConfigOne, ':03:', kind='config')
-    state04 = Cpt(TwinCATStateConfigOne, ':04:', kind='config')
-    state05 = Cpt(TwinCATStateConfigOne, ':05:', kind='config')
-    state06 = Cpt(TwinCATStateConfigOne, ':06:', kind='config')
-    state07 = Cpt(TwinCATStateConfigOne, ':07:', kind='config')
-    state08 = Cpt(TwinCATStateConfigOne, ':08:', kind='config')
-    state09 = Cpt(TwinCATStateConfigOne, ':09:', kind='config')
-    state10 = Cpt(TwinCATStateConfigOne, ':10:', kind='config')
-    state11 = Cpt(TwinCATStateConfigOne, ':11:', kind='config')
-    state12 = Cpt(TwinCATStateConfigOne, ':12:', kind='config')
-    state13 = Cpt(TwinCATStateConfigOne, ':13:', kind='config')
-    state14 = Cpt(TwinCATStateConfigOne, ':14:', kind='config')
-    state15 = Cpt(TwinCATStateConfigOne, ':15:', kind='config')
+    state01 = Cpt(TwinCATStateConfigOne, ':01', kind='config')
+    state02 = Cpt(TwinCATStateConfigOne, ':02', kind='config')
+    state03 = Cpt(TwinCATStateConfigOne, ':03', kind='config')
+    state04 = Cpt(TwinCATStateConfigOne, ':04', kind='config')
+    state05 = Cpt(TwinCATStateConfigOne, ':05', kind='config')
+    state06 = Cpt(TwinCATStateConfigOne, ':06', kind='config')
+    state07 = Cpt(TwinCATStateConfigOne, ':07', kind='config')
+    state08 = Cpt(TwinCATStateConfigOne, ':08', kind='config')
+    state09 = Cpt(TwinCATStateConfigOne, ':09', kind='config')
+    state10 = Cpt(TwinCATStateConfigOne, ':10', kind='config')
+    state11 = Cpt(TwinCATStateConfigOne, ':11', kind='config')
+    state12 = Cpt(TwinCATStateConfigOne, ':12', kind='config')
+    state13 = Cpt(TwinCATStateConfigOne, ':13', kind='config')
+    state14 = Cpt(TwinCATStateConfigOne, ':14', kind='config')
+    state15 = Cpt(TwinCATStateConfigOne, ':15', kind='config')
 
 
 class TwinCATStatePositioner(StatePositioner):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -537,6 +537,18 @@ class TwinCATStatePositioner(StatePositioner):
 
     reset_cmd = Cpt(PytmcSignal, ':RESET', io='o', kind='omitted')
 
+    @required_for_connection
+    def _state_init(self):
+        super()._state_init()
+        # Clean up the kind on the config objects based on states list
+        state_count = len(self.states_list)
+        if self._unknown:
+            state_count -= 1
+        for i in range(1, 16):
+            if i > state_count:
+                state_config = getattr(self.config, f'state{i:02}')
+                state_config.kind = 'omitted'
+
 
 class StateStatus(SubscriptionStatus):
     """

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -528,7 +528,7 @@ class TwinCATStatePositioner(StatePositioner):
         The amount of time to wait before automatically marking a long
         in-progress move as failed.
     """
-    state = Cpt(EpicsSignal, ':GET_RBV', write_pv='SET', kind='hinted')
+    state = Cpt(EpicsSignal, ':GET_RBV', write_pv=':SET', kind='hinted')
 
     error = Cpt(PytmcSignal, ':ERR', io='i', kind='normal')
     error_id = Cpt(PytmcSignal, ':ERRID', io='i', kind='normal')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,17 @@
+from pathlib import Path
 import os
 import shutil
 import warnings
 
 import pytest
+from ophyd.sim import (make_fake_device, fake_device_cache,
+                       FakeEpicsSignal, FakeEpicsSignalRO)
 
+from pytmc.pragmas import normalize_io
 from pcdsdevices.attenuator import (Attenuator, MAX_FILTERS,
                                     _att_classes, _att3_classes)
-from ophyd.sim import make_fake_device
-from pathlib import Path
 from pcdsdevices.mv_interface import setup_preset_paths
+from pcdsdevices.signal import PytmcSignal
 
 
 # Signal.put warning is a testing artifact.
@@ -16,6 +19,19 @@ from pcdsdevices.mv_interface import setup_preset_paths
 # Needs to not pass tons of kwargs up to Signal.put
 warnings.filterwarnings('ignore',
                         message='Signal.put no longer takes keyword arguments')
+
+# Make sure an acceptable fake class is set for PytmcSignal
+def FakePytmcSignal(prefix, *, io, **kwargs):
+    norm = normalize_io(io)
+    if norm == 'output':
+        return FakeEpicsSignal(prefix, **kwargs)
+    elif norm == 'input':
+        return FakeEpicsSignalRO(prefix, **kwargs)
+    else:
+        # Give us the normal error message
+        return PytmcSignal(prefix, io=io, **kwargs)
+
+fake_device_cache[PytmcSignal] = FakePytmcSignal
 
 for name, cls in _att_classes.items():
     _att_classes[name] = make_fake_device(cls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from pcdsdevices.signal import PytmcSignal
 warnings.filterwarnings('ignore',
                         message='Signal.put no longer takes keyword arguments')
 
+
 # Make sure an acceptable fake class is set for PytmcSignal
 def FakePytmcSignal(prefix, *, io, **kwargs):
     norm = normalize_io(io)
@@ -30,6 +31,7 @@ def FakePytmcSignal(prefix, *, io, **kwargs):
     else:
         # Give us the normal error message
         return PytmcSignal(prefix, io=io, **kwargs)
+
 
 fake_device_cache[PytmcSignal] = FakePytmcSignal
 

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -198,7 +198,7 @@ def test_disable(fake_pcds_motor):
 def test_beckhoff_error_clear(fake_beckhoff):
     m = fake_beckhoff
     m.clear_error()
-    assert m.cmd_err_reset.get() == 1
+    assert m.plc.cmd_err_reset.get() == 1
     m.stage()
     m.unstage()
 

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -6,7 +6,8 @@ from ophyd.sim import make_fake_device
 
 from pcdsdevices.inout import (InOutPositioner,
                                InOutRecordPositioner,
-                               InOutPVStatePositioner)
+                               InOutPVStatePositioner,
+                               TwinCATInOutPositioner)
 
 logger = logging.getLogger(__name__)
 
@@ -69,3 +70,25 @@ def test_subcls_warning():
         InOutPositioner('prefix', name='name')
     with pytest.raises(TypeError):
         InOutPVStatePositioner('prefix', name='name')
+
+
+@pytest.fixture(scope='function')
+def fake_tcinout():
+    FakeCls = make_fake_device(TwinCATInOutPositioner)
+    device = FakeCls('FAKE:CLASS', name='faker')
+    return device
+
+
+def test_in_if_not_out(fake_tcinout):
+    enums = ('Unknown', 'Out', 'Fish')
+    fake_tcinout.state._run_subs(sub_type=fake_tcinout.state.SUB_META,
+                                 enum_strs=enums)
+    fake_tcinout.state.sim_put(0)
+    assert not fake_tcinout.inserted
+    assert not fake_tcinout.removed
+    fake_tcinout.state.sim_put(1)
+    assert not fake_tcinout.inserted
+    assert fake_tcinout.removed
+    fake_tcinout.state.sim_put(2)
+    assert fake_tcinout.inserted
+    assert not fake_tcinout.removed

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.pim import PIM, PIMMotor
+from pcdsdevices.pim import PIM, PIMMotor, PPM, XPIM
 
 logger = logging.getLogger(__name__)
 
@@ -64,3 +64,11 @@ def test_pim_subscription(fake_pim):
 @pytest.mark.timeout(5)
 def test_pim_disconnected():
     PIM('TST:YAG', name='tst', prefix_det='tstst')
+
+@pytest.mark.timeout(5)
+def test_ppm_disconnected():
+    PPM('IM7S7:PPM', name='im7s7')
+
+@pytest.mark.timeout(5)
+def test_xpim_disconnected():
+    XPIM('IM7S7:PPM', name='im7s7')

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -65,9 +65,11 @@ def test_pim_subscription(fake_pim):
 def test_pim_disconnected():
     PIM('TST:YAG', name='tst', prefix_det='tstst')
 
+
 @pytest.mark.timeout(5)
 def test_ppm_disconnected():
     PPM('IM7S7:PPM', name='im7s7')
+
 
 @pytest.mark.timeout(5)
 def test_xpim_disconnected():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -191,7 +191,7 @@ def test_subcls_warning():
 
 
 class InOutSignal(Signal):
-    enum_strs = ('Unknown', 'IN', 'OUT')
+    _metadata_keys = (Signal._core_metadata_keys + ('enum_strs',))
 
 
 class NoStatesList(StatePositioner):
@@ -201,5 +201,6 @@ class NoStatesList(StatePositioner):
 def test_auto_states():
     logger.debug('test_auto_states')
     states = NoStatesList(prefix='NOSTATE', name='no_state')
-    states.state.put(1)  # Force callback to run
-    assert states.states_list == ['Unknown', 'IN', 'OUT']
+    enum_strs = ('Unknown', 'IN', 'OUT')
+    states.state._run_subs(sub_type=states.state.SUB_META, enum_strs=enum_strs)
+    assert states.states_list == list(enum_strs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add PPM and XPIM classes. Add various other helper classes that may be useful to people developing with TwinCAT devices. Small fixes.

This is not complete, but it is far enough along for volunteer reviews. I will request reviews once I finish the TODO list.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Gotta get stuff ready

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for the code and checked against real PVs. One more check is needed once I fix the IOCs.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Autodocs and docstrings have been updated appropriately.

## TODO
- [x] Add docstrings
- [x] Get some consistency between whether prefixes include the `:` character
- [x] Make sure we can connect to the real devices
- [x] Add regression testing
- [x] Debug why `PPM` and `XPIM` take several seconds to instantiate
- [x] Make the repr shorter (includes so many config PVs)
- [x] Investigate switching the state config pvs to omitted for the invalid states after init