### PR TITLE
MNT: Fixed Valve.py VGC MPS status with correct PV, MPS_FAULT_OK_RBV

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -236,7 +236,7 @@ class VGC(VRC):
                  doc='at vacuum sp is reached')
     error = Cpt(EpicsSignalRO, ':ERROR_RBV', kind='normal',
                 doc='Error Present')
-    mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK', kind='omitted',
+    mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK_RBV', kind='omitted',
                     doc=('individual valve MPS state for debugging'))
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
MNT: Fixed Valve.py VGC MPS status with correct PV, MPS_FAULT_OK_RBV

## Motivation and Context
I forgot to put in _RBV in the previous commit and therefore the expert screens don't show up correctly.
