### PR TITLE
ENH: add LaserTiming PVPositioner

### DIFF
--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -214,7 +214,7 @@ class LaserEnergyPositioner(LookupTablePositioner, FltMvInterface):
         return super().wm[0]
 
 
-class LaserEnergyTimingLxt(PVPositioner, FltMvInterface):
+class LaserTiming(PVPositioner, FltMvInterface):
     """
     "lxt" motor, which may also have been referred to as Vitara.
 

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -235,4 +235,9 @@ class LaserEnergyTimingLxt(PVPositioner, FltMvInterface):
     done_value = 1
 
     def __init__(self, prefix='', *, egu=None, **kwargs):
+        if egu not in (None, 's'):
+            raise ValueError(
+                f'{self.__class__.__name__} is pre-configured to work in units'
+                f' of seconds.'
+            )
         super().__init__(prefix, egu='s', **kwargs)

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -35,11 +35,13 @@ import typing
 import numpy as np
 
 from ophyd import Component as Cpt
+from ophyd import EpicsSignal, PVPositioner
 
 from .epics_motor import EpicsMotorInterface
 from .interface import FltMvInterface
 from .pseudopos import (LookupTablePositioner, PseudoSingleInterface,
                         pseudo_position_argument)
+from .signal import UnitConversionDerivedSignal
 
 if typing.TYPE_CHECKING:
     import matplotlib  # noqa
@@ -210,3 +212,27 @@ class LaserEnergyPositioner(LookupTablePositioner, FltMvInterface):
     def wm(self) -> float:
         # Remove the PseudoPosition tuple for FltMvInterface compatibility
         return super().wm[0]
+
+
+class LaserEnergyTimingLxt(PVPositioner, FltMvInterface):
+    """
+    "lxt" motor, which may also have been referred to as Vitara.
+
+    Conversions for Vitara FS_TGT_TIME nanoseconds <-> seconds are done
+    internally, such that the user may work in units of seconds.
+    """
+
+    _fs_tgt_time = Cpt(EpicsSignal, ':VIT:FS_TGT_TIME', auto_monitor=True)
+    setpoint = Cpt(UnitConversionDerivedSignal,
+                   derived_from='_fs_tgt_time',
+                   derived_units='s',
+                   original_units='ns',
+                   )
+
+    # A motor (record) will be moved after the above record is touched, so
+    # use its done motion status:
+    done = Cpt(EpicsSignal, ':MMS:PH.DMOV', auto_monitor=True)
+    done_value = 1
+
+    def __init__(self, prefix='', *, egu=None, **kwargs):
+        super().__init__(prefix, egu='s', **kwargs)

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -6,10 +6,13 @@ import pytest
 from conftest import MODULE_PATH
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
-from pcdsdevices.lxe import LaserEnergyPlotContext, LaserEnergyPositioner
+from ophyd.sim import make_fake_device
+from pcdsdevices.lxe import (LaserEnergyPlotContext, LaserEnergyPositioner,
+                             LaserEnergyTimingLxt)
 from pcdsdevices.pseudopos import (DelayBase, LookupTablePositioner,
                                    PseudoSingleInterface, SimDelayStage,
                                    SyncAxesBase)
+from pcdsdevices.utils import convert_unit
 
 logger = logging.getLogger(__name__)
 
@@ -145,3 +148,26 @@ def test_laser_energy_positioner(monkeypatch, lxe_calibration_file):
     with pytest.raises(ValueError):
         # Out-of-range value
         lxe.move(1e9)
+
+
+def test_laser_energy_timing():
+    def _move_helper(pv_positioner, position):
+        # A useful helper for test_pvpositioner.py?
+        st = pv_positioner.move(position, wait=False)
+        if pv_positioner.done is not None:
+            pv_positioner.done.sim_put(1 - pv_positioner.done_value)
+            pv_positioner.done.sim_put(pv_positioner.done_value)
+        return st
+
+    lxt = make_fake_device(LaserEnergyTimingLxt)('prefix', name='lxt')
+    lxt._fs_tgt_time.sim_set_limits((0, 4e9))
+    lxt._fs_tgt_time.sim_put(0)
+
+    # A basic dependency sanity check...
+    np.testing.assert_allclose(convert_unit(1, 's', 'ns'), 1e9)
+
+    for pos in range(1, 3):
+        _move_helper(lxt, pos).wait(1)
+        np.testing.assert_allclose(lxt.position, pos)
+        np.testing.assert_allclose(lxt._fs_tgt_time.get(),
+                                   convert_unit(pos, 's', 'ns'))

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -8,7 +8,7 @@ from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
 from ophyd.sim import make_fake_device
 from pcdsdevices.lxe import (LaserEnergyPlotContext, LaserEnergyPositioner,
-                             LaserEnergyTimingLxt)
+                             LaserTiming)
 from pcdsdevices.pseudopos import (DelayBase, LookupTablePositioner,
                                    PseudoSingleInterface, SimDelayStage,
                                    SyncAxesBase)
@@ -159,7 +159,7 @@ def test_laser_energy_timing():
             pv_positioner.done.sim_put(pv_positioner.done_value)
         return st
 
-    lxt = make_fake_device(LaserEnergyTimingLxt)('prefix', name='lxt')
+    lxt = make_fake_device(LaserTiming)('prefix', name='lxt')
     lxt._fs_tgt_time.sim_set_limits((0, 4e9))
     lxt._fs_tgt_time.sim_put(0)
 
@@ -175,4 +175,4 @@ def test_laser_energy_timing():
 
 def test_laser_energy_timing_no_egu():
     with pytest.raises(ValueError):
-        LaserEnergyTimingLxt('', egu='foobar', name='lxt')
+        LaserTiming('', egu='foobar', name='lxt')

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -171,3 +171,8 @@ def test_laser_energy_timing():
         np.testing.assert_allclose(lxt.position, pos)
         np.testing.assert_allclose(lxt._fs_tgt_time.get(),
                                    convert_unit(pos, 's', 'ns'))
+
+
+def test_laser_energy_timing_no_egu():
+    with pytest.raises(ValueError):
+        LaserEnergyTimingLxt('', egu='foobar', name='lxt')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds "lxt" motor.

* Closes #516 
* Hopefully closes https://github.com/pcdshub/Bug-Reports-and-Requests/issues/27
* Previous PR and PVPositioner made this pretty simple, fortunately!
* Unclear as to whether or not we should implement the `stop` signal here. We know that there's a motor record sitting underneath, but the old code did not touch it (other than using its DMOV flag in a very convoluted way).
* Apologies for the dumb 'lxe' module name. I think this will have to be reorganized, but I don't really know where to put it.

## Motivation and Context
Required from old hutch python config.

## How Has This Been Tested?
Simple unit tests. Also locally with a simple caproto IOC:

```python
    mms_ph = SubGroup(FakeMotor, velocity=3., precision=2, prefix=':MMS:PH')
    fs_tgt_time = pvproperty(value=0.0, name=':VIT:FS_TGT_TIME')

    @fs_tgt_time.putter
    async def fs_tgt_time(self, instance, value):
        await self.mms_ph.motor.write(value / 1e9)
```