### PR TITLE
BUG: gauge protection setpoint should be treated writeable

### DIFF
--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -204,7 +204,7 @@ class GCCPLC(GaugePLC):
     high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_DO_RBV', kind='normal',
                                doc=('enables the high voltage on the cold '
                                     'cathode gauge'))
-    protection_setpoint = Cpt(EpicsSignalRO, ':PRO_SP_RBV', kind='normal',
+    protection_setpoint = Cpt(EpicsSignalWithRBV, ':PRO_SP', kind='normal',
                               doc=('Protection setpoint for ion gauges at '
                                    'which the gauge turns off'))
     setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':SP_HYS', kind='config',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make GCC protection set point writable. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this cold cathode gauges cannot configure the point at which they enable. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests pass. 

