### PR TITLE
MNT: restore lightpath interface

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,10 +17,10 @@ requirements:
     - setuptools
   run:
     - python >=3.6
-    - ophyd >=1.5.0
-    - bluesky >=1.2.0
-    - pyepics >=3.4.1
-    - pytmc >=2.4.0
+    - ophyd >=1.5.1
+    - bluesky >=1.6.4
+    - pyepics >=3.4.2
+    - pytmc >=2.7.0
     - pyyaml
     - pint
     - scipy

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -400,11 +400,10 @@ class FEESolidAttenuator(Device, BaseInterface, LightpathMixin):
         self._blade_positions = {}
         super().__init__(prefix, name=name, **kwargs)
 
-    def _set_lightpath_states(self, *args, value, obj, **kwargs):
-        self._blade_positions[obj.name] = value
+    def _set_lightpath_states(self, lightpath_values):
+        values = [kw['value'] for kw in lightpath_values.values()]
         # In is at zero
-        self._inserted = any((value < 4 for value in
-                             self._blade_positions.values()))
+        self._inserted = any((value < 4 for value in values))
         self._removed = not self._inserted
         # No calc yet
         self._transmission = 1

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -8,7 +8,7 @@ import numpy as np
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
-from ophyd.pv_positioner import PVPositioner
+from ophyd.pv_positioner import PVPositioner, PVPositionerPC
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal, SignalRO
 
 from .epics_motor import BeckhoffAxis
@@ -252,7 +252,7 @@ class AttBase3rd(AttBase):
     user_energy = Cpt(EpicsSignal, ':COM:E3DES', kind='omitted')
 
 
-class FeeAtt(AttBase):
+class FeeAtt(AttBase, PVPositionerPC):
     """Old attenuator IOC in the FEE."""
     # Positioner Signals
     setpoint = Cpt(EpicsSignal, ':RDES', kind='normal')

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -222,7 +222,11 @@ class AttBase(FltMvInterface, PVPositioner):
         if event_type is None:
             event_type = self._default_sub
         if event_type == self.SUB_STATE and not self._has_subscribed_state:
-            self.done.subscribe(self._run_filt_state, run=False)
+            if self.done is not None:
+                obj = self.done
+            else:
+                obj = self.readback
+            obj.subscribe(self._run_filt_state, run=False)
             self._has_subscribed_state = True
         return cid
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -411,8 +411,8 @@ class FEESolidAttenuator(Device, BaseInterface, LightpathMixin):
 
     def _set_lightpath_states(self, lightpath_values):
         values = [kw['value'] for kw in lightpath_values.values()]
-        # In is at zero
-        inserted_list = [value < 4 for value in values]
+        # In is at zero, 2mm deadband is standard
+        inserted_list = [value < 2 for value in values]
         self._inserted = any(inserted_list)
         self._removed = not self._inserted
         self.num_in.put(inserted_list.count(True), force=True)

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -78,12 +78,20 @@ class InOutPositioner(StatePositioner):
     @property
     def inserted(self):
         """`True` if the device is inserted."""
-        return self._pos_in_list(self.in_states)
+        return self.check_inserted()
+
+    def check_inserted(self, state=None):
+        """Query if a particular state counts as inserted."""
+        return self._pos_in_list(self.in_states, check_state=state)
 
     @property
     def removed(self):
         """`True` if the device is removed."""
-        return self._pos_in_list(self.out_states)
+        return self.check_removed()
+
+    def check_removed(self, state=None):
+        """Query if a particular state counts as removed."""
+        return self._pos_in_list(self.out_states, check_state=state)
 
     def insert(self, moved_cb=None, timeout=None, wait=False):
         """
@@ -125,8 +133,11 @@ class InOutPositioner(StatePositioner):
             index = self.states_list.index(state)
             self._trans_enum[index] = self._transmission.get(state, default)
 
-    def _pos_in_list(self, state_list):
-        current_state = self.get_state(self.position)
+    def _pos_in_list(self, state_list, check_state=None):
+        if check_state is None:
+            current_state = self.get_state(self.position)
+        else:
+            current_state = self.get_state(check_state)
         for state in state_list:
             if current_state == self.get_state(state):
                 return True

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -124,14 +124,22 @@ class InOutPositioner(StatePositioner):
         This will be a float between 0 and 1, where 0 is no beam and 1 is full
         transmission.
         """
+        return self.check_transmission()
 
-        state_index = self.get_state(self.position).value
+    def check_transmission(self, state=None):
+        """Query the transition at a particular state."""
+        if state is None:
+            state = self.position
+        state_index = self.get_state(state).value
         return self._trans_enum.get(state_index, math.nan)
 
     def _extend_trans_enum(self, state_list, default):
         for state in state_list:
-            index = self.states_list.index(state)
-            self._trans_enum[index] = self._transmission.get(state, default)
+            self._update_trans_enum(state, default)
+
+    def _update_trans_enum(self, state, default):
+        index = self.states_list.index(state)
+        self._trans_enum[index] = self._transmission.get(state, default)
 
     def _pos_in_list(self, state_list, check_state=None):
         if check_state is None:

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -911,6 +911,7 @@ class LightpathMixin(OphydObject):
 
     def __init__(self, *args, **kwargs):
         self._lightpath_values = {}
+        self._lightpath_ready = False
         super().__init__(*args, **kwargs)
 
     def __init_subclass__(cls, **kwargs):
@@ -940,6 +941,7 @@ class LightpathMixin(OphydObject):
             if len(self._lightpath_values) >= len(self.lightpath_cpts):
                 # Pass user function the full set of values
                 self._set_lightpath_states(self._lightpath_values)
+                self._lightpath_ready = True
                 # Tell lightpath that we are ready
                 self._run_subs(sub_type=self.SUB_STATE)
         except Exception:
@@ -948,11 +950,17 @@ class LightpathMixin(OphydObject):
 
     @property
     def inserted(self):
-        return self._inserted
+        if self._lightpath_ready:
+            return self._inserted
+        else:
+            return False
 
     @property
     def removed(self):
-        return self._removed
+        if self._lightpath_ready:
+            return self._removed
+        else:
+            return False
 
     @property
     def transmission(self):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -927,7 +927,8 @@ class LightpathMixin(OphydObject):
 
     def _set_lightpath_states(self, *args, **kwargs):
         # Override based on the use case
-        # update self._inserted and self._removed
+        # update self._inserted, self._removed,
+        # and optionally self._transmission
         raise NotImplementedError('Did not implement LightpathMixin')
 
     def _update_lightpath(self, *args, **kwargs):
@@ -941,6 +942,16 @@ class LightpathMixin(OphydObject):
     @property
     def removed(self):
         return self._removed
+
+    @property
+    def transmission(self):
+        try:
+            return self._transmission
+        except AttributeError:
+            if self.inserted:
+                return 0
+            else:
+                return 1
 
 
 class LightpathInOutMixin(LightpathMixin):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -952,14 +952,14 @@ class LightpathMixin(OphydObject):
     @property
     def inserted(self):
         if self._lightpath_ready:
-            return self._inserted
+            return bool(self._inserted)
         else:
             return False
 
     @property
     def removed(self):
         if self._lightpath_ready:
-            return self._removed
+            return bool(self._removed)
         else:
             return False
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1,6 +1,7 @@
 """
 Module for defining bell-and-whistles movement features.
 """
+import functools
 import logging
 import numbers
 import re
@@ -982,9 +983,12 @@ class LightpathInOutMixin(LightpathMixin):
     def _set_lightpath_states(self, lightpath_values):
         in_check = []
         out_check = []
+        trans_check = []
         for obj, kwarg_dct in lightpath_values.items():
             in_check.append(obj.check_inserted(kwarg_dct['value']))
             out_check.append(obj.check_removed(kwarg_dct['value']))
-        self._inserted = all(in_check)
+            trans_check.append(obj.check_transmission(kwarg_dct['value']))
+        self._inserted = any(in_check)
         self._removed = all(out_check)
+        self._transmission = functools.reduce(lambda a, b: a*b, trans_check)
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -962,17 +962,11 @@ class LightpathMixin(OphydObject):
 
     @property
     def inserted(self):
-        if self._lightpath_ready:
-            return bool(self._inserted)
-        else:
-            return False
+        return self._lightpath_ready and bool(self._inserted)
 
     @property
     def removed(self):
-        if self._lightpath_ready:
-            return bool(self._removed)
-        else:
-            return False
+        return self._lightpath_ready and bool(self._removed)
 
     @property
     def transmission(self):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -7,7 +7,6 @@ import numbers
 import re
 import signal
 import time
-import threading
 from contextlib import contextmanager
 from pathlib import Path
 from threading import Event, Thread
@@ -950,12 +949,10 @@ class LightpathMixin(OphydObject):
                     self._run_subs(sub_type=self.SUB_STATE)
                 elif self._retry_lightpath and not self._destroyed:
                     # Use this when the device wasn't ready to set states
-                    time.sleep(0.1)
                     kw = dict(obj=obj)
                     kw.update(kwargs)
-                    thread = threading.Thread(target=self._update_lightpath,
-                                              args=args, kwargs=kw)
-                    thread.start()
+                    util.schedule_task(self._update_lightpath,
+                                       args=args, kwargs=kw, delay=0.2)
         except Exception:
             # Without this, callbacks fail silently
             logger.exception('Error in lightpath update callback.')

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -909,7 +909,6 @@ class LightpathMixin(OphydObject):
     # Flag to signify that subclass is another mixin, rather than a device
     _lightpath_mixin = False
 
-
     def __init__(self, *args, **kwargs):
         self._lightpath_values = {}
         self._lightpath_ready = False
@@ -991,4 +990,3 @@ class LightpathInOutMixin(LightpathMixin):
         self._inserted = any(in_check)
         self._removed = all(out_check)
         self._transmission = functools.reduce(lambda a, b: a*b, trans_check)
-

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -921,10 +921,6 @@ class LightpathMixin(OphydObject):
                 cpt = getattr(cls, cpt_name)
                 cpt.sub_default(cls._update_lightpath)
 
-    @classmethod
-    def register_child_interface(self, cls):
-        self._child_interfaces.add(cls)
-
     def _set_lightpath_states(self, *args, **kwargs):
         # Override based on the use case
         # update self._inserted, self._removed,
@@ -932,8 +928,11 @@ class LightpathMixin(OphydObject):
         raise NotImplementedError('Did not implement LightpathMixin')
 
     def _update_lightpath(self, *args, **kwargs):
-        self._set_lightpath_states(*args, **kwargs)
-        self._run_subs(sub_type=self.SUB_STATE)
+        try:
+            self._set_lightpath_states(*args, **kwargs)
+            self._run_subs(sub_type=self.SUB_STATE)
+        except Exception:
+            logger.exception('Error in lightpath update callback.')
 
     @property
     def inserted(self):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -285,6 +285,8 @@ class XOffsetMirror(Device, BaseInterface):
     name : str
         Alias for the device.
     """
+    # UI representation
+    _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
     y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='normal')
@@ -312,3 +314,11 @@ class XOffsetMirror(Device, BaseInterface):
     pitch_enc_rms = Cpt(PytmcSignal, ':ENC:PITCH:RMS', io='i', kind='normal')
     bender_enc_rms = Cpt(PytmcSignal, ':ENC:BENDER:RMS', io='i',
                          kind='normal')
+
+    # Lightpath config: implement inserted, removed, transmission, subscribe
+    # For now, keep it simple. Some mirrors need more than this, but it is
+    # sufficient for MR1L0 and MR2L0 for today.
+    inserted = True
+    removed = False
+    transmission = 1
+    SUB_STATE = 'state'

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -289,12 +289,12 @@ class XOffsetMirror(Device, BaseInterface):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='normal')
-    y_dwn = Cpt(BeckhoffAxis, ':MMS:YDWN', kind='config')
-    x_up = Cpt(BeckhoffAxis, ':MMS:XUP', kind='normal')
-    x_dwn = Cpt(BeckhoffAxis, ':MMS:XDWN', kind='config')
-    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='normal')
+    y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='hinted')
+    x_up = Cpt(BeckhoffAxis, ':MMS:XUP', kind='hinted')
+    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='hinted')
     bender = Cpt(BeckhoffAxis, ':MMS:BENDER', kind='normal')
+    y_dwn = Cpt(BeckhoffAxis, ':MMS:YDWN', kind='config')
+    x_dwn = Cpt(BeckhoffAxis, ':MMS:XDWN', kind='config')
 
     # Gantry components
     gantry_x = Cpt(PytmcSignal, ':GANTRY_X', io='i', kind='normal')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -17,7 +17,7 @@ from ophyd.signal import EpicsSignal
 from .areadetector.detectors import PCDSAreaDetectorEmbedded
 from .epics_motor import IMS, BeckhoffAxis
 from .inout import InOutRecordPositioner, TwinCATInOutPositioner
-from .interface import BaseInterface, LightpathMixin
+from .interface import BaseInterface, LightpathInOutMixin
 from .sensors import TwinCATThermocouple
 from .signal import PytmcSignal
 from .state import StatePositioner
@@ -250,7 +250,7 @@ class PIMWithBoth(PIMWithFocus, PIMWithLED):
     pass
 
 
-class LCLS2ImagerBase(Device, BaseInterface, LightpathMixin):
+class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
     """
     Shared PVs and components from the LCLS2 imagers.
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -260,11 +260,11 @@ class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
 
     tab_component_names = True
 
-    lightpath_cpts = ['y_states']
+    lightpath_cpts = ['target']
     _icon = 'fa.video-camera'
 
-    y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted',
-                   doc='Control of the diagnostic stack via saved positions.')
+    target = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted',
+                 doc='Control of the diagnostic stack via saved positions.')
     y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal',
                   doc='Direct control of the diagnostic stack motor.')
     detector = Cpt(PCDSAreaDetectorEmbedded, ':CAM:', kind='normal',
@@ -272,6 +272,11 @@ class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
                     doc='Camera power supply controls.')
     set_metadata(cam_power, dict(variety='command-enum'))
+
+    @property
+    def y_states(self):
+        """Alias old name. Will deprecate."""
+        return self.target
 
 
 class PPMPowerMeter(Device, BaseInterface):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -260,6 +260,9 @@ class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
 
     tab_component_names = True
 
+    lightpath_cpts = ['y_states']
+    _icon = 'fa.video-camera'
+
     y_states = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted',
                    doc='Control of the diagnostic stack via saved positions.')
     y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal',
@@ -269,8 +272,6 @@ class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
                     doc='Camera power supply controls.')
     set_metadata(cam_power, dict(variety='command-enum'))
-
-    lightpath_cpts = ['y_states']
 
 
 class PPMPowerMeter(Device, BaseInterface):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -17,7 +17,7 @@ from ophyd.signal import EpicsSignal
 from .areadetector.detectors import PCDSAreaDetectorEmbedded
 from .epics_motor import IMS, BeckhoffAxis
 from .inout import InOutRecordPositioner, TwinCATInOutPositioner
-from .interface import BaseInterface
+from .interface import BaseInterface, LightpathMixin
 from .sensors import TwinCATThermocouple
 from .signal import PytmcSignal
 from .state import StatePositioner
@@ -250,7 +250,7 @@ class PIMWithBoth(PIMWithFocus, PIMWithLED):
     pass
 
 
-class LCLS2ImagerBase(Device, BaseInterface):
+class LCLS2ImagerBase(Device, BaseInterface, LightpathMixin):
     """
     Shared PVs and components from the LCLS2 imagers.
 
@@ -269,6 +269,8 @@ class LCLS2ImagerBase(Device, BaseInterface):
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
                     doc='Camera power supply controls.')
     set_metadata(cam_power, dict(variety='command-enum'))
+
+    lightpath_cpts = ['y_states']
 
 
 class PPMPowerMeter(Device, BaseInterface):

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -1,8 +1,9 @@
-from ophyd import Device, Signal, EpicsSignal, Component as Cpt
+from ophyd import Device, Signal, Component as Cpt
 
 from .inout import InOutPositioner
 from .interface import BaseInterface, LightpathInOutMixin
 from .signal import PytmcSignal
+
 
 class PneumaticActuator(InOutPositioner):
     states_list = ['RETRACTED', 'INSERTED', 'MOVING', 'INVALID']
@@ -22,7 +23,6 @@ class PneumaticActuator(InOutPositioner):
     filter_type = Cpt(Signal, value='Unknown filter', kind='config')
 
     done = Cpt(PytmcSignal, ':MOT_DONE', io='i', kind='omitted')
-
 
     def __init__(self, prefix, *, name, transmission=1,
                  filter_type='Unknown filter', **kwargs):

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -1,0 +1,67 @@
+from ophyd import Device, Signal, EpicsSignal, Component as Cpt
+
+from .inout import InOutPositioner
+from .interface import BaseInterface, LightpathInOutMixin
+from .signal import PytmcSignal
+
+class PneumaticActuator(InOutPositioner):
+    states_list = ['RETRACTED', 'INSERTED', 'MOVING', 'INVALID']
+    in_states = ['INSERTED']
+    out_states = ['RETRACTED']
+    _invalid_states = ['MOVING', 'INVALID']
+    _unknown = False
+
+    state = Cpt(PytmcSignal, ':POS_STATE', io='i', kind='hinted')
+
+    in_sw = Cpt(PytmcSignal, ':IN', io='i', kind='normal')
+    out_sw = Cpt(PytmcSignal, ':OUT', io='i', kind='normal')
+    error = Cpt(PytmcSignal, ':ERROR', io='i', kind='normal')
+
+    in_cmd = Cpt(PytmcSignal, ':IN_CMD', io='io', kind='config')
+    out_cmd = Cpt(PytmcSignal, ':OUT_CMD', io='io', kind='config')
+    filter_type = Cpt(Signal, value='Unknown filter', kind='config')
+
+    done = Cpt(PytmcSignal, ':MOT_DONE', io='i', kind='omitted')
+
+
+    def __init__(self, prefix, *, name, transmission=1,
+                 filter_type='Unknown filter', **kwargs):
+        self._transmission = {'INSERTED': transmission}
+        super().__init__(prefix, name=name, **kwargs)
+        self.filter_type.put(filter_type)
+
+    def _do_move(self, state):
+        """
+        Override state move because we can't use the default.
+
+        Here we need to put 1 to the proper command pv.
+        """
+        if state.name == 'INSERTED':
+            self.in_cmd.put(1)
+        elif state.name == 'RETRACTED':
+            self.out_cmd.put(1)
+
+
+class RTDSBase(Device, BaseInterface, LightpathInOutMixin):
+    """Rapid Turnaround Diagnostic Station."""
+    lightpath_cpts = ['mpa1', 'mpa2', 'mpa3', 'mpa4']
+    _lightpath_mixin = True
+
+    _icon = 'fa.stop-circle'
+
+    mpa1 = Cpt(PneumaticActuator, ':MPA:01', kind='normal')
+    mpa2 = Cpt(PneumaticActuator, ':MPA:02', kind='normal')
+    mpa3 = Cpt(PneumaticActuator, ':MPA:03', kind='normal')
+    mpa4 = Cpt(PneumaticActuator, ':MPA:04', kind='normal')
+
+
+class RTDSL0(RTDSBase):
+    """RTDS Configuration on the HXR Line."""
+    lightpath_cpts = ['mpa1', 'mpa2', 'mpa3']
+
+    mpa4 = None
+
+
+class RTDSK0(RTDSBase):
+    """RTDS Configuration on the SXR Line."""
+    pass

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -275,3 +275,21 @@ class NotImplementedSignal(SignalRO):
     def __init__(self, *args, **kwargs):
         kwargs.pop('value', None)
         super().__init__(value='Not implemented', **kwargs)
+
+
+class InternalSignal(SignalRO):
+    """
+    Class Signal that stores info but should only be updated by the class.
+
+    SignalRO can be updated with _readback, but this does not process
+    callbacks. For the signal to behave normally, we need to bypass the put
+    override.
+
+    To put to one of these signals, simply call put with force=True
+    """
+
+    def put(self, value, *, timestamp=None, force=False):
+        return Signal.put(self, value, timestamp=timestamp, force=force)
+
+    def set(self, value, *, timestamp=None, force=False):
+        return Signal.set(self, value, timestamp=timestamp, force=force)

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -13,7 +13,8 @@ import logging
 from threading import RLock, Thread
 
 import numpy as np
-from ophyd.signal import EpicsSignal, EpicsSignalBase, EpicsSignalRO, Signal
+from ophyd.signal import (EpicsSignal, EpicsSignalBase, EpicsSignalRO,
+                          Signal, SignalRO)
 from ophyd.sim import FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache
 from pytmc.pragmas import normalize_io
 
@@ -266,3 +267,11 @@ class AvgSignal(Signal):
             self.index = (self.index + 1) % len(self.values)
             # This takes a mean, skipping nan values.
             self.put(np.nanmean(self.values))
+
+
+class NotImplementedSignal(SignalRO):
+    """Dummy signal for a not implemented feature."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.pop('value', None)
+        super().__init__(value='Not implemented', **kwargs)

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -28,7 +28,7 @@ from ophyd.status import wait as status_wait, Status
 from .epics_motor import BeckhoffAxis
 from .interface import (BaseInterface, FltMvInterface, MvInterface,
                         LightpathMixin)
-from .signal import PytmcSignal
+from .signal import PytmcSignal, NotImplementedSignal
 from .sensors import RTD
 
 logger = logging.getLogger(__name__)
@@ -415,4 +415,4 @@ class PowerSlits(BeckhoffSlits):
     """
 
     rtds = DDCpt(_rtd_fields(RTD, 'rtd', range(1, 9)))
-    fsw = Cpt(EpicsSignalRO, ':FSW', kind='normal')
+    fsw = Cpt(NotImplementedSignal, ':FSW', kind='normal')

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -37,10 +37,6 @@ class SlitsBase(Device, MvInterface, LightpathMixin):
     """
     Base class for slit motion interfacing.
     """
-    # Subscription information
-    SUB_STATE = 'sub_state_changed'
-    _default_sub = SUB_STATE
-
     # QIcon for UX
     _icon = 'fa.th-large'
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -212,9 +212,9 @@ class SlitsBase(Device, MvInterface, LightpathMixin):
 class BadSlitPositionerBase(PVPositioner, FltMvInterface):
     """Base class for slit positioner with awful PV names."""
 
-    readback = FCpt(EpicsSignalRO, '{self.prefix}:ACTUAL_{self._dirlong}',
+    readback = FCpt(EpicsSignalRO, '{prefix}:ACTUAL_{_dirlong}',
                     auto_monitor=True, kind='normal')
-    setpoint = FCpt(EpicsSignal, '{self.prefix}:{self._dirshort}_REQ',
+    setpoint = FCpt(EpicsSignal, '{prefix}:{_dirshort}_REQ',
                     auto_monitor=True, kind='normal')
 
     def __init__(self, prefix, *, slit_type="", limits=None, **kwargs):

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -26,8 +26,7 @@ from ophyd.signal import Signal
 from ophyd.status import wait as status_wait, Status
 
 from .epics_motor import BeckhoffAxis
-from .interface import (BaseInterface, FltMvInterface, MvInterface,
-                        LightpathMixin)
+from .interface import FltMvInterface, MvInterface, LightpathMixin
 from .signal import PytmcSignal, NotImplementedSignal
 from .sensors import RTD
 
@@ -334,9 +333,9 @@ class BeckhoffSlits(SlitsBase):
     # Base class overrides
     xwidth = Cpt(BeckhoffSlitPositioner, '', slit_type='XWIDTH', kind='hinted')
     ywidth = Cpt(BeckhoffSlitPositioner, '', slit_type='YWIDTH', kind='hinted')
-    xcenter = Cpt(BeckhoffSlitPositioner, '', slit_type= 'XCENTER',
+    xcenter = Cpt(BeckhoffSlitPositioner, '', slit_type='XCENTER',
                   kind='normal')
-    ycenter = Cpt(BeckhoffSlitPositioner, '', slit_type= 'YCENTER',
+    ycenter = Cpt(BeckhoffSlitPositioner, '', slit_type='YCENTER',
                   kind='normal')
 
     # Slit state commands

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -176,9 +176,9 @@ class SlitsBase(Device, MvInterface, LightpathMixin):
         self._original_vals[self.ywidth.setpoint] = self.ywidth.readback.get()
         return super().stage()
 
-    def _set_lightpath_states(self, *args, **kwargs):
-        self._inserted = (min(self.current_aperture)
-                          < self.nominal_aperture.get())
+    def _set_lightpath_states(self, lightpath_values):
+        widths = [kw['value'] for kw in lightpath_values.values()]
+        self._inserted = (min(widths) < self.nominal_aperture.get())
         self._removed = not self._inserted
 
 

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -81,13 +81,13 @@ class Kmono(Device, BaseInterface, LightpathMixin):
             removed = value > 96.5
             self._update_state(inserted, removed, 'diode')
 
-    def _set_lightpath_states(self, *args, value, obj, **kwargs):
-        xtal_in = self.xtal_in.get()
-        xtal_out = self.xtal_out.get()
-        ret_in = self.ret_in.get()
-        ret_out = self.ret_out.get()
-        diode_in = self.diode_in.get()
-        diode_out = self.diode_out.get()
+    def _set_lightpath_states(self, lightpath_values):
+        xtal_in = lightpath_values[self.xtal_in]['value']
+        xtal_out = lightpath_values[self.xtal_out]['value']
+        ret_in = lightpath_values[self.ret_in]['value']
+        ret_out = lightpath_values[self.ret_out]['value']
+        diode_in = lightpath_values[self.diode_in]['value']
+        diode_out = lightpath_values[self.diode_out]['value']
 
         self._inserted = any((xtal_in, ret_in, diode_in))
         self._removed = all((xtal_out, ret_out, diode_out))

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -4,10 +4,10 @@ Module for the various spectrometers.
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
-from ophyd.signal import Signal
 
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface, LightpathMixin
+from .signal import InternalSignal
 
 
 class Kmono(Device, BaseInterface, LightpathMixin):
@@ -44,16 +44,16 @@ class Kmono(Device, BaseInterface, LightpathMixin):
     diode_horiz = Cpt(BeckhoffAxis, ':DIODE_HORIZ', kind='normal')
     diode_vert = Cpt(BeckhoffAxis, ':DIODE_VERT', kind='normal')
 
-    xtal_in = Cpt(Signal, value=None, kind='omitted')
-    xtal_out = Cpt(Signal, value=None, kind='omitted')
-    ret_in = Cpt(Signal, value=None, kind='omitted')
-    ret_out = Cpt(Signal, value=None, kind='omitted')
-    diode_in = Cpt(Signal, value=None, kind='omitted')
-    diode_out = Cpt(Signal, value=None, kind='omitted')
+    xtal_in = Cpt(InternalSignal, value=None, kind='omitted')
+    xtal_out = Cpt(InternalSignal, value=None, kind='omitted')
+    ret_in = Cpt(InternalSignal, value=None, kind='omitted')
+    ret_out = Cpt(InternalSignal, value=None, kind='omitted')
+    diode_in = Cpt(InternalSignal, value=None, kind='omitted')
+    diode_out = Cpt(InternalSignal, value=None, kind='omitted')
 
     def _update_if_changed(self, value, signal):
         if value != signal.get():
-            signal.put(value)
+            signal.put(value, force=True)
 
     def _update_state(self, inserted, removed, state):
         self._update_if_changed(inserted, getattr(self, state + '_in'))

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -44,13 +44,12 @@ class Kmono(Device, BaseInterface, LightpathMixin):
     diode_horiz = Cpt(BeckhoffAxis, ':DIODE_HORIZ', kind='normal')
     diode_vert = Cpt(BeckhoffAxis, ':DIODE_VERT', kind='normal')
 
-    xtal_in = Cpt(Signal, kind='omitted')
-    xtal_out = Cpt(Signal, kind='omitted')
-    ret_in = Cpt(Signal, kind='omitted')
-    ret_out = Cpt(Signal, kind='omitted')
-    diode_in = Cpt(Signal, kind='omitted')
-    diode_out = Cpt(Signal, kind='omitted')
-
+    xtal_in = Cpt(Signal, value=None, kind='omitted')
+    xtal_out = Cpt(Signal, value=None, kind='omitted')
+    ret_in = Cpt(Signal, value=None, kind='omitted')
+    ret_out = Cpt(Signal, value=None, kind='omitted')
+    diode_in = Cpt(Signal, value=None, kind='omitted')
+    diode_out = Cpt(Signal, value=None, kind='omitted')
 
     def _update_if_changed(self, value, signal):
         if value != signal.get():

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -188,6 +188,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         cid = super().subscribe(cb, event_type=event_type, run=run)
         if event_type is None:
             event_type = self._default_sub
+        self.wait_for_connection()
         if event_type == self.SUB_STATE and not self._has_subscribed_state:
             self.state.subscribe(self._run_sub_state, run=False)
             self._has_subscribed_state = True

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -79,6 +79,7 @@ class StatePositioner(Device, PositionerBase, MvInterface):
             raise TypeError(('StatePositioner must be subclassed with at '
                              'least a state signal'))
         self._state_initialized = False
+        self._has_subscribed_state = False
         super().__init__(prefix, name=name, **kwargs)
         if self.states_list:
             self._state_init()
@@ -99,7 +100,6 @@ class StatePositioner(Device, PositionerBase, MvInterface):
                 self._invalid_states = [self._unknown] + self._invalid_states
             if not hasattr(self, 'states_enum'):
                 self.states_enum = self._create_states_enum()
-            self._has_subscribed_state = False
             self._state_initialized = True
 
     def _late_state_init(self, *args, enum_strs=None, **kwargs):
@@ -188,7 +188,6 @@ class StatePositioner(Device, PositionerBase, MvInterface):
         cid = super().subscribe(cb, event_type=event_type, run=run)
         if event_type is None:
             event_type = self._default_sub
-        self.wait_for_connection()
         if event_type == self.SUB_STATE and not self._has_subscribed_state:
             self.state.subscribe(self._run_sub_state, run=False)
             self._has_subscribed_state = True

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -185,20 +185,18 @@ def schedule_task(func, args=None, kwargs=None, delay=None):
             context = dispatcher.get_thread_context(matched_thread)
             break
 
-    if delay is None:
+    def schedule():
         if matched_thread is None:
-            # Put into utility queue right away
+            # Put into utility queue
             dispatcher.schedule_utility_task(func, *args, **kwargs)
         else:
-            # Put into same queue right away
+            # Put into same queue
             context.event_thread.queue.put((func, args, kwargs))
+
+    if delay is None:
+        # Do it right away
+        schedule()
     else:
-        if matched_thread is None:
-            # Put into utility queue later
-            timer = threading.Timer(delay, dispatcher.schedule_utility_task,
-                                    args=args, kwargs=kwargs)
-        else:
-            # Put into same queue later
-            timer = threading.Timer(delay, context.event_thread.queue.put,
-                                    args=((func, args, kwargs),))
+        # Do it later
+        timer = threading.Timer(delay, schedule)
         timer.start()

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -249,11 +249,16 @@ class VGC(VRC):
                                       'interlocking this valve')
 
 
-class VFS(Device):
+class VFS(Device, LightpathMixin):
     """Class for Fast Shutter Valve."""
-    valve_position = Cpt(EpicsSignalRO, ':POS_STATE_RBV', kind='normal',
+
+    # Configuration for lightpath
+    lightpath_cpts = ['position_open', 'position_close']
+    _icon = 'fa.shield'
+
+    valve_position = Cpt(EpicsSignalRO, ':POS_STATE_RBV', kind='hinted',
                          doc='Ex: OPEN, CLOSED, MOVING, INVALID, OPEN_F')
-    vfs_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal',
+    vfs_state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='hinted',
                     doc='Fast Shutter Current State')
     request_close = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',
                         doc=('Request Fast Shutter to Close. When both close'
@@ -284,6 +289,10 @@ class VFS(Device):
                        doc=('Fast Shutter Vacuum Fault OK Readback'))
     mps_ok = Cpt(EpicsSignalRO, ':MPS_FAULT_OK_RBV', kind='normal',
                  doc='Fast Shutter Fast Fault Output OK')
+
+    def _set_lightpath_states(self, lightpath_values):
+        self._inserted = lightpath_values[self.position_close]['value']
+        self._removed = lightpath_values[self.position_open]['value']
 
 
 class VVCNO(Device):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -8,6 +8,7 @@ from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 
 from .inout import InOutPositioner, InOutPVStatePositioner
+from .interface import LightpathMixin
 
 logger = logging.getLogger(__name__)
 
@@ -202,13 +203,24 @@ class VGCLegacy(ValveBase):
                        doc='Closed limit switch digital input')
 
 
-class VRC(VVC):
+class VRC(VVC, LightpathMixin):
     """Class for Gate Valves with Control and readback."""
+
+    # Configuration for lightpath
+    lightpath_cpts = ['open_limit', 'closed_limit']
+    _icon = 'fa.hourglass'
+
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal', doc='Valve state')
     open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
                      doc='Open limit switch digital input')
     closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',
                        doc='Closed limit switch digital input')
+
+    def _set_lightpath_states(self, lightpath_values):
+        """Callback for updating inserted/removed for lightpath."""
+
+        self._inserted = lightpath_values[self.closed_limit]['value']
+        self._removed = lightpath_values[self.open_limit]['value']
 
 
 class VGC(VRC):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The goal is to restore the lightpath interface to working order for all HXR classes.
Lightpath should be able to:
- display status for every pcdsdevices class in use
- display a proper icon for every pcdsdevices class in use

And nothing else is in scope for now since it already does a good job at opening up typhos screens.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is clamoring for this tool to work again. There is not enough time to do a full rework of lightpath interfaces like I want to do in https://github.com/pcdshub/lightpath/issues/106, instead I will make sure `inserted`, `removed`, `subscribe`, and `transmission` work how lightpath is expecting to properly display status.

I will also need to dig into the attenuator handling logic in lightpath to properly signal when the attenuators are blocking vs not blocking vs attenuating.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I'm not quite sure I how I plan to go about testing this in the suite, but I'm progressing through while opening the lightpath screen in dev mode.
