### PR TITLE
ENH: clean up pcds detector and add embedded version

### DIFF
--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = ['PCDSAreaDetectorBase',
+           'PCDSAreaDetectorEmbedded',
            'PCDSAreaDetector']
 
 
@@ -27,8 +28,51 @@ class PCDSAreaDetectorBase(DetectorBase):
     """Standard area detector with no plugins."""
     cam = ADComponent(cam.CamBase, '')
 
+    def get_plugin_graph_edges(self, *, use_names=True, include_cam=False):
+        """
+        Get a list of (source, destination) ports for all plugin chains.
 
-class PCDSAreaDetector(PCDSAreaDetectorBase):
+        Parameters
+        ----------
+        use_names : bool, optional
+            By default, the ophyd names for each plugin are used. Set this to
+            False to instead get the AreaDetector port names.
+        include_cam : bool, optional
+            Include plugins with 'CAM' as the source.  As it is easy to assume
+            that a camera without an explicit source is CAM, by default this
+            method does not include it in the list.
+        """
+
+        cam_port = self.cam.port_name.get()
+        graph, port_map = self.get_asyn_digraph()
+        port_edges = [(src, dest) for src, dest in graph.edges
+                      if src != cam_port or include_cam]
+        if use_names:
+            port_edges = [(port_map[src].name, port_map[dest].name)
+                          for src, dest in port_edges]
+        return port_edges
+
+
+class PCDSAreaDetectorEmbedded(PCDSAreaDetectorBase):
+    """
+    Minimal area detector including only the most-used PCDS plugins.
+
+    The plugins included are:
+        IMAGE2: reduced rate image, used for camera viewer.
+        Stats2: reduced rate stats.
+    """
+    image2 = Cpt(ImagePlugin, 'IMAGE2:', kind='normal',
+                 doc='Image plugin used for the camera viewer')
+    stats2 = Cpt(StatsPlugin, 'Stats2:', kind='normal',
+                 doc='Stats plugin used for alignments')
+
+    def get_full_area_detector(self):
+        if isinstance(self, PCDSAreaDetector):
+            return self
+        return PCDSAreaDetector(self.prefix, name=self.name + '_full')
+
+
+class PCDSAreaDetector(PCDSAreaDetectorEmbedded):
     """
     Standard area detector including all (*) standard PCDS plugins.
 
@@ -82,14 +126,12 @@ class PCDSAreaDetector(PCDSAreaDetectorBase):
     detector.
     """
 
-    image1 = Cpt(ImagePlugin, 'IMAGE1:', read_attrs=['array_data'],
-                 doc='Image plugin for general usage')
+    image1 = Cpt(ImagePlugin, 'IMAGE1:')
     image1_roi = Cpt(ROIPlugin, 'IMAGE1:ROI:')
     image1_cc = Cpt(ColorConvPlugin, 'IMAGE1:CC:')
     image1_proc = Cpt(ProcessPlugin, 'IMAGE1:Proc:')
     image1_over = Cpt(OverlayPlugin, 'IMAGE1:Over:')
-    image2 = Cpt(ImagePlugin, 'IMAGE2:', read_attrs=['array_data'],
-                 doc='Image plugin used for the camera viewer')
+    # image2 in parent
     image2_roi = Cpt(ROIPlugin, 'IMAGE2:ROI:')
     image2_cc = Cpt(ColorConvPlugin, 'IMAGE2:CC:')
     image2_proc = Cpt(ProcessPlugin, 'IMAGE2:Proc:')
@@ -111,60 +153,10 @@ class PCDSAreaDetector(PCDSAreaDetectorBase):
     roi2 = Cpt(ROIPlugin, 'ROI2:')
     roi3 = Cpt(ROIPlugin, 'ROI3:')
     roi4 = Cpt(ROIPlugin, 'ROI4:')
-    stats1 = Cpt(StatsPlugin, 'Stats1:', read_attrs=['centroid', 'mean_value',
-                                                     'sigma_x', 'sigma_y'])
-    stats2 = Cpt(StatsPlugin, 'Stats2:', read_attrs=['centroid', 'mean_value',
-                                                     'sigma_x', 'sigma_y'])
-    stats3 = Cpt(StatsPlugin, 'Stats3:', read_attrs=['centroid', 'mean_value',
-                                                     'sigma_x', 'sigma_y'])
-    stats4 = Cpt(StatsPlugin, 'Stats4:', read_attrs=['centroid', 'mean_value',
-                                                     'sigma_x', 'sigma_y'])
-    stats5 = Cpt(StatsPlugin, 'Stats5:', read_attrs=['centroid', 'mean_value',
-                                                     'sigma_x', 'sigma_y'])
+    stats1 = Cpt(StatsPlugin, 'Stats1:')
+    # stats2 in parent
+    stats3 = Cpt(StatsPlugin, 'Stats3:')
+    stats4 = Cpt(StatsPlugin, 'Stats4:')
+    stats5 = Cpt(StatsPlugin, 'Stats5:')
     tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
     trans1 = Cpt(TransformPlugin, 'Trans1:')
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.image2.stage_sigs['enable'] = 1
-        self.stats2.stage_sigs['enable'] = 1
-        self.stats2.stage_sigs['compute_statistics'] = 'Yes'
-        self.stats2.stage_sigs['compute_centroid'] = 'Yes'
-
-    def get_plugin_graph_edges(self, *, use_names=True, include_cam=False):
-        """
-        Get a list of (source, destination) ports for all plugin chains.
-
-        Parameters
-        ----------
-        use_names : bool, optional
-            By default, the ophyd names for each plugin are used. Set this to
-            False to instead get the AreaDetector port names.
-        include_cam : bool, optional
-            Include plugins with 'CAM' as the source.  As it is easy to assume
-            that a camera without an explicit source is CAM, by default this
-            method does not include it in the list.
-        """
-
-        cam_port = self.cam.port_name.get()
-        graph, port_map = self.get_asyn_digraph()
-        port_edges = [(src, dest) for src, dest in graph.edges
-                      if src != cam_port or include_cam]
-        if use_names:
-            port_edges = [(port_map[src].name, port_map[dest].name)
-                          for src, dest in port_edges]
-        return port_edges
-
-    @property
-    def image(self):
-        """Deprecated - alias for `image2`."""
-        warnings.warn('PCDSAreaDetector.image is deprecated; use {}.image2 '
-                      'instead'.format(self.name))
-        return self.image2
-
-    @property
-    def stats(self):
-        """Deprecated - alias for `stats2`."""
-        warnings.warn('PCDSAreaDetector.image is deprecated; use {}.stats2 '
-                      'instead'.format(self.name))
-        return self.stats2

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -61,6 +61,7 @@ class PCDSAreaDetectorEmbedded(PCDSAreaDetectorBase):
         IMAGE2: reduced rate image, used for camera viewer.
         Stats2: reduced rate stats.
     """
+
     image2 = Cpt(ImagePlugin, 'IMAGE2:', kind='normal',
                  doc='Image plugin used for the camera viewer')
     stats2 = Cpt(StatsPlugin, 'Stats2:', kind='normal',

--- a/pcdsdevices/areadetector/plugins.py
+++ b/pcdsdevices/areadetector/plugins.py
@@ -104,7 +104,10 @@ class ImagePlugin(ophyd.plugins.ImagePlugin, PluginBase):
 
 
 class StatsPlugin(ophyd.plugins.StatsPlugin, PluginBase):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stage_sigs['compute_statistics'] = 'Yes'
+        self.stage_sigs['compute_centroid'] = 'Yes'
 
 
 class ColorConvPlugin(ophyd.plugins.ColorConvPlugin, PluginBase):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -14,7 +14,7 @@ from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import EpicsSignal
 
-from .areadetector.detectors import PCDSAreaDetector
+from .areadetector.detectors import PCDSAreaDetectorEmbedded
 from .epics_motor import IMS, BeckhoffAxis
 from .inout import InOutRecordPositioner, TwinCATInOutPositioner
 from .interface import BaseInterface
@@ -75,7 +75,8 @@ class PIM(Device, BaseInterface):
 
     state = Cpt(PIMY, '', kind='omitted')
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
-    detector = FCpt(PCDSAreaDetector, '{self._prefix_det}', kind='normal')
+    detector = FCpt(PCDSAreaDetectorEmbedded, '{self._prefix_det}',
+                    kind='normal')
 
     tab_whitelist = ['y_motor', 'remove', 'insert', 'removed', 'inserted']
     tab_component_names = True
@@ -260,7 +261,7 @@ class LCLS2ImagerBase(Device, BaseInterface):
 
     y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted')
     y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal')
-    detector = Cpt(PCDSAreaDetector, ':CAM:', kind='normal')
+    detector = Cpt(PCDSAreaDetectorEmbedded, ':CAM:', kind='normal')
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config')
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
See title

New class heirarchy is:
`PCDSAreaDetectorBase`: Just cam + utility methods
`PCDSAreaDetectorEmbedded`: plugins that are used very very frequently
`PCDSAreaDetector`: all plugins we put on every device

And the embedded version is used as the detector on the PIM, PPM, and XPIM.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See associated issue
closes #421 

In general, having large area detector devices embedded onto motion devices causes degradation of performance, both in `IPython` and in `typhos`. I may even want to reduce this more in the future (to just having cam)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests still pass
`typhos` screen loads

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Just in docstrings

<!--
## Screenshots (if appropriate):
-->
