### PR TITLE
MNT: kluge to make tests pass for now

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
 
   run:
     - python >=3.6
-    - ophyd 1.4.0rc4|>=1.4.0
+    - ophyd >=1.4.1
     - bluesky >=1.2.0
     - pyepics >=3.4.1
     - pytmc >=2.4.0

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -49,9 +49,11 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     # been changed without a re-connection of the PV. Instead we trust the soft
     # limits records
     user_setpoint = Cpt(EpicsSignal, ".VAL", limits=False, kind='normal')
-    # Additional soft limit configurations
-    low_soft_limit = Cpt(EpicsSignal, ".LLM", kind='omitted')
-    high_soft_limit = Cpt(EpicsSignal, ".HLM", kind='omitted')
+    # Kluge override for auto_monitor=True to help disconnected instantiation
+    low_limit_travel = Cpt(EpicsSignal, ".LLM", kind='omitted',
+                           auto_monitor=True)
+    high_limit_travel = Cpt(EpicsSignal, ".HLM", kind='omitted',
+                            auto_monitor=True)
     # Enable/Disable puts
     disabled = Cpt(EpicsSignal, ".DISP", kind='omitted')
     # Description is valuable
@@ -65,22 +67,22 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         """
         The lower soft limit for the motor.
         """
-        return self.low_soft_limit.value
+        return self.low_limit_travel.value
 
     @low_limit.setter
     def low_limit(self, value):
-        self.low_soft_limit.put(value)
+        self.low_limit_travel.put(value)
 
     @property
     def high_limit(self):
         """
         The higher soft limit for the motor.
         """
-        return self.high_soft_limit.value
+        return self.high_limit_travel.value
 
     @high_limit.setter
     def high_limit(self, value):
-        self.high_soft_limit.put(value)
+        self.high_limit_travel.put(value)
 
     @property
     def limits(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Override `ophyd`'s `EpicsMotor` limit signals with `auto_monitor=True`.
Replace our signals with the new names decided upon in `ophyd`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`subscribe` on a non-auto_monitored signal blocks on connection, which is not ok during init. The subscribe calls were added in a recent `ophyd` PR. This PR would not be needed at all if https://github.com/bluesky/ophyd/issues/847 was solved. I will make an ophyd PR to similarly stopgap this on the ophyd end, but this PR will still be needed after that to keep providing some of the methods here. (and then we'd be able to drop the redundant component definitions)

closes #425 