### PR TITLE
ENH: CCM with Vernier

### DIFF
--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,8 +1,10 @@
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
-from ophyd.signal import AttributeSignal, EpicsSignalRO
+from ophyd.device import FormattedComponent as FCpt
+from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 
 from .interface import BaseInterface
+from .pv_positioner import PVPositionerIsClose
 from .signal import AvgSignal
 
 
@@ -26,3 +28,63 @@ class SxrGmd(Device):
 
     def __init__(self, prefix='', name='sxr_gmd', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)
+
+
+class BeamEnergyRequest(PVPositionerIsClose):
+    """
+    Positioner to request beam color changes from ACR in eV.
+
+    It is up to ACR how to and whether to fulfil these requests. This is often
+    fulfilled by moving the Vernier but can also be a more involved process.
+
+    Motion is considered "done" when the photon energy readback is close enough
+    to the requested value. The default tolerance here is 30 eV, but this can
+    be changed on a per-instance basis by passing atol into the init, or on a
+    per-subclass basis by overriding the default.
+
+    Parameters
+    ----------
+    prefix: str
+        PV prefix for the request setpoint. This should always be a hutch name.
+
+    name: str, required keyword
+        Name to use for this device in log messages, data streams, etc.
+
+    energy_pv: str, optional
+        PV to use for the beam energy readback in eV. The default is
+        BLD:SYS0:500:PHOTONENERGY, same as used in the BeamStats class.
+
+    skip_small_moves: bool, optional
+        Defaults to True, which ignores move requests that are smaller than the
+        atol factor. If False, we'll perform every requested move.
+        This can be very useful for synchronized energy scans where the ACR
+        side of the process can be very slow, but does not necessarily need to
+        happen at every step. Rather than design complicated scan patterns, we
+        can skip the small moves here and move the monochromater and beam
+        request devices in parallel.
+
+    atol: int, optional
+        Absolute tolerance that determines when the move is done and when to
+        skip moves using the skip_small_moves parameter.
+    """
+
+    # Default tolerance from Vernier in legacy XCS python
+    atol = 30
+
+    setpoint = Cpt(EpicsSignal, ':USER:MCC:EPHOT', kind='hinted')
+    readback = FCpt(EpicsSignalRO, '{energy_pv}', kind='hinted')
+
+    def __init__(self, prefix, *, name, energy_pv='BLD:SYS0:500:PHOTONENERGY',
+                 skip_small_moves=True, **kwargs):
+        self.energy_pv = energy_pv
+        self.skip_small_moves = skip_small_moves
+        super.__init__(prefix, name=name, **kwargs)
+
+    def _setup_move(self, position):
+        """Skip the move part of the move if below the tolerance."""
+        if self.skip_small_moves and abs(position-self.position) < self.atol:
+            # Toggle the done bit
+            self._update_setpoint(value=self._last_setpoint)
+        else:
+            # Do a move
+            super()._setup_move(position)

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -84,7 +84,9 @@ class BeamEnergyRequest(PVPositionerIsClose):
         """Skip the move part of the move if below the tolerance."""
         if self.skip_small_moves and abs(position-self.position) < self.atol:
             # Toggle the done bit
+            self.log.debug('Skipping small move in beam energy request')
             self._update_setpoint(value=self._last_setpoint)
         else:
             # Do a move
+            self.log.debug('Doing beam energy request move')
             super()._setup_move(position)

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -78,7 +78,7 @@ class BeamEnergyRequest(PVPositionerIsClose):
                  skip_small_moves=True, **kwargs):
         self.energy_pv = energy_pv
         self.skip_small_moves = skip_small_moves
-        super.__init__(prefix, name=name, **kwargs)
+        super().__init__(prefix, name=name, **kwargs)
 
     def _setup_move(self, position):
         """Skip the move part of the move if below the tolerance."""

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -34,13 +34,13 @@ class BeamEnergyRequest(PVPositionerIsClose):
     """
     Positioner to request beam color changes from ACR in eV.
 
-    It is up to ACR how to and whether to fulfil these requests. This is often
+    It is up to ACR how to and whether to fulfill these requests. This is often
     fulfilled by moving the Vernier but can also be a more involved process.
 
     Motion is considered "done" when the photon energy readback is close enough
     to the requested value. The default tolerance here is 30 eV, but this can
-    be changed on a per-instance basis by passing atol into the init, or on a
-    per-subclass basis by overriding the default.
+    be changed on a per-instance basis by passing ``atol`` into the
+    initializer, or on a per-subclass basis by overriding the default.
 
     Parameters
     ----------

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -86,21 +86,24 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
 
     tab_component_names = True
 
-    def __init__(self, *args, theta0=default_theta0, dspacing=default_dspacing,
-                 gr=default_gr, gd=default_gd, hutch='', **kwargs):
+    def __init__(self, prefix, *args, theta0=default_theta0,
+                 dspacing=default_dspacing, gr=default_gr, gd=default_gd,
+                 hutch=None, **kwargs):
         self.theta0 = theta0
         self.dspacing = dspacing
         self.gr = gr
         self.gd = gd
-        if hutch:
+        if hutch is not None:
             self.hutch = hutch
         # Put some effort into filling this automatically
         # CCM exists only in two hutches
-        elif 'XPP' in theta0:
+        elif 'XPP' in prefix:
             self.hutch = 'XPP'
-        elif 'XCS' in theta0:
+        elif 'XCS' in prefix:
             self.hutch = 'XCS'
-        super().__init__(*args, auto_target=False, **kwargs)
+        else:
+            self.hutch = 'TST'
+        super().__init__(prefix, *args, auto_target=False, **kwargs)
 
     def forward(self, pseudo_pos):
         """
@@ -210,7 +213,9 @@ class CCM(InOutPositioner):
     def __init__(self, alio_prefix, theta2fine_prefix, theta2coarse_prefix,
                  chi2_prefix, x_down_prefix, x_up_prefix,
                  y_down_prefix, y_up_north_prefix, y_up_south_prefix,
-                 in_pos, out_pos, *args, **kwargs):
+                 in_pos, out_pos, *args,
+                 theta0=default_theta0, dspacing=default_dspacing,
+                 gr=default_gr, gd=default_gd, **kwargs):
         self.alio_prefix = alio_prefix
         self.theta2fine_prefix = theta2fine_prefix
         self.theta2coarse_prefix = theta2coarse_prefix
@@ -223,6 +228,10 @@ class CCM(InOutPositioner):
         self._in_pos = in_pos
         self._out_pos = out_pos
         super().__init__(alio_prefix, *args, **kwargs)
+        self.calc.theta0 = theta0
+        self.calc.dspacing = dspacing
+        self.calc.gr = gr
+        self.calc.gd = gd
 
     @property
     def _state(self):

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -124,7 +124,10 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
             theta = pseudo_pos.theta
         else:
             alio = self.alio.position
-        logger.debug((energy, wavelength, theta, energy_with_vernier))
+        logger.debug('Forward (move) calculation args: '
+                     f'energy={energy}, wavelength={wavelength}, '
+                     f'theta={theta}, '
+                     f'energy_with_vernier={energy_with_vernier}')
         if energy_with_vernier is not None:
             energy = energy_with_vernier
             energy_request = energy_with_vernier * 1000
@@ -137,6 +140,8 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
         if theta is not None:
             alio = theta_to_alio(theta * np.pi/180, self.theta0,
                                  self.gr, self.gd)
+        logger.debug('Forward (move) calculation results: '
+                     f'alio={alio}, energy_request={energy_request}')
         return self.RealPosition(alio=alio, energy_request=energy_request)
 
     def inverse(self, real_pos):

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -5,14 +5,13 @@ import numpy as np
 from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.pseudopos import PseudoPositioner
-from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO, Signal
 
 from .epics_motor import IMS, EpicsMotorInterface
 from .inout import InOutPositioner
 from .interface import FltMvInterface
 from .pseudopos import PseudoSingleInterface, SyncAxesBase
-from .signal import InternalSignal
+from .pv_positioner import PVPositionerIsClose
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ default_gr = 3.175
 default_gd = 231.303
 
 
-class CCMMotor(PVPositioner, FltMvInterface):
+class CCMMotor(PVPositionerIsClose):
     """
     Goofy records used in the CCM.
     """
@@ -35,42 +34,19 @@ class CCMMotor(PVPositioner, FltMvInterface):
     setpoint = Cpt(EpicsSignal, ":POSITIONSET", auto_monitor=True)
     readback = Cpt(EpicsSignalRO, ":POSITIONGET", auto_monitor=True,
                    kind='hinted')
-    done = Cpt(InternalSignal, value=0)
-    done_value = 1
 
-    limits = None
+    # Tolerance from old xcs python code
+    atol = 3e-4
 
-    def __init__(self, prefix, *, name, **kwargs):
-        self._last_readback = None
-        self._last_setpoint = None
-        super().__init__(prefix, name=name, **kwargs)
 
-    @readback.sub_value
-    def _update_readback(self, *args, value, **kwargs):
-        """Callback to cache the readback and update done state."""
-        self._last_readback = value
-        self._update_done()
+class VernierMotor(PVPositionerIsClose):
+    """
+    Dummy motor that sets and reads from the vernier PV.
 
-    @setpoint.sub_value
-    def _update_setpoint(self, *args, value, **kwargs):
-        """Callback to cache the setpoint and update done state."""
-        self._last_setpoint = value
-        # Always set done to False when a move is requested
-        # This means we always get a rising edge when finished moving
-        # Even if the move distance is under our done moving tolerance
-        self.done.put(0, force=True)
-        self._update_done()
-
-    def _update_done(self):
-        """
-        Update our status to done if we are within the tolerance.
-
-        This tolerance of 3e-4 was copied as-is from old xcs python code.
-        """
-        if None not in (self._last_readback, self._last_setpoint):
-            is_done = np.isclose(self._last_readback, self._last_setpoint,
-                                 atol=3e-4)
-            self.done.put(int(is_done), force=True)
+    Pseudo positioners need a positioner subclass to work properly.
+    """
+    setpoint = Cpt(EpicsSignal, "", auto_monitor=True)
+    readback = Cpt(EpicsSignal, "", auto_monitor=True)
 
 
 class CCMPico(EpicsMotorInterface):
@@ -109,26 +85,37 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
     """
 
     energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted')
-    wavelength = Cpt(PseudoSingleInterface, egu='A')
-    theta = Cpt(PseudoSingleInterface, egu='deg')
-    alio = Cpt(CCMMotor, '')
+    wavelength = Cpt(PseudoSingleInterface, egu='A', kind='normal')
+    theta = Cpt(PseudoSingleInterface, egu='deg', kind='normal')
+    energy_with_vernier = Cpt(PseudoSingleInterface, egu='keV',
+                              kind='omitted')
+
+    alio = Cpt(CCMMotor, '', kind='normal')
+    vernier = FCpt(VernierMotor, '{vernier_prefix}', kind='normal')
 
     tab_component_names = True
 
     def __init__(self, *args, theta0=default_theta0, dspacing=default_dspacing,
-                 gr=default_gr, gd=default_gd, **kwargs):
+                 gr=default_gr, gd=default_gd, vernier_prefix='', **kwargs):
         self.theta0 = theta0
         self.dspacing = dspacing
         self.gr = gr
         self.gd = gd
+        self.vernier_prefix = vernier_prefix
         super().__init__(*args, auto_target=False, **kwargs)
 
     def forward(self, pseudo_pos):
-        """Take energy, wavelength, or theta and map to alio."""
+        """
+        Take energy, wavelength, theta, or energy_with_vernier and map to
+        alio and vernier.
+        """
         pseudo_pos = self.PseudoPosition(*pseudo_pos)
         # Figure out which one changed.
-        energy, wavelength, theta = None, None, None
-        if not np.isclose(pseudo_pos.energy, self.energy.position):
+        energy_with_vernier, energy, wavelength, theta = None, None, None, None
+        if not np.isclose(pseudo_pos.energy_with_vernier,
+                          self.energy_with_vernier.position):
+            energy_with_vernier = pseudo_pos.energy_with_vernier
+        elif not np.isclose(pseudo_pos.energy, self.energy.position):
             energy = pseudo_pos.energy
         elif not np.isclose(pseudo_pos.wavelength, self.wavelength.position):
             wavelength = pseudo_pos.wavelength
@@ -136,7 +123,12 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
             theta = pseudo_pos.theta
         else:
             alio = self.alio.position
-        logger.debug((energy, wavelength, theta))
+        logger.debug((energy, wavelength, theta, energy_with_vernier))
+        if energy_with_vernier is not None:
+            energy = energy_with_vernier
+            vernier = energy_with_vernier
+        else:
+            vernier = self.vernier.position
         if energy is not None:
             wavelength = energy_to_wavelength(energy)
         if wavelength is not None:
@@ -144,7 +136,7 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
         if theta is not None:
             alio = theta_to_alio(theta * np.pi/180, self.theta0,
                                  self.gr, self.gd)
-        return self.RealPosition(alio=alio)
+        return self.RealPosition(alio=alio, vernier=vernier)
 
     def inverse(self, real_pos):
         """Take alio and map to energy, wavelength, and theta."""
@@ -154,7 +146,8 @@ class CCMCalc(PseudoPositioner, FltMvInterface):
         energy = wavelength_to_energy(wavelength)
         return self.PseudoPosition(energy=energy,
                                    wavelength=wavelength,
-                                   theta=theta*180/np.pi)
+                                   theta=theta*180/np.pi,
+                                   energy_with_vernier=energy)
 
 
 class CCMX(SyncAxesBase):

--- a/pcdsdevices/pv_positioner.py
+++ b/pcdsdevices/pv_positioner.py
@@ -87,4 +87,9 @@ class PVPositionerIsClose(PVPositionerComparator):
         super().__init__(prefix, name=name, **kwargs)
 
     def done_comparator(self, readback, setpoint):
-        return np.isclose(readback, setpoint, atol=self.atol, rtol=self.rtol)
+        kwargs = {}
+        if self.atol is not None:
+            kwargs['atol'] = self.atol
+        if self.rtol is not None:
+            kwargs['rtol'] = self.rtol
+        return np.isclose(readback, setpoint, **kwargs)

--- a/pcdsdevices/pv_positioner.py
+++ b/pcdsdevices/pv_positioner.py
@@ -1,0 +1,86 @@
+import numpy as np
+from ophyd.device import Component as Cpt
+from ophyd.positioner import PVPositioner
+
+from .interface import FltMvInterface
+from .signal import InternalSignal
+
+
+class PVPositionerComparator(PVPositioner, FltMvInterface):
+    """
+    PV Positioner with a software done signal.
+
+    The done state is set by a comparison function defined in the class body.
+    The comparison function takes two arguments, readback and setpoint,
+    returning True if we are close enough to be considered done or False if we
+    are too far away.
+    """
+
+    # Override setpoint, readback in subclass
+    setpoint = None
+    readback = None
+
+    done = Cpt(InternalSignal, value=0)
+    done_value = 1
+
+    # Optionally override limits to a 2-element tuple in subclass
+    limits = None
+
+    def __init__(self, prefix, *, name, **kwargs):
+        self._last_readback = None
+        self._last_setpoint = None
+        super().__init__(prefix, name=name, **kwargs)
+
+    def done_comparator(self, readback, setpoint):
+        """Override done_comparator in subclass."""
+        raise NotImplementedError('Must implement a done comparator!')
+
+    def __init_subclass__(cls, **kwargs):
+        """Set up callbacks in subclass."""
+        super().__init_subclass__(**kwargs)
+        if None not in (cls.setpoint, cls.readback):
+            cls.setpoint.sub_value(cls._update_setpoint)
+            cls.readback.sub_value(cls._update_readback)
+
+    def _update_setpoint(self, *args, value, **kwargs):
+        """Callback to cache the setpoint and update done state."""
+        self._last_setpoint = value
+        # Always set done to False when a move is requested
+        # This means we always get a rising edge when finished moving
+        # Even if the move distance is under our done moving tolerance
+        self.done.put(0, force=True)
+        self._update_done()
+
+    def _update_readback(self, *args, value, **kwargs):
+        """Callback to cache the readback and update done state."""
+        self._last_readback = value
+        self._update_done()
+
+    def _update_done(self):
+        """Update our status to done if we pass the comparator."""
+        if None not in (self._last_readback, self._last_setpoint):
+            is_done = self.done_comparator(self._last_readback,
+                                           self._last_setpoint)
+            self.done.put(int(is_done), force=True)
+
+
+class PVPositionerIsClose(PVPositionerComparator):
+    """
+    PV Positioner that updates done state based on np.isclose.
+
+    The arguments atol and rtol can be set as class attributes or passed as
+    initialization arguments.
+    """
+
+    atol = None
+    rtol = None
+
+    def __init__(self, prefix, *, name, atol=None, rtol=None, **kwargs):
+        if atol is not None:
+            self.atol = atol
+        if rtol is not None:
+            self.rtol = rtol
+        super().__init__(prefix, name=name, **kwargs)
+
+    def done_comparator(self, readback, setpoint):
+        return np.isclose(readback, setpoint, atol=self.atol, rtol=self.rtol)

--- a/pcdsdevices/pv_positioner.py
+++ b/pcdsdevices/pv_positioner.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ophyd.device import Component as Cpt
-from ophyd.positioner import PVPositioner
+from ophyd.pv_positioner import PVPositioner
 
 from .interface import FltMvInterface
 from .signal import InternalSignal

--- a/pcdsdevices/pv_positioner.py
+++ b/pcdsdevices/pv_positioner.py
@@ -30,6 +30,10 @@ class PVPositionerComparator(PVPositioner, FltMvInterface):
         self._last_readback = None
         self._last_setpoint = None
         super().__init__(prefix, name=name, **kwargs)
+        if None in (self.setpoint, self.readback):
+            raise NotImplementedError('PVPositionerComparator requires both '
+                                      'a setpoint and a readback signal to '
+                                      'compare!')
 
     def done_comparator(self, readback, setpoint):
         """Override done_comparator in subclass."""

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -192,7 +192,7 @@ def test_vernier(fake_ccm):
     assert fake_ccm.calc.energy_request.position == 9000
 
     # Unless we set the option for not skipping them
-    fake_ccm.calc.skip_small_moves = False
+    fake_ccm.calc.energy_request.skip_small_moves = False
     fake_ccm.calc.energy_with_vernier.move(9.002, wait=False)
     finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 9.002)

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -72,6 +72,13 @@ def make_fake_ccm():
     init_pos(fake_ccm.y.down)
     init_pos(fake_ccm.y.up_north)
     init_pos(fake_ccm.y.up_south)
+
+    def init_pvpos(mot, pos=0):
+        mot.setpoint.sim_put(0)
+        mot.readback.sim_put(0)
+
+    init_pvpos(fake_ccm.calc.energy_request)
+
     return fake_ccm
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add vernier integration into the CCM class.
This includes a beam requests pv positioner and a vernier with ccm energy motor.
Also adds new positioner base classes whose utility seems to crop up multiple times.

The vernier is something the accelerator crew can use to adjust the beam energy (frequency/color, not intensity).
We manipulate the vernier when it has been agreed upon that we can do so with ACR.
We do this by putting to an energy request PV, then ACR satisfies the request.
We need to move the energy during energy scans that are larger than the SASE bandwidth.

Contributes to #488 
Closes #498

Some unanswered questions:
- Should this really be called the vernier if it is a generic PV that the accelerator chooses how to satisfy?
- Should the vernier move to exactly our energy value? Or is it better to move a little bit past it so we can scan the full SASE?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Large-range energy scans need accelerator adjustments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for all permutations of vernier moves

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only
<!--
## Screenshots (if appropriate):
-->
