### PR TITLE
BLD: Fix m2r

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs
 
 # Sphinx
 docs/source/generated/*
+docs/source/README.rst
 
 #pytest
 .pytest_cache

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,4 +21,5 @@ clean:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	m2r ../README.md --dry-run > source/README.rst
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,8 +43,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'IPython.sphinxext.ipython_directive',
               'IPython.sphinxext.ipython_console_highlighting',
-              'sphinx.ext.autosectionlabel',
-              'm2r'
+              'sphinx.ext.autosectionlabel'
              ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -55,8 +54,7 @@ autosummary_generate = True
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = '.rst'
-source_suffix = ['.rst', '.md']
+source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. mdinclude:: ../../README.md
+.. include:: README.rst
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Description
So it turns out recommonmark isn't a full solution to our situation because it doesn't support include. The best you can do with it is use the markdown file inside a toctree but can't use it as a homepage. I'll leave up #414 in case anyone can figure out how to get it to display as index.html

As an alternative, I offer this (slightly messier) solution:
Since `m2r` is also available as a command line tool, I removed it from the `sphinx` extensions and instead added it as an extra step in the Makefile. Please let me know your thoughts.

## Motivation and Context
Fixes #410 

## How Has This Been Tested?
Tested locally and travis passes.