### PR TITLE
ENH: changed cmd_err_reset so its accessible from a typhos screen

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -442,7 +442,7 @@ class BeckhoffAxisPLC(Device):
     status = Cpt(PytmcSignal, 'sErrorMessage', io='i', kind='normal',
                  string=True)
     err_code = Cpt(PytmcSignal, 'nErrorId', io='i', kind='normal')
-    cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='o', kind='omitted')
+    cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='o', kind='config')
 
 
 class BeckhoffAxis(EpicsMotorInterface):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Just changing the `kind` attribute of `epics_motor.BeckhoffAxisPLC.cmd_err_reset` from `omitted` to `config` so that we have access to it from a Typhos screen.

## Motivation and Context
One needs to write to this variable after an NC error to resume motion through epics and it is convenient to have it on the control screen.

## How Has This Been Tested?
After setting `PYTHONPATH` to look first for a local version, the following command generates a test screen with the reset parameter shown in the `config` window:
`typhos 'pcdsdevices.mirror.XOffsetMirror[{"prefix":"MR1L0:LFE"}]'`

## Screenshot:
![typhos-cmd-err-reset](https://user-images.githubusercontent.com/37093966/75936538-43af5e00-5e37-11ea-82eb-892a3d4554e1.PNG)
