### PR TITLE
ENH: Add Valve Fast Shutter class

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -226,22 +226,25 @@ class VGC(VRC):
     mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK_RBV', kind='omitted',
                     doc=('individual valve MPS state for debugging'))
 
+
 class VFS(VRC):
     """Class for Fast Shutter Valve."""
-    vfs_closed = Cpt(EpicsSignalRO, ':CLS_RBV', kind='normal', 
+    vfs_closed = Cpt(EpicsSignalRO, ':CLS_RBV', kind='normal',
                      doc='Fast Shutter Closed Status')
     vfs_open = Cpt(EpicsSignalRO, ':OPEN_RBV', kind='normal',
                    doc='Fast Shutter Open Status')
     vfs_vac_fault_ok = Cpt(EpicsSignalRO, ':FAULT_OK_RBV', kind='normal',
                            doc='Fast Shutter Vacuum Fault OK')
-    vfs_vac_fault_reset = Cpt(EpicsSignalWithRBV, ':FAULT_RESET', kind='normal'
-                              , doc='Fast Shutter Vacuum Fault Reset'
+    vfs_vac_fault_reset = Cpt(EpicsSignalWithRBV, ':FAULT_RESET',
+                              kind='normal',
+                              doc='Fast Shutter Vacuum Fault Reset')
     vfs_mps_ok = Cpt(EpicsSignalRO, ':FFO_OK_RBV', kind='normal',
                      doc='Fast Shutter Fast Fault Output OK')
     vfs_trigger = Cpt(EpicsSignalRO, ':TRIG_RBV', kind='normal',
                       doc='Fast Sensor Input Trigger')
     vfs_close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal'
                             doc='EPICS Command To Close Fast Shutter')
+
 
 class VVCNO(Device):
     """Vent Valve, Controlled, Normally Open."""

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -242,7 +242,7 @@ class VFS(VRC):
                      doc='Fast Shutter Fast Fault Output OK')
     vfs_trigger = Cpt(EpicsSignalRO, ':TRIG_RBV', kind='normal',
                       doc='Fast Sensor Input Trigger')
-    vfs_close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal'
+    vfs_close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',
                             doc='EPICS Command To Close Fast Shutter')
 
 

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -226,6 +226,22 @@ class VGC(VRC):
     mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK_RBV', kind='omitted',
                     doc=('individual valve MPS state for debugging'))
 
+class VFS(VRC):
+    """Class for Fast Shutter Valve."""
+    vfs_closed = Cpt(EpicsSignalRO, ':CLS_RBV', kind='normal', 
+                     doc='Fast Shutter Closed Status')
+    vfs_open = Cpt(EpicsSignalRO, ':OPEN_RBV', kind='normal',
+                   doc='Fast Shutter Open Status')
+    vfs_vac_fault_ok = Cpt(EpicsSignalRO, ':FAULT_OK_RBV', kind='normal',
+                           doc='Fast Shutter Vacuum Fault OK')
+    vfs_vac_fault_reset = Cpt(EpicsSignalWithRBV, ':FAULT_RESET', kind='normal'
+                              , doc='Fast Shutter Vacuum Fault Reset'
+    vfs_mps_ok = Cpt(EpicsSignalRO, ':FFO_OK_RBV', kind='normal',
+                     doc='Fast Shutter Fast Fault Output OK')
+    vfs_trigger = Cpt(EpicsSignalRO, ':TRIG_RBV', kind='normal',
+                      doc='Fast Sensor Input Trigger')
+    vfs_close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal'
+                            doc='EPICS Command To Close Fast Shutter')
 
 class VVCNO(Device):
     """Vent Valve, Controlled, Normally Open."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Create new Valve Fast Shutter (VFS) class by inheriting VRC. Added VFS closed, VFS open, vfs vac fault ok, vfs vac fault reset, vfs mps ok, vfs trigger, and vfs close command. 

## Motivation and Context
This allows for the generation for fast shutter expert screens.

## How Has This Been Tested?
This is the first iteration. The pragmas are all based from the vacuum lib library.

## Where Has This Been Documented?
Not sure where

<!--
## Screenshots (if appropriate):
-->
![image](https://user-images.githubusercontent.com/42284230/83214013-6e4c4280-a118-11ea-9c32-e2233b90557f.png)
