### PR TITLE
ENH: Update PIM classes

### DIFF
--- a/pcdsdevices/doc_stubs.py
+++ b/pcdsdevices/doc_stubs.py
@@ -39,24 +39,6 @@ insert_remove = """
 
 """
 
-PIM_base = """
-    Profile intensity monitor
-
-    Parameters
-    ----------
-    prefix : str
-        The EPICS base of the motor
-
-    name : str
-        A name to refer to the device
-
-    prefix_det : str
-        The EPICS base PV of the detector
-
-    prefix_zoom : str
-        The EPICS base PV of the zoom motor
-    """
-
 IonPump_base = """
     Ion Pump
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -120,7 +120,7 @@ class PIM(Device):
         self.y_motor = self.state.motor
 
 
-class PIM_withFocus(PIM):
+class PIMWithFocus(PIM):
     """
     Profile intensity monitor with y-motion motor, zoom motor, focus motor, and
     a detector.
@@ -159,7 +159,7 @@ class PIM_withFocus(PIM):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class PIM_withLED(PIM):
+class PIMWithLED(PIM):
     """
     Profile intensity monitor with y-motion motor, zoom motor, LED, and a
     detector.
@@ -198,7 +198,7 @@ class PIM_withLED(PIM):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class PIM_withBoth(PIM_withLED, PIM_withFocus):
+class PIMWithBoth(PIMWithFocus, PIMWithLED):
     """
     Profile intensity monitor with y-motion motor, zoom motor, focus motor,
     LED, and a detector.

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -56,7 +56,7 @@ class PIM(Device):
         be inferred from `prefix`
     """
 
-    _area = ''
+    _prefix_start = ''
 
     state = Cpt(PIM_Y, '', kind='normal')
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
@@ -65,13 +65,13 @@ class PIM(Device):
     tab_whitelist = ['y_motor', 'zoom_motor', 'detector']
 
     def infer_prefix(self, prefix):
-        if not self._area:
-            self._area = prefix.split(':')[0]
-            self._section = prefix.split(':')[1]
+        if not self._prefix_start:
+            self._prefix_start = '{0}:{1}:'.format(prefix.split(':')[0],
+                                                   prefix.split(':')[1])
 
     @property
     def prefix_start(self):
-        return '{0}:{1}:'.format(self._area, self._section)
+        return str(self._prefix_start)
 
     @property
     def removed(self):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -2,7 +2,7 @@
 Module for the `PIM` profile intensity monitor classes
 
 This module contains all the classes relating to the profile intensity monitor
-classes at the user level. A PIM always has a motor to control yag/diode 
+classes at the user level. A PIM always has a motor to control yag/diode
 position, a zoom motor, and a camera to view the yag. Some PIMs have LEDs for
 illumination and/or a focus motor. Each of these configurations is set up as
 its own class.
@@ -62,7 +62,7 @@ class PIM(Device):
 
     _prefix_start = ''
 
-    state = Cpt(PIM_Y, '', kind='normal')
+    state = Cpt(PIMY, '', kind='normal')
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetector, '{self._prefix_det}', kind='normal')
 
@@ -91,12 +91,12 @@ class PIM(Device):
         return self.state.inserted
 
     def insert(self, moved_cb=None, timeout=None, wait=False):
-        """Moves the diode into the beam."""
+        """Moves the YAG into the beam."""
         return self.state.insert(moved_cb=moved_cb, timeout=timeout,
                                  wait=wait)
 
     def remove(self, moved_cb=None, timeout=None, wait=False):
-        """Moves the diode out of the beam."""
+        """Moves the YAG and diode out of the beam."""
         return self.state.remove(moved_cb=moved_cb, timeout=timeout,
                                  wait=wait)
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -55,10 +55,10 @@ class PIM(Device):
         The EPICS base PV of the zoom motor. If None, it will be attempted to
         be inferred from `prefix`
     """
-    y_motor = Cpt(PIM_Y, '', kind='normal')
 
     _area = ''
 
+    state = Cpt(PIM_Y, '', kind='normal')
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetector, '{self._prefix_det}', kind='normal')
 
@@ -72,6 +72,24 @@ class PIM(Device):
     @property
     def prefix_start(self):
         return '{0}:{1}:'.format(self._area, self._section)
+
+    @property
+    def removed(self):
+        return self.state.removed
+
+    @property
+    def inserted(self):
+        return self.state.inserted
+
+    def insert(self, moved_cb=None, timeout=None, wait=False):
+        """Moves the diode into the beam."""
+        return self.state.insert(moved_cb=moved_cb, timeout=timeout,
+                                 wait=wait)
+
+    def remove(self, moved_cb=None, timeout=None, wait=False):
+        """Moves the diode out of the beam."""
+        return self.state.remove(moved_cb=moved_cb, timeout=timeout,
+                                 wait=wait)
 
     def __init__(self, prefix, *, name, prefix_det=None, prefix_zoom=None,
                  **kwargs):
@@ -90,6 +108,7 @@ class PIM(Device):
             self._prefix_zoom = self.prefix_start+'CLZ:01'
 
         super().__init__(prefix, name=name, **kwargs)
+        self.y_motor = self.state.motor
 
 
 class PIM_withFocus(PIM):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class PIM_Y(InOutRecordPositioner):
     """
-    Standard position monitor Y motor.
+    Standard profile monitor Y motor.
 
     This can move the stage to insert the yag
     or diode, or retract from the beam path.
@@ -38,8 +38,6 @@ class PIM_Y(InOutRecordPositioner):
 class PIM(Device):
     """
     Profile intensity monitor with y-motion motor, zoom motor, and a detector.
-    A PIM will usually have at least a motor to control yag position and a
-    camera to view the YAG.
 
     Parameters
     ----------
@@ -92,6 +90,30 @@ class PIM(Device):
 
 
 class PIM_withFocus(PIM):
+    """
+    Profile intensity monitor with y-motion motor, zoom motor, focus motor, and
+    a detector.
+
+    Parameters
+    ----------
+    prefix : str
+        The EPICS base of the PIM
+
+    name : str
+        A name to refer to the device
+
+    prefix_det : str, optional
+        The EPICS base PV of the detector. If None, it will be attemptted to be
+        inferred from `prefix`
+
+    prefix_zoom : str, optional
+        The EPICS base PV of the zoom motor. If None, it will be attempted to
+        be inferred from `prefix`
+
+    prefix_focus : str, optional
+        The EPICS base PV of the focus motor. If None, it will be attempted to
+        be inferred from `prefix`
+    """
     focus_motor = FCpt(IMS, '{self._prefix_focus}')
 
     def __init__(self, prefix, *, name, prefix_det=None, prefix_zoom=None,
@@ -109,6 +131,30 @@ class PIM_withFocus(PIM):
 
 
 class PIM_withLED(PIM):
+    """
+    Profile intensity monitor with y-motion motor, zoom motor, LED, and a
+    detector.
+
+    Parameters
+    ----------
+    prefix : str
+        The EPICS base of the PIM
+
+    name : str
+        A name to refer to the device
+
+    prefix_det : str, optional
+        The EPICS base PV of the detector. If None, it will be attemptted to be
+        inferred from `prefix`
+
+    prefix_zoom : str, optional
+        The EPICS base PV of the zoom motor. If None, it will be attempted to
+        be inferred from `prefix`
+
+    prefix_led : str, optional
+        The EPICS base PV of the LED. If None, it will be attempted to be
+        inferred from `prefix`
+    """
     led = FCpt(EpicsSignal, '{self._prefix_led}')
 
     def __init__(self, prefix, *, name, prefix_det=None, prefix_zoom=None,
@@ -126,4 +172,32 @@ class PIM_withLED(PIM):
 
 
 class PIM_withBoth(PIM_withLED, PIM_withFocus):
+    """
+    Profile intensity monitor with y-motion motor, zoom motor, focus motor,
+    LED, and a detector.
+
+    Parameters
+    ----------
+    prefix : str
+        The EPICS base of the PIM
+
+    name : str
+        A name to refer to the device
+
+    prefix_det : str, optional
+        The EPICS base PV of the detector. If None, it will be attemptted to be
+        inferred from `prefix`
+
+    prefix_zoom : str, optional
+        The EPICS base PV of the zoom motor. If None, it will be attempted to
+        be inferred from `prefix`
+
+    prefix_focus : str, optional
+        The EPICS base PV of the focus motor. If None, it will be attempted to
+        be inferred from `prefix`
+
+    prefix_led : str, optional
+        The EPICS base PV of the LED. If None, it will be attempted to be
+        inferred from `prefix`
+    """
     pass

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -56,6 +56,9 @@ class PIM(Device):
         be inferred from `prefix`
     """
     y_motor = Cpt(PIM_Y, '', kind='normal')
+
+    _area = ''
+
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetector, '{self._prefix_det}', kind='normal')
 
@@ -116,8 +119,7 @@ class PIM_withFocus(PIM):
     """
     focus_motor = FCpt(IMS, '{self._prefix_focus}')
 
-    def __init__(self, prefix, *, name, prefix_det=None, prefix_zoom=None,
-                 prefix_focus=None, **kwargs):
+    def __init__(self, prefix, *, name, prefix_focus=None, **kwargs):
         self.infer_prefix(prefix)
 
         # Infer the focus motor PV from the base prefix
@@ -126,8 +128,7 @@ class PIM_withFocus(PIM):
         else:
             self._prefix_focus = self.prefix_start+'CLF:01'
 
-        self.__init__(prefix, name=name, prefix_det=prefix_det,
-                      prefix_zoom=prefix_zoom, **kwargs)
+        super().__init__(prefix, name=name, **kwargs)
 
 
 class PIM_withLED(PIM):
@@ -157,8 +158,7 @@ class PIM_withLED(PIM):
     """
     led = FCpt(EpicsSignal, '{self._prefix_led}')
 
-    def __init__(self, prefix, *, name, prefix_det=None, prefix_zoom=None,
-                 prefix_led=None, **kwargs):
+    def __init__(self, prefix, *, name, prefix_led=None, **kwargs):
         self.infer_prefix(prefix)
 
         # Infer the illuminator PV from the base prefix
@@ -167,8 +167,7 @@ class PIM_withLED(PIM):
         else:
             self._prefix_led = self.prefix_start+'CIL:01'
 
-        self.__init__(prefix, name=name, prefix_det=prefix_det,
-                      prefix_zoom=prefix_zoom, **kwargs)
+        super().__init__(prefix, name=name, **kwargs)
 
 
 class PIM_withBoth(PIM_withLED, PIM_withFocus):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -55,7 +55,7 @@ class PIM(Device, BaseInterface):
         A name to refer to the device
 
     prefix_det : str, optional
-        The EPICS base PV of the detector. If None, it will be attemptted to be
+        The EPICS base PV of the detector. If None, it will be attempted to be
         inferred from `prefix`
 
     prefix_zoom : str, optional
@@ -65,7 +65,7 @@ class PIM(Device, BaseInterface):
 
     _prefix_start = ''
 
-    state = Cpt(PIMY, '', kind='normal')
+    state = Cpt(PIMY, '', kind='omitted')
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetector, '{self._prefix_det}', kind='normal')
 
@@ -138,7 +138,7 @@ class PIMWithFocus(PIM):
         A name to refer to the device
 
     prefix_det : str, optional
-        The EPICS base PV of the detector. If None, it will be attemptted to be
+        The EPICS base PV of the detector. If None, it will be attempted to be
         inferred from `prefix`
 
     prefix_zoom : str, optional
@@ -149,7 +149,7 @@ class PIMWithFocus(PIM):
         The EPICS base PV of the focus motor. If None, it will be attempted to
         be inferred from `prefix`
     """
-    focus_motor = FCpt(IMS, '{self._prefix_focus}')
+    focus_motor = FCpt(IMS, '{self._prefix_focus}', kind='normal')
 
     def __init__(self, prefix, *, name, prefix_focus=None, **kwargs):
         self.infer_prefix(prefix)
@@ -177,7 +177,7 @@ class PIMWithLED(PIM):
         A name to refer to the device
 
     prefix_det : str, optional
-        The EPICS base PV of the detector. If None, it will be attemptted to be
+        The EPICS base PV of the detector. If None, it will be attempted to be
         inferred from `prefix`
 
     prefix_zoom : str, optional
@@ -188,7 +188,7 @@ class PIMWithLED(PIM):
         The EPICS base PV of the LED. If None, it will be attempted to be
         inferred from `prefix`
     """
-    led = FCpt(EpicsSignal, '{self._prefix_led}')
+    led = FCpt(EpicsSignal, '{self._prefix_led}', kind='normal')
 
     def __init__(self, prefix, *, name, prefix_led=None, **kwargs):
         self.infer_prefix(prefix)

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -1,5 +1,11 @@
 """
 Module for the `PIM` profile intensity monitor classes
+
+This module contains all the classes relating to the profile intensity monitor
+classes at the user level. A PIM always has a motor to control yag/diode 
+position, a zoom motor, and a camera to view the yag. Some PIMs have LEDs for
+illumination and/or a focus motor. Each of these configurations is set up as
+its own class.
 """
 import logging
 
@@ -13,7 +19,7 @@ from .inout import InOutRecordPositioner
 logger = logging.getLogger(__name__)
 
 
-class PIM_Y(InOutRecordPositioner):
+class PIMY(InOutRecordPositioner):
     """
     Standard profile monitor Y motor.
 
@@ -206,7 +212,7 @@ class PIM_withBoth(PIM_withLED, PIM_withFocus):
         A name to refer to the device
 
     prefix_det : str, optional
-        The EPICS base PV of the detector. If None, it will be attemptted to be
+        The EPICS base PV of the detector. If None, it will be attempted to be
         inferred from `prefix`
 
     prefix_zoom : str, optional

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -28,9 +28,7 @@ class PIM_Y(InOutRecordPositioner):
     _icon = 'fa.camera-retro'
 
     def stage(self):
-        """
-        Save the original position to be restored on `unstage`.
-        """
+        """Save the original position to be restored on `unstage`."""
         self._original_vals[self.state] = self.state.value
         return super().stage()
 
@@ -65,20 +63,25 @@ class PIM(Device):
     tab_whitelist = ['y_motor', 'zoom_motor', 'detector']
 
     def infer_prefix(self, prefix):
+        """Pulls out the first two segments of the prefix PV, if not already
+           done"""
         if not self._prefix_start:
             self._prefix_start = '{0}:{1}:'.format(prefix.split(':')[0],
                                                    prefix.split(':')[1])
 
     @property
     def prefix_start(self):
+        """Returns the first two segments of the prefix PV."""
         return str(self._prefix_start)
 
     @property
     def removed(self):
+        """Returns ``True`` if the yag and diode are removed from the beam."""
         return self.state.removed
 
     @property
     def inserted(self):
+        """Returns ``True`` if yag or diode are inserted."""
         return self.state.inserted
 
     def insert(self, moved_cb=None, timeout=None, wait=False):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -15,11 +15,12 @@ from ophyd.signal import EpicsSignal
 from .epics_motor import IMS
 from .areadetector.detectors import PCDSAreaDetector
 from .inout import InOutRecordPositioner
+from .interface import BaseInterface
 
 logger = logging.getLogger(__name__)
 
 
-class PIMY(InOutRecordPositioner):
+class PIMY(InOutRecordPositioner, BaseInterface):
     """
     Standard profile monitor Y motor.
 
@@ -33,13 +34,15 @@ class PIMY(InOutRecordPositioner):
     # QIcon for UX
     _icon = 'fa.camera-retro'
 
+    tab_whitelist = ['stage']
+
     def stage(self):
         """Save the original position to be restored on `unstage`."""
         self._original_vals[self.state] = self.state.value
         return super().stage()
 
 
-class PIM(Device):
+class PIM(Device, BaseInterface):
     """
     Profile intensity monitor with y-motion motor, zoom motor, and a detector.
 
@@ -66,7 +69,8 @@ class PIM(Device):
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetector, '{self._prefix_det}', kind='normal')
 
-    tab_whitelist = ['y_motor', 'zoom_motor', 'detector']
+    tab_whitelist = ['y_motor', 'remove', 'insert', 'removed', 'inserted']
+    tab_component_names = True
 
     def infer_prefix(self, prefix):
         """Pulls out the first two segments of the prefix PV, if not already

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 def fake_pim():
     FakePIM = make_fake_device(PIM)
     pim = FakePIM('Test:Yag', name='test')
-    pim.state.sim_put(0)
-    pim.state.sim_set_enum_strs(['Unknown'] + PIM_Y.states_list)
-    pim.motor.error_severity.sim_put(0)
-    pim.motor.bit_status.sim_put(0)
-    pim.motor.motor_spg.sim_put(2)
+    pim.state.state.sim_put(0)
+    pim.state.state.sim_set_enum_strs(['Unknown'] + PIM_Y.states_list)
+    pim.y_motor.error_severity.sim_put(0)
+    pim.y_motor.bit_status.sim_put(0)
+    pim.y_motor.motor_spg.sim_put(2)
     return pim
 
 
@@ -28,19 +28,19 @@ def test_pim_stage(fake_pim):
     logger.debug('test_pim_stage')
     pim = fake_pim
     # Should return to original position on unstage
-    pim.move('OUT', wait=True)
+    pim.state.move('OUT', wait=True)
     assert pim.removed
-    pim.stage()
-    pim.move('IN', wait=True)
+    pim.state.stage()
+    pim.state.move('IN', wait=True)
     assert pim.inserted
-    pim.unstage()
+    pim.state.unstage()
     assert pim.removed
-    pim.move('IN', wait=True)
+    pim.state.move('IN', wait=True)
     assert pim.inserted
-    pim.stage()
-    pim.move('OUT', wait=True)
+    pim.state.stage()
+    pim.state.move('OUT', wait=True)
     assert pim.removed
-    pim.unstage()
+    pim.state.unstage()
     assert pim.inserted
 
 
@@ -96,8 +96,8 @@ def test_pim_subscription(fake_pim):
     logger.debug('test_pim_subscription')
     pim = fake_pim
     cb = Mock()
-    pim.subscribe(cb, event_type=pim.SUB_STATE, run=False)
-    pim.state.sim_put(2)
+    pim.state.subscribe(cb, event_type=pim.state.SUB_STATE, run=False)
+    pim.state.state.sim_put(2)
     assert cb.called
 
 

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.pim import (PIM, PIM_Y, PIM_withLED, PIM_withFocus,
+from pcdsdevices.pim import (PIM, PIMY, PIM_withLED, PIM_withFocus,
                              PIM_withBoth)
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ def fake_pim():
     FakePIM = make_fake_device(PIM)
     pim = FakePIM('Test:Yag', name='test')
     pim.state.state.sim_put(0)
-    pim.state.state.sim_set_enum_strs(['Unknown'] + PIM_Y.states_list)
+    pim.state.state.sim_set_enum_strs(['Unknown'] + PIMY.states_list)
     pim.y_motor.error_severity.sim_put(0)
     pim.y_motor.bit_status.sim_put(0)
     pim.y_motor.motor_spg.sim_put(2)

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock
 
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.pim import (PIM, PIMY, PIM_withLED, PIM_withFocus,
-                             PIM_withBoth)
+from pcdsdevices.pim import (PIM, PIMY, PIMWithLED, PIMWithFocus,
+                             PIMWithBoth)
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def test_pim_init():
     FakePIM('Test:Yag', name='test', prefix_det='potato')
     FakePIM('Test:Yag', name='test', prefix_zoom='potato')
     FakePIM('Test:Yag', name='test')
-    FakePIM = make_fake_device(PIM_withLED)
+    FakePIM = make_fake_device(PIMWithLED)
     FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
             prefix_led='shiny')
     FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_led='shiny')
@@ -61,7 +61,7 @@ def test_pim_init():
     FakePIM('Test:Yag', name='test', prefix_det='potato')
     FakePIM('Test:Yag', name='test', prefix_zoom='potato')
     FakePIM('Test:Yag', name='test')
-    FakePIM = make_fake_device(PIM_withFocus)
+    FakePIM = make_fake_device(PIMWithFocus)
     FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
             prefix_focus='blur')
     FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_focus='blur')
@@ -70,7 +70,7 @@ def test_pim_init():
     FakePIM('Test:Yag', name='test', prefix_det='potato')
     FakePIM('Test:Yag', name='test', prefix_zoom='potato')
     FakePIM('Test:Yag', name='test')
-    FakePIM = make_fake_device(PIM_withBoth)
+    FakePIM = make_fake_device(PIMWithBoth)
     FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
             prefix_focus='blur', prefix_led='shiny')
     FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_focus='blur',

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -28,17 +28,17 @@ def test_pim_stage(fake_pim):
     logger.debug('test_pim_stage')
     pim = fake_pim
     # Should return to original position on unstage
-    pim.state.move('OUT', wait=True)
+    pim.remove()
     assert pim.removed
     pim.state.stage()
-    pim.state.move('IN', wait=True)
+    pim.insert()
     assert pim.inserted
     pim.state.unstage()
     assert pim.removed
-    pim.state.move('IN', wait=True)
+    pim.insert()
     assert pim.inserted
     pim.state.stage()
-    pim.state.move('OUT', wait=True)
+    pim.remove()
     assert pim.removed
     pim.state.unstage()
     assert pim.inserted

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -5,17 +5,18 @@ from unittest.mock import Mock
 
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.pim import PIM, PIMMotor
+from pcdsdevices.pim import (PIM, PIM_Y, PIM_withLED, PIM_withFocus,
+                             PIM_withBoth)
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_pim():
-    FakePIM = make_fake_device(PIMMotor)
+    FakePIM = make_fake_device(PIM)
     pim = FakePIM('Test:Yag', name='test')
     pim.state.sim_put(0)
-    pim.state.sim_set_enum_strs(['Unknown'] + PIMMotor.states_list)
+    pim.state.sim_set_enum_strs(['Unknown'] + PIM_Y.states_list)
     pim.motor.error_severity.sim_put(0)
     pim.motor.bit_status.sim_put(0)
     pim.motor.motor_spg.sim_put(2)
@@ -44,10 +45,49 @@ def test_pim_stage(fake_pim):
 
 
 @pytest.mark.timeout(5)
-def test_pim_det():
+def test_pim_init():
     logger.debug('test_pim_det')
     FakePIM = make_fake_device(PIM)
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh')
     FakePIM('Test:Yag', name='test', prefix_det='potato')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato')
+    FakePIM('Test:Yag', name='test')
+    FakePIM = make_fake_device(PIM_withLED)
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
+            prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_det='potato')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato')
+    FakePIM('Test:Yag', name='test')
+    FakePIM = make_fake_device(PIM_withFocus)
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
+            prefix_focus='blur')
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_focus='blur')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato', prefix_focus='blur')
+    FakePIM('Test:Yag', name='test', prefix_focus='blurry')
+    FakePIM('Test:Yag', name='test', prefix_det='potato')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato')
+    FakePIM('Test:Yag', name='test')
+    FakePIM = make_fake_device(PIM_withBoth)
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
+            prefix_focus='blur', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_focus='blur',
+            prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato', prefix_focus='blur',
+            prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_focus='blurry', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_led='shiny')
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_zoom='woosh',
+            prefix_focus='blur')
+    FakePIM('Test:Yag', name='test', prefix_det='potato', prefix_focus='blur')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato', prefix_focus='blur')
+    FakePIM('Test:Yag', name='test', prefix_focus='blurry')
+    FakePIM('Test:Yag', name='test', prefix_det='potato')
+    FakePIM('Test:Yag', name='test', prefix_zoom='potato')
     FakePIM('Test:Yag', name='test')
 
 


### PR DESCRIPTION
## Description
Changed hierarchy so that a PIM object has an InOutPositioner instead of being one.
Added classes for multiple configurations for PIMs which have LEDs, focus motors, or both.

Looking for feedback on a bunch of things. e.g. I'm not sure if the way I did some things is allowed/good practice. Also, please let me know if you have any suggestions for better class names or the current ones don't follow naming standards.

## Motivation and Context
Gives a better representation of what's actually on the beamline and allows for better control of the device.

## How Has This Been Tested?
Hasn't yet.

## Where Has This Been Documented?
Docstrings 