### PR TITLE
ENH: add start of "variety" concept + schema validation

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,7 +15,6 @@ requirements:
   build:
     - python >=3.6
     - setuptools
-
   run:
     - python >=3.6
     - ophyd >=1.5.0
@@ -28,6 +27,7 @@ requirements:
     - matplotlib <3
     - periodictable
     - happi
+    - schema
 
 test:
   imports:

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -4,6 +4,8 @@ import shutil
 import sys
 import time
 
+from cf_units import Unit
+
 try:
     import tty
     import termios
@@ -11,7 +13,6 @@ except ImportError:
     tty = None
     termios = None
 
-from cf_units import Unit
 
 arrow_up = '\x1b[A'
 arrow_down = '\x1b[B'
@@ -135,3 +136,20 @@ def ipm_screen(dettype, prefix, prefix_ioc):
                                % executable)
     os.system('%s --base %s --ioc %s --evr %s &' %
               (executable, prefix, prefix_ioc, prefix+':TRIG'))
+
+
+def get_component(obj):
+    """
+    Get the component that made the given object.
+
+    Parameters
+    ----------
+    obj : ophyd.OphydItem
+        The ophyd item for which to get the component.
+
+    Returns
+    -------
+    component : ophyd.Component
+        The component, if available.
+    """
+    return getattr(type(obj.parent), obj.attr_name)

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -42,6 +42,75 @@ varieties_by_category = {
 }
 
 
+def _length_validate(min_count, max_count, type_):
+    """
+    Wrapper to validate a value, based on the given length.
+    """
+
+    def validate(value):
+        try:
+            assert min_count <= len(value) <= max_count
+        except Exception:
+            ...
+        else:
+            for item in value:
+                assert isinstance(item, type_)
+            return True
+
+        if min_count == max_count:
+            raise ValueError(
+                f'Expecting a sequence of {min_count} values ({type_})'
+            )
+
+        raise ValueError(
+            f'Expecting a sequence betweeen {min_count} and {max_count} values'
+            f' ({type_})'
+        )
+
+    return validate
+
+
+schema_by_category = {
+    'command': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['command']),
+        schema.Optional('value', default=1): schema.Or(float, int, str),
+        schema.Optional('enum_strings'): [str],
+        # schema.Optional('enum_dict'): dict,
+    }),
+
+    'tweakable': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['tweakable']),
+        'value': schema.Or(float, int),
+        schema.Optional('value_range'): _length_validate(2, 2, (float, int)),
+        schema.Optional('source_signal'): str,
+        schema.Optional('source'): schema.Or('setpoint', 'readback',
+                                             'other-signal'),
+    }),
+
+    'array': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['array']),
+        schema.Optional('shape'): _length_validate(1, 10, int),
+        schema.Optional('dimension'): int,
+    }),
+
+    'scalar': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['scalar']),
+        schema.Optional('range'): _length_validate(2, 2, (float, int)),
+        schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
+    }),
+
+    'text': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['text']),
+        schema.Optional('enum_strings'): [str],
+    }),
+
+    'enum': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['enum']),
+        schema.Optional('enum_strings'): [str],
+    }),
+}
+
+
 def validate_metadata(md):
     """
     Validate a given metadata dictionary.
@@ -77,78 +146,6 @@ def validate_metadata(md):
         ) from None
 
     return schema.validate(md)
-
-
-def _length_validate(min_count, max_count, type_):
-    """
-    Wrapper to validate a value, based on the given length.
-    """
-
-    def validate(value):
-        try:
-            assert min_count <= len(value) <= max_count
-        except Exception:
-            ...
-        else:
-            for item in value:
-                assert isinstance(item, type_)
-            return True
-
-        if min_count == max_count:
-            raise ValueError(
-                f'Expecting a sequence of {min_count} values ({type_})'
-            )
-
-        raise ValueError(
-            f'Expecting a sequence betweeen {min_count} and {max_count} values'
-            f' ({type_})'
-        )
-
-    return validate
-
-
-schema_by_category = {
-    'command': schema.Schema(
-        {
-            'variety': schema.Or(*varieties_by_category['command']),
-            schema.Optional('value', default=1): schema.Or(float, int, str),
-            schema.Optional('enum_strings'): [str],
-            # schema.Optional('enum_dict'): dict,
-        },
-        description="Schema for the 'command' variety"
-    ),
-
-    'tweakable': schema.Schema({
-        'variety': schema.Or(*varieties_by_category['tweakable']),
-        'value': schema.Or(float, int),
-        schema.Optional('value_range'): _length_validate(2, 2, (float, int)),
-        schema.Optional('source_signal'): str,
-        schema.Optional('source'): schema.Or('setpoint', 'readback',
-                                             'other-signal'),
-    }),
-
-    'array': schema.Schema({
-        'variety': schema.Or(*varieties_by_category['array']),
-        schema.Optional('shape'): _length_validate(1, 10, int),
-        schema.Optional('dimension'): int,
-    }),
-
-    'scalar': schema.Schema({
-        'variety': schema.Or(*varieties_by_category['scalar']),
-        schema.Optional('range'): _length_validate(2, 2, (float, int)),
-        schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
-    }),
-
-    'text': schema.Schema({
-        'variety': schema.Or(*varieties_by_category['text']),
-        schema.Optional('enum_strings'): [str],
-    }),
-
-    'enum': schema.Schema({
-        'variety': schema.Or(*varieties_by_category['enum']),
-        schema.Optional('enum_strings'): [str],
-    }),
-}
 
 
 def _initialize_varieties():

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -76,8 +76,8 @@ schema_by_category = {
 
     'tweakable': schema.Schema({
         'variety': schema.Or(*varieties_by_category['tweakable']),
-        'value': schema.Or(float, int),
-        schema.Optional('value_range'): _length_validate(2, 2, (float, int)),
+        'delta': schema.Or(float, int),
+        schema.Optional('delta_range'): _length_validate(2, 2, (float, int)),
         schema.Optional('source_signal'): str,
         schema.Optional('source'): schema.Or('setpoint', 'readback',
                                              'other-signal'),

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -1,0 +1,195 @@
+"""
+Additional component metadata, classifying each into a "variety".
+
+TODO, something like the following:
+
+    def get_component_metadata(cpt):
+       if not isinstance(cpt, Component):
+           return get_component_metadata(get_component_from_signal(cpt))
+        return cpt.additional_metadata
+"""
+import schema
+
+COMMAND_VARIETIES = (
+    'command',
+    'command-proc',
+    'command-enum',
+    'command-setpoint-tracks-readback',
+)
+
+TWEAKABLE_VARIETIES = [
+    'tweakable',
+]
+
+ARRAY_VARIETIES = [
+    'array-timeseries',
+    'array-histogram',
+    'array-image',
+    'array-nd',
+]
+
+SCALAR_VARIETIES = [
+    'scalar',
+    'scalar-range',
+]
+
+TEXT_VARIETIES = [
+    'text',
+    'text-multiline',
+    'text-enum',
+]
+
+ENUM_VARIETIES = [
+    'enum',
+]
+
+OTHER_VARIETIES = [
+    'unknown',
+]
+
+_schemas = {}
+
+
+def add_variety_schema(variety, schema):
+    _schemas[variety] = schema
+
+
+def validate_metadata(md):
+    """
+    Validate a given metadata dictionary.
+
+    Parameters
+    ----------
+    md : dict
+        The metadata dictionary.
+
+    Returns
+    -------
+    md : dict
+        The validated metadata dictionary, with default values filled in if
+        necessary.
+    """
+    if not md:
+        return md
+
+    try:
+        variety = md['variety']
+    except KeyError:
+        raise ValueError(
+            'Unexpected metadata keys without variety specified: ' +
+            ', '.join(md)
+        ) from None
+
+    try:
+        schema = _schemas[variety]
+    except KeyError:
+        raise ValueError(
+            f'Unexpected variety: {variety!r}.  Valid options: ' +
+            ', '.join(_schemas)
+        ) from None
+
+    return schema.validate(md)
+
+
+COMMAND_SCHEMA = schema.Schema(
+    {
+        'variety': schema.Or(*COMMAND_VARIETIES),
+        schema.Optional('value', default=1): schema.Or(float, int, str),
+        schema.Optional('enum_strings'): [str],
+        # schema.Optional('enum_dict'): dict,
+    },
+    description="Schema for the 'command' variety"
+)
+
+
+def _length_validate(min_count, max_count, type_):
+    """
+    Wrapper to validate a value, based on the given length.
+    """
+
+    def validate(value):
+        try:
+            assert min_count <= len(value) <= max_count
+        except Exception:
+            ...
+        else:
+            for item in value:
+                assert isinstance(item, type_)
+            return True
+
+        if min_count == max_count:
+            raise ValueError(
+                f'Expecting a sequence of {min_count} values ({type_})'
+            )
+
+        raise ValueError(
+            f'Expecting a sequence betweeen {min_count} and {max_count} values'
+            f' ({type_})'
+        )
+
+    return validate
+
+
+TWEAKABLE_SCHEMA = schema.Schema(
+    {
+        'variety': schema.Or(*TWEAKABLE_VARIETIES),
+        'value': schema.Or(float, int),
+        schema.Optional('value_range'): _length_validate(2, 2, (float, int)),
+        schema.Optional('source_signal'): str,
+        schema.Optional('source'): schema.Or('setpoint', 'readback',
+                                             'other-signal'),
+    },
+    description="Schema for the 'tweakable' variety"
+)
+
+ARRAY_SCHEMA = schema.Schema(
+    {
+        'variety': schema.Or(*ARRAY_VARIETIES),
+        schema.Optional('shape'): _length_validate(1, 10, int),
+        schema.Optional('dimension'): int,
+    },
+    description="Schema for the 'array' variety"
+)
+
+SCALAR_SCHEMA = schema.Schema(
+    {
+        'variety': schema.Or(*SCALAR_VARIETIES),
+        schema.Optional('range'): _length_validate(2, 2, (float, int)),
+        schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
+    },
+    description="Schema for the 'scalar' variety"
+)
+
+TEXT_SCHEMA = schema.Schema(
+    {
+        'variety': schema.Or(*TEXT_VARIETIES),
+        schema.Optional('enum_strings'): [str],
+    },
+    description="Schema for the 'text' variety"
+)
+
+ENUM_SCHEMA = schema.Schema(
+    {
+        'variety': schema.Or(*ENUM_VARIETIES),
+        schema.Optional('enum_strings'): [str],
+    },
+    description="Schema for the 'enum' variety"
+)
+
+for variety in COMMAND_VARIETIES:
+    add_variety_schema(variety, COMMAND_SCHEMA)
+
+for variety in TWEAKABLE_VARIETIES:
+    add_variety_schema(variety, TWEAKABLE_SCHEMA)
+
+for variety in ARRAY_VARIETIES:
+    add_variety_schema(variety, ARRAY_SCHEMA)
+
+for variety in SCALAR_VARIETIES:
+    add_variety_schema(variety, SCALAR_SCHEMA)
+
+for variety in TEXT_VARIETIES:
+    add_variety_schema(variety, TEXT_SCHEMA)
+
+for variety in ENUM_VARIETIES:
+    add_variety_schema(variety, ENUM_SCHEMA)

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -87,6 +87,8 @@ schema_by_category = {
         'variety': schema.Or(*varieties_by_category['array']),
         schema.Optional('shape'): _length_validate(1, 10, int),
         schema.Optional('dimension'): int,
+        schema.Optional('embed'): bool,
+        schema.Optional('colormap'): str,
     }),
 
     'scalar': schema.Schema({

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -116,6 +116,8 @@ schema_by_category = {
         'variety': schema.Or(*varieties_by_category['scalar']),
         schema.Optional('range'): _length_validate(2, 2, (float, int)),
         schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
+        schema.Optional('display_format', default='default'): schema.Or(
+            'default', 'string', 'decimal', 'exponential', 'hex', 'binary'),
     }),
 
     'text': schema.Schema({

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -10,48 +10,36 @@ TODO, something like the following:
 """
 import schema
 
-COMMAND_VARIETIES = (
-    'command',
-    'command-proc',
-    'command-enum',
-    'command-setpoint-tracks-readback',
-)
-
-TWEAKABLE_VARIETIES = [
-    'tweakable',
-]
-
-ARRAY_VARIETIES = [
-    'array-timeseries',
-    'array-histogram',
-    'array-image',
-    'array-nd',
-]
-
-SCALAR_VARIETIES = [
-    'scalar',
-    'scalar-range',
-]
-
-TEXT_VARIETIES = [
-    'text',
-    'text-multiline',
-    'text-enum',
-]
-
-ENUM_VARIETIES = [
-    'enum',
-]
-
-OTHER_VARIETIES = [
-    'unknown',
-]
-
-_schemas = {}
-
-
-def add_variety_schema(variety, schema):
-    _schemas[variety] = schema
+_schema_registry = {}
+varieties_by_category = {
+    'command': {
+        'command',
+        'command-proc',
+        'command-enum',
+        'command-setpoint-tracks-readback',
+    },
+    'tweakable': {
+        'tweakable'
+    },
+    'array': {
+        'array-timeseries',
+        'array-histogram',
+        'array-image',
+        'array-nd',
+    },
+    'scalar': {
+        'scalar',
+        'scalar-range',
+    },
+    'text': {
+        'text',
+        'text-multiline',
+        'text-enum',
+    },
+    'enum': {
+        'enum',
+    },
+}
 
 
 def validate_metadata(md):
@@ -81,25 +69,14 @@ def validate_metadata(md):
         ) from None
 
     try:
-        schema = _schemas[variety]
+        schema = _schema_registry[variety]
     except KeyError:
         raise ValueError(
             f'Unexpected variety: {variety!r}.  Valid options: ' +
-            ', '.join(_schemas)
+            ', '.join(_schema_registry)
         ) from None
 
     return schema.validate(md)
-
-
-COMMAND_SCHEMA = schema.Schema(
-    {
-        'variety': schema.Or(*COMMAND_VARIETIES),
-        schema.Optional('value', default=1): schema.Or(float, int, str),
-        schema.Optional('enum_strings'): [str],
-        # schema.Optional('enum_dict'): dict,
-    },
-    description="Schema for the 'command' variety"
-)
 
 
 def _length_validate(min_count, max_count, type_):
@@ -130,66 +107,56 @@ def _length_validate(min_count, max_count, type_):
     return validate
 
 
-TWEAKABLE_SCHEMA = schema.Schema(
-    {
-        'variety': schema.Or(*TWEAKABLE_VARIETIES),
+schema_by_category = {
+    'command': schema.Schema(
+        {
+            'variety': schema.Or(*varieties_by_category['command']),
+            schema.Optional('value', default=1): schema.Or(float, int, str),
+            schema.Optional('enum_strings'): [str],
+            # schema.Optional('enum_dict'): dict,
+        },
+        description="Schema for the 'command' variety"
+    ),
+
+    'tweakable': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['tweakable']),
         'value': schema.Or(float, int),
         schema.Optional('value_range'): _length_validate(2, 2, (float, int)),
         schema.Optional('source_signal'): str,
         schema.Optional('source'): schema.Or('setpoint', 'readback',
                                              'other-signal'),
-    },
-    description="Schema for the 'tweakable' variety"
-)
+    }),
 
-ARRAY_SCHEMA = schema.Schema(
-    {
-        'variety': schema.Or(*ARRAY_VARIETIES),
+    'array': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['array']),
         schema.Optional('shape'): _length_validate(1, 10, int),
         schema.Optional('dimension'): int,
-    },
-    description="Schema for the 'array' variety"
-)
+    }),
 
-SCALAR_SCHEMA = schema.Schema(
-    {
-        'variety': schema.Or(*SCALAR_VARIETIES),
+    'scalar': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['scalar']),
         schema.Optional('range'): _length_validate(2, 2, (float, int)),
         schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
-    },
-    description="Schema for the 'scalar' variety"
-)
+    }),
 
-TEXT_SCHEMA = schema.Schema(
-    {
-        'variety': schema.Or(*TEXT_VARIETIES),
+    'text': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['text']),
         schema.Optional('enum_strings'): [str],
-    },
-    description="Schema for the 'text' variety"
-)
+    }),
 
-ENUM_SCHEMA = schema.Schema(
-    {
-        'variety': schema.Or(*ENUM_VARIETIES),
+    'enum': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['enum']),
         schema.Optional('enum_strings'): [str],
-    },
-    description="Schema for the 'enum' variety"
-)
+    }),
+}
 
-for variety in COMMAND_VARIETIES:
-    add_variety_schema(variety, COMMAND_SCHEMA)
 
-for variety in TWEAKABLE_VARIETIES:
-    add_variety_schema(variety, TWEAKABLE_SCHEMA)
+def _initialize_varieties():
+    """Add all available varieties + schemas to the module-global registry."""
+    for category, varieties in varieties_by_category.items():
+        schema = schema_by_category[category]
+        for variety in varieties:
+            _schema_registry[variety] = schema
 
-for variety in ARRAY_VARIETIES:
-    add_variety_schema(variety, ARRAY_SCHEMA)
 
-for variety in SCALAR_VARIETIES:
-    add_variety_schema(variety, SCALAR_SCHEMA)
-
-for variety in TEXT_VARIETIES:
-    add_variety_schema(variety, TEXT_SCHEMA)
-
-for variety in ENUM_VARIETIES:
-    add_variety_schema(variety, ENUM_SCHEMA)
+_initialize_varieties()

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -27,6 +27,9 @@ varieties_by_category = {
         'scalar',
         'scalar-range',
     },
+    'bitmask': {
+        'bitmask',
+    },
     'text': {
         'text',
         'text-multiline',
@@ -89,6 +92,24 @@ schema_by_category = {
         schema.Optional('dimension'): int,
         schema.Optional('embed'): bool,
         schema.Optional('colormap'): str,
+    }),
+
+    'bitmask': schema.Schema({
+        'variety': schema.Or(*varieties_by_category['bitmask']),
+        schema.Optional('orientation',
+                        default='horizontal'): schema.Or('horizontal',
+                                                         'vertical'),
+        schema.Optional('bits', default=8): int,
+        schema.Optional(
+            'first_bit',
+            default='most-significant'): schema.Or('most-significant',
+                                                   'least-significant'),
+
+        # Style:
+        schema.Optional('shape', default='rectangle'): schema.Or('circle',
+                                                                 'rectangle'),
+        schema.Optional('on_color', default='green'): str,
+        schema.Optional('off_color', default='gray'): str,
     }),
 
     'scalar': schema.Schema({

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytmc
 pyyaml
 cf-units
 scipy
+schema

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -136,31 +136,35 @@ def test_no_variety():
 
         # ** scalar - numeric **
         pytest.param(
-            dict(variety='scalar',),
-            SAME,
+            dict(variety='scalar'),
+            dict(variety='scalar', display_format='default'),
             id='scalar'
         ),
 
         pytest.param(
-            dict(variety='scalar-range',),
+            dict(variety='scalar-range', display_format='default'),
             SAME,
             id='scalar-range'
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='use_limits'),
+            dict(variety='scalar-range', range_source='use_limits',
+                 display_format='exponential'),
             SAME,
             id='scalar-use_limits'
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='custom'),
+            dict(variety='scalar-range', range_source='custom',
+                 display_format='default'),
             SAME,
             id='scalar-custom'
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='custom', range=[0, 5]),
+            dict(variety='scalar-range', range_source='custom', range=[0, 5],
+                 display_format='default',
+                 ),
             SAME,
             id='scalar-custom-range'
         ),

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -3,7 +3,8 @@ import inspect
 import pytest
 import schema
 
-from pcdsdevices.variety import validate_metadata
+import ophyd
+from pcdsdevices.variety import get_metadata, set_metadata, validate_metadata
 
 # A sentinel indicating the validated metadata should match the provided
 # metadata exactly
@@ -219,3 +220,24 @@ def test_schemas(md, expected):
             validate_metadata(md)
     else:
         assert validate_metadata(md) == expected
+
+
+def test_component():
+    md = dict(variety='command', value=5)
+
+    class MyDevice(ophyd.Device):
+        cpt = ophyd.Component(ophyd.Signal)
+        set_metadata(cpt, md)
+
+    assert get_metadata(MyDevice.cpt) == md
+    assert get_metadata(MyDevice(name='dev').cpt) == md
+
+
+def test_component_empty_md():
+    class MyDevice(ophyd.Device):
+        cpt = ophyd.Component(ophyd.Signal)
+        set_metadata(cpt, None)
+        unset_cpt = ophyd.Component(ophyd.Signal)
+
+    assert get_metadata(MyDevice.cpt) == {}
+    assert get_metadata(MyDevice.unset_cpt) == {}

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -196,6 +196,23 @@ def test_no_variety():
             id='text-bad-keys'
         ),
 
+        # ** bitmask **
+        pytest.param(
+            dict(variety='bitmask'),
+            dict(variety='bitmask', bits=8, shape='rectangle',
+                 orientation='horizontal', first_bit='most-significant',
+                 on_color='green', off_color='gray'),
+            id='bitmask-defaults',
+        ),
+
+        pytest.param(
+            dict(variety='bitmask', bits=32, first_bit='least-significant'),
+            dict(variety='bitmask', bits=32, shape='rectangle',
+                 orientation='horizontal', first_bit='least-significant',
+                 on_color='green', off_color='gray'),
+            id='bitmask-custom',
+        ),
+
         # ** general enum **
         pytest.param(
             dict(variety='enum', enum_strings=['a', 'b', 'c']),

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -1,0 +1,221 @@
+import inspect
+
+import pytest
+import schema
+
+from pcdsdevices.variety import validate_metadata
+
+# A sentinel indicating the validated metadata should match the provided
+# metadata exactly
+SAME = object()
+
+
+def test_empty_md():
+    validate_metadata({})
+
+
+def test_no_variety():
+    with pytest.raises(ValueError):
+        validate_metadata({'test': 'a'})
+
+
+@pytest.mark.parametrize(
+    'md, expected',
+    [
+        # ** command **
+        pytest.param(
+            dict(variety='command'),
+            dict(variety='command', value=1),  # <-- picks up default
+            id='command-default-value',
+        ),
+
+        pytest.param(
+            dict(variety='command', value=0, enum_strings=['a', 'b', 'c']),
+            SAME,
+            id='command-with-enum-strs',
+        ),
+
+        pytest.param(
+            dict(variety='command', value='a', enum_strings=['a', 'b', 'c']),
+            SAME,
+            id='command-str-with-enum-strs',
+        ),
+
+        pytest.param(
+            dict(variety='command-proc'),
+            dict(variety='command-proc', value=1),  # <-- picks up default
+            id='command-proc',
+        ),
+
+        pytest.param(
+            dict(variety='command-enum', value=0),
+            dict(variety='command-enum', value=0),
+            id='command-enum',
+        ),
+
+        pytest.param(
+            dict(variety='command-setpoint-tracks-readback', value=0),
+            dict(variety='command-setpoint-tracks-readback', value=0),
+            id='command-setpoint-tracks-readback',
+        ),
+
+        # ** tweakable **
+        pytest.param(
+            dict(variety='tweakable'),
+            schema.SchemaMissingKeyError,
+            id='tweakable-no-value',
+        ),
+
+        pytest.param(
+            dict(variety='tweakable', value=3),
+            SAME,
+            id='tweakable-value',
+        ),
+
+        pytest.param(
+            dict(variety='tweakable', value=3, value_range=[-1, 10]),
+            SAME,
+            id='tweakable-good-range',
+        ),
+
+        pytest.param(
+            dict(variety='tweakable', value=3, value_range=-1),
+            schema.SchemaError,
+            id='tweakable-bad-range',
+        ),
+
+        pytest.param(
+            dict(variety='tweakable', value=3, value_range=[-1, 'q']),
+            schema.SchemaError,
+            id='tweakable-bad-range-type',
+        ),
+
+        # ** arrays / waveforms **
+        pytest.param(
+            dict(variety='array-timeseries'),
+            SAME,
+            id='array-timeseries'
+        ),
+
+        pytest.param(
+            dict(variety='array-histogram'),
+            SAME,
+            id='array-histogram'
+        ),
+
+        pytest.param(
+            dict(variety='array-image'),
+            SAME,
+            id='array-image'
+        ),
+
+        pytest.param(
+            dict(variety='array-nd'),
+            SAME,
+            id='array-nd'
+        ),
+
+        pytest.param(
+            dict(variety='array-nd', dimension=2, shape=(512, 512)),
+            SAME,
+            id='array-2d'
+        ),
+
+        pytest.param(
+            dict(variety='array-nd', dimension=3, shape=(512, 512, 512)),
+            SAME,
+            id='array-3d'
+        ),
+
+        pytest.param(
+            dict(variety='array-nd', shape=()),
+            schema.SchemaError,
+            id='array-bad-shape'
+        ),
+
+        # ** scalar - numeric **
+        pytest.param(
+            dict(variety='scalar',),
+            SAME,
+            id='scalar'
+        ),
+
+        pytest.param(
+            dict(variety='scalar-range',),
+            SAME,
+            id='scalar-range'
+        ),
+
+        pytest.param(
+            dict(variety='scalar-range', range_source='use_limits'),
+            SAME,
+            id='scalar-use_limits'
+        ),
+
+        pytest.param(
+            dict(variety='scalar-range', range_source='custom'),
+            SAME,
+            id='scalar-custom'
+        ),
+
+        pytest.param(
+            dict(variety='scalar-range', range_source='custom', range=[0, 5]),
+            SAME,
+            id='scalar-custom-range'
+        ),
+
+        pytest.param(
+            dict(variety='scalar-range', range_source='custom', range=[0]),
+            schema.SchemaError,
+            id='scalar-bad-range'
+        ),
+
+        # ** text **
+        pytest.param(
+            dict(variety='text', enum_strings=['a', 'b', 'c']),
+            SAME,
+            id='text-enum_strings'
+        ),
+
+        pytest.param(
+            dict(variety='text-enum', enum_strings=['a', 'b', 'c']),
+            SAME,
+            id='text-enum'
+        ),
+
+        pytest.param(
+            dict(variety='text-multiline', enum_strings=['a', 'b', 'c']),
+            SAME,
+            id='text-multiline'
+        ),
+
+        pytest.param(
+            dict(variety='text', range_source='custom', range=[0]),
+            schema.SchemaError,
+            id='text-bad-keys'
+        ),
+
+        # ** general enum **
+        pytest.param(
+            dict(variety='enum', enum_strings=['a', 'b', 'c']),
+            SAME,
+            id='enum-basic',
+        ),
+
+        pytest.param(
+            dict(variety='enum', enum_strings='a'),
+            schema.SchemaError,
+            id='enum-not-a-list',
+        ),
+
+    ]
+)
+def test_schemas(md, expected):
+    if expected is SAME:
+        expected = dict(md)
+
+    if inspect.isclass(expected):
+        with pytest.raises(expected):
+            validate_metadata(md)
+    else:
+        assert validate_metadata(md) == expected

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -64,29 +64,29 @@ def test_no_variety():
         pytest.param(
             dict(variety='tweakable'),
             schema.SchemaMissingKeyError,
-            id='tweakable-no-value',
+            id='tweakable-no-delta',
         ),
 
         pytest.param(
-            dict(variety='tweakable', value=3),
+            dict(variety='tweakable', delta=3),
             SAME,
-            id='tweakable-value',
+            id='tweakable-delta',
         ),
 
         pytest.param(
-            dict(variety='tweakable', value=3, value_range=[-1, 10]),
+            dict(variety='tweakable', delta=3, delta_range=[-1, 10]),
             SAME,
             id='tweakable-good-range',
         ),
 
         pytest.param(
-            dict(variety='tweakable', value=3, value_range=-1),
+            dict(variety='tweakable', delta=3, delta_range=-1),
             schema.SchemaError,
             id='tweakable-bad-range',
         ),
 
         pytest.param(
-            dict(variety='tweakable', value=3, value_range=[-1, 'q']),
+            dict(variety='tweakable', delta=3, delta_range=[-1, 'q']),
             schema.SchemaError,
             id='tweakable-bad-range-type',
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
(Typhos related issue: https://github.com/pcdshub/typhos/issues/332)

This is a first pass at creating a place for more ophyd Device component metadata, which further classify the type of information a signal might hold without requiring a connection to the underlying control system.

Until such metadata is built into ophyd, we plan to have utility functions which add or inspect this additional metadata in `pcdsdevices`. The metadata will be checked with reasonable rigor, such that failures happen sooner (on load) rather than later (on instantiation of your device/screen/etc).

My proposal for the varieties you see in this PR is here, along with the additional metadata keys (anyone at Stanford should be able to comment): https://docs.google.com/spreadsheets/d/1nQQQvR-uqtAohpzqdLGxb8heDeT_sttbo3yS93yjE58/edit?ts=5ed199cc#gid=0

This utilizes the library [schema](https://github.com/keleshev/schema), which seems to work reasonably well. It would not be too difficult to refactor this to be validated with jsonschema, code (though this may be more error prone), or `your_favorite_library_here`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Typhos can only do so much with a component class, requiring a connection to EPICS (or the underlying control system) to determine which widgets to create. 

Typhos then calls `describe()` on a signal, attempting to figure out more about it. The presence or absence of keys in that describe dictionary (such as `data_type`, `enum_strs` or `precision`) may change the widget that gets created or various properties of that widget. However, it may still not paint a complete picture to disambiguate, for example, a scalar-valued PV which should be represented as a button instead of a text entry widget.

The goal of this PR, as you'll note, is not to assign a specific widget name to each signal: this would severely limit the scope and utility of the additional metadata provided. Instead, metadata is kept general, and it's up to downstream software to determine what to do with it. For example, a signal that falls into the variety of `command` would indicate to typhos that a button would be an appropriate widget. Further customization of that button might be dependent on other metadata (including that which comes from `describe()`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Schema tests
- [x] Attaching/accessing metadata tests

## TODO
- [x] Attaching / accessing metadata
- [ ] Documenting the above
- [ ] Add preliminary metadata to some ambiguous signals
- [ ] Refactor typhos to use this metadata