### PR TITLE
MNT: local limit overrides, rely more on base class after updates

### DIFF
--- a/docs/source/upcoming_release_notes/536-limit-overrides.rst
+++ b/docs/source/upcoming_release_notes/536-limit-overrides.rst
@@ -1,0 +1,37 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Epics motors can now have local limits updated per-session, rather than
+  only having the option of the EPICS limits. Setting limits attributes will
+  update the python limits, putting to the limits PVs will update the limits
+  PVs.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where putting to the limits property would update live PVs,
+  contrary to the behavior of all other limits attributes in ophyd.
+- Fix issue where doing a getattr on the limits properties would fetch
+  live PVs, which can cause slowdowns and instabilities.
+
+Maintenance
+-----------
+- Use more of the built-in ophyd mechanisms for limits rather than
+  relying on local overrides.
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -65,20 +65,20 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     @property
     def low_limit(self):
         """The lower soft limit for the motor."""
-        return max(self._limits[0], super().limits[0])
+        return max(self._limits[0], self._get_epics_limits()[0])
 
     @low_limit.setter
     def low_limit(self, value):
-        self._limits[0] = value
+        self._limits = (value, self._limits[1])
 
     @property
     def high_limit(self):
         """The higher soft limit for the motor."""
-        return min(self._limits[1], super().limits[1])
+        return min(self._limits[1], self._get_epics_limits()[1])
 
     @high_limit.setter
     def high_limit(self, value):
-        self._limits[1] = value
+        self._limits = (self._limits[0], value)
 
     @property
     def limits(self):
@@ -88,6 +88,14 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     @limits.setter
     def limits(self, limits):
         self._limits = limits
+
+    def _get_epics_limits(self):
+        limits = self.user_setpoint.limits
+        if limits is None:
+            # Not initialized
+            return (0, 0)
+        else:
+            return limits
 
     def enable(self):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -60,7 +60,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     def __init__(self, *args, **kwargs):
         # Locally defined limit overrides, note can only make limits narrower
         self._limits = (-math.inf, math.inf)
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def low_limit(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,8 @@ MODULE_PATH = Path(__file__).parent
 # Needs to not pass tons of kwargs up to Signal.put
 warnings.filterwarnings('ignore',
                         message='Signal.put no longer takes keyword arguments')
+
+
 # Other temporary patches to FakeEpicsSignal
 def check_value(self, value):
     if value is None:
@@ -35,6 +37,7 @@ def check_value(self, value):
     if not (low_limit <= value <= high_limit):
         raise LimitError('Value {} outside of range: [{}, {}]'
                          .format(value, low_limit, high_limit))
+
 
 # Check value is busted, ignores (0, 0) no limits case
 FakeEpicsSignal.check_value = check_value

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -64,6 +64,7 @@ def make_fake_ccm():
     def init_pos(mot, pos=0):
         mot.user_readback.sim_put(0)
         mot.user_setpoint.sim_put(0)
+        mot.user_setpoint.sim_set_limits((0, 0))
         mot.motor_spg.sim_put(2)
         mot.part_number.sim_put('tasdf')
 

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -28,7 +28,8 @@ def motor_setup(motor):
     """
     if isinstance(motor, EpicsMotorInterface):
         motor.user_readback.sim_put(0)
-        motor.limits = (-100, 100)
+        motor.high_limit_travel.put(100)
+        motor.low_limit_travel.put(-100)
 
     if isinstance(motor, PCDSMotorBase):
         motor.motor_spg.sim_put(2)
@@ -97,6 +98,17 @@ def test_epics_motor_soft_limits(fake_epics_motor):
     # Check that we can not move past the soft limits
     with pytest.raises(ValueError):
         m.move(-150)
+    # Try the local soft limits override
+    m.limits = (-50, 50)
+    with pytest.raises(ValueError):
+        m.move(-75)
+    m.low_limit = -25
+    with pytest.raises(ValueError):
+        m.move(-40)
+    m.high_limit = 25
+    with pytest.raises(ValueError):
+        m.move(40)
+
 
 
 def test_epics_motor_tdir(fake_pcds_motor):

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -114,7 +114,6 @@ def test_epics_motor_soft_limits(fake_epics_motor):
     m.check_value(42)
 
 
-
 def test_epics_motor_tdir(fake_pcds_motor):
     logger.debug('test_epics_motor_tdir')
     m = fake_pcds_motor

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -30,6 +30,7 @@ def motor_setup(motor):
         motor.user_readback.sim_put(0)
         motor.high_limit_travel.put(100)
         motor.low_limit_travel.put(-100)
+        motor.user_setpoint.sim_set_limits((-100, 100))
 
     if isinstance(motor, PCDSMotorBase):
         motor.motor_spg.sim_put(2)
@@ -108,6 +109,9 @@ def test_epics_motor_soft_limits(fake_epics_motor):
     m.high_limit = 25
     with pytest.raises(ValueError):
         m.move(40)
+    # Try with no limits set, e.g. (0, 0)
+    m.user_setpoint.sim_set_limits((0, 0))
+    m.check_value(42)
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Provide mechanisms for overriding the epics limits in software without changing them
- Remove all epics gets/puts from limit properties in our `EpicsMotorInterface`
- Use base class's mechanisms for getting epics limits. We had overrided these, but upstream ophyd has fixed this long ago (and handled it better than we were)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pcdshub/pcdsdevices/issues/530#issuecomment-680276993

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added relevant test cases.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Going to write it up right now

<!--
## Screenshots (if appropriate):
-->
