### PR TITLE
SXR Test Absorber addition

### DIFF
--- a/pcdsdevices/absorber.py
+++ b/pcdsdevices/absorber.py
@@ -1,0 +1,26 @@
+"""
+Module for the various absorbers.
+"""
+from ophyd.device import Component as Cpt
+from ophyd.device import Device
+
+from .epics_motor import BeckhoffAxis
+
+# from ophyd.device import FormattedComponent as FCpt
+
+# from .interface import BaseInterface
+
+
+class TestAbsorber(Device):
+    """
+    SXR Test Absorber: Used for testing the sxr beamline at high pulse rates.
+
+    This device has 1 main members: the stopper/absorber (diamond stopper).
+
+    The vertical motor moves stopper in and out of the beam path in
+    the +/- y direction.
+    """
+
+    tab_component_names = True
+
+    absorber_vert = Cpt(BeckhoffAxis, ':absorber_vert', kind='normal')

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -19,4 +19,4 @@ class SxrTestAbsorber(Device):
 
     tab_component_names = True
 
-    absorber_vert = Cpt(BeckhoffAxis, ':absorber_vert', kind='normal')
+    absorber_vert = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -1,17 +1,13 @@
 """
-Module for the various absorbers.
+Module for the SXR Test Absorbers.
 """
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 
 from .epics_motor import BeckhoffAxis
 
-# from ophyd.device import FormattedComponent as FCpt
 
-# from .interface import BaseInterface
-
-
-class TestAbsorber(Device):
+class SxrTestAbsorber(Device):
     """
     SXR Test Absorber: Used for testing the sxr beamline at high pulse rates.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Summary
Added sxr_test_absorber.py and SxrTestAbsorber class. There are one off components. Although the name is an absorber, its function is a sacrifical stopper for the 1Mhz sxr beam and used when they are ramping up. 

## Motivation and Context
Add the SXR test absorber to pcdsdevices so a gui can appear.

