### PR TITLE
ENH: Add support for Tuttifrutti diagnostic stack

### DIFF
--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -2,22 +2,22 @@
 Classes for the Tuttifrutti diagnostic stack designed for the MODS TILEs.
 """
 
-
 from ophyd import Component as Cpt
-from ophyd import Device, DynamicDeviceComponent
+from ophyd import Device
 from ophyd.device import create_device_from_components
-from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from pcdsdevices.areadetector.detectors import PCDSAreaDetectorTyphos
 from pcdsdevices.lasers.qmini import QminiSpectrometer
 from pcdsdevices.lasers.ek9000 import El3174AiCh
 from pcdsdevices.lasers.elliptec import Ell6
 
+
 def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
                 diode=False, em=False, qc=False, pd=False, wfs=False,
-                ell=False):
+                ell=False, misc=[]):
     """
-    Base class for Tuttifrutti.
+    Factory function for Tuttifrutti diagnostic stack device. Returns a class
+    based on the diagnostics installed.
 
     Sufficient for basic control and generation of Typhos screens.
 
@@ -27,14 +27,17 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
         The PV base of the tuttifrutti diagnostic stack. All consituent
         diagnostics have regimented PV suffixes based on this prefix.
 
+    name: str
+        The name of the TuttiFrutti device.
+
     nf : bool <False>
-        Flag indicating if a near-field camera is installed. 
-        
+        Flag indicating if a near-field camera is installed.
+
     ff : bool <False>
-        Flag indicating if a far-field camera is installed. 
+        Flag indicating if a far-field camera is installed.
 
     spec : bool <False>
-        Flag indicating if a spectrometer is installed. 
+        Flag indicating if a spectrometer is installed.
 
     pm : bool <False>
         Flag indicating if a power meter is installed.
@@ -47,23 +50,46 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
 
     qc : bool <False> (Not Implemented)
         Flag indicating if a quad cell detector is installed.
-    
+
     pd : bool <False> (Not Implemented)
-        Flag indicating if a pulse duration diagnostic is installed.  
+        Flag indicating if a pulse duration diagnostic is installed.
 
     wfs : bool <False> (Not Implemented)
-        Flag indicating if a wavefront sensor is installed.  
+        Flag indicating if a wavefront sensor is installed.
 
     ell : bool <False>
         Flag indicating if a 2-position filter slider is installed is
         installed.
 
+    misc : dict of ophyd.FormattedComponent <empty>
+        Dictionary of FCpt for providing miscellaneous Ophyd Component objects
+        to the TuttiFrutti. Used for non-standard devices or when you need to 
+        hack in a component that hasn't made it into a released TuttiFrutti
+        object yet (can you say "Commissioning"?). The dictionary key is the
+        desired name of the component. 
+
+        Note: you must use the full base PV in the FCpt when instantiating it
+        (see example), even if the base PV is the same as the TuttiFrutti. We 
+        are using FCpt here to get around possible PV naming incompatibilities          (I'm looking at you, EK9000...). 
+
     Examples
     --------
     # Create an object for a basic tuttifrutti containing NF/FF cameras,
-    # a spectrometer, and a filter slider. 
+    # a spectrometer, and a filter slider.
 
     ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True)
+
+    # Create a TuttiFrutti as above, while including a non-standard component.
+
+    from ophyd import FormattedComponent as FCpt
+
+    from fruit import Banana
+    banana = FCpt(Banana, 'IOC:LAS:BANANA', kind='normal') # Use full base PV
+
+    dmisc = {'banana' : banana}
+
+    ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
+                           misc=[dmisc])
     """
     cpts = {}
     if nf:
@@ -91,7 +117,10 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     if ell:
         cpt = Cpt(Ell6, '_SL', kind='normal')
         cpts['slider'] = cpt
-
+    # This feels kind of hacky, but also kind of cool.
+    if misc:
+        for cptname, cpt in misc.items():
+            cpts[cptname] = cpt
     cls_name = prefix.replace(':', '_') + '_TuttiFrutti'
     cls = create_device_from_components(cls_name, base_class=Device,
                                         class_kwargs=None, **cpts)

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -12,12 +12,54 @@ from pcdsdevices.lasers.ek9000 import El3174AiCh
 from pcdsdevices.lasers.elliptec import Ell6
 
 
+def TuttiFruttiCls(prefix, name, nf=False, ff=False, spec=False, pm=False,
+                   diode=False, em=False, qc=False, pd=False, wfs=False,
+                   ell=False, misc=[]):
+    """
+    Instantiate a TuttiFrutti class. See TuttiFrutti function for more details.
+    """
+    cpts = {}
+    if nf:
+        cpt = Cpt(PCDSAreaDetectorTyphos, '_NF1:', kind='normal')
+        cpts['nf_camera'] = cpt
+    if nf:
+        cpt = Cpt(PCDSAreaDetectorTyphos, '_FF1:', kind='normal')
+        cpts['ff_camera'] = cpt
+    if spec:
+        cpt = Cpt(QminiSpectrometer, '_SP1', kind='normal')
+        cpts['spectrometer'] = cpt
+    if pm:
+        cpt = Cpt(El3174AiCh, '_PM1', kind='normal')
+        cpts['power_meter'] = cpt
+    if diode:
+        raise(NotImplemented, "Diode is not yet implemented")
+    if em:
+        raise(NotImplemented, "Energy meter is not yet implemented")
+    if qc:
+        raise(NotImplemented, "Quad cell is not yet implemented")
+    if pd:
+        raise(NotImplemented, "Pulse duration is not yet implemented")
+    if wfs:
+        raise(NotImplemented, "Wavefront sensor is not yet implemented")
+    if ell:
+        cpt = Cpt(Ell6, '_SL1:ELL:M1', kind='normal')
+        cpts['slider'] = cpt
+    if misc:  # This feels kind of hacky, but also kind of cool.
+        for cptname, cpt in misc.items():
+            cpts[cptname] = cpt
+    cls_name = prefix.replace(':', '_') + '_TuttiFrutti'
+    cls = create_device_from_components(cls_name, base_class=Device,
+                                        class_kwargs=None, **cpts)
+
+    return cls
+
+
 def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
                 diode=False, em=False, qc=False, pd=False, wfs=False,
                 ell=False, misc=[]):
     """
-    Factory function for Tuttifrutti diagnostic stack device. Returns a class
-    based on the diagnostics installed.
+    Factory function for Tuttifrutti diagnostic stack device. Returns a device
+    based on the specified components.
 
     Sufficient for basic control and generation of Typhos screens.
 
@@ -61,17 +103,19 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
         Flag indicating if a 2-position filter slider is installed is
         installed.
 
-    misc : dict of ophyd.FormattedComponent <empty>
-        Dictionary of FCpt for providing miscellaneous Ophyd Component objects
-        to the TuttiFrutti. Used for non-standard devices or when you need to
-        hack in a component that hasn't made it into a released TuttiFrutti
-        object yet (can you say "Commissioning"?). The dictionary key is the
-        desired name of the component.
+    misc : dict of ophyd.Component or ophyd.FormattedComponent <empty>
+        Dictionary of Cpt and/or FCpt for providing miscellaneous Ophyd
+        Component objects to the TuttiFrutti. Used for non-standard devices or
+        when you need to hack in a component that hasn't made it into a
+        released version of TuttiFrutti object yet (can you say
+        "Commissioning"?). The dictionary key is the desired name of the
+        attribute name for the component.
 
         Note: you must use the full base PV in the FCpt when instantiating it
         (see example), even if the base PV is the same as the TuttiFrutti. We
-        are using FCpt here to get around possible PV naming incompatibilities
-        (I'm looking at you, EK9000...).
+        can use FCpt here to temporarily get around possible PV naming
+        incompatibilities with the L2SI laser PV naming convention (I'm looking
+        at you, EK9000...).
 
     Examples
     --------
@@ -82,50 +126,21 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
 
     # Create a TuttiFrutti as above, while including a non-standard component.
 
+    from ophyd import Component as Cpt
     from ophyd import FormattedComponent as FCpt
 
-    from fruit import Banana
-    banana = FCpt(Banana, 'IOC:LAS:BANANA', kind='normal') # Use full base PV
+    from fruit import Apple, Orange
+    apple = Cpt(Apple, ':APPLE', kind='normal') # Use TuttiFrutti base PV
+    orange = FCpt(Orange, 'IOC:LAS:ORANGE', kind='normal') # Use full base PV
 
-    dmisc = {'banana' : banana}
+    dmisc = {'apple': apple, 'banana' : banana}
 
     ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
                            misc=dmisc)
     """
-    cpts = {}
-    if nf:
-        cpt = Cpt(PCDSAreaDetectorTyphos, '_NF1:', kind='normal')
-        cpts['nf_camera'] = cpt
-    if nf:
-        cpt = Cpt(PCDSAreaDetectorTyphos, '_FF1:', kind='normal')
-        cpts['ff_camera'] = cpt
-    if spec:
-        cpt = Cpt(QminiSpectrometer, '_SP1', kind='normal')
-        cpts['spectrometer'] = cpt
-    if pm:
-        cpt = Cpt(El3174AiCh, '_PM1', kind='normal')
-        cpts['power_meter'] = cpt
-    if diode:
-        raise(NotImplemented, "Diode is not yet implemented")
-    if em:
-        raise(NotImplemented, "Energy meter is not yet implemented")
-    if qc:
-        raise(NotImplemented, "Quad cell is not yet implemented")
-    if pd:
-        raise(NotImplemented, "Pulse duration is not yet implemented")
-    if wfs:
-        raise(NotImplemented, "Wavefront sensor is not yet implemented")
-    if ell:
-        cpt = Cpt(Ell6, '_SL1:ELL:M1', kind='normal')
-        cpts['slider'] = cpt
-    # This feels kind of hacky, but also kind of cool.
-    if misc:
-        for cptname, cpt in misc.items():
-            cpts[cptname] = cpt
-    cls_name = prefix.replace(':', '_') + '_TuttiFrutti'
-    cls = create_device_from_components(cls_name, base_class=Device,
-                                        class_kwargs=None, **cpts)
-
+    cls = TuttiFruttiCls(prefix, name, nf=nf, ff=ff, spec=spec, pm=pm,
+                         diode=diode, em=em, qc=qc, pd=pd, wfs=wfs, ell=False,
+                         misc=misc)
     dev = cls(prefix, name=name)
 
     return dev

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -90,7 +90,7 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     dmisc = {'banana' : banana}
 
     ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
-                           misc=[dmisc])
+                           misc=dmisc)
     """
     cpts = {}
     if nf:

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -16,7 +16,7 @@ def TuttiFruttiCls(prefix, name, nf=False, ff=False, spec=False, pm=False,
                    diode=False, em=False, qc=False, pd=False, wfs=False,
                    ell=False, misc=[]):
     """
-    Instantiate a TuttiFrutti class. See TuttiFrutti function for more details.
+    Generate a TuttiFrutti class. See TuttiFrutti function for more details.
     """
     cpts = {}
     if nf:

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -63,14 +63,15 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
 
     misc : dict of ophyd.FormattedComponent <empty>
         Dictionary of FCpt for providing miscellaneous Ophyd Component objects
-        to the TuttiFrutti. Used for non-standard devices or when you need to 
+        to the TuttiFrutti. Used for non-standard devices or when you need to
         hack in a component that hasn't made it into a released TuttiFrutti
         object yet (can you say "Commissioning"?). The dictionary key is the
-        desired name of the component. 
+        desired name of the component.
 
         Note: you must use the full base PV in the FCpt when instantiating it
-        (see example), even if the base PV is the same as the TuttiFrutti. We 
-        are using FCpt here to get around possible PV naming incompatibilities          (I'm looking at you, EK9000...). 
+        (see example), even if the base PV is the same as the TuttiFrutti. We
+        are using FCpt here to get around possible PV naming incompatibilities
+        (I'm looking at you, EK9000...).
 
     Examples
     --------

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -32,15 +32,15 @@ def TuttiFruttiCls(prefix, name, nf=False, ff=False, spec=False, pm=False,
         cpt = Cpt(El3174AiCh, '_PM1', kind='normal')
         cpts['power_meter'] = cpt
     if diode:
-        raise(NotImplemented, "Diode is not yet implemented")
+        raise NotImplementedError("Diode is not yet implemented")
     if em:
-        raise(NotImplemented, "Energy meter is not yet implemented")
+        raise NotImplementedError("Energy meter is not yet implemented")
     if qc:
-        raise(NotImplemented, "Quad cell is not yet implemented")
+        raise NotImplementedError("Quad cell is not yet implemented")
     if pd:
-        raise(NotImplemented, "Pulse duration is not yet implemented")
+        raise NotImplementedError("Pulse duration is not yet implemented")
     if wfs:
-        raise(NotImplemented, "Wavefront sensor is not yet implemented")
+        raise NotImplementedError("Wavefront sensor is not yet implemented")
     if ell:
         cpt = Cpt(Ell6, '_SL1:ELL:M1', kind='normal')
         cpts['slider'] = cpt
@@ -122,7 +122,7 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     # Create an object for a basic tuttifrutti containing NF/FF cameras,
     # a spectrometer, and a filter slider.
 
-    ttf = TutttFrutti('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True)
+    ttf = TuttiFrutti('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True)
 
     # Create a TuttiFrutti as above, while including a non-standard component.
 
@@ -135,7 +135,7 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
 
     dmisc = {'apple': apple, 'orange' : orange}
 
-    ttf = TutttFrutti('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
+    ttf = TuttiFrutti('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
                            misc=dmisc)
     """
     cls = TuttiFruttiCls(prefix, name, nf=nf, ff=ff, spec=spec, pm=pm,

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -1,0 +1,101 @@
+"""
+Classes for the Tuttifrutti diagnostic stack designed for the MODS TILEs.
+"""
+
+
+from ophyd import Component as Cpt
+from ophyd import Device, DynamicDeviceComponent
+from ophyd.device import create_device_from_components
+from ophyd.signal import EpicsSignal, EpicsSignalRO
+
+from pcdsdevices.areadetector.detectors import PCDSAreaDetectorTyphos
+from pcdsdevices.lasers.qmini import QminiSpectrometer
+from pcdsdevices.lasers.ek9000 import El3174AiCh
+from pcdsdevices.lasers.elliptec import Ell6
+
+def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
+                diode=False, em=False, qc=False, pd=False, wfs=False,
+                ell=False):
+    """
+    Base class for Tuttifrutti.
+
+    Sufficient for basic control and generation of Typhos screens.
+
+    Parameters
+    ----------
+    prefix : str
+        The PV base of the tuttifrutti diagnostic stack. All consituent
+        diagnostics have regimented PV suffixes based on this prefix.
+
+    nf : bool <False>
+        Flag indicating if a near-field camera is installed. 
+        
+    ff : bool <False>
+        Flag indicating if a far-field camera is installed. 
+
+    spec : bool <False>
+        Flag indicating if a spectrometer is installed. 
+
+    pm : bool <False>
+        Flag indicating if a power meter is installed.
+
+    diode : bool <False> (Not Implemented)
+        Flag indicating if a diode is installed.
+
+    em : bool <False> (Not Implemented)
+        Flag indicating if an energy meter is installed.
+
+    qc : bool <False> (Not Implemented)
+        Flag indicating if a quad cell detector is installed.
+    
+    pd : bool <False> (Not Implemented)
+        Flag indicating if a pulse duration diagnostic is installed.  
+
+    wfs : bool <False> (Not Implemented)
+        Flag indicating if a wavefront sensor is installed.  
+
+    ell : bool <False>
+        Flag indicating if a 2-position filter slider is installed is
+        installed.
+
+    Examples
+    --------
+    # Create an object for a basic tuttifrutti containing NF/FF cameras,
+    # a spectrometer, and a filter slider. 
+
+    ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True)
+    """
+    cpts = {}
+    if nf:
+        cpt = Cpt(PCDSAreaDetectorTyphos, '_NF:', kind='normal')
+        cpts['nf_camera'] = cpt
+    if nf:
+        cpt = Cpt(PCDSAreaDetectorTyphos, '_FF:', kind='normal')
+        cpts['ff_camera'] = cpt
+    if spec:
+        cpt = Cpt(QminiSpectrometer, '_SP', kind='normal')
+        cpts['spectrometer'] = cpt
+    if pm:
+        cpt = Cpt(El3174AiCh, '_PM', kind='normal')
+        cpts['power_meter'] = cpt
+    if diode:
+        raise(NotImplemented, "Diode is not yet implemented")
+    if em:
+        raise(NotImplemented, "Energy meter is not yet implemented")
+    if qc:
+        raise(NotImplemented, "Quad cell is not yet implemented")
+    if pd:
+        raise(NotImplemented, "Pulse duration is not yet implemented")
+    if wfs:
+        raise(NotImplemented, "Wavefront sensor is not yet implemented")
+    if ell:
+        cpt = Cpt(Ell6, '_SL', kind='normal')
+        cpts['slider'] = cpt
+
+    cls_name = prefix.replace(':', '_') + '_TuttiFrutti'
+    cls = create_device_from_components(cls_name, base_class=Device,
+                                        class_kwargs=None, **cpts)
+
+    dev = cls(prefix, name=name)
+
+    return dev

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -122,7 +122,7 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     # Create an object for a basic tuttifrutti containing NF/FF cameras,
     # a spectrometer, and a filter slider.
 
-    ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True)
+    ttf = TutttFrutti('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True)
 
     # Create a TuttiFrutti as above, while including a non-standard component.
 
@@ -133,9 +133,9 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     apple = Cpt(Apple, ':APPLE', kind='normal') # Use TuttiFrutti base PV
     orange = FCpt(Orange, 'IOC:LAS:ORANGE', kind='normal') # Use full base PV
 
-    dmisc = {'apple': apple, 'banana' : banana}
+    dmisc = {'apple': apple, 'orange' : orange}
 
-    ttf = TutttFruttiBase('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
+    ttf = TutttFrutti('LAS:TTF:01', nf=True, ff=True, spec=True, ell=True,
                            misc=dmisc)
     """
     cls = TuttiFruttiCls(prefix, name, nf=nf, ff=ff, spec=spec, pm=pm,

--- a/pcdsdevices/lasers/tuttifrutti.py
+++ b/pcdsdevices/lasers/tuttifrutti.py
@@ -94,16 +94,16 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     """
     cpts = {}
     if nf:
-        cpt = Cpt(PCDSAreaDetectorTyphos, '_NF:', kind='normal')
+        cpt = Cpt(PCDSAreaDetectorTyphos, '_NF1:', kind='normal')
         cpts['nf_camera'] = cpt
     if nf:
-        cpt = Cpt(PCDSAreaDetectorTyphos, '_FF:', kind='normal')
+        cpt = Cpt(PCDSAreaDetectorTyphos, '_FF1:', kind='normal')
         cpts['ff_camera'] = cpt
     if spec:
-        cpt = Cpt(QminiSpectrometer, '_SP', kind='normal')
+        cpt = Cpt(QminiSpectrometer, '_SP1', kind='normal')
         cpts['spectrometer'] = cpt
     if pm:
-        cpt = Cpt(El3174AiCh, '_PM', kind='normal')
+        cpt = Cpt(El3174AiCh, '_PM1', kind='normal')
         cpts['power_meter'] = cpt
     if diode:
         raise(NotImplemented, "Diode is not yet implemented")
@@ -116,7 +116,7 @@ def TuttiFrutti(prefix, name, nf=False, ff=False, spec=False, pm=False,
     if wfs:
         raise(NotImplemented, "Wavefront sensor is not yet implemented")
     if ell:
-        cpt = Cpt(Ell6, '_SL', kind='normal')
+        cpt = Cpt(Ell6, '_SL1:ELL:M1', kind='normal')
         cpts['slider'] = cpt
     # This feels kind of hacky, but also kind of cool.
     if misc:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a module for generating TuttiFrutti classes and instantiating them.

Classes are dynamically created based on the specified diagnostics/devices. In theory there are about factorial(10) combinations of diagnostics/devices, so this seems like the way to go.

A factory function is provided for creating custom TuttiFrutti classes. Another function instantiates the device for you and returns it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The new laser control system uses TuttiFrutti diagnostic packages all over the place. Each TuttiFrutti is a special snowflake of diagnostics, tailored to the application. The suite of diagnostics used is standardized, and each TuttiFrutti is a single assembly, so it still makes sense to group them. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using devices in the B40 Heinz lab. Used as components in a forthcoming PR with MODS and TILE devices. 

Generates nice Typhos screens as well. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I wrote a long and somewhat silly docstring. 
<!--
## Screenshots (if appropriate):
-->
