### PR TITLE
REF: restructure and rework variety metadata: use nested schema, expand dotted dictionaries

### DIFF
--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -352,7 +352,10 @@ class PPM(LCLS2ImagerBase):
 
     led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config',
               doc='Percent of light from the dimmable illuminatior.')
-    set_metadata(led, dict(variety='scalar-range', range=(0, 100)))
+    set_metadata(led, dict(variety='scalar-range',
+                           range={'value': (0, 100),
+                                  'source': 'value'}
+                           ))
 
 
 class XPIMFilterWheel(StatePositioner):

--- a/pcdsdevices/tags.py
+++ b/pcdsdevices/tags.py
@@ -1,5 +1,6 @@
 tag_to_explanation = {
     'protected': 'May require additional privileges to change.',
+    'confirm': 'User should confirm changes.',
 }
 
 

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -152,4 +152,7 @@ def get_component(obj):
     component : ophyd.Component
         The component, if available.
     """
-    return getattr(type(obj.parent), obj.attr_name)
+    if obj.parent is None:
+        return None
+
+    return getattr(type(obj.parent), obj.attr_name, None)

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -76,6 +76,9 @@ common_schema = {
 }
 
 
+_default_bitmask_style = dict(shape='rectangle', on_color='green',
+                              off_color='gray')
+
 schema_by_category = {
     'command': schema.Schema({
         'variety': schema.Or(*varieties_by_category['command']),
@@ -103,12 +106,13 @@ schema_by_category = {
         Optional('first_bit', default='most-significant'): schema.Or(
             'most-significant', 'least-significant'),
 
-        # Style:
-        Optional('shape', default='rectangle'): schema.Or(
-            'circle', 'rectangle'),
+        Optional('style', default=_default_bitmask_style): schema.Schema({
+            Optional('shape', default='rectangle'): schema.Or(
+                'circle', 'rectangle'),
 
-        Optional('on_color', default='green'): str,
-        Optional('off_color', default='gray'): str,
+            Optional('on_color', default='green'): str,
+            Optional('off_color', default='gray'): str,
+        }),
         **common_schema
     }),
 

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -1,10 +1,14 @@
 """Additional component metadata, classifying each into a "variety"."""
 
 import schema
+from schema import Optional
 
 import ophyd
 
 from . import tags, utils
+
+# Ideas: tabular-string? csv format table?
+# Ideas: array-tabular?  reshaped array put in a table?
 
 _schema_registry = {}
 varieties_by_category = {
@@ -13,9 +17,6 @@ varieties_by_category = {
         'command-proc',
         'command-enum',
         'command-setpoint-tracks-readback',
-    },
-    'tweakable': {
-        'tweakable'
     },
     'array': {
         'array-timeseries',
@@ -26,6 +27,7 @@ varieties_by_category = {
     'scalar': {
         'scalar',
         'scalar-range',
+        'scalar-tweakable',
     },
     'bitmask': {
         'bitmask',
@@ -70,83 +72,157 @@ def _length_validate(min_count, max_count, type_):
 
 
 common_schema = {
-    schema.Optional('tags'): {schema.Or(*tags.get_valid_tags())},
+    Optional('tags'): {schema.Or(*tags.get_valid_tags())},
 }
 
 
 schema_by_category = {
     'command': schema.Schema({
         'variety': schema.Or(*varieties_by_category['command']),
-        schema.Optional('value', default=1): schema.Or(float, int, str),
-        schema.Optional('enum_strings'): [str],
-        # schema.Optional('enum_dict'): dict,
-        **common_schema
-    }),
-
-    'tweakable': schema.Schema({
-        'variety': schema.Or(*varieties_by_category['tweakable']),
-        'delta': schema.Or(float, int),
-        schema.Optional('delta_range'): _length_validate(2, 2, (float, int)),
-        schema.Optional('source_signal'): str,
-        schema.Optional('source'): schema.Or('setpoint', 'readback',
-                                             'other-signal'),
+        Optional('value', default=1): schema.Or(float, int, str),
+        Optional('enum_strings'): [str],
+        # Optional('enum_dict'): dict,
         **common_schema
     }),
 
     'array': schema.Schema({
         'variety': schema.Or(*varieties_by_category['array']),
-        schema.Optional('shape'): _length_validate(1, 10, int),
-        schema.Optional('dimension'): int,
-        schema.Optional('embed'): bool,
-        schema.Optional('colormap'): str,
+        Optional('shape'): _length_validate(1, 10, int),
+        Optional('shape_signal'): str,
+        Optional('dimension'): int,
+        Optional('embed'): bool,
+        Optional('colormap'): str,
         **common_schema
     }),
 
     'bitmask': schema.Schema({
         'variety': schema.Or(*varieties_by_category['bitmask']),
-        schema.Optional('orientation',
-                        default='horizontal'): schema.Or('horizontal',
-                                                         'vertical'),
-        schema.Optional('bits', default=8): int,
-        schema.Optional(
-            'first_bit',
-            default='most-significant'): schema.Or('most-significant',
-                                                   'least-significant'),
+        Optional('orientation', default='horizontal'): schema.Or(
+            'horizontal', 'vertical'),
+        Optional('bits', default=8): int,
+        Optional('first_bit', default='most-significant'): schema.Or(
+            'most-significant', 'least-significant'),
 
         # Style:
-        schema.Optional('shape', default='rectangle'): schema.Or('circle',
-                                                                 'rectangle'),
-        schema.Optional('on_color', default='green'): str,
-        schema.Optional('off_color', default='gray'): str,
+        Optional('shape', default='rectangle'): schema.Or(
+            'circle', 'rectangle'),
+
+        Optional('on_color', default='green'): str,
+        Optional('off_color', default='gray'): str,
         **common_schema
     }),
 
     'scalar': schema.Schema({
         'variety': schema.Or(*varieties_by_category['scalar']),
-        schema.Optional('range'): _length_validate(2, 2, (float, int)),
-        schema.Optional('range_source'): schema.Or('use_limits', 'custom'),
-        schema.Optional('display_format', default='default'): schema.Or(
+        Optional('display_format', default='default'): schema.Or(
             'default', 'string', 'decimal', 'exponential', 'hex', 'binary'),
+
+        Optional('range'): schema.Schema({
+            Optional('value'): _length_validate(2, 2, (float, int)),
+            Optional('source', default='use_limits'): schema.Or(
+                'use_limits', 'value'),
+        }),
+
+        Optional('delta'): schema.Schema({
+            'value': schema.Or(float, int),
+            Optional('range'): _length_validate(2, 2, (float, int)),
+            Optional('source', default='value'): schema.Or(
+                'signal', 'value'),
+            Optional('signal'): str,
+
+            Optional('add_signal'): str,
+            Optional('adds_to', default='setpoint'): schema.Or(
+                'setpoint', 'readback', 'custom-signal'),
+        }),
         **common_schema
     }),
 
     'text': schema.Schema({
         'variety': schema.Or(*varieties_by_category['text']),
-        schema.Optional('enum_strings'): [str],
+        Optional('enum_strings'): [str],
+        Optional('delimiter', default='\n'): [str],
         **common_schema
     }),
 
     'enum': schema.Schema({
         'variety': schema.Or(*varieties_by_category['enum']),
-        schema.Optional('enum_strings'): [str],
+        Optional('enum_strings'): [str],
         **common_schema
     }),
 }
 
 
+def expand_dotted_dict(root):
+    """
+    Expand dotted dictionary keys.
+
+    Parameters
+    ----------
+    root : dict
+        The dictionary to expand.
+
+    Returns
+    -------
+    dct : dict
+        The expanded dictionary.
+    """
+    if not root:
+        return {}
+
+    if not isinstance(root, dict):
+        raise ValueError('A dictionary is required')
+
+    res = {}
+
+    def expand_key(dct, key, value):
+        if isinstance(value, dict):
+            # specifies a sub-dict; use full dotted name
+            parts = key.split('.')
+        else:
+            # specifies a value; last part refers to a value
+            parts = key.split('.')[:-1]
+
+        for part in parts:
+            if not part:
+                raise ValueError('Dotted key cannot contain empty part '
+                                 f'({key})')
+
+            if part not in dct:
+                dct[part] = {}
+            elif not isinstance(dct[part], dict):
+                raise ValueError('Dotted key does not refer to a dictionary '
+                                 f'({part} of {key})')
+
+            dct = dct[part]
+
+        return dct
+
+    def set_values(dct, value):
+        dotted_keys = set(key for key in value if '.' in key)
+        non_dotted = set(value) - dotted_keys
+
+        for key in non_dotted:
+            if key in dct:
+                raise KeyError(f'Key specified multiple times: {key}')
+            dct[key] = value[key]
+
+        for key in dotted_keys:
+            sub_value = value[key]
+            sub_dict = expand_key(dct, key, sub_value)
+            if isinstance(sub_value, dict):
+                set_values(sub_dict, sub_value)
+            else:
+                last_part = key.split('.')[-1]
+                sub_dict[last_part] = sub_value
+
+        return dct
+
+    return set_values(res, root)
+
+
 def validate_metadata(md):
     """
-    Validate a given metadata dictionary.
+    Validate a given metadata dictionary.  Expands dotted dictionary keys.
 
     Parameters
     ----------
@@ -169,6 +245,8 @@ def validate_metadata(md):
             'Unexpected metadata keys without variety specified: ' +
             ', '.join(md)
         ) from None
+
+    md = expand_dotted_dict(md)
 
     try:
         schema = _schema_registry[variety]
@@ -213,6 +291,8 @@ def get_metadata(cpt):
 def set_metadata(cpt, metadata):
     """
     Set "variety" metadata on a given component.
+
+    Expands dotted keys into sub-dictionaries.
 
     Validates the metadata against the known schema.
 

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -19,6 +19,7 @@ varieties_by_category = {
         'command-setpoint-tracks-readback',
     },
     'array': {
+        'array-tabular',
         'array-timeseries',
         'array-histogram',
         'array-image',

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -124,11 +124,11 @@ schema_by_category = {
         }),
 
         Optional('delta'): schema.Schema({
-            'value': schema.Or(float, int),
+            Optional('value'): schema.Or(float, int),
             Optional('range'): _length_validate(2, 2, (float, int)),
             Optional('source', default='value'): schema.Or(
                 'signal', 'value'),
-            Optional('signal'): str,
+            Optional('signal'): schema.Or(str, ophyd.Component),
 
             Optional('add_signal'): str,
             Optional('adds_to', default='setpoint'): schema.Or(

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -84,7 +84,7 @@ schema_by_category = {
         'variety': schema.Or(*varieties_by_category['command']),
         Optional('value', default=1): schema.Or(float, int, str),
         Optional('enum_strings'): [str],
-        # Optional('enum_dict'): dict,
+        Optional('enum_dict'): dict,
         **common_schema
     }),
 
@@ -105,6 +105,7 @@ schema_by_category = {
         Optional('bits', default=8): int,
         Optional('first_bit', default='most-significant'): schema.Or(
             'most-significant', 'least-significant'),
+        Optional('meaning', default=None): [str],
 
         Optional('style', default=_default_bitmask_style): schema.Schema({
             Optional('shape', default='rectangle'): schema.Or(

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -7,9 +7,6 @@ import ophyd
 
 from . import tags, utils
 
-# Ideas: tabular-string? csv format table?
-# Ideas: array-tabular?  reshaped array put in a table?
-
 _schema_registry = {}
 varieties_by_category = {
     'command': {

--- a/pcdsdevices/variety.py
+++ b/pcdsdevices/variety.py
@@ -140,7 +140,11 @@ schema_by_category = {
     'text': schema.Schema({
         'variety': schema.Or(*varieties_by_category['text']),
         Optional('enum_strings'): [str],
-        Optional('delimiter', default='\n'): [str],
+        Optional('delimiter', default='\n'): str,
+        Optional('encoding', default='utf-8'): schema.Or('utf-8', 'latin-1',
+                                                         'ascii'),
+        Optional('format', default='plain'): schema.Or('plain', 'markdown',
+                                                       'html'),
         **common_schema
     }),
 

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -22,6 +22,9 @@ def test_no_variety():
         validate_metadata({'test': 'a'})
 
 
+text_defaults = dict(delimiter='\n', encoding='utf-8', format='plain')
+
+
 @pytest.mark.parametrize(
     'md, expected',
     [
@@ -64,31 +67,38 @@ def test_no_variety():
 
         # ** tweakable **
         pytest.param(
-            dict(variety='tweakable'),
-            schema.SchemaMissingKeyError,
-            id='tweakable-no-delta',
-        ),
-
-        pytest.param(
-            dict(variety='tweakable', delta=3),
+            {'variety': 'scalar-tweakable',
+             'display_format': 'default',
+             'delta': {'value': 3,
+                       'adds_to': 'setpoint',
+                       'source': 'value',
+                       }},
             SAME,
             id='tweakable-delta',
         ),
 
         pytest.param(
-            dict(variety='tweakable', delta=3, delta_range=[-1, 10]),
+            {'variety': 'scalar-tweakable',
+             'display_format': 'default',
+             'delta': {'value': 3,
+                       'adds_to': 'setpoint',
+                       'source': 'value',
+                       'range': [-1, 10]}},
             SAME,
             id='tweakable-good-range',
         ),
 
         pytest.param(
-            dict(variety='tweakable', delta=3, delta_range=-1),
+            {'variety': 'scalar-tweakable',
+             'delta': {'value': 3,
+                       'range': -1}},
             schema.SchemaError,
             id='tweakable-bad-range',
         ),
 
         pytest.param(
-            dict(variety='tweakable', delta=3, delta_range=[-1, 'q']),
+            dict(variety='scalar-tweakable', delta={'value': 3,
+                                                    'range': [-1, 'q']}),
             schema.SchemaError,
             id='tweakable-bad-range-type',
         ),
@@ -150,48 +160,59 @@ def test_no_variety():
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='use_limits',
-                 display_format='exponential'),
+            {'variety': 'scalar-range',
+             'display_format': 'exponential',
+             'range': {'source': 'use_limits'},
+             },
             SAME,
             id='scalar-use_limits'
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='custom',
-                 display_format='default'),
+            {'variety': 'scalar-range',
+             'range': dict(source='value'),
+             'display_format': 'default'
+             },
             SAME,
             id='scalar-custom'
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='custom', range=[0, 5],
-                 display_format='default',
-                 ),
+            {'variety': 'scalar-range',
+             'range': dict(source='value',
+                           value=[0, 5]),
+             'display_format': 'default',
+             },
             SAME,
             id='scalar-custom-range'
         ),
 
         pytest.param(
-            dict(variety='scalar-range', range_source='custom', range=[0]),
+            {'variety': 'scalar-range',
+             'range': dict(source='value', value=[0]),
+             },
             schema.SchemaError,
             id='scalar-bad-range'
         ),
 
         # ** text **
         pytest.param(
-            dict(variety='text', enum_strings=['a', 'b', 'c']),
+            dict(variety='text', enum_strings=['a', 'b', 'c'],
+                 **text_defaults),
             SAME,
             id='text-enum_strings'
         ),
 
         pytest.param(
-            dict(variety='text-enum', enum_strings=['a', 'b', 'c']),
+            dict(variety='text-enum', enum_strings=['a', 'b', 'c'],
+                 **text_defaults),
             SAME,
             id='text-enum'
         ),
 
         pytest.param(
-            dict(variety='text-multiline', enum_strings=['a', 'b', 'c']),
+            dict(variety='text-multiline', enum_strings=['a', 'b', 'c'],
+                 **text_defaults),
             SAME,
             id='text-multiline'
         ),
@@ -205,17 +226,23 @@ def test_no_variety():
         # ** bitmask **
         pytest.param(
             dict(variety='bitmask'),
-            dict(variety='bitmask', bits=8, shape='rectangle',
-                 orientation='horizontal', first_bit='most-significant',
-                 on_color='green', off_color='gray'),
+            dict(variety='bitmask', bits=8, orientation='horizontal',
+                 first_bit='most-significant',
+                 meaning=None,
+                 style=dict(on_color='green', off_color='gray',
+                            shape='rectangle')
+                 ),
             id='bitmask-defaults',
         ),
 
         pytest.param(
             dict(variety='bitmask', bits=32, first_bit='least-significant'),
-            dict(variety='bitmask', bits=32, shape='rectangle',
+            dict(variety='bitmask', bits=32,
                  orientation='horizontal', first_bit='least-significant',
-                 on_color='green', off_color='gray'),
+                 meaning=None,
+                 style=dict(shape='rectangle', on_color='green',
+                            off_color='gray'),
+                 ),
             id='bitmask-custom',
         ),
 

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -105,6 +105,12 @@ text_defaults = dict(delimiter='\n', encoding='utf-8', format='plain')
 
         # ** arrays / waveforms **
         pytest.param(
+            dict(variety='array-tabular'),
+            SAME,
+            id='array-tabular'
+        ),
+
+        pytest.param(
             dict(variety='array-timeseries'),
             SAME,
             id='array-timeseries'


### PR DESCRIPTION
This PR:
* Pairs with https://github.com/pcdshub/typhos/pull/357
* Adds dotted dictionary support ([example](https://github.com/pcdshub/typhos/blob/91989d836fb76b335900148b80c4f7cc12435fbc/tests/variety_ioc.py#L18-L23))
* Dotted schema dictionaries are automatically expanded prior to schema validation, requiring less nesting on definition.

The vast majority of this PR is the dotted dictionary support, which may well be moved to (e.g.) pcdsutils at some point. The remainder is changes to the schema that are required for https://github.com/pcdshub/typhos/pull/357 and appear to generally be a good thing, based solely on my own use/testing.