### PR TITLE
ENH: Add UnrelatedComponent

### DIFF
--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -40,7 +40,7 @@ class UnrelatedComponent(Component):
         # Needs to be non-None or it gets ignored
         if self.suffix is None:
             self.suffix = ''
-        add_prefix = kwargs.get('add_prefix', ['suffix'])
+        add_prefix = list(kwargs.get('add_prefix', ['suffix']))
 
         # Include subdevice UnrelatedComponent
         try:

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -40,7 +40,13 @@ class UnrelatedComponent(Component):
         add_prefix = kwargs.get('add_prefix', ['suffix'])
 
         # Include subdevice UnrelatedComponent
-        for cpt_walk in self.cls.walk_components():
+        try:
+            walk_iterator = self.cls.walk_components()
+        except AttributeError:
+            # No subdevices
+            walk_iterator = ()
+
+        for cpt_walk in walk_iterator:
             if isinstance(cpt_walk.item, UnrelatedComponent):
                 name = cpt_walk.dotted_name.replace('.', '_') + '_prefix'
                 add_prefix.append(name)

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -14,7 +14,7 @@ class UnrelatedComponent(Component):
     components.
     """
     @classmethod
-    def collect_prefixes(device, kwargs):
+    def collect_prefixes(cls, device, kwargs):
         """
         Gather all the special prefixes from a device's **kwargs
 

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -38,8 +38,7 @@ class UnrelatedComponent(Component):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Needs to be non-None or it gets ignored
-        if self.suffix is None:
-            self.suffix = ''
+        self.suffix = ''
         add_prefix = list(kwargs.get('add_prefix', ['suffix']))
 
         # Include subdevice UnrelatedComponent
@@ -58,7 +57,7 @@ class UnrelatedComponent(Component):
         self.add_prefix = tuple(add_prefix)
 
     def maybe_add_prefix(self, instance, kw, suffix):
-        if suffix or kw not in self.add_prefix:
+        if kw not in self.add_prefix:
             return suffix
 
         # Primary prefix for UnrelatedComponent

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -66,7 +66,7 @@ class UnrelatedComponent(Component):
             expected_kwarg = self.attr + '_prefix'
         # Subdevice UnrelatedComponent
         else:
-            expected_kwarg = self.attr + '_' + kw + '_prefix'
+            expected_kwarg = self.attr + '_' + kw
         try:
             return instance.unrelated_prefixes[expected_kwarg]
         except KeyError:

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -30,7 +30,7 @@ class UnrelatedComponent(Component):
             The **kwargs dictionary with extra prefixes defined
         """
         device.unrelated_prefixes = {}
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             if key.endswith('_prefix'):
                 device.unrelated_prefixes[key] = value
                 kwargs.pop(key)

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -37,6 +37,9 @@ class UnrelatedComponent(Component):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Needs to be non-None or it gets ignored
+        if self.suffix is None:
+            self.suffix = ''
         add_prefix = kwargs.get('add_prefix', ['suffix'])
 
         # Include subdevice UnrelatedComponent
@@ -55,7 +58,7 @@ class UnrelatedComponent(Component):
         self.add_prefix = tuple(add_prefix)
 
     def maybe_add_prefix(self, instance, kw, suffix):
-        if kw not in self.add_prefix or suffix is not None:
+        if suffix or kw not in self.add_prefix:
             return suffix
 
         # Primary prefix for UnrelatedComponent

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -1,0 +1,65 @@
+from ophyd.device import Component
+
+
+class UnrelatedComponent(Component):
+    """
+    Components that are unrelated to the main ``prefix`` attribute.
+
+    These components each need to have a full prefix specified rather than
+    the normal ``suffix`` extension or formatting. This is specified in the
+    device's **kwargs, e.g. subdevice_prefix='SOME:PV'.
+
+    The collect_prefixes class method is used to gather these special prefixes
+    in a convenient one-liner rather than needing to sift through formatted
+    components.
+    """
+    @classmethod
+    def collect_prefixes(device, kwargs):
+        """
+        Gather all the special prefixes from a device's **kwargs
+
+        This must be called once during the __init__ of a device with
+        UnrelatedComponent instances.
+
+        Parameters
+        ----------
+        device: Device
+            The device to gather prefixes for. Typically this is just self.
+
+        kwargs: dict
+            The **kwargs dictionary with extra prefixes defined
+        """
+        device.unrelated_prefixes = {}
+        for key, value in kwargs.items():
+            if key.endswith('_prefix'):
+                device.unrealated_prefixes[key] = value
+                kwargs.pop(key)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        add_prefix = kwargs.get('add_prefix', ['suffix'])
+
+        # Include subdevice UnrelatedComponent
+        for cpt_walk in self.cls.walk_components():
+            if isinstance(cpt_walk.item, UnrelatedComponent):
+                name = cpt_walk.dotted_name.replace('.', '_') + '_prefix'
+                add_prefix.append(name)
+                self.kwargs[name] = None
+
+        self.add_prefix = tuple(add_prefix)
+
+    def maybe_add_prefix(self, instance, kw, suffix):
+        if kw not in self.add_prefix or suffix is not None:
+            return suffix
+
+        # Primary prefix for UnrelatedComponent
+        if kw == 'suffix':
+            expected_kwarg = self.attr + '_prefix'
+        # Subdevice UnrelatedComponent
+        else:
+            expected_kwarg = self.attr + '_' + kw + '_prefix'
+        try:
+            return instance.unrelated_prefixes[expected_kwarg]
+        except KeyError:
+            raise ValueError(f'Missing {expected_kwarg} in __init__ for '
+                             f'{instance.name}.')

--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -32,7 +32,7 @@ class UnrelatedComponent(Component):
         device.unrelated_prefixes = {}
         for key, value in kwargs.items():
             if key.endswith('_prefix'):
-                device.unrealated_prefixes[key] = value
+                device.unrelated_prefixes[key] = value
                 kwargs.pop(key)
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -5,7 +5,7 @@ from ophyd.sim import FakeEpicsSignal
 from pcdsdevices.component import UnrelatedComponent as UCpt
 
 
-class TestClassBasic(Device):
+class Basic(Device):
     apple = UCpt(FakeEpicsSignal)
     sauce = UCpt(FakeEpicsSignal)
     full = UCpt(FakeEpicsSignal, 'FULL:HOUSE')
@@ -16,9 +16,9 @@ class TestClassBasic(Device):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class TestClassComplex(Device):
-    one = UCpt(TestClassBasic)
-    two = UCpt(TestClassBasic)
+class Complex(Device):
+    one = UCpt(Basic)
+    two = UCpt(Basic)
     pineapple = UCpt(FakeEpicsSignal, 'JUICE')
     tomayto = Cpt(FakeEpicsSignal, 'TOMAHTO')
 
@@ -28,8 +28,8 @@ class TestClassComplex(Device):
 
 
 def test_basic_class_good():
-    obj = TestClassBasic('GLASS', name='jar', apple_prefix='APPLE',
-                         sauce_prefix='SAUCE')
+    obj = Basic('GLASS', name='jar', apple_prefix='APPLE',
+                sauce_prefix='SAUCE')
     assert obj.prefix == 'GLASS'
     assert obj.apple.prefix == 'APPLE'
     assert obj.sauce.prefix == 'SAUCE'
@@ -39,17 +39,17 @@ def test_basic_class_good():
 
 def test_basic_class_bad():
     with pytest.raises(ValueError):
-        TestClassBasic('GLASS', name='jar', apple_prefix='APPLE')
+        Basic('GLASS', name='jar', apple_prefix='APPLE')
 
 
 def test_complex_class():
-    obj = TestClassComplex('APPT', name='apt',
-                           one_prefix='UNO',
-                           one_apple_prefix='APPLE:01',
-                           one_sauce_prefix='SAUCE:01',
-                           two_prefix='DOS',
-                           two_apple_prefix='APPLE:02',
-                           two_sauce_prefix='SAUCE:02')
+    obj = Complex('APPT', name='apt',
+                  one_prefix='UNO',
+                  one_apple_prefix='APPLE:01',
+                  one_sauce_prefix='SAUCE:01',
+                  two_prefix='DOS',
+                  two_apple_prefix='APPLE:02',
+                  two_sauce_prefix='SAUCE:02')
 
     assert obj.prefix == 'APPT'
     assert obj.one.prefix == 'UNO'

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,15 +1,14 @@
 import pytest
 from ophyd.device import Device, Component as Cpt
-from ophyd.sim import FakeEpicsSignal
 
 from pcdsdevices.component import UnrelatedComponent as UCpt
 
 
 class Basic(Device):
-    apple = UCpt(FakeEpicsSignal)
-    sauce = UCpt(FakeEpicsSignal)
-    full = UCpt(FakeEpicsSignal, 'FULL:HOUSE')
-    empty = Cpt(FakeEpicsSignal, ':EMPTY')
+    apple = UCpt(Device)
+    sauce = UCpt(Device)
+    full = UCpt(Device, 'FULL:HOUSE')
+    empty = Cpt(Device, ':EMPTY')
 
     def __init__(self, prefix, *, name, **kwargs):
         UCpt.collect_prefixes(self, kwargs)
@@ -19,8 +18,8 @@ class Basic(Device):
 class Complex(Device):
     one = UCpt(Basic)
     two = UCpt(Basic)
-    pineapple = UCpt(FakeEpicsSignal, 'JUICE')
-    tomayto = Cpt(FakeEpicsSignal, 'TOMAHTO')
+    pineapple = UCpt(Device, 'JUICE')
+    tomayto = Cpt(Device, 'TOMAHTO')
 
     def __init_(self, prefix, *, name, **kwargs):
         UCpt.collect_prefixes(self, kwargs)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,66 @@
+import pytest
+from ophyd.device import Device, Component as Cpt
+from ophyd.sim import FakeEpicsSignal
+
+from pcdsdevices.component import UnrelatedComponent as UCpt
+
+
+class TestClassBasic(Device):
+    apple = UCpt(FakeEpicsSignal)
+    sauce = UCpt(FakeEpicsSignal)
+    full = UCpt(FakeEpicsSignal, 'FULL:HOUSE')
+    empty = Cpt(FakeEpicsSignal, ':EMPTY')
+
+    def __init__(self, prefix, *, name, **kwargs):
+        UCpt.collect_prefixes(self, kwargs)
+        super().__init__(prefix, name=name, **kwargs)
+
+
+class TestClassComplex(Device):
+    one = UCpt(TestClassBasic)
+    two = UCpt(TestClassBasic)
+    pineapple = UCpt(FakeEpicsSignal, 'JUICE')
+    tomayto = Cpt(FakeEpicsSignal, 'TOMAHTO')
+
+    def __init_(self, prefix, *, name, **kwargs):
+        UCpt.collect_prefixes(self, kwargs)
+        super().__init__(prefix, name=name, **kwargs)
+
+
+def test_basic_class_good():
+    obj = TestClassBasic('GLASS', name='jar', apple_prefix='APPLE',
+                         sauce_prefix='SAUCE')
+    assert obj.prefix == 'GLASS'
+    assert obj.apple.prefix == 'APPLE'
+    assert obj.sauce.prefix == 'SAUCE'
+    assert obj.full.prefix == 'FULL:HOUSE'
+    assert obj.empty.prefix == 'GLASS:EMPTY'
+
+
+def test_basic_class_bad():
+    with pytest.raises(ValueError):
+        TestClassBasic('GLASS', name='jar', apple_prefix='APPLE')
+
+
+def test_complex_class():
+    obj = TestClassComplex('APPT', name='apt',
+                           one_prefix='UNO',
+                           one_apple_prefix='APPLE:01',
+                           one_sauce_prefix='SAUCE:01',
+                           two_prefix='DOS',
+                           two_apple_prefix='APPLE:02',
+                           two_sauce_prefix='SAUCE:02')
+
+    assert obj.prefix == 'APPT'
+    assert obj.one.prefix == 'UNO'
+    assert obj.one.apple.prefix == 'APPLE:01'
+    assert obj.one.sauce.prefix == 'SAUCE:01'
+    assert obj.one.full.prefix == 'FULL:HOUSE'
+    assert obj.one.empty.prefix == 'UNO:EMPTY'
+    assert obj.two.prefix == 'DOS'
+    assert obj.two.apple.prefix == 'APPLE:02'
+    assert obj.two.sauce.prefix == 'SAUCE:02'
+    assert obj.two.full.prefix == 'FULL:HOUSE'
+    assert obj.two.empty.prefix == 'DOS:EMPTY'
+    assert obj.pineapple.prefix == 'JUICE'
+    assert obj.tomayto.prefix == 'APPT:TOMAHTO'

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -7,7 +7,6 @@ from pcdsdevices.component import UnrelatedComponent as UCpt
 class Basic(Device):
     apple = UCpt(Device)
     sauce = UCpt(Device)
-    full = UCpt(Device, 'FULL:HOUSE')
     empty = Cpt(Device, ':EMPTY')
 
     def __init__(self, prefix, *, name, **kwargs):
@@ -18,8 +17,7 @@ class Basic(Device):
 class Complex(Device):
     one = UCpt(Basic)
     two = UCpt(Basic)
-    pineapple = UCpt(Device, 'JUICE')
-    tomayto = Cpt(Device, 'TOMAHTO')
+    tomayto = Cpt(Device, ':TOMAHTO')
 
     def __init__(self, prefix, *, name, **kwargs):
         UCpt.collect_prefixes(self, kwargs)
@@ -32,7 +30,6 @@ def test_basic_class_good():
     assert obj.prefix == 'GLASS'
     assert obj.apple.prefix == 'APPLE'
     assert obj.sauce.prefix == 'SAUCE'
-    assert obj.full.prefix == 'FULL:HOUSE'
     assert obj.empty.prefix == 'GLASS:EMPTY'
 
 
@@ -54,12 +51,9 @@ def test_complex_class():
     assert obj.one.prefix == 'UNO'
     assert obj.one.apple.prefix == 'APPLE:01'
     assert obj.one.sauce.prefix == 'SAUCE:01'
-    assert obj.one.full.prefix == 'FULL:HOUSE'
     assert obj.one.empty.prefix == 'UNO:EMPTY'
     assert obj.two.prefix == 'DOS'
     assert obj.two.apple.prefix == 'APPLE:02'
     assert obj.two.sauce.prefix == 'SAUCE:02'
-    assert obj.two.full.prefix == 'FULL:HOUSE'
     assert obj.two.empty.prefix == 'DOS:EMPTY'
-    assert obj.pineapple.prefix == 'JUICE'
     assert obj.tomayto.prefix == 'APPT:TOMAHTO'

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -21,7 +21,7 @@ class Complex(Device):
     pineapple = UCpt(Device, 'JUICE')
     tomayto = Cpt(Device, 'TOMAHTO')
 
-    def __init_(self, prefix, *, name, **kwargs):
+    def __init__(self, prefix, *, name, **kwargs):
         UCpt.collect_prefixes(self, kwargs)
         super().__init__(prefix, name=name, **kwargs)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `UnrelatedComponent` to help handle cases where we create "FrankenDevices" where many unrelated components (in the ophyd sense, with unrelated prefixes) are needed to be included in the same ophyd device. Functionally, the devices behave the same for the end-user, but can be implemented much more succinctly in the library here. See the example from the tests:

```
from ophyd.device import Component as Cpt
from pcdsdevices.component import UnrelatedComponent as UCpt

class Basic(Device):
    apple = UCpt(Device)
    sauce = UCpt(Device)
    empty = Cpt(Device, ':EMPTY')

    def __init__(self, prefix, *, name, **kwargs):
        UCpt.collect_prefixes(self, kwargs)
        super().__init__(prefix, name=name, **kwargs)

basic = Basic('PREFIX', name='basic', apple_prefix='APPLE', sauce_prefix='SAUCE')
```
This works recursively as well, e.g. you can have `UnrelatedComponent` point to devices that have `UnrelatedComponent` instances themselves and this will cascade the kwargs sensibly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was looking at the CCM class and getting sad about the many levels of passed prefixes here. This should be automated to the extent possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added tests, but need to add one more to verify 3 levels of recursion.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet...

<!--
## Screenshots (if appropriate):
-->
