### PR TITLE
BUG: Changed motor components to BeckhoffAxis to properly capture reaback and setpoints

### DIFF
--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -13,6 +13,7 @@ from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as Cpt,
                    PVPositioner, FormattedComponent as FCpt)
 
 from .doc_stubs import basic_positioner_init
+from .epics_motor import BeckhoffAxis
 from .inout import InOutRecordPositioner
 from .interface import FltMvInterface, BaseInterface
 from .signal import PytmcSignal
@@ -294,12 +295,12 @@ class XOffsetMirror(Device, BaseInterface):
         Alias for the device
     """
     # Motor components: can read/write positions
-    y_up = Cpt(EpicsSignal, ':MMS:YUP', kind='normal')
-    y_dwn = Cpt(EpicsSignal, ':MMS:YDWN', kind='config')
-    x_up = Cpt(EpicsSignal, ':MMS:XUP', kind='normal')
-    x_dwn = Cpt(EpicsSignal, ':MMS:XDWN', kind='config')
-    pitch = Cpt(EpicsSignal, ':MMS:PITCH', kind='normal')
-    bender = Cpt(EpicsSignal, ':MMS:BENDER', kind='normal')
+    y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='normal')
+    y_dwn = Cpt(BeckhoffAxis, ':MMS:YDWN', kind='config')
+    x_up = Cpt(BeckhoffAxis, ':MMS:XUP', kind='normal')
+    x_dwn = Cpt(BeckhoffAxis, ':MMS:XDWN', kind='config')
+    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='normal')
+    bender = Cpt(BeckhoffAxis, ':MMS:BENDER', kind='normal')
 
     # Gantry components
     gantry_x = Cpt(PytmcSignal, ':GANTRY_X', io='i', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Changed each motor component of `mirror.XOffsetMirror` from `EpicsSignal` to `BeckhoffAxis`
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Noticed readback field was always agreeing with its setpoint due to not differentiating the two when using `EpicsSignal`. Instead using `BeckhoffAxis` takes care of this.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Instantiated mirror in IPython session and inspected components:
```
In [1]: from pcdsdevices.mirror import XOffsetMirror

In [2]: mr2l0 = XOffsetMirror('MR2L0:LFE', name='mr2l0_lfe')

In [3]: mr2l0.component_names
Out[3]:
('y_up',
 'y_dwn',
 'x_up',
 'x_dwn',
 'pitch',
 'bender',
 'gantry_x',
 'gantry_y',
 'couple_y',
 'couple_x',
 'decouple_y',
 'decouple_x',
 'couple_status_y',
 'couple_status_x',
 'y_enc_rms',
 'x_enc_rms',
 'pitch_enc_rms',
 'bender_enc_rms')

In [4]: mr2l0.pitch.component_names
Out[4]:
('user_readback',
 'user_setpoint',
 'user_offset',
 'user_offset_dir',
 'offset_freeze_switch',
 'set_use_switch',
 'velocity',
 'acceleration',
 'motor_egu',
 'motor_is_moving',
 'motor_done_move',
 'high_limit_switch',
 'low_limit_switch',
 'direction_of_travel',
 'motor_stop',
 'home_forward',
 'home_reverse',
 'low_soft_limit',
 'high_soft_limit',
 'disabled',
 'description',
 'plc')

In [5]: mr2l0.pitch.user_readback.get()
Out[5]: 18000.037039

In [6]:

In [6]: mr2l0.pitch.user_readback.get()
Out[6]: 17999.974661
```

Opened test screen to see if fields update correctly:
`(dev) [sheppard@lfe-console  pcdsdevices]$ typhos 'pcdsdevices.mirror.XOffsetMirror[{"prefix":"MR2L0:LFE"}]'`
![typhos-BeckhoffAxis](https://user-images.githubusercontent.com/37093966/75715136-c2629a80-5c81-11ea-81aa-bb8f28e528b1.PNG)
