### PR TITLE
CI: ban defaults channel from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
   - conda update -q conda conda-build
   - conda config --add channels pcds-tag
   - conda config --append channels conda-forge
+  - conda config --remove channels defaults
   # Useful for debugging any issues with conda
   - conda info -a
   # Paranoid check of what version we're using

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
   - conda config --append channels conda-forge
   - conda config --remove channels defaults
   - conda config --set channel_priority strict
+  - conda config --set update_dependencies false
   # Useful for debugging any issues with conda
   - conda info -a
   # Paranoid check of what version we're using

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,9 @@ install:
   - conda activate base
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install conda-build
-  - conda update -q conda conda-build
+  - conda install python=$TRAVIS_PYTHON_VERSION conda-build=3.12.0
+  #- conda install conda-build
+  #- conda update -q conda conda-build
   - conda config --add channels pcds-tag
   - conda config --append channels conda-forge
   - conda config --remove channels defaults

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ install:
   - conda config --add channels pcds-tag
   - conda config --append channels conda-forge
   - conda config --remove channels defaults
-  - conda config --set channel_priority strict
-  - conda config --set update_dependencies false
+  - conda config --set channel_priority true
   # Useful for debugging any issues with conda
   - conda info -a
   # Paranoid check of what version we're using

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       env: BUILD_DOCS=1
 
 install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - source $HOME/miniconda/etc/profile.d/conda.sh
   - conda activate base
@@ -46,6 +46,7 @@ install:
   - conda config --add channels pcds-tag
   - conda config --append channels conda-forge
   - conda config --remove channels defaults
+  - conda config --set channel_priority strict
   # Useful for debugging any issues with conda
   - conda info -a
   # Paranoid check of what version we're using

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pyyaml
     - cf_units >=2.0.1
     - scipy
-    - matplotlib
+    - matplotlib <3
     - periodictable
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pyyaml
     - cf_units >=2.0.1
     - scipy
-    - matplotlib <3
+    - matplotlib
     - periodictable
 
 test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove `defaults` from conda channels list in travis build.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm planning to do this on the env builds because of exactly the issue here: https://travis-ci.org/github/pcdshub/pcdsdevices/jobs/661244275

There's some crossplay issues between `conda-forge` and `defaults` that we've been lucky to avoid up to this point. We can no longer ignore it, and we need `conda-forge`, so we're axing defaults.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was not

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It will not be

<!--
## Screenshots (if appropriate):
-->
