### PR TITLE
DOC: Display interlocking vacuum device in Typhos screen for VGC, PIP

### DIFF
--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -184,7 +184,7 @@ class PIPPLC(Device):
     qpc_pumpsize = Cpt(EpicsSignalRO, ':PUMPSIZE', kind='config',
                        doc='Ion Pump Size (L/s)')
     interlock_device = Cpt(EpicsSignalRO, ':ILK_DEVICE_RBV', kind='config',
-                           doc='Vacuum gauge used for interlocking this pump')
+                           doc='Vacuum device used for interlocking this pump')
 
 
 class PTMPLC(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -183,6 +183,8 @@ class PIPPLC(Device):
                    doc='Quad Ion Pump Controller Name')
     qpc_pumpsize = Cpt(EpicsSignalRO, ':PUMPSIZE', kind='config',
                        doc='Ion Pump Size (L/s)')
+    interlock_device = Cpt(EpicsSignalRO, ':ILK_DEVICE_RBV', kind='config',
+                           doc='Vacuum gauge used for interlocking this pump')
 
 
 class PTMPLC(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -172,10 +172,10 @@ class PIPPLC(Device):
     high_voltage_switch = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='config',
                               doc='epics command to switch on the '
                               'high voltage')
-    plc_ai_offset = Cpt(EpicsSignalWithRBV, ':AI_Offset', kind='config',
+    plc_ai_offset = Cpt(EpicsSignalRO, ':AI_Offset_RBV', kind='config',
                         doc=('Analog input offset must match ion pump '
                              'analog ouput offset. Default: 13'))
-    auto_on = Cpt(EpicsSignalWithRBV, ':Auto_On', kind='config',
+    auto_on = Cpt(EpicsSignalRO, ':Auto_On_RBV', kind='config',
                   doc=('Setting to automatically turn on the ion pump when the'
                        'reference gauge pressure is below protection '
                        'setpoint'))

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -235,7 +235,6 @@ class VGC(VRC):
                                       'interlocking this valve')
 
 
-
 class VFS(Device):
     """Class for Fast Shutter Valve."""
     request_close = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -225,6 +225,15 @@ class VGC(VRC):
                 doc='Error Present')
     mps_state = Cpt(EpicsSignalRO, ':MPS_FAULT_OK_RBV', kind='omitted',
                     doc=('individual valve MPS state for debugging'))
+    interlock_device_upstream = Cpt(EpicsSignalRO, ':ILK_DEVICE_US_RBV',
+                                    kind='config',
+                                    doc='Upstream vacuum device used for'
+                                    'interlocking this valve')
+    interlock_device_downstream = Cpt(EpicsSignalRO, ':ILK_DEVICE_DS_RBV',
+                                      kind='config',
+                                      doc='Downstream vacuum device used for'
+                                      'interlocking this valve')
+
 
 
 class VFS(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the :ILK_DEVICE* field to the VGC and PIP so it will display in a Typhos screen. This variable tracks the component the VGC or PIP is using to validate its pressure interlocks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will allow users to determine which gauges are required for this device to function from the Typhos screen. @slacAWallace 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Standard tests and style checks succeed.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
The component docstrings have been updated indicating the goal for this field.


<!--
## Screenshots (if appropriate):
-->
