### PR TITLE
ENH: add units to the handy IPython repr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.4.2
     hooks:
     -   id: isort


### PR DESCRIPTION
Closes #507 

Could use further testing, but in brief poking around the result looks something like:
```
In [22]: class MyDevice(pcdsdevices.interface.BaseInterface, ophyd.Device):
    ...:     cpt = ophyd.Component(ophyd.EpicsSignal, 'LCLS:HXR:BEAM:EV')
    ...:

In [23]: dev = MyDevice(name='dev')

In [24]: dev
Out[24]:

dev
---
cpt: 9500 [eV]
```

where `dev.cpt.metadata['units'] == 'eV'`