### PR TITLE
ENH: swap out cf-units for pint for portability

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pyepics >=3.4.1
     - pytmc >=2.4.0
     - pyyaml
-    - cf-units
+    - pint
     - scipy
     - matplotlib <3
     - periodictable

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 import time
 
-from cf_units import Unit
+import pint
 
 try:
     import tty
@@ -105,8 +105,8 @@ def convert_unit(value, unit, new_unit):
         The starting value, but converted to the new unit.
     """
 
-    start_unit = Unit(unit)
-    return start_unit.convert(value, new_unit)
+    ureg = pint.UnitRegistry()
+    return (value * ureg[unit]).to(new_unit).magnitude
 
 
 def ipm_screen(dettype, prefix, prefix_ioc):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ periodictable
 pyepics
 pytmc
 pyyaml
-cf-units
+pint
 scipy
 schema


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`cf-units` -> `pint`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`cf-units` is not platform-independent because it relies on udunits being installed
`pint` is pure python

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests still pass
