### PR TITLE
ENH: CCM missing motors and TST: Expanded test class

### DIFF
--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -8,7 +8,7 @@ from ophyd.pseudopos import PseudoPositioner
 from ophyd.pv_positioner import PVPositionerPC
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 
-from .epics_motor import IMS
+from .epics_motor import IMS, PCDSMotorBase
 from .inout import InOutPositioner
 from .interface import FltMvInterface
 from .pseudopos import PseudoSingleInterface, SyncAxesBase
@@ -138,6 +138,8 @@ class CCM(InOutPositioner):
 
     calc = FCpt(CCMCalc, '{self.alio_prefix}', kind='hinted')
     theta2fine = FCpt(CCMMotor, '{self.theta2fine_prefix}')
+    theta2coarse = FCpt(PCDSMotorBase, '{self.theta2coarse_prefix}')
+    chi2 = FCpt(PCDSMotorBase, '{self.chi2_prefix}')
     x = FCpt(CCMX,
              down_prefix='{self.x_down_prefix}',
              up_prefix='{self.x_up_prefix}',
@@ -156,11 +158,13 @@ class CCM(InOutPositioner):
 
     tab_component_names = True
 
-    def __init__(self, alio_prefix, theta2fine_prefix, x_down_prefix,
-                 x_up_prefix, y_down_prefix, y_up_north_prefix,
-                 y_up_south_prefix, in_pos, out_pos, *args, **kwargs):
+    def __init__(self, alio_prefix, theta2fine_prefix, theta2coarse_prefix,
+                 chi2_prefix, x_down_prefix, x_up_prefix,
+                 y_down_prefix, y_up_north_prefix, y_up_south_prefix,
+                 in_pos, out_pos, *args, **kwargs):
         self.alio_prefix = alio_prefix
         self.theta2fine_prefix = theta2fine_prefix
+        self.theta2coarse_prefix = theta2coarse_prefix
         self.x_down_prefix = x_down_prefix
         self.x_up_prefix = x_up_prefix
         self.y_down_prefix = y_down_prefix

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -59,11 +59,11 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
 
     def __init__(self, *args, theta0=default_theta0, dspacing=default_dspacing,
                  gr=default_gr, gd=default_gd, **kwargs):
-        super().__init__(*args, auto_target=False, **kwargs)
         self.theta0 = theta0
         self.dspacing = dspacing
         self.gr = gr
         self.gd = gd
+        super().__init__(*args, auto_target=False, **kwargs)
 
     def forward(self, pseudo_pos):
         """Take energy, wavelength, or theta and map to alio."""

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -165,6 +165,7 @@ class CCM(InOutPositioner):
         self.alio_prefix = alio_prefix
         self.theta2fine_prefix = theta2fine_prefix
         self.theta2coarse_prefix = theta2coarse_prefix
+        self.chi2_prefix = chi2_prefix
         self.x_down_prefix = x_down_prefix
         self.x_up_prefix = x_up_prefix
         self.y_down_prefix = y_down_prefix

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -45,13 +45,13 @@ class CCMMotor(PVPositioner, FltMvInterface):
         self._last_setpoint = None
         super().__init__(prefix, name=name, **kwargs)
 
-    @setpoint.sub_value
+    @readback.sub_value
     def _update_readback(self, *args, value, **kwargs):
         """Callback to cache the readback and update done state."""
         self._last_readback = value
         self._update_done()
 
-    @readback.sub_value
+    @setpoint.sub_value
     def _update_setpoint(self, *args, value, **kwargs):
         """Callback to cache the setpoint and update done state."""
         self._last_setpoint = value

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -53,7 +53,7 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
     energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted')
     wavelength = Cpt(PseudoSingleInterface, egu='A')
     theta = Cpt(PseudoSingleInterface, egu='deg')
-    alio = Cpt(CCMMotor)
+    alio = Cpt(CCMMotor, '')
 
     tab_component_names = True
 

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -34,7 +34,7 @@ class FastMotor(FltMvInterface, SoftPositioner, Device):
     user_readback = Cpt(AttributeSignal, 'position')
 
     def __init__(self, *args, init_pos=0, **kwargs):
-        super().__init__(*args, init_pos=init_pos, **kwargs)
+        super().__init__(init_pos=init_pos, **kwargs)
 
 
 class SlowMotor(FastMotor):

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -1,9 +1,10 @@
 import logging
 
 import numpy as np
-import pcdsdevices.ccm as ccm
 import pytest
 from ophyd.sim import fake_device_cache, make_fake_device
+
+import pcdsdevices.ccm as ccm
 from pcdsdevices.sim import FastMotor
 
 logger = logging.getLogger(__name__)
@@ -100,25 +101,22 @@ def test_ccm_calc(fake_ccm):
     energy_func = ccm.wavelength_to_energy(wavelength)
     assert energy == energy_func
 
-    calc.alio.readback.sim_put(0)
-    calc.alio.setpoint.sim_put(0)
+    calc.alio.move(0)
     calc.move(energy, wait=False)
-    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
+    assert np.isclose(calc.alio.position, SAMPLE_ALIO)
 
-    calc.alio.readback.sim_put(0)
-    calc.alio.setpoint.sim_put(0)
+    calc.alio.move(0)
     calc.move(wavelength=wavelength, wait=False)
-    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
+    assert np.isclose(calc.alio.position, SAMPLE_ALIO)
 
-    calc.alio.readback.sim_put(0)
-    calc.alio.setpoint.sim_put(0)
+    calc.alio.move(0)
     calc.move(theta=theta, wait=False)
-    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
+    assert np.isclose(calc.alio.position, SAMPLE_ALIO)
 
-    calc.alio.readback.sim_put(calc.alio.setpoint.get())
+    calc.alio.move(calc.alio.position)
     calc.move(energy=calc.energy.position, wavelength=calc.wavelength.position,
               theta=calc.theta.position, wait=False)
-    assert np.isclose(calc.alio.setpoint.get(), SAMPLE_ALIO)
+    assert np.isclose(calc.alio.position, SAMPLE_ALIO)
 
 
 # Make sure sync'd axes work and that unk/in/out states work
@@ -158,6 +156,7 @@ def test_ccm_main(fake_ccm):
 @pytest.mark.timeout(5)
 def test_disconnected_ccm():
     ccm.CCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
+            theta2coarse_prefix='THTA', chi2_prefix='CHI',
             x_down_prefix='X:DOWN', x_up_prefix='X:UP',
             y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
             y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -1,10 +1,10 @@
 import logging
 
 import numpy as np
-import pytest
-from ophyd.sim import make_fake_device
-
 import pcdsdevices.ccm as ccm
+import pytest
+from ophyd.sim import fake_device_cache, make_fake_device
+from pcdsdevices.sim import FastMotor
 
 logger = logging.getLogger(__name__)
 
@@ -46,19 +46,24 @@ def test_energy_wavelength_inversion():
 
 @pytest.fixture(scope='function')
 def fake_ccm():
+    return make_fake_ccm()
+
+
+def make_fake_ccm():
+    fake_device_cache[ccm.CCMMotor] = FastMotor
     FakeCCM = make_fake_device(ccm.CCM)
     fake_ccm = FakeCCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
                        x_down_prefix='X:DOWN', x_up_prefix='X:UP',
                        y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
                        y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,
                        name='fake_ccm')
-    fake_ccm.calc.alio.readback.sim_put(SAMPLE_ALIO)
-    fake_ccm.calc.alio.setpoint.sim_put(SAMPLE_ALIO)
+    fake_ccm.calc.alio.set(SAMPLE_ALIO)
 
     def init_pos(mot, pos=0):
         mot.user_readback.sim_put(0)
         mot.user_setpoint.sim_put(0)
         mot.motor_spg.sim_put(2)
+        mot.part_number.sim_put('tasdf')
 
     init_pos(fake_ccm.x.down)
     init_pos(fake_ccm.x.up)

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -53,6 +53,7 @@ def make_fake_ccm():
     fake_device_cache[ccm.CCMMotor] = FastMotor
     FakeCCM = make_fake_device(ccm.CCM)
     fake_ccm = FakeCCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
+                       theta2coarse_prefix='THTA', chi2_prefix='CHI',
                        x_down_prefix='X:DOWN', x_up_prefix='X:UP',
                        y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
                        y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add missing CCM motors (coarse theta, chi)
Fix bad CCM PVs so they all connect for XCS (XPP still has some IOCs down)
Add done flag to the PVPositioner so it will run properly in scans
Update test class to make it useful

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Beam time with the CCM soon
Motors were missing
PVs were wrong
Scans need to work
I wanted to verify bluesky scans worked with the energy motor but the test class was non-functional
partially addresses #488 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests pass
The logic seems sound
The PVs connect

Test cases:
```
xpp_ccm = CCM(alio_prefix='XPP:MON:MPZ:07A', theta2fine_prefix='XPP:MON:MPZ:08',
              theta2coarse_prefix='XPP:MON:PIC:06', chi2_prefix='XPP:MON:PIC:05',
              x_down_prefix='XPP:MON:MMS:22', x_up_prefix='XPP:MON:MMS:23',
              y_down_prefix='XPP:MON:MMS:24', y_up_north_prefix='XPP:MON:MMS:26',
              y_up_south_prefix='XPP:MON:MMS:25', in_pos=-8.92, out_pos=0,
              name='xpp_ccm')

xcs_ccm = CCM(alio_prefix='XCS:MON:MPZ:01', theta2fine_prefix='XCS:MON:MPZ:02',
              theta2coarse_prefix='XCS:MON:PIC:05', chi2_prefix='XCS:MON:PIC:06',
              x_down_prefix='XCS:MON:MMS:24', x_up_prefix='XCS:MON:MMS:25',
              y_down_prefix='XCS:MON:MMS:26', y_up_north_prefix='XCS:MON:MMS:27',
              y_up_south_prefix='XCS:MON:MMS:28', in_pos=3.3, out_pos=13.18,
              name='xcs_ccm')
```