### PR TITLE
DEV: Add roughing pump subclass specific to the Ebara EV-A03-1

### DIFF
--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -214,7 +214,7 @@ class PROPLC(Device):
 
 
 class Ebara_EV_A03_1(PROPLC):
-    """Class for the Ebara EV-A03-1 model of roughing pump"""
+    """Class for the Ebara EV-A03-1 model of roughing pump."""
     remote = Cpt(EpicsSignalWithRBV, ':REMOTE', kind='omitted')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='omitted')
     run_di = Cpt(EpicsSignalWithRBV, ':RUN_DI_RBV', kind='omitted')

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -213,6 +213,13 @@ class PROPLC(Device):
     pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='normal')
 
 
+class Ebara_EV_A03_1(PROPLC):
+    """Class for the Ebara EV-A03-1 model of roughing pump"""
+    remote = Cpt(EpicsSignalWithRBV, ':REMOTE', kind='omitted')
+    alarm = Cpt(EpicsSignalRO, ':ALARM_OK', kind='omitted')
+    run_di = Cpt(EpicsSignalWithRBV, ':RUN_DI', kind='omitted')
+
+
 class AgilentSerial(Device):
     """Class for Agilent Turbo Pump controlled via serial."""
     run = Cpt(EpicsSignal, ':RUN', kind='omitted')

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -216,8 +216,8 @@ class PROPLC(Device):
 class Ebara_EV_A03_1(PROPLC):
     """Class for the Ebara EV-A03-1 model of roughing pump"""
     remote = Cpt(EpicsSignalWithRBV, ':REMOTE', kind='omitted')
-    alarm = Cpt(EpicsSignalRO, ':ALARM_OK', kind='omitted')
-    run_di = Cpt(EpicsSignalWithRBV, ':RUN_DI', kind='omitted')
+    alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='omitted')
+    run_di = Cpt(EpicsSignalWithRBV, ':RUN_DI_RBV', kind='omitted')
 
 
 class AgilentSerial(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -217,7 +217,7 @@ class Ebara_EV_A03_1(PROPLC):
     """Class for the Ebara EV-A03-1 model of roughing pump."""
     remote = Cpt(EpicsSignalWithRBV, ':REMOTE', kind='omitted')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='omitted')
-    run_di = Cpt(EpicsSignalWithRBV, ':RUN_DI_RBV', kind='omitted')
+    run_di = Cpt(EpicsSignalRO, ':RUN_DI_RBV', kind='omitted')
 
 
 class AgilentSerial(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -216,7 +216,7 @@ class PROPLC(Device):
 class Ebara_EV_A03_1(PROPLC):
     """Class for the Ebara EV-A03-1 model of roughing pump."""
     remote = Cpt(EpicsSignalWithRBV, ':REMOTE', kind='omitted')
-    alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='omitted')
+    alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')
     run_di = Cpt(EpicsSignalRO, ':RUN_DI_RBV', kind='omitted')
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR adds a subclass of the roughing pump specific for the Ebara EV-A03-1 model of roughing pump. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The standard roughing pump model neglected a few important PVs. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Standard tests and style checks succeed. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
A docstring has been added specifically indicating the acceptable pump model No.
<!--
## Screenshots (if appropriate):
-->
