### PR TITLE
ENH: Add Smaract support

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -499,13 +499,14 @@ class MotorDisabledError(Exception):
     """Error that indicates that we are not allowed to move."""
     pass
 
+
 class SmarActOpenLoop(Device):
     """
     Class containing the open loop PVs used to control an un-encoded SmarAct
     stage.
 
     Can be used for sub-classing, or creating a simple  device without the
-    motor record PVs. 
+    motor record PVs.
     """
 
     # Voltage for sawtooth ramp
@@ -514,9 +515,9 @@ class SmarActOpenLoop(Device):
     step_freq = Cpt(EpicsSignal, ':STEP_FREQ', kind='config')
     # Number of steps per step forward, backward command
     jog_step_size = Cpt(EpicsSignal, ':STEP_COUNT', kind='normal')
-    # Jog forward 
+    # Jog forward
     jog_fwd = Cpt(EpicsSignal, ':STEP_FORWARD', kind='normal')
-    # Jog backward 
+    # Jog backward
     jog_rev = Cpt(EpicsSignal, ':STEP_REVERSE', kind='normal')
     # Total number of steps counted
     total_step_count = Cpt(EpicsSignalRO, ':TOTAL_STEP_COUNT', kind='normal')
@@ -524,18 +525,23 @@ class SmarActOpenLoop(Device):
     step_clear_cmd = Cpt(EpicsSignal, ':CLEAR_COUNT', kind='config')
     # Scan move
     scan_move_cmd = Cpt(EpicsSignal, ':SCAN_MOVE', kind='omitted')
-    # Scan pos 
+    # Scan pos
     scan_pos = Cpt(EpicsSignal, ':SCAN_POS', kind='omitted')
+
 
 class SmarAct(PCDSMotorBase):
     """
-    Class for SmarAct motors controlled via the MCS2 controller. 
-    Includes both the motor record PVs, as well as the open loop PVs for 
+    Class for SmarAct motors controlled via the MCS2 controller.
+    Includes both the motor record PVs, as well as the open loop PVs for
     controlling an un-encoded stage.
     """
     # These PVs will probably not be needed for most encoded motors, but can be
     # useful
-    open_loop = Cpt(SmarActOpenLoop, '', kind='config')
+
+    # Even when omitted, the open loop PVs still show up on the config screen.
+    # Leaving this off for now to keep screens clean.
+    # open_loop = Cpt(SmarActOpenLoop, '', kind='omitted')
+
 
 def Motor(prefix, **kwargs):
     """
@@ -561,6 +567,8 @@ def Motor(prefix, **kwargs):
     +---------------+-------------------------+
     | PIC           | :class:`.PCDSMotorBase` |
     +---------------+-------------------------+
+    | MCS           | :class:`.SmarAct`       |
+    +---------------+-------------------------+
 
     Parameters
     ----------
@@ -577,7 +585,8 @@ def Motor(prefix, **kwargs):
                    ('MMN', Newport),
                    ('MZM', PMC100),
                    ('MMB', BeckhoffAxis),
-                   ('PIC', PCDSMotorBase))
+                   ('PIC', PCDSMotorBase),
+                   ('MCS', SmarAct))
     # Search for component type in prefix
     for cpt_abbrev, _type in motor_types:
         if f':{cpt_abbrev}:' in prefix:

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -499,6 +499,43 @@ class MotorDisabledError(Exception):
     """Error that indicates that we are not allowed to move."""
     pass
 
+class SmarActOpenLoop(Device):
+    """
+    Class containing the open loop PVs used to control an un-encoded SmarAct
+    stage.
+
+    Can be used for sub-classing, or creating a simple  device without the
+    motor record PVs. 
+    """
+
+    # Voltage for sawtooth ramp
+    step_voltage = Cpt(EpicsSignal, ':STEP_VOLTAGE', kind='omitted')
+    # Frequency of steps
+    step_freq = Cpt(EpicsSignal, ':STEP_FREQ', kind='config')
+    # Number of steps per step forward, backward command
+    step_count = Cpt(EpicsSignal, ':STEP_COUNT', kind='normal')
+    # Jog forward 
+    step_fwd_cmd = Cpt(EpicsSignal, ':STEP_FORWARD', kind='normal')
+    # Jog backward 
+    step_rev_cmd = Cpt(EpicsSignal, ':STEP_REVERSE', kind='normal')
+    # Total number of steps counted
+    total_step_count = Cpt(EpicsSignal, ':TOTAL_STEP_COUNT', kind='normal')
+    # Reset steps ("home")
+    step_clear_cmd = Cpt(EpicsSignal, ':CLEAR_COUNT', kind='config')
+    # Scan move
+    scan_move_cmd = Cpt(EpicsSignal, ':SCAN_MOVE', kind='omitted')
+    # Scan pos 
+    scan_pos = Cpt(EpicsSignal, ':SCAN_POS', kind='omitted')
+
+class SmarAct(PCDSMotorBase):
+    """
+    Class for SmarAct motors controlled via the MCS2 controller. 
+    Includes both the motor record PVs, as well as the open loop PVs for 
+    controlling an un-encoded stage.
+    """
+    # These PVs will probably not be needed for most encoded motors, but can be
+    # useful
+    open_loop = Cpt(SmarActOpenLoop, '', kind='config')
 
 def Motor(prefix, **kwargs):
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -513,13 +513,13 @@ class SmarActOpenLoop(Device):
     # Frequency of steps
     step_freq = Cpt(EpicsSignal, ':STEP_FREQ', kind='config')
     # Number of steps per step forward, backward command
-    step_count = Cpt(EpicsSignal, ':STEP_COUNT', kind='normal')
+    jog_step_size = Cpt(EpicsSignal, ':STEP_COUNT', kind='normal')
     # Jog forward 
-    step_fwd_cmd = Cpt(EpicsSignal, ':STEP_FORWARD', kind='normal')
+    jog_fwd = Cpt(EpicsSignal, ':STEP_FORWARD', kind='normal')
     # Jog backward 
-    step_rev_cmd = Cpt(EpicsSignal, ':STEP_REVERSE', kind='normal')
+    jog_rev = Cpt(EpicsSignal, ':STEP_REVERSE', kind='normal')
     # Total number of steps counted
-    total_step_count = Cpt(EpicsSignal, ':TOTAL_STEP_COUNT', kind='normal')
+    total_step_count = Cpt(EpicsSignalRO, ':TOTAL_STEP_COUNT', kind='normal')
     # Reset steps ("home")
     step_clear_cmd = Cpt(EpicsSignal, ':CLEAR_COUNT', kind='config')
     # Scan move

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -531,9 +531,7 @@ class SmarActOpenLoop(Device):
 
 class SmarAct(PCDSMotorBase):
     """
-    Class for SmarAct motors controlled via the MCS2 controller.
-    Includes both the motor record PVs, as well as the open loop PVs for
-    controlling an un-encoded stage.
+    Class for encoded SmarAct motors controlled via the MCS2 controller.
     """
     # These PVs will probably not be needed for most encoded motors, but can be
     # useful


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add support for SmarAct motors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These are used heavily in the laser control system. Provides an Ophyd object for both encoded and un-encoded stages. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on motors in the B40 Heinz lab. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not much to document. Some docstrings describe the SmarAct open loop PVs. 

<!--
## Screenshots (if appropriate):
-->
