### PR TITLE
BUG: Fix typo in PV name of BeckhoffJet slits

### DIFF
--- a/pcdsdevices/jet.py
+++ b/pcdsdevices/jet.py
@@ -109,5 +109,5 @@ class BeckhoffJet(Device, BaseInterface):
     tab_component_names = True
 
     jet = Cpt(BeckhoffJetManipulator, ':JET', kind='normal')
-    ss = Cpt(BeckhoffJetSlits, ':SLIT', kind='normal')
+    ss = Cpt(BeckhoffJetSlits, ':SS', kind='normal')
     vh_epix_x = Cpt(BeckhoffAxis, ':DET:X', kind='normal')


### PR DESCRIPTION
## Description
IOC had ":SS", class had ":SLIT". Fixed the class to match.

## Motivation and Context
Devices work better when their PVs actually exist.

## How Has This Been Tested?
Ran xcs3, and `ljh` shows as connected now.

## Where Has This Been Documented?
Nowhere