### PR TITLE
ENH: specify typhos templates for some devices

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -58,6 +58,10 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     tab_whitelist = ["set_current_position", "home", "velocity",
                      "enable", "disable"]
 
+    typhos_detailed = 'detailed_positioner.ui'
+    typhos_screen = 'positioner.ui'
+    typhos_embedded = 'embedded_positioner.ui'
+
     @property
     def low_limit(self):
         """
@@ -456,6 +460,10 @@ class BeckhoffAxis(EpicsMotorInterface):
     """
     __doc__ += basic_positioner_init
     tab_whitelist = ['clear_error']
+
+    typhos_detailed = 'detailed_beckhoff_positioner.ui'
+    typhos_screen = 'beckhoff_positioner.ui'
+    typhos_embedded = 'embedded_beckhoff_positioner.ui'
 
     plc = Cpt(BeckhoffAxisPLC, ':PLC:', kind='normal')
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -83,6 +83,10 @@ class LCLS2ImagerBase(Device, BaseInterface):
     """
     tab_component_names = True
 
+    typhos_detailed = 'detailed_imager.ui'
+    typhos_screen = 'imager.ui'
+    typhos_embedded = 'embedded_imager.ui'
+
     y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted')
     y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal')
     detector = Cpt(PCDSAreaDetector, ':CAM:', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Quick proposal for an interface to specify which `typhos` template should be associated with each device class. In `typhos` we can check if `typhos_detailed`, etc. are defined and pick a screen from the `typhos` path appropriately, or use the default templates if none is found. It would be up to us to include the template ui files in our `typhos` path. A nice thing about doing it this way is that we could take adventage of class inheritance to specify a screen for all motors, then override it as needed to add vendor-specific functions cleanly, etc.

I'm not really sure the best place to keep these template files. `typhos` will get bloated if we put them all there. The best option may be to put them in this repo to keep them linked to the device classes and then append to the `typhos` path on install, but that will make this repo very large. It will also pick up a `typhos` dependency and the whole stack below that. Another choice would be to stash them in a third repo that depends on both `pcdsdevices` and `typhos`, but then we're maintaining an extra repo. We could also spread them out into the various IOC and PLC repos as appropriate, but then they are scattered everywhere.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Screens are looking good, but tweaked templates will make them even better. We should decide how we're specifying and deploying these.
