### PR TITLE
ENH: IPython status prints

### DIFF
--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -779,25 +779,24 @@ def render_ascii_att(blade_states):
         The lines that should be printed to the screen.
     """
     filter_line = 'filter # |'
-    out_line =    ' OUT     |'
-    in_line =     ' IN      |'
+    out_line = ' OUT     |'
+    in_line = ' IN      |'
     for i, state in enumerate(blade_states):
         state = get_blade_enum(state)
         filter_line += f'{i}|'
         if state == BladeStateEnum.OUT:
             out_line += 'X|'
-            in_line +=  ' |'
+            in_line += ' |'
         elif state == BladeStateEnum.IN:
             out_line += ' |'
-            in_line +=  'X|'
+            in_line += 'X|'
         elif state == BladeStateEnum.STUCK_OUT:
             out_line += 'S|'
-            in_line +=  ' |'
+            in_line += ' |'
         elif state == BladeStateEnum.STUCK_IN:
             out_line += ' |'
-            in_line +=  'S|'
+            in_line += 'S|'
         else:
             out_line += '?|'
-            in_line +=  '?|'
+            in_line += '?|'
     return [filter_line, out_line, in_line]
-

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -311,6 +311,8 @@ class AttBase3rd(AttBase):
     `~Attenuator.use_3rd` argument in the :func:`Attenuator` factory function.
     """
 
+    _harmonic = '3rd'
+
     # Positioner Signals
     setpoint = Cpt(EpicsSignal, ':COM:R3_DES', kind='normal')
     readback = Cpt(EpicsSignalRO, ':COM:R3_CUR', kind='hinted')

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -141,7 +141,10 @@ class BaseInterface(OphydObject):
             Formatted string with all relevant status information.
         """
         lines = self._status_info_lines(status_info)
-        return '\n'.join(lines)
+        if lines:
+            return '\n'.join(lines)
+        else:
+            return f'{self.name}: No status available'
 
     def _status_info_lines(self, status_info, prefix='', indent=0):
         full_name = status_info['name']
@@ -167,11 +170,15 @@ class BaseInterface(OphydObject):
                 else:
                     # Record extra value
                     data_lines.append(f'{key}: {value}')
-            # Indent the subdevices
-            if indent:
-                for i, line in enumerate(data_lines):
-                    data_lines[i] = ' ' * indent + line
-            return header_lines + data_lines
+            if data_lines:
+                # Indent the subdevices
+                if indent:
+                    for i, line in enumerate(data_lines):
+                        data_lines[i] = ' ' * indent + line
+                return header_lines + data_lines
+            else:
+                # No data = do not print header
+                return []
         else:
             # Just show the name/value pair
             value = status_info['value']

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -180,9 +180,17 @@ class BaseInterface(OphydObject):
                 # No data = do not print header
                 return []
         else:
-            # Just show the name/value pair
+            # Show the name/value pair for a signal
             value = status_info['value']
-            return [f'{name}: {value}']
+            value_text = str(value)
+            if '\n' in value_text:
+                # Multiline values (arrays) need special handling
+                value_lines = value_text.split('\n')
+                for i, line in enumerate(value_lines):
+                    value_lines[i] = ' ' * 2 + line
+                return [f'{name}:'] + value_lines
+            else:
+                return [f'{name}: {value}']
 
     def status_info(self):
         """

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -298,6 +298,8 @@ def device_info(device, subdevice_filter=None, devices=None):
                 cpt = getattr(device, cpt_name)
             except AttributeError:
                 # Why are we ever in this block?
+                logger.debug(f'Getattr {name}.{cpt_name} failed.',
+                             exc_info=True)
                 continue
             cpt_info = ophydobj_info(cpt, subdevice_filter=subdevice_filter,
                                      devices=devices)

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -21,6 +21,7 @@ from ophyd.signal import Signal, AttributeSignal
 from ophyd.status import wait as status_wait
 
 from . import utils as util
+from .signal import NotImplementedSignal
 
 try:
     import fcntl
@@ -271,9 +272,13 @@ def device_info(device, subdevice_filter=None, devices=None):
             # Usually these are lazy because they take too long to getattr
             if cpt_desc.lazy:
                 continue
-            # Skip attribute signals as well
+            # Skip attribute signals
             # Indeterminate get times, no real connected bool, etc.
             if issubclass(cpt_desc.cls, AttributeSignal):
+                continue
+            # Skip not implemented signals
+            # They never have interesting information
+            if issubclass(cpt_desc.cls, NotImplementedSignal):
                 continue
             try:
                 cpt = getattr(device, cpt_name)

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -253,6 +253,9 @@ def device_info(device, subdevice_filter=None, devices=None):
         info['position'] = device.position
     except AttributeError:
         pass
+    except Exception:
+        # Something else went wrong! We have a position but it didn't work
+        info['position'] = None
     if device not in devices:
         devices.add(device)
         for cpt_name, cpt_desc in device._sig_attrs.items():

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -289,7 +289,7 @@ def device_info(device, subdevice_filter=None, devices=None):
                         continue
                 except AttributeError:
                     pass
-                if cpt_name == 'user_readback':
+                if cpt_name in ('readback', 'user_readback'):
                     continue
 
             if not callable(subdevice_filter) or subdevice_filter(cpt_info):

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -75,7 +75,7 @@ class PIM(Device, BaseInterface):
 
     _prefix_start = ''
 
-    state = Cpt(PIMY, '', kind='omitted')
+    state = Cpt(PIMY, '', kind='normal')
     zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetectorEmbedded, '{self._prefix_det}',
                     kind='normal')

--- a/pcdsdevices/sensors.py
+++ b/pcdsdevices/sensors.py
@@ -5,7 +5,6 @@ Classes for the various thermocouples, rtds, flow meters, O2 sensors, etc.
 """
 from ophyd import Component as Cpt
 from ophyd import Device
-from ophyd.signal import SignalRO
 
 from .interface import BaseInterface
 from .signal import PytmcSignal, NotImplementedSignal

--- a/pcdsdevices/sensors.py
+++ b/pcdsdevices/sensors.py
@@ -8,7 +8,7 @@ from ophyd import Device
 from ophyd.signal import SignalRO
 
 from .interface import BaseInterface
-from .signal import PytmcSignal
+from .signal import PytmcSignal, NotImplementedSignal
 
 
 class TwinCATThermocouple(Device, BaseInterface):
@@ -36,5 +36,4 @@ class RTD(Device, BaseInterface):
         The PV base of the device.
     """
 
-    not_implemented = Cpt(SignalRO, name="Not Implemented",
-                          value="Not Implemented", kind='normal')
+    not_implemented = Cpt(NotImplementedSignal, kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make every PCDS device give a detailed printout of the current status when returned in the IPython terminal. This works by overriding the pretty printing behavior, which is what IPython uses to decide how to represent objects that it returns to the user. The implementation is set up so that you can override the value gatherer and the renderer separately, and so that the default implementation will never throw an exception (it will always show you "something").

This includes only one case of device-specific handling with the attenuators. Positioners and devices with presets also have some special handling in the form of extra data fields.

### TODO
- [x] Default behavior
- [x] Check tons of live devices
- [x] Attenuators
- [x] Preset positions

### Follow-ups for another PR
- Apply the attenuator status to the new hxr attenuator/calculator pair from #495 
- Combine att/3rd harmonic att into one class in a reasonable way (for ease of use) and include both the 1st/3rd harmonic status lines
- Use a custom ipython handler rather than the pretty print overrides to avoid situations like arrays of devices looking extremely unreadable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #502 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It looks good for my fake ccm. I will proceed to trying it on real devices and iterating as needed.
```
In [3]: fake_ccm
Out[3]:

fake_ccm
--------
position: OUT

calc
----
  position: FakeCCMCalcPseudoPos(energy=7.137728336602235, wavelength=1.7370260418039398, theta=16.08031436296102)

  energy
  ------
    position: 7.137728336602235
    setpoint: 7.137728336602235

  wavelength
  ----------
    position: 1.7370260418039398
    setpoint: 1.7370260418039398

  theta
  -----
    position: 16.08031436296102
    setpoint: 16.08031436296102

  alio
  ----
    position: 4.575

theta2fine
----------
  position: 0

theta2coarse
------------
  position: None
  user_setpoint: 0
  description: 0

chi2
----
  position: None
  user_setpoint: 0
  description: 0
```
