### PR TITLE
MNT: Ophyd 1.5 Changes

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
 
   run:
     - python >=3.6
-    - ophyd >=1.4.1
+    - ophyd >=1.5.0
     - bluesky >=1.2.0
     - pyepics >=3.4.1
     - pytmc >=2.4.0

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -5,7 +5,6 @@ import logging
 import time
 
 import numpy as np
-
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
@@ -199,7 +198,7 @@ class AttBase(FltMvInterface, PVPositioner):
                 self._original_vals[filt.state] = filt.out_states[0]
             # Otherwise, remember so we can restore
             else:
-                self._original_vals[filt.state] = filt.state.value
+                self._original_vals[filt.state] = filt.state.get()
         return super().stage()
 
     def _setup_move(self, position):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -384,7 +384,9 @@ class IMS(PCDSMotorBase):
         # Check that we need to actually set the flag
         if flag_is_cleared(value=self.bit_status.get()):
             logger.debug("%s flag is not currently active", flag)
-            return DeviceStatus(self, done=True, success=True)
+            st = DeviceStatus(self)
+            st.set_finished()
+            return st
 
         # Issue our command
         logger.info('Clearing %s flag ...', flag)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -49,11 +49,6 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     # been changed without a re-connection of the PV. Instead we trust the soft
     # limits records
     user_setpoint = Cpt(EpicsSignal, ".VAL", limits=False, kind='normal')
-    # Kluge override for auto_monitor=True to help disconnected instantiation
-    low_limit_travel = Cpt(EpicsSignal, ".LLM", kind='omitted',
-                           auto_monitor=True)
-    high_limit_travel = Cpt(EpicsSignal, ".HLM", kind='omitted',
-                            auto_monitor=True)
     # Enable/Disable puts
     disabled = Cpt(EpicsSignal, ".DISP", kind='omitted')
     # Description is valuable

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -67,7 +67,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         """
         The lower soft limit for the motor.
         """
-        return self.low_limit_travel.value
+        return self.low_limit_travel.get()
 
     @low_limit.setter
     def low_limit(self, value):
@@ -78,7 +78,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         """
         The higher soft limit for the motor.
         """
-        return self.high_limit_travel.value
+        return self.high_limit_travel.get()
 
     @high_limit.setter
     def high_limit(self, value):
@@ -142,7 +142,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
                                          self.high_limit))
 
         # Find the value for the disabled attribute
-        if self.disabled.value == 1:
+        if self.disabled.get() == 1:
             raise MotorDisabledError("Motor is not enabled. Motion requests "
                                      "ignored")
 
@@ -231,11 +231,11 @@ class PCDSMotorBase(EpicsMotorInterface):
         """
         super().check_value(value)
 
-        if self.motor_spg.value in [0, 'Stop']:
+        if self.motor_spg.get() in [0, 'Stop']:
             raise MotorDisabledError("Motor is stopped.  Motion requests "
                                      "ignored until motor is set to 'Go'")
 
-        if self.motor_spg.value in [1, 'Pause']:
+        if self.motor_spg.get() in [1, 'Pause']:
             raise MotorDisabledError("Motor is paused.  If a move is set, "
                                      "motion will resume when motor is set "
                                      "to 'Go'")

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -14,7 +14,6 @@ from types import MethodType, SimpleNamespace
 from weakref import WeakSet
 
 import yaml
-
 from bluesky.utils import ProgressBar
 from ophyd.device import Kind
 from ophyd.ophydobj import OphydObject
@@ -866,7 +865,7 @@ def tweak_base(*args):
                 movement(-scale, up)
             elif len(args) > 1 and inp == up:
                 movement(scale, inp)
-            elif inp not in(up, down, left, right, shift_down, shift_up):
+            elif inp not in (up, down, left, right, shift_down, shift_up):
                 print()  # Newline
                 if len(args) == 1:
                     print(" Left: move x motor backward")

--- a/pcdsdevices/mps.py
+++ b/pcdsdevices/mps.py
@@ -112,14 +112,14 @@ class MPS(MPSBase, Device):
         """
         Whether the MPS bit is faulted or not
         """
-        return bool(self.fault.value)
+        return bool(self.fault.get())
 
     @property
     def bypassed(self):
         """
         Bypass state of the MPS bit
         """
-        return bool(self.bypass.value)
+        return bool(self.bypass.get())
 
     def _sub_to_children(self):
         """

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -43,7 +43,7 @@ class PIMY(InOutRecordPositioner, BaseInterface):
 
     def stage(self):
         """Save the original position to be restored on `unstage`."""
-        self._original_vals[self.state] = self.state.value
+        self._original_vals[self.state] = self.state.get()
         return super().stage()
 
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -272,8 +272,8 @@ class Slits(Device, MvInterface):
         """
         Store the initial values of the aperture position before scanning
         """
-        self._original_vals[self.xwidth.setpoint] = self.xwidth.readback.value
-        self._original_vals[self.ywidth.setpoint] = self.ywidth.readback.value
+        self._original_vals[self.xwidth.setpoint] = self.xwidth.readback.get()
+        self._original_vals[self.ywidth.setpoint] = self.ywidth.readback.get()
         return super().stage()
 
     def subscribe(self, cb, event_type=None, run=True):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -627,6 +627,10 @@ class StateStatus(SubscriptionStatus):
         super().__init__(device, check_state, event_type=device.SUB_STATE,
                          timeout=timeout, settle_time=settle_time)
 
-    def _finished(self, success=True, **kwargs):
-        self.device._done_moving(success=success)
-        super()._finished(success=success, **kwargs)
+    def set_finished(self, **kwargs):
+        self.device._done_moving(success=True)
+        super().set_finished(**kwargs)
+
+    def set_exception(self, exc):
+        self.device._done_moving(success=False)
+        super().set_exception(exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from epics import PV
 from ophyd.sim import FakeEpicsSignal, make_fake_device
 
 from pcdsdevices.attenuator import (MAX_FILTERS, Attenuator, _att3_classes,
@@ -20,6 +21,8 @@ warnings.filterwarnings('ignore',
 FakeEpicsSignal._metadata_changed = lambda *args, **kwargs: None
 FakeEpicsSignal.pvname = ''
 FakeEpicsSignal._read_pv = SimpleNamespace(get_ctrlvars=lambda: None)
+# Stupid patch that somehow makes the test cleanup bug go away
+PV.count = property(lambda self: 1)
 
 for name, cls in _att_classes.items():
     _att_classes[name] = make_fake_device(cls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,10 @@ import os
 import shutil
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from ophyd.sim import make_fake_device
+from ophyd.sim import FakeEpicsSignal, make_fake_device
 
 from pcdsdevices.attenuator import (MAX_FILTERS, Attenuator, _att3_classes,
                                     _att_classes)
@@ -15,7 +16,10 @@ from pcdsdevices.mv_interface import setup_preset_paths
 # Needs to not pass tons of kwargs up to Signal.put
 warnings.filterwarnings('ignore',
                         message='Signal.put no longer takes keyword arguments')
-
+# Other temporary patches to FakeEpicsSignal
+FakeEpicsSignal._metadata_changed = lambda *args, **kwargs: None
+FakeEpicsSignal.pvname = ''
+FakeEpicsSignal._read_pv = SimpleNamespace(get_ctrlvars=lambda: None)
 
 for name, cls in _att_classes.items():
     _att_classes[name] = make_fake_device(cls)

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
+
 from pcdsdevices.attenuator import (MAX_FILTERS, AttBase, Attenuator,
                                     _att3_classes, _att_classes)
 
@@ -61,21 +62,21 @@ def test_attenuator_motion(fake_att):
     # Move to ceil
     status = att.move(0.8, wait=False)
     fake_move_transition(att, status, 0.8001)
-    assert att.setpoint.value == 0.8
+    assert att.setpoint.get() == 0.8
     assert att.actuate_value == 3
     # Move to floor
     status = att.move(0.5, wait=False)
     fake_move_transition(att, status, 0.5001)
-    assert att.setpoint.value == 0.5
+    assert att.setpoint.get() == 0.5
     assert att.actuate_value == 2
     # Call remove method
     status = att.remove(wait=False)
     fake_move_transition(att, status, 1)
-    assert att.setpoint.value == 1
+    assert att.setpoint.get() == 1
     # Call insert method
     status = att.insert(wait=False)
     fake_move_transition(att, status, 0)
-    assert att.setpoint.value == 0
+    assert att.setpoint.get() == 0
 
 
 @pytest.mark.timeout(5)

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from ophyd.sim import make_fake_device
+
 from pcdsdevices.beam_stats import BeamStats
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ def test_beam_stats_avg(fake_beam_stats):
     for i in range(10):
         stats.mj.sim_put(i)
 
-    assert stats.mj_avg.value == sum(range(10))/10
+    assert stats.mj_avg.get() == sum(range(10))/10
 
     stats.configure(dict(mj_buffersize=20))
     cfg = stats.read_configuration()

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -1,9 +1,10 @@
 import logging
 
 import numpy as np
-import pcdsdevices.ccm as ccm
 import pytest
 from ophyd.sim import make_fake_device
+
+import pcdsdevices.ccm as ccm
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ def fake_ccm():
     def init_pos(mot, pos=0):
         mot.user_readback.sim_put(0)
         mot.user_setpoint.sim_put(0)
+        mot.motor_spg.sim_put(2)
 
     init_pos(fake_ccm.x.down)
     init_pos(fake_ccm.x.up)

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -5,6 +5,7 @@ from bluesky import RunEngine
 from bluesky.plan_stubs import close_run, open_run, stage, unstage
 from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
+
 from pcdsdevices.epics_motor import (IMS, PMC100, BeckhoffAxis, EpicsMotor,
                                      EpicsMotorInterface, Motor,
                                      MotorDisabledError, Newport,
@@ -121,6 +122,7 @@ def test_ims_clear_flag(fake_ims):
     assert not st.done
     assert not st.success
     m.bit_status.sim_put(0)
+    st.wait(timeout=1)
     assert st.done
     assert st.success
 

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -3,6 +3,7 @@ import logging
 
 import pytest
 from ophyd.sim import make_fake_device
+
 from pcdsdevices.gauge import (GaugeSet, GaugeSetBase, GaugeSetMks,
                                GaugeSetPirani, GaugeSetPiraniMks)
 
@@ -44,6 +45,8 @@ def test_gauge_factory():
 kw_defaults = {'name': 'gauge',
                'index': 1,
                'prefix_controller': 'CONTROLLER'}
+
+
 @pytest.mark.parametrize('cls', [GaugeSetPirani, GaugeSetBase, GaugeSetMks,
                                  GaugeSetPiraniMks])
 @pytest.mark.timeout(5)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from ophyd.sim import make_fake_device
+
 from pcdsdevices.mirror import OffsetMirror, PointingMirror
 
 
@@ -97,12 +98,12 @@ def test_branching_mirror_moves(fake_branching_mirror):
     assert branching_mirror.xgantry.setpoint.get() == 0.2
     # Test removal
     branching_mirror.remove()
-    assert branching_mirror.state.value == 1
+    assert branching_mirror.state.get() == 1
     # Finish simulated move manually
     branching_mirror.state.sim_put(2)
     # Insert
     branching_mirror.insert()
-    assert branching_mirror.state.value == 2
+    assert branching_mirror.state.get() == 2
 
 
 def test_epics_mirror_subscription(fake_branching_mirror):

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -73,6 +73,7 @@ def test_kickoff(sequence):
     # Our status should not be done until the sequencer starts
     assert not st.done
     seq.play_status.sim_put(2)
+    st.wait(timeout=1)
     assert st.done
     assert st.success
 
@@ -86,6 +87,7 @@ def test_trigger(sequence):
     # Sequencer has started
     assert sequence.play_control.get() == 1
     # Trigger is automatically complete
+    trig_status.wait(timeout=1)
     assert trig_status.done
     assert trig_status.success
     # Stop sequencer
@@ -102,6 +104,7 @@ def test_trigger(sequence):
     assert not trig_status.done
     # Simulate the sequence ending
     sequence.play_status.sim_put(0)
+    trig_status.wait(timeout=1)
     assert trig_status.done
     assert trig_status.success
 
@@ -113,6 +116,7 @@ def test_complete_run_forever(sequence):
     # Run Forever mode should tell this to stop
     st = seq.complete()
     assert seq.play_control.get() == 0
+    st.wait(timeout=1)
     assert st.done
     assert st.success
 
@@ -128,6 +132,7 @@ def test_complete_run_once(sequence):
     # Our status should not be done until the sequence stops naturally
     assert not st.done
     seq.play_status.sim_put(0)
+    st.wait(timeout=1)
     assert st.done
     assert st.success
 

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,11 +1,12 @@
 import logging
 
-import pcdsdevices.sequencer
 import pytest
 from bluesky import RunEngine
 from bluesky.plan_stubs import sleep
 from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from ophyd.sim import NullStatus, make_fake_device
+
+import pcdsdevices.sequencer
 from pcdsdevices.sequencer import EventSequence, EventSequencer
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,7 @@ def test_complete_run_forever(sequence):
     seq._acquiring = True
     # Run Forever mode should tell this to stop
     st = seq.complete()
-    assert seq.play_control.value == 0
+    assert seq.play_control.get() == 0
     assert st.done
     assert st.success
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -2,6 +2,7 @@ import logging
 from unittest.mock import Mock
 
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
+
 from pcdsdevices.signal import AvgSignal, PytmcSignal
 
 logger = logging.getLogger(__name__)
@@ -26,20 +27,20 @@ def test_avg_signal():
     assert avg.averages == 2
 
     sig.put(1)
-    assert avg.value == 1
+    assert avg.get() == 1
     sig.put(3)
-    assert avg.value == 2
+    assert avg.get() == 2
     sig.put(2)
-    assert avg.value == 2.5
+    assert avg.get() == 2.5
 
     avg.averages = 3
 
     sig.put(1)
-    assert avg.value == 1
+    assert avg.get() == 1
     sig.put(3)
-    assert avg.value == 2
+    assert avg.get() == 2
     sig.put(2)
-    assert avg.value == 2
+    assert avg.get() == 2
 
     cb = Mock()
     avg.subscribe(cb)

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from ophyd.sim import make_fake_device
+
 from pcdsdevices.slits import Slits
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ def test_slit_motion(fake_slits):
     slits.xwidth.done.sim_put(1)
     slits.ywidth.readback.sim_put(10.0)
     slits.ywidth.done.sim_put(1)
+    status.wait(timeout=1)
     assert status.done and status.success
     # Reset DMOV flags
     slits.xwidth.done.sim_put(0)
@@ -69,6 +71,7 @@ def test_slit_motion(fake_slits):
     slits.xwidth.done.sim_put(1)
     slits.ywidth.readback.sim_put(40.0)
     slits.ywidth.done.sim_put(1)
+    status.wait(timeout=1)
     assert status.done and status.success
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,6 +5,7 @@ import pytest
 from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
 from ophyd.sim import make_fake_device
+
 from pcdsdevices.state import (PVStatePositioner, StatePositioner,
                                StateRecordPositioner, StateStatus)
 
@@ -111,7 +112,7 @@ def test_pvstate_positioner_sets():
     with pytest.raises(ValueError):
         lim_obj2.move('Unknown')
     cb = Mock()
-    lim_obj2.move('OUT', moved_cb=cb)
+    lim_obj2.move('OUT', moved_cb=cb).wait(timeout=1)
     assert(cb.called)
     assert(lim_obj2.position == 'OUT')
     lim_obj2.move('IN', wait=True)
@@ -165,6 +166,7 @@ def test_state_status():
     # Put readback to 'in'
     lim_obj.lowlim.put(0)
     lim_obj.highlim.put(1)
+    status.wait(timeout=1)
     assert status.done and status.success
     # Check our callback was cleared
     assert status.check_value not in lim_obj._callbacks[lim_obj.SUB_STATE]

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from ophyd.sim import make_fake_device
+
 from pcdsdevices.valve import GateValve, InterlockError, PPSStopper, Stopper
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,7 @@ def test_stopper_motion(fake_stopper):
     # Remove
     stopper.open(wait=False)
     # Check write PV
-    assert stopper.command.value == stopper.commands.open_valve.value
+    assert stopper.command.get() == stopper.commands.open_valve.value
 
 
 def test_stopper_subscriptions(fake_stopper):
@@ -109,7 +110,7 @@ def test_valve_motion(fake_valve):
     # Remove
     valve.open(wait=False)
     # Check write PV
-    assert valve.command.value == valve.commands.open_valve.value
+    assert valve.command.get() == valve.commands.open_valve.value
     # Raises interlock
     valve.interlock.sim_put(0)
     assert valve.interlocked

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -87,6 +87,7 @@ def test_stopper_motion(fake_stopper):
     status = stopper.close(wait=False)
     stopper.open_limit.sim_put(0)
     stopper.closed_limit.sim_put(1)
+    status.wait(timeout=1)
     assert status.done and status.success
     # Remove
     stopper.open(wait=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Update the library for ophyd=1.5.0

- [x] Fix the test suite
- [x] `Signal.value` -> `Signal.get()` (careful to not break `Enum.value`)
- [x] `Status._finished` -> `Status.set_finished` and related changes

The test suite was broken for two main reasons:

- `FakeEpicsSignal` is no longer a usable stand-in for `EpicsSignal` in `EpicsMotor` after the limit-updating patch. Long term I believe this class should be replaced with a true `sim` control layer at `ophyd`.
- `Status` objects are no longer guaranteed to be ready immediately when checked from the same thread that calls `_finished/set_finished/set_exception`... or at least I think that's what's going on. Adding waits fixed it.

Additionally, there was one test that was simply broken and I could not figure out how it originally passed. I adjusted this test appropriately.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The tests are broken, there are new deprecation warnings, and there are new toys.
closes #423 
closes #429 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests still pass after my mucking about, and the number of deprecation warnings has been minimized. A few remain but I do not think they originate from this repo.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
These are internals that will likely only be documented via this PR and the release notes.
<!--
## Screenshots (if appropriate):
-->
