### PR TITLE
DOC: Annotate LCLS2 Imagers and Related Classes

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -17,6 +17,7 @@ from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import DelayBase
 from .signal import PytmcSignal
+from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -443,11 +444,15 @@ class PMC100(PCDSMotorBase):
 
 
 class BeckhoffAxisPLC(Device):
-    """Debug PVs from the Beckhoff Axis PLC code"""
+    """Error handling for the Beckhoff Axis PLC code."""
     status = Cpt(PytmcSignal, 'sErrorMessage', io='i', kind='normal',
-                 string=True)
-    err_code = Cpt(PytmcSignal, 'nErrorId', io='i', kind='normal')
-    cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='o', kind='config')
+                 string=True, doc='PLC error or warning')
+    err_code = Cpt(PytmcSignal, 'nErrorId', io='i', kind='normal',
+                   doc='Current NC error code')
+    cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='o', kind='config',
+                        doc='Command to reset an active error')
+
+    set_metadata(cmd_err_reset, dict(variety='command', value=1))
 
 
 class BeckhoffAxis(EpicsMotorInterface):
@@ -463,7 +468,8 @@ class BeckhoffAxis(EpicsMotorInterface):
     __doc__ += basic_positioner_init
     tab_whitelist = ['clear_error']
 
-    plc = Cpt(BeckhoffAxisPLC, ':PLC:', kind='normal')
+    plc = Cpt(BeckhoffAxisPLC, ':PLC:', kind='normal',
+              doc='PLC error handling.')
 
     def clear_error(self):
         """Clear any active motion errors on this axis."""

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -452,6 +452,7 @@ class BeckhoffAxisPLC(Device):
     cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='o', kind='config',
                         doc='Command to reset an active error')
 
+    set_metadata(err_code, dict(variety='scalar', display_format='hex'))
     set_metadata(cmd_err_reset, dict(variety='command', value=1))
 
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -21,6 +21,7 @@ from .interface import BaseInterface
 from .sensors import TwinCATThermocouple
 from .signal import PytmcSignal
 from .state import StatePositioner
+from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -267,6 +268,7 @@ class LCLS2ImagerBase(Device, BaseInterface):
                    doc='Area detector settings and readbacks.')
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
                     doc='Camera power supply controls.')
+    set_metadata(cam_power, dict(variety='command-enum'))
 
 
 class PPMPowerMeter(Device, BaseInterface):
@@ -350,6 +352,7 @@ class PPM(LCLS2ImagerBase):
 
     led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config',
               doc='Percent of light from the dimmable illuminatior.')
+    set_metadata(led, dict(variety='scalar-range', range=(0, 100)))
 
 
 class XPIMFilterWheel(StatePositioner):
@@ -372,6 +375,8 @@ class XPIMFilterWheel(StatePositioner):
     error_message = Cpt(PytmcSignal, ':ERR:MSG', io='i', kind='omitted',
                         string=True,
                         doc='Error text for a filter wheel error.')
+
+    set_metadata(state, dict(variety='command-enum'))
 
 
 class XPIMLED(Device):
@@ -407,6 +412,9 @@ class XPIMLED(Device):
                     doc='Configure auto mode vs manual mode for turning '
                         'the LED on and off.')
 
+    set_metadata(power, dict(variety='command-enum'))
+    set_metadata(auto_mode, dict(variety='command-enum'))
+
 
 class XPIM(LCLS2ImagerBase):
     """
@@ -439,3 +447,6 @@ class XPIM(LCLS2ImagerBase):
     filter_wheel = Cpt(XPIMFilterWheel, ':MFW', kind='config',
                        doc='Optical filter wheel in front of the camera '
                            'to prevent saturation.')
+
+    set_metadata(zoom_lock, dict(variety='command-enum'))
+    set_metadata(focus_lock, dict(variety='command-enum'))

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -433,7 +433,7 @@ class XPIM(LCLS2ImagerBase):
     zoom_lock = Cpt(PytmcSignal, ':CLZ:LOCK', io='io', kind='config',
                     doc='Lockout to prevent zoom motion.')
     focus_lock = Cpt(PytmcSignal, ':CLF:LOCK', io='io', kind='config',
-                     doc='Lockout to prevent focus motion.'))
+                     doc='Lockout to prevent focus motion.')
     led = Cpt(XPIMLED, ':CIL', kind='config',
               doc='LED for viewing the reticle.')
     filter_wheel = Cpt(XPIMFilterWheel, ':MFW', kind='config',

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -343,10 +343,13 @@ class PPM(LCLS2ImagerBase):
         An identifying name for this motor, e.g. 'im3l0'.
     """
 
-    power_meter = Cpt(PPMPowerMeter, ':SPM', kind='normal')
-    yag_thermocouple = Cpt(TwinCATThermocouple, ':YAG', kind='normal')
+    power_meter = Cpt(PPMPowerMeter, ':SPM', kind='normal',
+                      doc='Device that measures power of incident beam.')
+    yag_thermocouple = Cpt(TwinCATThermocouple, ':YAG', kind='normal',
+                           doc='Thermocouple on the YAG holder.')
 
-    led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config')
+    led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config',
+              doc='Percent of light from the dimmable illuminatior.')
 
 
 class XPIMFilterWheel(StatePositioner):
@@ -360,10 +363,15 @@ class XPIMFilterWheel(StatePositioner):
 
     tab_component_names = True
 
-    state = Cpt(EpicsSignal, ':GET_RBV', write_pv=':SET', kind='normal')
+    state = Cpt(EpicsSignal, ':GET_RBV', write_pv=':SET', kind='normal',
+                doc='Control of the filter wheel state by preset '
+                    'transmission percentages.')
 
-    reset_cmd = Cpt(PytmcSignal, ':ERR:RESET', io='i', kind='omitted')
-    error_message = Cpt(PytmcSignal, ':ERR:MSG', io='i', kind='omitted')
+    reset_cmd = Cpt(PytmcSignal, ':ERR:RESET', io='i', kind='omitted',
+                    doc='Command to reset a filter wheel error.')
+    error_message = Cpt(PytmcSignal, ':ERR:MSG', io='i', kind='omitted',
+                        string=True,
+                        doc='Error text for a filter wheel error.')
 
 
 class XPIMLED(Device):
@@ -389,10 +397,15 @@ class XPIMLED(Device):
 
     tab_component_names = True
 
-    power = Cpt(PytmcSignal, ':PWR', io='io', kind='normal')
-    power_timeout = Cpt(PytmcSignal, ':CLK:TIMEOUT', io='io', kind='config')
-    time_remaining = Cpt(PytmcSignal, ':CLK:REMAINING', io='io', kind='config')
-    auto_mode = Cpt(PytmcSignal, ':AUTO', io='io', kind='config')
+    power = Cpt(PytmcSignal, ':PWR', io='io', kind='normal',
+                doc='LED power state, either on or off.')
+    power_timeout = Cpt(PytmcSignal, ':CLK:TIMEOUT', io='io', kind='config',
+                        doc='Configured auto-shutdown timeout for the led.')
+    time_remaining = Cpt(PytmcSignal, ':CLK:REMAINING', io='io', kind='config',
+                         doc='Remaining time before auto-shutoff.')
+    auto_mode = Cpt(PytmcSignal, ':AUTO', io='io', kind='config',
+                    doc='Configure auto mode vs manual mode for turning '
+                        'the LED on and off.')
 
 
 class XPIM(LCLS2ImagerBase):
@@ -412,10 +425,17 @@ class XPIM(LCLS2ImagerBase):
         An identifying name for this motor, e.g. 'im3l0'.
     """
 
-    zoom_motor = Cpt(BeckhoffAxis, ':CLZ', kind='normal')
-    focus_motor = Cpt(BeckhoffAxis, ':CLF', kind='normal')
+    zoom_motor = Cpt(BeckhoffAxis, ':CLZ', kind='normal',
+                     doc='Motorized zoom.')
+    focus_motor = Cpt(BeckhoffAxis, ':CLF', kind='normal',
+                      doc='Motorized focus.')
 
-    zoom_lock = Cpt(PytmcSignal, ':CLZ:LOCK', io='io', kind='config')
-    focus_lock = Cpt(PytmcSignal, ':CLF:LOCK', io='io', kind='config')
-    led = Cpt(XPIMLED, ':CIL', kind='config')
-    filter_wheel = Cpt(XPIMFilterWheel, ':MFW', kind='config')
+    zoom_lock = Cpt(PytmcSignal, ':CLZ:LOCK', io='io', kind='config',
+                    doc='Lockout to prevent zoom motion.')
+    focus_lock = Cpt(PytmcSignal, ':CLF:LOCK', io='io', kind='config',
+                     doc='Lockout to prevent focus motion.'))
+    led = Cpt(XPIMLED, ':CIL', kind='config',
+              doc='LED for viewing the reticle.')
+    filter_wheel = Cpt(XPIMFilterWheel, ':MFW', kind='config',
+                       doc='Optical filter wheel in front of the camera '
+                           'to prevent saturation.')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -259,10 +259,14 @@ class LCLS2ImagerBase(Device, BaseInterface):
 
     tab_component_names = True
 
-    y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted')
-    y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal')
-    detector = Cpt(PCDSAreaDetectorEmbedded, ':CAM:', kind='normal')
-    cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config')
+    y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted',
+                   doc='Control of the diagnostic stack via saved positions.')
+    y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal',
+                  doc='Direct control of the diagnostic stack motor.')
+    detector = Cpt(PCDSAreaDetectorEmbedded, ':CAM:', kind='normal',
+                   doc='Area detector settings and readbacks.')
+    cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
+                    doc='Camera power supply controls.')
 
 
 class PPMPowerMeter(Device, BaseInterface):
@@ -282,22 +286,44 @@ class PPMPowerMeter(Device, BaseInterface):
 
     tab_component_names = True
 
-    raw_voltage = Cpt(PytmcSignal, ':VOLT', io='i', kind='normal')
-    dimensionless = Cpt(PytmcSignal, ':CALIB', io='i', kind='normal')
-    calibrated_mj = Cpt(PytmcSignal, ':MJ', io='i', kind='normal')
-    thermocouple = Cpt(TwinCATThermocouple, '', kind='normal')
+    raw_voltage = Cpt(PytmcSignal, ':VOLT', io='i', kind='normal',
+                      doc='Raw readback from the power meter.')
+    dimensionless = Cpt(PytmcSignal, ':CALIB', io='i', kind='normal',
+                        doc='Calibrated dimensionless readback '
+                            'for cross-meter comparisons.')
+    calibrated_mj = Cpt(PytmcSignal, ':MJ', io='i', kind='normal',
+                        doc='Calibrated absolute measurement of beam '
+                            'power in physics units.')
+    thermocouple = Cpt(TwinCATThermocouple, '', kind='normal',
+                       doc='Thermocouple on the power meter holder.')
 
-    calib_offset = Cpt(PytmcSignal, ':CALIB:OFFSET', io='io', kind='config')
-    calib_ratio = Cpt(PytmcSignal, ':CALIB:RATIO', io='io', kind='config')
+    calib_offset = Cpt(PytmcSignal, ':CALIB:OFFSET', io='io', kind='config',
+                       doc='Calibration parameter to offset raw voltage to '
+                           'zero for the calibrated quantities. Unique per '
+                           'power meter.')
+    calib_ratio = Cpt(PytmcSignal, ':CALIB:RATIO', io='io', kind='config',
+                      doc='Calibration multiplier to convert to the '
+                          'dimensionless constant. Unique per power meter.')
     calib_mj_ratio = Cpt(PytmcSignal, ':CALIB:MJ_RATIO', io='io',
-                         kind='config')
+                         kind='config',
+                         doc='Calibration multiplier to convert from the '
+                             'dimensionless constant to calibrated scientific '
+                             'quantity. Same for every power meter.')
 
     raw_voltage_buffer = Cpt(PytmcSignal, ':VOLT_BUFFER', io='i',
-                             kind='omitted')
+                             kind='omitted',
+                             doc='Array of the last 1000 raw measurements. '
+                                 'Polls faster than the EPICS updates.')
     dimensionless_buffer = Cpt(PytmcSignal, ':CALIB_BUFFER', io='i',
-                               kind='omitted')
+                               kind='omitted',
+                               doc='Array of the last 1000 dimensionless '
+                                   'measurements. Polls faster than the '
+                                   'EPICS updates.')
     calibrated_mj_buffer = Cpt(PytmcSignal, ':MJ_BUFFER', io='i',
-                               kind='omitted')
+                               kind='omitted',
+                               doc='Array of the last 1000 fully calibrated '
+                                   'measurements. Polls faster than the '
+                                   'EPICS updates.')
 
 
 class PPM(LCLS2ImagerBase):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -16,6 +16,7 @@ from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .interface import MvInterface
 from .signal import AggregateSignal, PytmcSignal
+from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -517,15 +518,25 @@ class TwinCATStateConfigOne(Device):
     Corresponds with ``DUT_PositionState``.
     """
 
-    state_name = Cpt(PytmcSignal, ':NAME', io='i', kind='omitted', string=True)
-    setpoint = Cpt(PytmcSignal, ':SETPOINT', io='io', kind='omitted')
-    delta = Cpt(PytmcSignal, ':DELTA', io='io', kind='omitted')
-    velo = Cpt(PytmcSignal, ':VELO', io='io', kind='omitted')
-    accl = Cpt(PytmcSignal, ':ACCL', io='io', kind='omitted')
-    dccl = Cpt(PytmcSignal, ':DCCL', io='io', kind='omitted')
-    move_ok = Cpt(PytmcSignal, ':MOVE_OK', io='i', kind='omitted')
-    locked = Cpt(PytmcSignal, ':LOCKED', io='i', kind='omitted')
-    valid = Cpt(PytmcSignal, ':VALID', io='i', kind='omitted')
+    state_name = Cpt(PytmcSignal, ':NAME', io='i', kind='omitted', string=True,
+                     doc='The defined state name.')
+    setpoint = Cpt(PytmcSignal, ':SETPOINT', io='io', kind='omitted',
+                   doc='The corresponding motor set position.')
+    delta = Cpt(PytmcSignal, ':DELTA', io='io', kind='omitted',
+                doc='The deviation from setpoint that still counts '
+                    'as at the position.')
+    velo = Cpt(PytmcSignal, ':VELO', io='io', kind='omitted',
+               doc='Velocity to move to the state at.')
+    accl = Cpt(PytmcSignal, ':ACCL', io='io', kind='omitted',
+               doc='Acceleration to move to the state with.')
+    dccl = Cpt(PytmcSignal, ':DCCL', io='io', kind='omitted',
+               doc='Deceleration to move to the state with.')
+    move_ok = Cpt(PytmcSignal, ':MOVE_OK', io='i', kind='omitted',
+                  doc='True if a move to this state is allowed.')
+    locked = Cpt(PytmcSignal, ':LOCKED', io='i', kind='omitted',
+                 doc='True if the PLC will not permit config edits here.')
+    valid = Cpt(PytmcSignal, ':VALID', io='i', kind='omitted',
+                doc='True if the state is defined (not empty).')
 
 
 class TwinCATStateConfigAll(Device):
@@ -583,17 +594,26 @@ class TwinCATStatePositioner(StatePositioner):
         in-progress move as failed.
     """
 
-    state = Cpt(EpicsSignal, ':GET_RBV', write_pv=':SET', kind='hinted')
+    state = Cpt(EpicsSignal, ':GET_RBV', write_pv=':SET', kind='hinted',
+                doc='Setpoint and readback for TwinCAT state position.')
+    set_metadata(state, dict(variety='command-enum'))
 
-    error = Cpt(PytmcSignal, ':ERR', io='i', kind='normal')
-    error_id = Cpt(PytmcSignal, ':ERRID', io='i', kind='normal')
+    error = Cpt(PytmcSignal, ':ERR', io='i', kind='normal',
+                doc='True if we have an error.')
+    error_id = Cpt(PytmcSignal, ':ERRID', io='i', kind='normal',
+                   doc='Error code.')
     error_message = Cpt(PytmcSignal, ':ERRMSG', io='i', kind='normal',
-                        string=True)
-    busy = Cpt(PytmcSignal, ':BUSY', io='i', kind='normal')
-    done = Cpt(PytmcSignal, ':DONE', io='i', kind='normal')
+                        string=True, doc='Error message')
+    busy = Cpt(PytmcSignal, ':BUSY', io='i', kind='normal',
+               doc='True if we have an ongoing move.')
+    done = Cpt(PytmcSignal, ':DONE', io='i', kind='normal',
+               doc='True if we completed the last move.')
 
-    config = Cpt(TwinCATStateConfigAll, '', kind='omitted')
-    reset_cmd = Cpt(PytmcSignal, ':RESET', io='o', kind='omitted')
+    config = Cpt(TwinCATStateConfigAll, '', kind='omitted',
+                 doc='Configuration of state positions, deltas, etc.')
+    reset_cmd = Cpt(PytmcSignal, ':RESET', io='o', kind='omitted',
+                    doc='Command to reset an error.')
+    set_metadata(reset_cmd, dict(variety='command', value=1))
 
 
 class StateStatus(SubscriptionStatus):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -613,6 +613,8 @@ class TwinCATStatePositioner(StatePositioner):
                  doc='Configuration of state positions, deltas, etc.')
     reset_cmd = Cpt(PytmcSignal, ':RESET', io='o', kind='omitted',
                     doc='Command to reset an error.')
+
+    set_metadata(error_id, dict(variety='scalar', display_format='hex'))
     set_metadata(reset_cmd, dict(variety='command', value=1))
 
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -517,7 +517,7 @@ class TwinCATStateConfigOne(Device):
     Corresponds with ``DUT_PositionState``.
     """
 
-    state_name = Cpt(PytmcSignal, ':NAME', io='i', kind='omitted')
+    state_name = Cpt(PytmcSignal, ':NAME', io='i', kind='omitted', string=True)
     setpoint = Cpt(PytmcSignal, ':SETPOINT', io='io', kind='omitted')
     delta = Cpt(PytmcSignal, ':DELTA', io='io', kind='omitted')
     velo = Cpt(PytmcSignal, ':VELO', io='io', kind='omitted')
@@ -587,7 +587,8 @@ class TwinCATStatePositioner(StatePositioner):
 
     error = Cpt(PytmcSignal, ':ERR', io='i', kind='normal')
     error_id = Cpt(PytmcSignal, ':ERRID', io='i', kind='normal')
-    error_message = Cpt(PytmcSignal, ':ERRMSG', io='i', kind='normal')
+    error_message = Cpt(PytmcSignal, ':ERRMSG', io='i', kind='normal',
+                        string=True)
     busy = Cpt(PytmcSignal, ':BUSY', io='i', kind='normal')
     done = Cpt(PytmcSignal, ':DONE', io='i', kind='normal')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
For LCLS2 imagers and related classes:
- Try out the shiny `variety` schemas on a subset of the component signals
- Fill in the empty `doc` kwargs on many components

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- I felt weird poring over `doc=` tags in the new PRs while all of my devices don't have these defined
- Hopefully `doc=` becomes mouse-over help text in a screen somewhere
- Variety will be used in `typhos` at some point, and it will be nice to have some users ahead of that

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is docs
<!--
## Screenshots (if appropriate):
-->
