### PR TITLE
MNT: updated doc for FSV open to require rising edge for valve to open.

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -264,7 +264,8 @@ class VFS(Device, LightpathMixin):
                         doc=('Request Fast Shutter to Close. When both close'
                              'and open are requested, VFS will close.'))
     request_open = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',
-                       doc=('Request Fast Shutter to Open. When both close and'
+                       doc=('Request Fast Shutter to Open. Requires a rising'
+                            'EPICS signal to open. When both close and'
                             'open are requested, VFS will close.'))
     reset_vacuum_fault = Cpt(EpicsSignalWithRBV, ':ALM_RST', kind='normal',
                              doc=('Reset Fast Shutter Vacuum Faults: fast'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
The plc requires a rising edge epics open signal in order to open the fast shutter valve. In the past, there was no mention of this and would be confusing to the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
