### PR TITLE
MNT: Moved PIPPLC protection_setpoint and setpoint_hysterisis to conf…

### DIFF
--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -160,14 +160,14 @@ class PIPPLC(Device):
                           doc='high voltage digital output')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock  is ok when true')
-    protection_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
+    protection_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
                               doc='Protection/At Vacuum Setpoint')
-    setpoint_hysteresis = Cpt(EpicsSignalWithRBV, ':SP_HYS', kind='omitted',
+    setpoint_hysteresis = Cpt(EpicsSignalWithRBV, ':SP_HYS', kind='config',
                               doc='Protection Setpoint Hysteresis')
     pump_on_status = Cpt(EpicsSignalRO, ':HV_DI_RBV', kind='normal',
                          doc='ion pump output state')
     pump_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted')
-    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='config',
+    at_vac_setpoint = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP', kind='omitted',
                           doc='at vacuum set point')
     high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='config',
                               doc='epics command to switch on the '


### PR DESCRIPTION
…ig. Moved at_vacuum_setpoint to omitted.

<!--- Provide a general summary of your changes in the Title above -->
## Description
Moved PIPPLC protection_setpoint and setpoint_hysterisis to config. Moved at_vacuum_setpoint to omitted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
