### PR TITLE
ENH: add SPMG for BeckhoffAxis screens

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -471,6 +471,8 @@ class BeckhoffAxis(EpicsMotorInterface):
 
     plc = Cpt(BeckhoffAxisPLC, ':PLC:', kind='normal',
               doc='PLC error handling.')
+    motor_spmg = Cpt(EpicsSignal, '.SPMG', kind='config',
+                     doc='Stop, Pause, Move, Go')
 
     def clear_error(self):
         """Clear any active motion errors on this axis."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Link to the motor record's `SPMG` field, which allows you to set the motor to `Stop`, `Pause`, `Move`, or `Go` mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was used in LCLS1 to soft-disable motors at some beamlines by setting them to `Stop` state. I used this yesterday at Bill's request to disable all the motors on the LFE line to prevent MPS issues during accelerator beam dump commissioning.

Now that every LFE motor is in `Stop` mode, it will be useful to have this field on the screen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I opened up a `typhos` screen with the positioner template and was satisfied.
