### PR TITLE
ENH: add UnitConversionDerivedSignal

### DIFF
--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -22,6 +22,10 @@ las_pol_wp::
 LXE::
 
     Laser energy motor, I assume
+
+LXT::
+
+    Laser x-ray timing, probably
 """
 
 import pathlib

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -306,7 +306,6 @@ class UnitConversionDerivedSignal(DerivedSignal):
     Custom units may be specified for the original signal, or if specified, the
     original signal's units may be retrieved upon first connection.
 
-
     Parameters
     ----------
     derived_from : Signal or str
@@ -314,6 +313,13 @@ class UnitConversionDerivedSignal(DerivedSignal):
         attribute name that indicates a sibling to use.  When used in a
         ``Device``, this is then simply the attribute name of another
         ``Component``.
+
+    derived_units : str
+        The desired units to use for this signal.
+
+    original_units : str, optional
+        The units from the original signal.  If not specified, control system
+        information regarding units will be retrieved upon first connection.
 
     write_access : bool, optional
         Write access may be disabled by setting this to ``False``, regardless
@@ -324,15 +330,18 @@ class UnitConversionDerivedSignal(DerivedSignal):
 
     parent : Device, optional
         The parent device.  Required if ``derived_from`` is an attribute name.
+
+    **kwargs :
+        Keyword arguments are passed to the superclass.
     """
 
-    def __init__(self, *args,
+    def __init__(self, derived_from, *,
                  derived_units: str,
                  original_units: typing.Optional[str] = None,
                  **kwargs):
         self.derived_units = derived_units
         self.original_units = original_units
-        super().__init__(*args, **kwargs)
+        super().__init__(derived_from, **kwargs)
 
     def forward(self, value):
         '''Compute derived signal value -> original signal value'''

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -10,13 +10,17 @@ if __name__ != 'pcdsdevices.signal':
                        'extremely confusing bugs. Please run your script '
                        'elsewhere for better results.')
 import logging
+import typing
 from threading import RLock, Thread
 
 import numpy as np
-from ophyd.signal import (EpicsSignal, EpicsSignalBase, EpicsSignalRO,
-                          Signal, SignalRO)
+
+from ophyd.signal import (DerivedSignal, EpicsSignal, EpicsSignalBase,
+                          EpicsSignalRO, Signal, SignalRO)
 from ophyd.sim import FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache
 from pytmc.pragmas import normalize_io
+
+from .utils import convert_unit
 
 logger = logging.getLogger(__name__)
 
@@ -293,3 +297,63 @@ class InternalSignal(SignalRO):
 
     def set(self, value, *, timestamp=None, force=False):
         return Signal.set(self, value, timestamp=timestamp, force=force)
+
+
+class UnitConversionDerivedSignal(DerivedSignal):
+    """
+    A DerivedSignal which performs unit conversion.
+
+    Custom units may be specified for the original signal, or if specified, the
+    original signal's units may be retrieved upon first connection.
+
+
+    Parameters
+    ----------
+    derived_from : Signal or str
+        The signal from which this one is derived.  This may be a string
+        attribute name that indicates a sibling to use.  When used in a
+        ``Device``, this is then simply the attribute name of another
+        ``Component``.
+
+    write_access : bool, optional
+        Write access may be disabled by setting this to ``False``, regardless
+        of the write access of the underlying signal.
+
+    name : str, optional
+        The signal name.
+
+    parent : Device, optional
+        The parent device.  Required if ``derived_from`` is an attribute name.
+    """
+
+    def __init__(self, *args,
+                 derived_units: str,
+                 original_units: typing.Optional[str] = None,
+                 **kwargs):
+        self.derived_units = derived_units
+        self.original_units = original_units
+        super().__init__(*args, **kwargs)
+
+    def forward(self, value):
+        '''Compute derived signal value -> original signal value'''
+        return convert_unit(value, self.derived_units, self.original_units)
+
+    def inverse(self, value):
+        '''Compute original signal value -> derived signal value'''
+        return convert_unit(value, self.original_units, self.derived_units)
+
+    def _derived_metadata_callback(self, *, connected, **kwargs):
+        super()._derived_metadata_callback(connected=connected, **kwargs)
+        if connected and 'units' in kwargs:
+            if self.original_units is None:
+                self.original_units = kwargs['units']
+
+    def describe(self):
+        full_desc = super().describe()
+        desc = full_desc[self.name]
+        desc['units'] = self.derived_units
+        # Note: this should be handled in ophyd:
+        for key in ('lower_ctrl_limit', 'upper_ctrl_limit'):
+            if key in desc:
+                desc[key] = self.inverse(desc[key])
+        return full_desc

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -65,8 +65,8 @@ def test_unit_conversion_signal():
     assert converted.derived_units == 'mm'
     assert converted.describe()[converted.name]['units'] == 'mm'
 
-    assert converted.get() == 5000
-    converted.put(10000, wait=True)
+    assert converted.get() == 5_000
+    converted.put(10_000, wait=True)
     assert orig.get() == 10
 
     event = threading.Event()
@@ -83,4 +83,4 @@ def test_unit_conversion_signal():
 
     args, kwargs = cb.call_args
     assert kwargs['value'] == 20_000
-    assert converted.get() == 20000
+    assert converted.get() == 20_000

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,9 +1,11 @@
 import logging
+import threading
 from unittest.mock import Mock
 
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
-
-from pcdsdevices.signal import AvgSignal, PytmcSignal
+from ophyd.sim import FakeEpicsSignal
+from pcdsdevices.signal import (AvgSignal, PytmcSignal,
+                                UnitConversionDerivedSignal)
 
 logger = logging.getLogger(__name__)
 
@@ -46,3 +48,39 @@ def test_avg_signal():
     avg.subscribe(cb)
     sig.put(0)
     assert cb.called
+
+
+def test_unit_conversion_signal():
+    orig = FakeEpicsSignal('sig', name='orig')
+    orig.sim_put(5)
+
+    converted = UnitConversionDerivedSignal(
+        derived_from=orig,
+        original_units='m',
+        derived_units='mm',
+        name='converted',
+    )
+
+    assert converted.original_units == 'm'
+    assert converted.derived_units == 'mm'
+    assert converted.describe()[converted.name]['units'] == 'mm'
+
+    assert converted.get() == 5000
+    converted.put(10000, wait=True)
+    assert orig.get() == 10
+
+    event = threading.Event()
+    cb = Mock()
+
+    def callback(**kwargs):
+        cb(**kwargs)
+        event.set()
+
+    converted.subscribe(callback, run=False)
+    orig.put(20, wait=True)
+    event.wait(1)
+    cb.assert_called_once()
+
+    args, kwargs = cb.call_args
+    assert kwargs['value'] == 20_000
+    assert converted.get() == 20000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a new signal class to aid in simple unit conversions.
This is the first part of the upcoming `lxt` motor support.

## Motivation and Context
Though it's preferable to do these at the IOC level so all clients - not just hutch-python/typhos - benefit, it's not always possible.

## How Has This Been Tested?
A simple unit test.

## Where Has This Been Documented?
Docstring