### PR TITLE
ENH: include calculator in AT2L0 object

### DIFF
--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -432,61 +432,6 @@ class FEESolidAttenuatorBlade(Device, BaseInterface, LightpathInOutMixin):
     motor = Cpt(BeckhoffAxis, '')
 
 
-class FEESolidAttenuator(Device, BaseInterface, LightpathInOutMixin):
-    """
-    Solid attenuator variant from the LCLS-II XTES project.
-
-    Motorized, 18 filters + 1 inspection mirror.
-
-    This is a quick-and-dirty Ophyd device for controlling AT2L0 motion and
-    generating a PyDM control screen.
-
-    Parameters
-    ----------
-    prefix : str
-        Full Solid Attenuator base PV.
-
-    name : str
-        Alias for the Solid Attenuator.
-    """
-
-    # QIcon for UX
-    _icon = 'fa.barcode'
-
-    # Register that all blades are needed for lightpath calc
-    lightpath_cpts = ['blade_{:02}'.format(i+1) for i in range(19)]
-
-    # Summary for lightpath view
-    num_in = Cpt(InternalSignal, kind='hinted')
-    num_out = Cpt(InternalSignal, kind='hinted')
-
-    blade_01 = Cpt(FEESolidAttenuatorBlade, ':MMS:01')
-    blade_02 = Cpt(FEESolidAttenuatorBlade, ':MMS:02')
-    blade_03 = Cpt(FEESolidAttenuatorBlade, ':MMS:03')
-    blade_04 = Cpt(FEESolidAttenuatorBlade, ':MMS:04')
-    blade_05 = Cpt(FEESolidAttenuatorBlade, ':MMS:05')
-    blade_06 = Cpt(FEESolidAttenuatorBlade, ':MMS:06')
-    blade_07 = Cpt(FEESolidAttenuatorBlade, ':MMS:07')
-    blade_08 = Cpt(FEESolidAttenuatorBlade, ':MMS:08')
-    blade_09 = Cpt(FEESolidAttenuatorBlade, ':MMS:09')
-    blade_10 = Cpt(FEESolidAttenuatorBlade, ':MMS:10')
-    blade_11 = Cpt(FEESolidAttenuatorBlade, ':MMS:11')
-    blade_12 = Cpt(FEESolidAttenuatorBlade, ':MMS:12')
-    blade_13 = Cpt(FEESolidAttenuatorBlade, ':MMS:13')
-    blade_14 = Cpt(FEESolidAttenuatorBlade, ':MMS:14')
-    blade_15 = Cpt(FEESolidAttenuatorBlade, ':MMS:15')
-    blade_16 = Cpt(FEESolidAttenuatorBlade, ':MMS:16')
-    blade_17 = Cpt(FEESolidAttenuatorBlade, ':MMS:17')
-    blade_18 = Cpt(FEESolidAttenuatorBlade, ':MMS:18')
-    blade_19 = Cpt(FEESolidAttenuatorBlade, ':MMS:19')
-
-    def _set_lightpath_states(self, lightpath_values):
-        info = super()._set_lightpath_states(lightpath_values)
-        if info is not None:
-            self.num_in.put(info['in_check'].count(True), force=True)
-            self.num_out.put(info['out_check'].count(True), force=True)
-
-
 class GasAttenuator(Device, BaseInterface):
     """
     AT*:GAS, Base class for an LCLS-II XTES gas attenuator.
@@ -749,6 +694,61 @@ class AttenuatorCalculator_AT2L0(AttenuatorCalculatorBase):
          for idx, attr in _filter_index_to_attr.items()
          }
     )
+
+
+class FEESolidAttenuator(Device, BaseInterface, LightpathInOutMixin):
+    """
+    Solid attenuator variant from the LCLS-II XTES project.
+
+    Motorized, 18 filters + 1 inspection mirror.
+    This class includes a calculator to aid in determining which filters to
+    insert for a given attenuation at a specific energy.
+
+    Parameters
+    ----------
+    prefix : str
+        Solid Attenuator base PV.
+
+    name : str
+        Alias for the Solid Attenuator.
+    """
+
+    # QIcon for UX
+    _icon = 'fa.barcode'
+
+    # Register that all blades are needed for lightpath calc
+    lightpath_cpts = ['blade_{:02}'.format(i+1) for i in range(19)]
+
+    # Summary for lightpath view
+    num_in = Cpt(InternalSignal, kind='hinted')
+    num_out = Cpt(InternalSignal, kind='hinted')
+
+    calculator = Cpt(AttenuatorCalculator_AT2L0, ':CALC')
+    blade_01 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:01')
+    blade_02 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:02')
+    blade_03 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:03')
+    blade_04 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:04')
+    blade_05 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:05')
+    blade_06 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:06')
+    blade_07 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:07')
+    blade_08 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:08')
+    blade_09 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:09')
+    blade_10 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:10')
+    blade_11 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:11')
+    blade_12 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:12')
+    blade_13 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:13')
+    blade_14 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:14')
+    blade_15 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:15')
+    blade_16 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:16')
+    blade_17 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:17')
+    blade_18 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:18')
+    blade_19 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:19')
+
+    def _set_lightpath_states(self, lightpath_values):
+        info = super()._set_lightpath_states(lightpath_values)
+        if info is not None:
+            self.num_in.put(info['in_check'].count(True), force=True)
+            self.num_out.put(info['out_check'].count(True), force=True)
 
 
 class BladeStateEnum(enum.Enum):

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -6,6 +6,7 @@ import logging
 import time
 
 import numpy as np
+
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import DynamicDeviceComponent as DDC
@@ -13,10 +14,10 @@ from ophyd.device import FormattedComponent as FCpt
 from ophyd.pv_positioner import PVPositioner, PVPositionerPC
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal, SignalRO
 
+from .component import UnrelatedComponent as UCpt
 from .epics_motor import BeckhoffAxis
 from .inout import InOutPositioner, TwinCATInOutPositioner
-from .interface import (BaseInterface, FltMvInterface,
-                        LightpathInOutMixin)
+from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
 from .signal import InternalSignal
 from .variety import set_metadata
 
@@ -696,9 +697,9 @@ class AttenuatorCalculator_AT2L0(AttenuatorCalculatorBase):
     )
 
 
-class FEESolidAttenuator(Device, BaseInterface, LightpathInOutMixin):
+class AT2L0(Device, BaseInterface, LightpathInOutMixin):
     """
-    Solid attenuator variant from the LCLS-II XTES project.
+    AT2L0 solid attenuator variant from the LCLS-II XTES project.
 
     Motorized, 18 filters + 1 inspection mirror.
     This class includes a calculator to aid in determining which filters to
@@ -723,32 +724,39 @@ class FEESolidAttenuator(Device, BaseInterface, LightpathInOutMixin):
     num_in = Cpt(InternalSignal, kind='hinted')
     num_out = Cpt(InternalSignal, kind='hinted')
 
-    calculator = Cpt(AttenuatorCalculator_AT2L0, ':CALC')
-    blade_01 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:01')
-    blade_02 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:02')
-    blade_03 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:03')
-    blade_04 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:04')
-    blade_05 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:05')
-    blade_06 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:06')
-    blade_07 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:07')
-    blade_08 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:08')
-    blade_09 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:09')
-    blade_10 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:10')
-    blade_11 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:11')
-    blade_12 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:12')
-    blade_13 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:13')
-    blade_14 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:14')
-    blade_15 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:15')
-    blade_16 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:16')
-    blade_17 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:17')
-    blade_18 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:18')
-    blade_19 = Cpt(FEESolidAttenuatorBlade, 'XTES:MMS:19')
+    calculator = UCpt(AttenuatorCalculator_AT2L0)
+    blade_01 = Cpt(FEESolidAttenuatorBlade, ':MMS:01')
+    blade_02 = Cpt(FEESolidAttenuatorBlade, ':MMS:02')
+    blade_03 = Cpt(FEESolidAttenuatorBlade, ':MMS:03')
+    blade_04 = Cpt(FEESolidAttenuatorBlade, ':MMS:04')
+    blade_05 = Cpt(FEESolidAttenuatorBlade, ':MMS:05')
+    blade_06 = Cpt(FEESolidAttenuatorBlade, ':MMS:06')
+    blade_07 = Cpt(FEESolidAttenuatorBlade, ':MMS:07')
+    blade_08 = Cpt(FEESolidAttenuatorBlade, ':MMS:08')
+    blade_09 = Cpt(FEESolidAttenuatorBlade, ':MMS:09')
+    blade_10 = Cpt(FEESolidAttenuatorBlade, ':MMS:10')
+    blade_11 = Cpt(FEESolidAttenuatorBlade, ':MMS:11')
+    blade_12 = Cpt(FEESolidAttenuatorBlade, ':MMS:12')
+    blade_13 = Cpt(FEESolidAttenuatorBlade, ':MMS:13')
+    blade_14 = Cpt(FEESolidAttenuatorBlade, ':MMS:14')
+    blade_15 = Cpt(FEESolidAttenuatorBlade, ':MMS:15')
+    blade_16 = Cpt(FEESolidAttenuatorBlade, ':MMS:16')
+    blade_17 = Cpt(FEESolidAttenuatorBlade, ':MMS:17')
+    blade_18 = Cpt(FEESolidAttenuatorBlade, ':MMS:18')
+    blade_19 = Cpt(FEESolidAttenuatorBlade, ':MMS:19')
+
+    def __init__(self, *args, **kwargs):
+        UCpt.collect_prefixes(self, dict(calculator_prefix='AT2L0:CALC'))
+        super().__init__(*args, **kwargs)
 
     def _set_lightpath_states(self, lightpath_values):
         info = super()._set_lightpath_states(lightpath_values)
         if info is not None:
             self.num_in.put(info['in_check'].count(True), force=True)
             self.num_out.put(info['out_check'].count(True), force=True)
+
+
+FEESolidAttenuator = AT2L0  # back-compatibility
 
 
 class BladeStateEnum(enum.Enum):


### PR DESCRIPTION
Closes #495 

There's a slight issue here as I'm modifying an existing object with an existing happi entry.

Two options that seem obvious to me:
1. Merging/using this will have to wait for a tag as I modified the prefix of the `FEESolidAttenuator` object (was: `ATL0:XTES`, now: `AT2L0`)
2. Or, if needed before a tag, these could become 'UnrelatedComponents' and have two separate prefixes (ignoring the fact that `AT2L0:CALC` and `AT2L0:XTES` do share a base PV)

Opinions?

Screen:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/5139267/90186577-35158d00-dd6d-11ea-9f5b-1d8511eb9ec8.png">