### PR TITLE
MNT: Bring FakePytmcSignal into main module

### DIFF
--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -91,11 +91,12 @@ class FakePytmcSignal(FakeEpicsSignal):
         return super().__new__(new_cls)
 
     def __init__(self, prefix, io=None, **kwargs):
-        super().__init__(prefix, **kwargs)
+        super().__init__(prefix + '_RBV', **kwargs)
 
 
 class FakePytmcSignalRW(FakePytmcSignal, FakeEpicsSignal):
-    pass
+    def __init__(self, prefix, **kwargs):
+        super().__init__(prefix, write_pv=prefix, **kwargs)
 
 
 class FakePytmcSignalRO(FakePytmcSignal, FakeEpicsSignalRO):

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -45,7 +45,7 @@ class PytmcSignal(EpicsSignalBase):
 
 
 def select_pytmc_class(io=None, *, prefix, write_cls, read_only_cls):
-    """Return the class to use for PytmcSignal's constructor"""
+    """Return the class to use for PytmcSignal's constructor."""
     if io is None:
         # Provide a better error here than "__new__ missing an arg"
         raise ValueError('Must provide an "io" argument to PytmcSignal. '
@@ -59,7 +59,7 @@ def select_pytmc_class(io=None, *, prefix, write_cls, read_only_cls):
 
 
 def pytmc_writable(io):
-    """Returns True if the pytmc io arg represents a writable PV"""
+    """Returns True if the pytmc io arg represents a writable PV."""
     norm = normalize_io(io)
     if norm == 'output':
         return True
@@ -71,19 +71,19 @@ def pytmc_writable(io):
 
 
 class PytmcSignalRW(PytmcSignal, EpicsSignal):
-    """Read-write connection to a pytmc-generated EPICS record"""
+    """Read-write connection to a pytmc-generated EPICS record."""
     def __init__(self, prefix, **kwargs):
         super().__init__(prefix, write_pv=prefix, **kwargs)
 
 
 class PytmcSignalRO(PytmcSignal, EpicsSignalRO):
-    """Read-only connection to a pytmc-generated EPICS record"""
+    """Read-only connection to a pytmc-generated EPICS record."""
     pass
 
 
 # Make sure an acceptable fake class is set for PytmcSignal
 class FakePytmcSignal(FakeEpicsSignal):
-    """A suitable fake class for PytmcSignal"""
+    """A suitable fake class for PytmcSignal."""
     def __new__(cls, prefix, io=None, **kwargs):
         new_cls = select_pytmc_class(io=io, prefix=prefix,
                                      write_cls=FakePytmcSignalRW,
@@ -116,7 +116,7 @@ class AggregateSignal(Signal):
     Attributes
     ----------
     _cache: dict
-        Mapping from signal to last known value
+        Mapping from signal to last known value.
 
     _sub_signals: list
         Signals that contribute to this signal.
@@ -144,7 +144,7 @@ class AggregateSignal(Signal):
 
     def _insert_value(self, signal, value):
         """
-        Update the cache with one value and recalculate
+        Update the cache with one value and recalculate.
         """
         with self._lock:
             self._cache[signal] = value
@@ -160,7 +160,7 @@ class AggregateSignal(Signal):
 
     def get(self, **kwargs):
         """
-        Update all values and recalculate
+        Update all values and recalculate.
         """
         with self._lock:
             for signal in self._sub_signals:

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -13,8 +13,8 @@ import logging
 from threading import RLock, Thread
 
 import numpy as np
-
 from ophyd.signal import EpicsSignal, EpicsSignalBase, EpicsSignalRO, Signal
+from ophyd.sim import FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache
 from pytmc.pragmas import normalize_io
 
 logger = logging.getLogger(__name__)
@@ -67,6 +67,21 @@ class PytmcSignalRO(PytmcSignal, EpicsSignalRO):
     Read-only connection to a pytmc-generated EPICS record
     """
     pass
+
+
+# Make sure an acceptable fake class is set for PytmcSignal
+def FakePytmcSignal(prefix, *, io, **kwargs):
+    norm = normalize_io(io)
+    if norm == 'output':
+        return FakeEpicsSignal(prefix, **kwargs)
+    elif norm == 'input':
+        return FakeEpicsSignalRO(prefix, **kwargs)
+    else:
+        # Give us the normal error message
+        return PytmcSignal(prefix, io=io, **kwargs)
+
+
+fake_device_cache[PytmcSignal] = FakePytmcSignal
 
 
 class AggregateSignal(Signal):

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -86,9 +86,20 @@ class FakePytmcSignal(FakeEpicsSignal):
     """A suitable fake class for PytmcSignal"""
     def __new__(cls, prefix, io=None, **kwargs):
         new_cls = select_pytmc_class(io=io, prefix=prefix,
-                                     write_cls=FakeEpicsSignal,
-                                     read_only_cls=FakeEpicsSignalRO)
+                                     write_cls=FakePytmcSignalRW,
+                                     read_only_cls=FakePytmcSignalRO)
         return super().__new__(new_cls)
+
+    def __init__(self, prefix, io=None, **kwargs):
+        super().__init__(prefix, **kwargs)
+
+
+class FakePytmcSignalRW(FakePytmcSignal, FakeEpicsSignal):
+    pass
+
+
+class FakePytmcSignalRO(FakePytmcSignal, FakeEpicsSignalRO):
+    pass
 
 
 fake_device_cache[PytmcSignal] = FakePytmcSignal

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -102,6 +102,7 @@ class FakePytmcSignalRO(FakePytmcSignal, FakeEpicsSignalRO):
     pass
 
 
+# NOTE: This is an *on-import* update of the ophyd "fake" device cache
 fake_device_cache[PytmcSignal] = FakePytmcSignal
 
 

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -51,6 +51,7 @@ class PytmcSignal(EpicsSignalBase):
 
 
 def pytmc_writable(io):
+    """Returns True if the pytmc io arg represents a writable PV"""
     norm = normalize_io(io)
     if norm == 'output':
         return True
@@ -62,22 +63,19 @@ def pytmc_writable(io):
 
 
 class PytmcSignalRW(PytmcSignal, EpicsSignal):
-    """
-    Read-write connection to a pytmc-generated EPICS record
-    """
+    """Read-write connection to a pytmc-generated EPICS record"""
     def __init__(self, prefix, **kwargs):
         super().__init__(prefix, write_pv=prefix, **kwargs)
 
 
 class PytmcSignalRO(PytmcSignal, EpicsSignalRO):
-    """
-    Read-only connection to a pytmc-generated EPICS record
-    """
+    """Read-only connection to a pytmc-generated EPICS record"""
     pass
 
 
 # Make sure an acceptable fake class is set for PytmcSignal
 def FakePytmcSignal(prefix, *, io, **kwargs):
+    """Returns a suitable fake class for a PytmcSignal"""
     if pytmc_writable(io):
         return FakeEpicsSignal(prefix, **kwargs)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,11 @@ import warnings
 from pathlib import Path
 
 import pytest
-from ophyd.sim import (FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache,
-                       make_fake_device)
+from ophyd.sim import make_fake_device
+
 from pcdsdevices.attenuator import (MAX_FILTERS, Attenuator, _att3_classes,
                                     _att_classes)
 from pcdsdevices.mv_interface import setup_preset_paths
-from pcdsdevices.signal import PytmcSignal
-from pytmc.pragmas import normalize_io
 
 # Signal.put warning is a testing artifact.
 # FakeEpicsSignal needs an update, but I don't have time today
@@ -18,20 +16,6 @@ from pytmc.pragmas import normalize_io
 warnings.filterwarnings('ignore',
                         message='Signal.put no longer takes keyword arguments')
 
-
-# Make sure an acceptable fake class is set for PytmcSignal
-def FakePytmcSignal(prefix, *, io, **kwargs):
-    norm = normalize_io(io)
-    if norm == 'output':
-        return FakeEpicsSignal(prefix, **kwargs)
-    elif norm == 'input':
-        return FakeEpicsSignalRO(prefix, **kwargs)
-    else:
-        # Give us the normal error message
-        return PytmcSignal(prefix, io=io, **kwargs)
-
-
-fake_device_cache[PytmcSignal] = FakePytmcSignal
 
 for name, cls in _att_classes.items():
     _att_classes[name] = make_fake_device(cls)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Extract `FakePytmcSignal` from `conftest.py` to `pcdsdevices/signal.py`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fake devices that include `PytmcSignal` don't work because `PytmcSignal` is not a suitable base class. The conftest patch fixes this for the tests here, but bringing it out allows us to use fake devices that include `PytmcSignal` in other contexts.
closes #422 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
If the tests still pass, this worked.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings edited as appropriate.