### PR TITLE
MNT: changed PIPPLC class by adding state_rbv and SP_DI->HV_DI

### DIFF
--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -167,8 +167,9 @@ class PIPPLC(Device):
                        doc='interlock  is ok when true')
     at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
                     doc='at vacuum set point')
-    set_point_relay = Cpt(EpicsSignalRO, ':SP_DI_RBV', kind='normal',
-                          doc='set point digital input relay')
+    pump_on = Cpt(EpicsSignalRO, ':HV_DI_RBV', kind='normal',
+                          doc='ion pump output state')
+    pump_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted')
 
 
 class PTMPLC(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -168,7 +168,7 @@ class PIPPLC(Device):
     at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
                     doc='at vacuum set point')
     pump_on = Cpt(EpicsSignalRO, ':HV_DI_RBV', kind='normal',
-                          doc='ion pump output state')
+                  doc='ion pump output state')
     pump_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted')
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
 changed PIPPLC class by adding state_rbv and SP_DI->HV_DI

## Motivation and Context
Updating ion pump plc logic. The state variable has been addded to report whether or not the pump is off, starting, on, faulted. 

The SP_DI was changed to the HV_DI because the relay output is used to report the ion pump output state.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
