### PR TITLE
MNT: fix issue with failed subscription callback.

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -242,8 +242,13 @@ class PCDSMotorBase(EpicsMotorInterface):
                      value=None, **kwargs):
         # Store the internal travelling direction of the motor to account for
         # the fact that our EPICS motor does not have TDIR field
-        if None not in (value, old_value):
-            self.direction_of_travel.put(int(value > old_value))
+        try:
+            comparison = int(value > old_value)
+            self.direction_of_travel.put(comparison)
+        except TypeError:
+            # We have some sort of null/None/default value
+            logger.debug('Could not compare value=%s > old_value=%s',
+                         value, old_value)
         # Pass information to PositionerBase
         super()._pos_changed(timestamp=timestamp, old_value=old_value,
                              value=value, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Switch None-check to TypeError try/except to skip comparison regardless of the failure mode here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If this subscription fails, the motor will have lots of issues like the `position` property failing to work.
Recently the default value was changed from `None` to `object()` for epics signals. This fixes it so we can bypass an error regardless of why the comparison check fails here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works locally in xcs python. Probably passes tests, I did not check.