### PR TITLE
Remove monkeypatch of EventSequence

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pyepics >=3.4.1
     - pytmc >=2.4.0
     - pyyaml
-    - cf_units >=2.0.1
+    - cf-units
     - scipy
     - matplotlib <3
     - periodictable

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ periodictable
 pyepics
 pytmc
 pyyaml
-cf_units>=2.0.1
+cf-units
 scipy

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -6,13 +6,11 @@ from bluesky.plan_stubs import sleep
 from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from ophyd.sim import NullStatus, make_fake_device
 
-import pcdsdevices.sequencer
-from pcdsdevices.sequencer import EventSequence, EventSequencer
+from pcdsdevices.sequencer import EventSequencer
 
 logger = logging.getLogger(__name__)
 
 FakeSequencer = make_fake_device(EventSequencer)
-pcdsdevices.sequencer.EventSequence = make_fake_device(EventSequence)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Description
As the title says. The patch is not (at least not anymore) necessary for the tests the pass. Also stuffed a rename of `cf_units` -> `cf-units` in here.

## Motivation and Context
Not really a required change. Just a removal of an obscure vestigial code piece.
Also fixes #318.

## How Has This Been Tested?
Travis build passes.

## Where Has This Been Documented?
It hasn't been. This PR should be record enough.