### PR TITLE
ENH: State positioners for New HXR FEE attenuator

### DIFF
--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -14,7 +14,7 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal, SignalRO
 from .epics_motor import BeckhoffAxis
 from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import (BaseInterface, FltMvInterface,
-                        LightpathMixin, LightpathInOutMixin)
+                        LightpathInOutMixin)
 from .signal import InternalSignal
 
 logger = logging.getLogger(__name__)
@@ -356,6 +356,7 @@ def set_combined_attenuation(attenuation, *attenuators):
         else:
             attenuators[i].actuate_value()
 '''
+
 
 class FEESolidAttenuatorBlade(Device, BaseInterface, LightpathInOutMixin):
     lightpath_cpts = ['state']

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -552,16 +552,6 @@ class TwinCATStateConfigAll(Device):
     state03 = Cpt(TwinCATStateConfigOne, ':03', kind='omitted')
     state04 = Cpt(TwinCATStateConfigOne, ':04', kind='omitted')
     state05 = Cpt(TwinCATStateConfigOne, ':05', kind='omitted')
-    state06 = Cpt(TwinCATStateConfigOne, ':06', kind='omitted')
-    state07 = Cpt(TwinCATStateConfigOne, ':07', kind='omitted')
-    state08 = Cpt(TwinCATStateConfigOne, ':08', kind='omitted')
-    state09 = Cpt(TwinCATStateConfigOne, ':09', kind='omitted')
-    state10 = Cpt(TwinCATStateConfigOne, ':10', kind='omitted')
-    state11 = Cpt(TwinCATStateConfigOne, ':11', kind='omitted')
-    state12 = Cpt(TwinCATStateConfigOne, ':12', kind='omitted')
-    state13 = Cpt(TwinCATStateConfigOne, ':13', kind='omitted')
-    state14 = Cpt(TwinCATStateConfigOne, ':14', kind='omitted')
-    state15 = Cpt(TwinCATStateConfigOne, ':15', kind='omitted')
 
 
 class TwinCATStatePositioner(StatePositioner):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the newly added state positioners into the ophyd device for the new hxr fee attenuator.
This PR also contains some backend work on the lightpath interface features that were needed for this device.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Companion to #489 
Needed before we address #495 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The blades move. All PVs connect. The typhos screen looks OK (about as good as a screen with 19 motors and 19 state positioners could look). The lightpath that I'm working on looks good.