### PR TITLE
CI: allow docs failure to let build finish before docs are done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
     - name: "Python 3.8 Unit Tests"
       python: 3.8
       env: UNIT_TEST=1
+    - name: "Build Docs"
+      python: 3.6
+      env: BUILD_DOCS=1
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add build docs to the allowed failures

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We DO want the docs to succeed, but we do not want to wait 20 minutes to get the unit test and style pass/fail summary on the PR (which happen on the order of 5 minutes)