### PR TITLE
ENH/FIX: user offsets for lxt motor and general UnitConversionDerivedSignal

### DIFF
--- a/docs/pre-release-notes.sh
+++ b/docs/pre-release-notes.sh
@@ -5,5 +5,9 @@ FILENAME=source/upcoming_release_notes/${ISSUE}-${DESCRIPTION}.rst
 
 pushd "$(dirname "$0")"
 cp source/upcoming_release_notes/template-short.rst ${FILENAME}
-${EDITOR} ${FILENAME}
+if ${EDITOR} "${FILENAME}"; then
+    echo "Adding ${FILENAME} to the git repository..."
+    git add ${FILENAME}
+fi
+
 popd

--- a/docs/source/upcoming_release_notes/531-derived_signal_offset.rst
+++ b/docs/source/upcoming_release_notes/531-derived_signal_offset.rst
@@ -1,0 +1,34 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add ``user_offset`` to :class:`~pcdsdevices.signal.UnitConversionDerivedSignal`,
+  allowing for an arbitrary user offset in user-facing units.
+- Add ``user_offset`` signal to the :class:`pcdsdevices.lxe.LaserTiming`, by
+  way of :class:`~pcdsdevices.signal.UnitConversionDerivedSignal`, offset
+  support.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/531-derived_signal_offset.rst
+++ b/docs/source/upcoming_release_notes/531-derived_signal_offset.rst
@@ -1,5 +1,5 @@
-IssueNumber Title
-#################
+531 Derived signal offset
+#########################
 
 API Changes
 -----------
@@ -31,4 +31,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- klauer

--- a/docs/source/upcoming_release_notes/532-lxt_hinted.rst
+++ b/docs/source/upcoming_release_notes/532-lxt_hinted.rst
@@ -1,0 +1,31 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Adds hints to the :class:`pcdsdevices.lxe.LaserTiming` class for
+  ``LiveTable`` support.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/532-lxt_hinted.rst
+++ b/docs/source/upcoming_release_notes/532-lxt_hinted.rst
@@ -1,5 +1,5 @@
-IssueNumber Title
-#################
+532 / LXT Missing Kinds
+#######################
 
 API Changes
 -----------
@@ -28,4 +28,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- klauer

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -257,6 +257,5 @@ class LaserTiming(PVPositioner, FltMvInterface):
             The new current position.
         '''
         self.user_offset.put(0.0)
-
-        new_offset = self.setpoint.get() - position
+        new_offset = self.setpoint.get() + position
         self.user_offset.put(new_offset)

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -33,9 +33,9 @@ import types
 import typing
 
 import numpy as np
-
 from ophyd import Component as Cpt
 from ophyd import EpicsSignal, PVPositioner
+from ophyd.signal import AttributeSignal
 
 from .epics_motor import EpicsMotorInterface
 from .interface import FltMvInterface
@@ -222,16 +222,20 @@ class LaserTiming(PVPositioner, FltMvInterface):
     internally, such that the user may work in units of seconds.
     """
 
-    _fs_tgt_time = Cpt(EpicsSignal, ':VIT:FS_TGT_TIME', auto_monitor=True)
+    _fs_tgt_time = Cpt(EpicsSignal, ':VIT:FS_TGT_TIME', auto_monitor=True,
+                       kind='omitted')
     setpoint = Cpt(UnitConversionDerivedSignal,
                    derived_from='_fs_tgt_time',
                    derived_units='s',
                    original_units='ns',
+                   kind='hinted',
                    )
+    user_offset = Cpt(AttributeSignal, attr='setpoint.user_offset',
+                      kind='config')
 
     # A motor (record) will be moved after the above record is touched, so
     # use its done motion status:
-    done = Cpt(EpicsSignal, ':MMS:PH.DMOV', auto_monitor=True)
+    done = Cpt(EpicsSignal, ':MMS:PH.DMOV', auto_monitor=True, kind='omitted')
     done_value = 1
 
     def __init__(self, prefix='', *, egu=None, **kwargs):

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -245,3 +245,18 @@ class LaserTiming(PVPositioner, FltMvInterface):
                 f' of seconds.'
             )
         super().__init__(prefix, egu='s', **kwargs)
+
+    def set_current_position(self, position):
+        '''
+        Calculate and configure the user_offset value, indicating the provided
+        ``position`` as the new current position.
+
+        Parameters
+        ----------
+        position
+            The new current position.
+        '''
+        self.user_offset.put(0.0)
+
+        new_offset = self.setpoint.get() - position
+        self.user_offset.put(new_offset)

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -14,7 +14,6 @@ import typing
 from threading import RLock, Thread
 
 import numpy as np
-
 from ophyd.signal import (DerivedSignal, EpicsSignal, EpicsSignalBase,
                           EpicsSignalRO, Signal, SignalRO)
 from ophyd.sim import FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -322,10 +322,15 @@ class UnitConversionDerivedSignal(DerivedSignal):
         information regarding units will be retrieved upon first connection.
 
     user_offset : any, optional
-        An optional user offset that will be *added* when updating the original
-        signal, and *subtracted* when calculating the derived value.
+        An optional user offset that will be *subtracted* when updating the
+        original signal, and *added* when calculating the derived value.
         This offset should be supplied in ``derived_units`` and not
         ``original_units``.
+
+        For example, if the original signal updates to a converted value of
+        500 ``derived_units`` and the ``user_offset`` is set to 100, this
+        ``DerivedSignal`` will show a value of 600.  When providing a new
+        setpoint, the ``user_offset`` will be subtracted.
 
     write_access : bool, optional
         Write access may be disabled by setting this to ``False``, regardless
@@ -357,7 +362,7 @@ class UnitConversionDerivedSignal(DerivedSignal):
     def forward(self, value):
         '''Compute derived signal value -> original signal value'''
         if self.user_offset is not None:
-            value = value + self.user_offset
+            value = value - self.user_offset
         return convert_unit(value, self.derived_units, self.original_units)
 
     def inverse(self, value):
@@ -365,7 +370,7 @@ class UnitConversionDerivedSignal(DerivedSignal):
         derived_value = convert_unit(value, self.original_units,
                                      self.derived_units)
         if self.user_offset is not None:
-            derived_value = derived_value - self.user_offset
+            derived_value = derived_value + self.user_offset
         return derived_value
 
     @property

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -315,11 +315,18 @@ class UnitConversionDerivedSignal(DerivedSignal):
         ``Component``.
 
     derived_units : str
-        The desired units to use for this signal.
+        The desired units to use for this signal.  These can also be referred
+        to as the "user-facing" units.
 
     original_units : str, optional
         The units from the original signal.  If not specified, control system
         information regarding units will be retrieved upon first connection.
+
+    user_offset : any, optional
+        An optional user offset that will be *added* when updating the original
+        signal, and *subtracted* when calculating the derived value.
+        This offset should be supplied in ``derived_units`` and not
+        ``original_units``.
 
     write_access : bool, optional
         Write access may be disabled by setting this to ``False``, regardless
@@ -335,21 +342,56 @@ class UnitConversionDerivedSignal(DerivedSignal):
         Keyword arguments are passed to the superclass.
     """
 
+    derived_units: str
+    original_units: str
+
     def __init__(self, derived_from, *,
                  derived_units: str,
                  original_units: typing.Optional[str] = None,
+                 user_offset: typing.Optional[typing.Any] = None,
                  **kwargs):
         self.derived_units = derived_units
         self.original_units = original_units
+        self._user_offset = user_offset
         super().__init__(derived_from, **kwargs)
 
     def forward(self, value):
         '''Compute derived signal value -> original signal value'''
+        if self.user_offset is not None:
+            value = value + self.user_offset
         return convert_unit(value, self.derived_units, self.original_units)
 
     def inverse(self, value):
         '''Compute original signal value -> derived signal value'''
-        return convert_unit(value, self.original_units, self.derived_units)
+        derived_value = convert_unit(value, self.original_units,
+                                     self.derived_units)
+        if self.user_offset is not None:
+            derived_value = derived_value - self.user_offset
+        return derived_value
+
+    @property
+    def user_offset(self) -> typing.Optional[typing.Any]:
+        """A user-specified offset in *derived*, user-facing units."""
+        return self._user_offset
+
+    @user_offset.setter
+    def user_offset(self, offset):
+        self._user_offset = offset
+        self._recalculate_position()
+
+    def _recalculate_position(self):
+        """
+        Recalculate the derived position and send subscription updates.
+
+        No-operation if the original signal is not connected.
+        """
+        if not self._derived_from.connected:
+            return
+
+        value = self._derived_from.get()
+        if value is not None:
+            # Note: no kwargs here; no metadata updates
+            self._derived_value_callback(value)
 
     def _derived_metadata_callback(self, *, connected, **kwargs):
         super()._derived_metadata_callback(connected=connected, **kwargs)

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -108,7 +108,8 @@ def convert_unit(value, unit, new_unit):
     """
 
     ureg = pint.UnitRegistry()
-    return (value * ureg[unit]).to(new_unit).magnitude
+    expr = ureg.parse_expression(unit)
+    return (value * expr).to(new_unit).magnitude
 
 
 def ipm_screen(dettype, prefix, prefix_ioc):

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -9,8 +9,8 @@ import ophyd
 import pint
 
 try:
-    import tty
     import termios
+    import tty
 except ImportError:
     tty = None
     termios = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add ``user_offset`` to :class:`~pcdsdevices.signal.UnitConversionDerivedSignal`,
  allowing for an arbitrary user offset in user-facing units.
- Add ``user_offset`` signal to the :class:`pcdsdevices.lxe.LaserTiming`, by
  way of :class:`~pcdsdevices.signal.UnitConversionDerivedSignal`, offset
  support.
- Adds hints to the :class:`pcdsdevices.lxe.LaserTiming` class for
  ``LiveTable`` support.

Tweaks the developer utility script, adding release note files to `git` if the editor reported success.

## Motivation and Context
Closes #531 
Closes #532 

## How Has This Been Tested?
Included unit tests.

## Where Has This Been Documented?
Docstrings have been updated.