### PR TITLE
ENH: Add new detector class specifically for creating areaDetector Typhos screens

### DIFF
--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -9,6 +9,7 @@ import warnings
 
 from ophyd.areadetector import cam
 from ophyd.areadetector.base import ADComponent, NDDerivedSignal
+from ophyd.areadetector.base import EpicsSignalWithRBV
 from ophyd.areadetector.detectors import DetectorBase
 from ophyd.device import Component as Cpt
 from ophyd import Device
@@ -176,23 +177,15 @@ class PCDSAreaDetectorTyphos(Device):
     camera_model = Cpt(EpicsSignalRO, 'Model_RBV', kind='normal')
     sensor_size_x = Cpt(EpicsSignalRO, 'MaxSizeX_RBV', kind='config')
     sensor_size_y = Cpt(EpicsSignalRO, 'MaxSizeY_RBV', kind='config')
-    data_type = Cpt(EpicsSignal, 'DataType', kind='config')
-    data_type_RBV = Cpt(EpicsSignalRO, 'DataType_RBV', kind='config')
+    data_type = Cpt(EpicsSignalWithRBV, 'DataType', kind='config')
 
     # Acquisition settings
-    exposure = Cpt(EpicsSignal, 'AcquireTime', kind='config')
-    exposure_rbv = Cpt(EpicsSignalRO, 'AcquireTime_RBV', kind='config')
-    gain = Cpt(EpicsSignal, 'Gain', kind='config')
-    gain_rbv = Cpt(EpicsSignalRO, 'Gain_RBV', kind='config')
-    num_images = Cpt(EpicsSignal, 'NumImages', kind='config')
-    num_images_rbv = Cpt(EpicsSignalRO, 'NumImages_RBV', kind='config')
-    image_mode = Cpt(EpicsSignal, 'ImageMode', kind='config')
-    image_mode_rbv = Cpt(EpicsSignalRO, 'ImageMode_RBV', kind='config')
-    trigger_mode = Cpt(EpicsSignal, 'TriggerMode', kind='config')
-    trigger_mode_rbv = Cpt(EpicsSignalRO, 'TriggerMode_RBV', kind='config')
-    acquisition_period = Cpt(EpicsSignal, 'AcquirePeriod', kind='config')
-    acquisition_period_rbv = Cpt(EpicsSignalRO, 'AcquirePeriod_RBV',
-                                 kind='config')
+    exposure = Cpt(EpicsSignalWithRBV, 'AcquireTime', kind='config')
+    gain = Cpt(EpicsSignalWithRBV, 'Gain', kind='config')
+    num_images = Cpt(EpicsSignalWithRBV, 'NumImages', kind='config')
+    image_mode = Cpt(EpicsSignalWithRBV, 'ImageMode', kind='config')
+    trigger_mode = Cpt(EpicsSignalWithRBV, 'TriggerMode', kind='config')
+    acquisition_period = Cpt(EpicsSignalWithRBV, 'AcquirePeriod', kind='config')
 
     # Image collection settings
     acquire = Cpt(EpicsSignal, 'Acquire', kind='normal')

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -8,17 +8,15 @@ import logging
 import warnings
 
 from ophyd.areadetector import cam
-from ophyd.areadetector.base import ADComponent, DDC_EpicsSignalRO, NDDerivedSignal
+from ophyd.areadetector.base import ADComponent, NDDerivedSignal
 from ophyd.areadetector.detectors import DetectorBase
 from ophyd.device import Component as Cpt
 from ophyd import Device
-from ophyd.signal import EpicsSignal, EpicsSignalRO, AttributeSignal
+from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from .plugins import (ColorConvPlugin, HDF5Plugin, ImagePlugin, JPEGPlugin,
                       NetCDFPlugin, NexusPlugin, OverlayPlugin, ProcessPlugin,
                       ROIPlugin, StatsPlugin, TIFFPlugin, TransformPlugin)
-
-import numpy as np
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This adds a new class, PCDSAreaDetectorTyphos, for creating areaDetector Typhos screens. This cuts out much of the extra areaDetector plugins and PVs that are not often used, and creates a fairly slim screen for simple AD camera configuration and operation. Includes a pop-up screen for camera viewing. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Other PCDSAreaDetector classes have a lot of PVs that are not needed most of the time. The other classes also did not allow for viewing the image. 
This
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this in the Heinz lab on a Basler camera. 
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not much to document since this is mainly just a pile of PVs. 
<!--
## Screenshots (if appropriate):
-->
See screen shot with the generated screen, compared to the camera viewer. 
![typhos_gige](https://user-images.githubusercontent.com/29102919/88326825-4bcf4380-ccdb-11ea-9cf2-3e9c0f3f2dd0.PNG)


## Notes
I will note one annoyance with this screen right now. When you first open the image viewer, the image is not immediately visible. It appears that the default color map (Magma) does not work with this viewer. In fact, I only got a few of the color maps to work: Jet, Monochrome, and Hot. Once you have set the color map, if you close the image viewer it will retain the color map if you open it back up again. 
