### PR TITLE
DEV: added VGC MPS status, moved ION Pump expert screen's pv's from o…

### DIFF
--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -161,15 +161,15 @@ class PIPPLC(Device):
                    doc='pressure reading')
     high_voltage_do = Cpt(EpicsSignalRO, ':HV_DO_RBV', kind='normal',
                           doc='high voltage digital output')
-    high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='omitted',
-                              doc='epics command to witch on the high voltage')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock  is ok when true')
-    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
-                    doc='at vacuum set point')
-    pump_on = Cpt(EpicsSignalRO, ':HV_DI_RBV', kind='normal',
+    pump_on_status = Cpt(EpicsSignalRO, ':HV_DI_RBV', kind='normal',
                   doc='ion pump output state')
     pump_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted')
+    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
+                    doc='at vacuum set point')
+    high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='config',
+                              doc='epics command to switch on the high voltage')
 
 
 class PTMPLC(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -164,12 +164,13 @@ class PIPPLC(Device):
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock  is ok when true')
     pump_on_status = Cpt(EpicsSignalRO, ':HV_DI_RBV', kind='normal',
-                  doc='ion pump output state')
+                         doc='ion pump output state')
     pump_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted')
     at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
-                    doc='at vacuum set point')
+                          doc='at vacuum set point')
     high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='config',
-                              doc='epics command to switch on the high voltage')
+                              doc='epics command to switch on the '
+                              'high voltage')
 
 
 class PTMPLC(Device):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -229,15 +229,15 @@ class VGC(VRC):
     ext_ilk_ok = Cpt(EpicsSignalRO, ':EXT_ILK_OK_RBV', kind='normal',
                      doc='External interlock ok')
     at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
-                    doc='AT VAC Set point value')
+                          doc='AT VAC Set point value')
     setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS', kind='config',
-                            doc='AT VAC Hysterisis')
+                              doc='AT VAC Hysterisis')
     at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV', kind='normal',
                  doc='at vacuum sp is reached')
     error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal',
                 doc='Error Present')
     mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK', kind='omitted',
-                     doc=('individual valve MPS state for debugging')) 
+                    doc=('individual valve MPS state for debugging'))
 
 
 class VVCNO(Device):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -228,14 +228,16 @@ class VGC(VRC):
                         doc='Differential pressure interlock ok')
     ext_ilk_ok = Cpt(EpicsSignalRO, ':EXT_ILK_OK_RBV', kind='normal',
                      doc='External interlock ok')
-    at_vac_sp = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
+    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
                     doc='AT VAC Set point value')
-    at_vac_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS', kind='config',
+    setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS', kind='config',
                             doc='AT VAC Hysterisis')
     at_vac = Cpt(EpicsSignalRO, ':AT_VAC_RBV', kind='normal',
                  doc='at vacuum sp is reached')
     error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal',
                 doc='Error Present')
+    mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK', kind='omitted',
+                     doc=('individual valve MPS state for debugging')) 
 
 
 class VVCNO(Device):


### PR DESCRIPTION
## Description
DEV: added VGC MPS status, moved ION Pump expert screen's pv's from omitted to config. renamed expert screen names so they line up between cold cathodes and gate valves.


## Motivation and Context
Renamed expert screen names so they line up between cold cathodes and gate valves. Added VGC MPS status for local MPS status debugging and also for checkout. 

The Ion Pump expert screen change and gate valve changes are based on client feedback to make expert screens more useable and consistent. 


