### PR TITLE
FIX: "typo" in TwinCAT states class

### DIFF
--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -209,7 +209,5 @@ class TwinCATInOutPositioner(TwinCATStatePositioner, InOutPositioner):
     """
     # Clear the default in/out state list
     states_list = []
-    # Override the default out name
-    out_states = ['Out']
     # In should be everything except state 0 (Unknown) and state 1 (Out)
     _in_if_not_out = True

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -77,7 +77,7 @@ def fake_tcinout():
 
 
 def test_in_if_not_out(fake_tcinout):
-    enums = ('Unknown', 'Out', 'Fish')
+    enums = ('Unknown', 'OUT', 'Fish')
     fake_tcinout.state._run_subs(sub_type=fake_tcinout.state.SUB_META,
                                  enum_strs=enums)
     fake_tcinout.state.sim_put(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
At some point the TwinCAT Enum had a non-standard setup here, but it was fixed and the class was never adjusted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All devices that use this class with the newest PLC code do not work