### PR TITLE
ENH: add concept of "tags" to variety metadata

### DIFF
--- a/pcdsdevices/tags.py
+++ b/pcdsdevices/tags.py
@@ -1,0 +1,13 @@
+tag_to_explanation = {
+    'protected': 'May require additional privileges to change.',
+}
+
+
+def get_valid_tags():
+    """Return a list of all valid variety tags."""
+    return list(tag_to_explanation)
+
+
+def explain_tag(tag_name):
+    """Return a user-friendly explanation of a tag's meaning."""
+    return tag_to_explanation[tag_name]

--- a/pcdsdevices/tags.py
+++ b/pcdsdevices/tags.py
@@ -4,8 +4,8 @@ tag_to_explanation = {
 
 
 def get_valid_tags():
-    """Return a list of all valid variety tags."""
-    return list(tag_to_explanation)
+    """Return a set of all valid variety tags."""
+    return set(tag_to_explanation)
 
 
 def explain_tag(tag_name):

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -4,7 +4,7 @@ import schema
 
 import ophyd
 
-from . import utils
+from . import tags, utils
 
 _schema_registry = {}
 varieties_by_category = {
@@ -69,12 +69,18 @@ def _length_validate(min_count, max_count, type_):
     return validate
 
 
+common_schema = {
+    schema.Optional('tags'): {schema.Or(*tags.get_valid_tags())},
+}
+
+
 schema_by_category = {
     'command': schema.Schema({
         'variety': schema.Or(*varieties_by_category['command']),
         schema.Optional('value', default=1): schema.Or(float, int, str),
         schema.Optional('enum_strings'): [str],
         # schema.Optional('enum_dict'): dict,
+        **common_schema
     }),
 
     'tweakable': schema.Schema({
@@ -84,6 +90,7 @@ schema_by_category = {
         schema.Optional('source_signal'): str,
         schema.Optional('source'): schema.Or('setpoint', 'readback',
                                              'other-signal'),
+        **common_schema
     }),
 
     'array': schema.Schema({
@@ -92,6 +99,7 @@ schema_by_category = {
         schema.Optional('dimension'): int,
         schema.Optional('embed'): bool,
         schema.Optional('colormap'): str,
+        **common_schema
     }),
 
     'bitmask': schema.Schema({
@@ -110,6 +118,7 @@ schema_by_category = {
                                                                  'rectangle'),
         schema.Optional('on_color', default='green'): str,
         schema.Optional('off_color', default='gray'): str,
+        **common_schema
     }),
 
     'scalar': schema.Schema({
@@ -118,16 +127,19 @@ schema_by_category = {
         schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
         schema.Optional('display_format', default='default'): schema.Or(
             'default', 'string', 'decimal', 'exponential', 'hex', 'binary'),
+        **common_schema
     }),
 
     'text': schema.Schema({
         'variety': schema.Or(*varieties_by_category['text']),
         schema.Optional('enum_strings'): [str],
+        **common_schema
     }),
 
     'enum': schema.Schema({
         'variety': schema.Or(*varieties_by_category['enum']),
         schema.Optional('enum_strings'): [str],
+        **common_schema
     }),
 }
 

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -4,6 +4,7 @@ import pytest
 import schema
 
 import ophyd
+from pcdsdevices import tags
 from pcdsdevices.variety import get_metadata, set_metadata, validate_metadata
 
 # A sentinel indicating the validated metadata should match the provided
@@ -225,9 +226,23 @@ def test_no_variety():
         ),
 
         pytest.param(
+            dict(variety='enum', enum_strings=['a', 'b', 'c'],
+                 tags={'protected'}),
+            SAME,
+            id='enum-basic-with-tags',
+        ),
+
+        pytest.param(
             dict(variety='enum', enum_strings='a'),
             schema.SchemaError,
             id='enum-not-a-list',
+        ),
+
+        pytest.param(
+            dict(variety='enum', enum_strings=['a', 'b', 'c'],
+                 tags={'this-is-an-unknown-tag'}),
+            schema.SchemaError,
+            id='enum-basic-with-bad-tag',
         ),
 
     ]
@@ -262,3 +277,11 @@ def test_component_empty_md():
 
     assert get_metadata(MyDevice.cpt) == {}
     assert get_metadata(MyDevice.unset_cpt) == {}
+
+
+def test_tag_explain():
+    for tag in tags.get_valid_tags():
+        print(tag, tags.explain_tag(tag))
+
+    with pytest.raises(KeyError):
+        tags.explain_tag('this-is-a-bad-tag')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds the 'tags' key to all variety metadata schemas.
'tags' is a `set()` of curated string values that classify components.

An example would be that which is presented in this PR: a "protected" signal. If a GUI client sees this tag, it may require a password or mode-dependent (expert vs user) verification before proceeding.

Additional tags will require follow-up PRs, along with single-line explanations as to what the tag means.
Explanations should be written in a way that they can be used consistently from higher-level applications.
`The component: (tag_reason=* May require additional privileges to change.)`