### PR TITLE
FIX: importability on win32

### DIFF
--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1,7 +1,6 @@
 """
 Module for defining bell-and-whistles movement features
 """
-import fcntl
 import logging
 import numbers
 import re
@@ -20,6 +19,11 @@ from ophyd.ophydobj import OphydObject
 from ophyd.status import wait as status_wait
 
 from . import utils as util
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 logger = logging.getLogger(__name__)
 engineering_mode = True

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -2,9 +2,14 @@ import os
 import select
 import shutil
 import sys
-import termios
 import time
-import tty
+
+try:
+    import tty
+    import termios
+except ImportError:
+    tty = None
+    termios = None
 
 from cf_units import Unit
 
@@ -50,6 +55,9 @@ def get_input():
     -------
     input: ``str``
     """
+    if termios is None:
+        raise RuntimeError('Not supported on this platform')
+
     # Save old terminal settings
     old_settings = termios.tcgetattr(sys.stdin)
     # Stash a None here in case we get interrupted


### PR DESCRIPTION
This is not necessary to actually merge, as we have no _real_ use case for Windows instantiations of pcdsdevices.

However, for typhos testing I wanted to show the same device without copy/pasting it out of the library, and these were the fixes necessary to do so.

Here's what typhos + pcdsdevices on Windows looks like, for those interested:
![image](https://user-images.githubusercontent.com/5139267/81754810-e86b9e80-946b-11ea-9bf1-07dbecc6b00e.png)
