### PR TITLE
FIX: tab completion + inheritance

### DIFF
--- a/docs/source/upcoming_release_notes/537-tab-completion-and-inheritance.rst
+++ b/docs/source/upcoming_release_notes/537-tab-completion-and-inheritance.rst
@@ -1,0 +1,35 @@
+537 tab_component_names failing and inheritance issues
+######################################################
+
+API Changes
+-----------
+- :class:`BaseInterface` no longer inherits from :class:`ophyd.OphydObject`.
+- The order of multiple inheritance for many devices using the LCLS-enhanced
+  :class:`BaseInterface`, :class:`MvInterface`, and :class:`FltMvInterface` has
+  been changed.
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Tab completion for many devices has been fixed. Regression tests have been
+  added.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer
+- zrylettc

--- a/pcdsdevices/analog_signals.py
+++ b/pcdsdevices/analog_signals.py
@@ -8,7 +8,7 @@ from . import utils as key_press
 from .interface import BaseInterface
 
 
-class Acromag(Device, BaseInterface):
+class Acromag(BaseInterface, Device):
     """
     Class for Acromag analog input/ouput signals.
 
@@ -61,7 +61,7 @@ class Acromag(Device, BaseInterface):
     tab_component_names = True
 
 
-class Mesh(Device, BaseInterface):
+class Mesh(BaseInterface, Device):
     """
     Class for Mesh HV Supply that is connected to Acromag inputs and outputs.
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -426,14 +426,14 @@ def set_combined_attenuation(attenuation, *attenuators):
 '''
 
 
-class FEESolidAttenuatorBlade(Device, BaseInterface, LightpathInOutMixin):
+class FEESolidAttenuatorBlade(BaseInterface, Device, LightpathInOutMixin):
     lightpath_cpts = ['state']
 
     state = Cpt(TwinCATInOutPositioner, ':STATE')
     motor = Cpt(BeckhoffAxis, '')
 
 
-class GasAttenuator(Device, BaseInterface):
+class GasAttenuator(BaseInterface, Device):
     """
     AT*:GAS, Base class for an LCLS-II XTES gas attenuator.
 
@@ -455,7 +455,7 @@ class GasAttenuator(Device, BaseInterface):
                           value="Not Implemented", kind='normal')
 
 
-class AttenuatorCalculatorFilter(Device, BaseInterface):
+class AttenuatorCalculatorFilter(BaseInterface, Device):
     material = Cpt(
         EpicsSignal, 'Material', kind='hinted', string=True,
         doc='The material formula (e.g., Si, C)'
@@ -490,7 +490,7 @@ class AttenuatorCalculatorFilter(Device, BaseInterface):
         self.index = index
 
 
-class AttenuatorCalculatorBase(Device, BaseInterface):
+class AttenuatorCalculatorBase(BaseInterface, Device):
     """Base class for new-style caproto IOC attenuator calculator devices."""
 
     # QIcon for UX
@@ -697,7 +697,7 @@ class AttenuatorCalculator_AT2L0(AttenuatorCalculatorBase):
     )
 
 
-class AT2L0(Device, BaseInterface, LightpathInOutMixin):
+class AT2L0(BaseInterface, Device, LightpathInOutMixin):
     """
     AT2L0 solid attenuator variant from the LCLS-II XTES project.
 

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -8,7 +8,7 @@ from .pv_positioner import PVPositionerIsClose
 from .signal import AvgSignal
 
 
-class BeamStats(Device, BaseInterface):
+class BeamStats(BaseInterface, Device):
     mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted')
     ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal')
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE', kind='normal')

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -66,7 +66,7 @@ class CCMPico(EpicsMotorInterface):
                              value=value, **kwargs)
 
 
-class CCMCalc(PseudoPositioner, FltMvInterface):
+class CCMCalc(FltMvInterface, PseudoPositioner):
     """
     CCM calculation motors to move in terms of physics quantities.
 

--- a/pcdsdevices/dc_devices.py
+++ b/pcdsdevices/dc_devices.py
@@ -80,7 +80,7 @@ class ICTBus(Device):
         return self.bus_voltage.get()
 
 
-class ICT(Device, BaseInterface):
+class ICT(BaseInterface, Device):
     """Complete ICT device with access to all buses and channels."""
     bus_A = FCpt(ICTBus, '{self.prefix}', bus='A')
     bus_B = FCpt(ICTBus, '{self.prefix}', bus='B')

--- a/pcdsdevices/energy_monitor.py
+++ b/pcdsdevices/energy_monitor.py
@@ -12,7 +12,7 @@ from .interface import BaseInterface
 logger = logging.getLogger(__name__)
 
 
-class GEM(Device, BaseInterface):
+class GEM(BaseInterface, Device):
     """
     Gas Energy Monitor from the LUSI project.
 
@@ -31,7 +31,7 @@ class GEM(Device, BaseInterface):
                           value="Not Implemented", kind='normal')
 
 
-class GMD(Device, BaseInterface):
+class GMD(BaseInterface, Device):
     """
     Gas Monitor Detector, installed in the LCLS-II XTES project.
 
@@ -50,7 +50,7 @@ class GMD(Device, BaseInterface):
                           value="Not Implemented", kind='normal')
 
 
-class XGMD(Device, BaseInterface):
+class XGMD(BaseInterface, Device):
     """
     X Gas Monitor Detector (2nd generation GMD).
 

--- a/pcdsdevices/evr.py
+++ b/pcdsdevices/evr.py
@@ -4,7 +4,7 @@ from ophyd import Device, EpicsSignal, EpicsSignalRO
 from .interface import BaseInterface
 
 
-class Trigger(Device, BaseInterface):
+class Trigger(BaseInterface, Device):
     """Class for an individual Trigger."""
     eventcode = Cpt(EpicsSignal, ':EC_RBV', write_pv=':TEC', kind="config")
     eventrate = Cpt(EpicsSignalRO, ':RATE', kind="normal")

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -13,7 +13,7 @@ from .interface import BaseInterface
 logger = logging.getLogger(__name__)
 
 
-class MKS937a(Device, BaseInterface):
+class MKS937a(BaseInterface, Device):
     """
     A base class for an MKS637a vacuum gauge controller.
 
@@ -40,7 +40,7 @@ class MKS937a(Device, BaseInterface):
     tab_component_names = True
 
 
-class BaseGauge(Device, BaseInterface):
+class BaseGauge(BaseInterface, Device):
     """
     Base class for vacuum gauges.
 
@@ -91,7 +91,7 @@ class GaugeColdCathode(BaseGauge):
     tab_component_names = True
 
 
-class GaugeSetBase(Device, BaseInterface):
+class GaugeSetBase(BaseInterface, Device):
     """
 %s
     """

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -8,7 +8,7 @@ from .epics_motor import IMS
 from .interface import BaseInterface
 
 
-class BaseGon(Device, BaseInterface):
+class BaseGon(BaseInterface, Device):
     """
     Basic goniometer, as present in XPP.
 
@@ -151,7 +151,7 @@ def Goniometer(**kwargs):
         return BaseGon(**kwargs)
 
 
-class XYZStage(Device, BaseInterface):
+class XYZStage(BaseInterface, Device):
     """
     Sample XYZ stage.
 
@@ -183,7 +183,7 @@ class XYZStage(Device, BaseInterface):
         super().__init__('', name=name, **kwargs)
 
 
-class SamPhi(Device, BaseInterface):
+class SamPhi(BaseInterface, Device):
     """
     Sample Phi stage.
 
@@ -210,7 +210,7 @@ class SamPhi(Device, BaseInterface):
         super().__init__('', name=name, **kwargs)
 
 
-class Kappa(Device, BaseInterface):
+class Kappa(BaseInterface, Device):
     """
     Kappa stage.
 

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -36,7 +36,7 @@ class IPMTarget(InOutRecordPositioner):
         self.y_motor = self.motor
 
 
-class IPMDiode(Device, BaseInterface):
+class IPMDiode(BaseInterface, Device):
     """
     Diode of a standard intensity position monitor.
 
@@ -86,7 +86,7 @@ class IPMDiode(Device, BaseInterface):
     remove.__doc__ += insert_remove
 
 
-class IPMMotion(Device, BaseInterface):
+class IPMMotion(BaseInterface, Device):
     """
     Standard intensity position monitor.
 
@@ -142,7 +142,7 @@ class IPMMotion(Device, BaseInterface):
         return self.target.transmission * self.diode.transmission
 
 
-class IPIMBChannel(Device, BaseInterface):
+class IPIMBChannel(BaseInterface, Device):
     """
     Class for a single channel read out by an IPIMB box.
 
@@ -176,7 +176,7 @@ class IPIMBChannel(Device, BaseInterface):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class IPIMB(Device, BaseInterface):
+class IPIMB(BaseInterface, Device):
     """
     Class for an IPIMB box.
 
@@ -234,7 +234,7 @@ class IPIMB(Device, BaseInterface):
         return ipm_screen('IPIMB', self._prefix, self._prefix_ioc)
 
 
-class Wave8Channel(Device, BaseInterface):
+class Wave8Channel(BaseInterface, Device):
     """
     Class for a single channel read out by a wave8.
 
@@ -269,7 +269,7 @@ class Wave8Channel(Device, BaseInterface):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class Wave8(Device, BaseInterface):
+class Wave8(BaseInterface, Device):
     """
     Class for a wave8.
 
@@ -325,7 +325,7 @@ class Wave8(Device, BaseInterface):
         raise NotImplementedError
 
 
-class IPM_Det(Device, BaseInterface):
+class IPM_Det(BaseInterface, Device):
     """Base class for IPM_IPIMB and IPM_Wave8. Not meant to be instantiated."""
     tab_component_names = True
 

--- a/pcdsdevices/jet.py
+++ b/pcdsdevices/jet.py
@@ -9,7 +9,7 @@ from .epics_motor import IMS, BeckhoffAxis
 from .interface import BaseInterface
 
 
-class Injector(Device, BaseInterface):
+class Injector(BaseInterface, Device):
     """
     Positioner for liquid jet Injector.
 
@@ -69,7 +69,7 @@ class InjectorWithFine(Injector):
     fine_z = UCpt(IMS)
 
 
-class BeckhoffJetManipulator(Device, BaseInterface):
+class BeckhoffJetManipulator(BaseInterface, Device):
     """Jet Manipulator controlled by Beckhoff PLC."""
 
     tab_component_names = True
@@ -79,7 +79,7 @@ class BeckhoffJetManipulator(Device, BaseInterface):
     z = Cpt(BeckhoffAxis, ':Z', kind='normal')
 
 
-class BeckhoffJetSlits(Device, BaseInterface):
+class BeckhoffJetSlits(BaseInterface, Device):
     """Pair of Beckhoff-controlled slits where each blade has X & Y motors."""
     tab_component_names = True
 
@@ -89,7 +89,7 @@ class BeckhoffJetSlits(Device, BaseInterface):
     bot_y = Cpt(BeckhoffAxis, ':BOT_Y', kind='normal')
 
 
-class BeckhoffJet(Device, BaseInterface):
+class BeckhoffJet(BaseInterface, Device):
     """
     Full liquid jet setup controlled by a Beckhoff PLC.
 

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -17,7 +17,7 @@ from periodictable import xsf
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .inout import CombinedInOutRecordPositioner, InOutRecordPositioner
-from .interface import tweak_base, BaseInterface
+from .interface import BaseInterface, tweak_base
 from .sim import FastMotor
 
 LENS_RADII = [50e-6, 100e-6, 200e-6, 300e-6, 500e-6, 1000e-6, 1500e-6]
@@ -324,5 +324,5 @@ class SimLensStackBase(LensStackBase):
     z = Cpt(FastMotor, limits=(-100, 100))
 
 
-class SimLensStack(LensStack, SimLensStackBase):
+class SimLensStack(SimLensStackBase, LensStack):
     pass

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -17,7 +17,7 @@ from periodictable import xsf
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .inout import CombinedInOutRecordPositioner, InOutRecordPositioner
-from .interface import tweak_base
+from .interface import tweak_base, BaseInterface
 from .sim import FastMotor
 
 LENS_RADII = [50e-6, 100e-6, 200e-6, 300e-6, 500e-6, 1000e-6, 1500e-6]
@@ -79,7 +79,7 @@ class Prefocus(CombinedInOutRecordPositioner):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class LensStackBase(PseudoPositioner):
+class LensStackBase(BaseInterface, PseudoPositioner):
     """Class for Be lens macros and safe operations."""
     x = FCpt(IMS, '{self.x_prefix}')
     y = FCpt(IMS, '{self.y_prefix}')
@@ -324,5 +324,5 @@ class SimLensStackBase(LensStackBase):
     z = Cpt(FastMotor, limits=(-100, 100))
 
 
-class SimLensStack(SimLensStackBase, LensStack):
+class SimLensStack(LensStack, SimLensStackBase):
     pass

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -60,7 +60,7 @@ class Foil(InOutRecordPositioner):
         super().__init__(prefix, *args, **kwargs)
 
 
-class LODCM(Device, BaseInterface):
+class LODCM(BaseInterface, Device):
     """
     Large Offset Dual Crystal Monochromator.
 

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -142,7 +142,7 @@ class LaserEnergyPlotContext:
         self.figure.canvas.draw()
 
 
-class LaserEnergyPositioner(LookupTablePositioner, FltMvInterface):
+class LaserEnergyPositioner(FltMvInterface, LookupTablePositioner):
     """
     Uses the lookup-table positioner to convert energy <-> motor positions.
 
@@ -214,7 +214,7 @@ class LaserEnergyPositioner(LookupTablePositioner, FltMvInterface):
         return super().wm[0]
 
 
-class LaserTiming(PVPositioner, FltMvInterface):
+class LaserTiming(FltMvInterface, PVPositioner):
     """
     "lxt" motor, which may also have been referred to as Vitara.
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -149,7 +149,7 @@ class Gantry(OMMotor):
         super().check_value(pos)
 
 
-class OffsetMirror(Device, BaseInterface):
+class OffsetMirror(BaseInterface, Device):
     """
     X-ray Offset Mirror class.
 
@@ -271,7 +271,7 @@ class PointingMirror(InOutRecordPositioner, OffsetMirror):
         return super().check_value(pos)
 
 
-class XOffsetMirror(Device, BaseInterface):
+class XOffsetMirror(BaseInterface, Device):
     """
     X-ray Offset Mirror.
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -50,7 +50,7 @@ class PIMY(InOutRecordPositioner, BaseInterface):
         return super().stage()
 
 
-class PIM(Device, BaseInterface):
+class PIM(BaseInterface, Device):
     """
     Profile Intensity Monitor.
 
@@ -251,7 +251,7 @@ class PIMWithBoth(PIMWithFocus, PIMWithLED):
     pass
 
 
-class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
+class LCLS2ImagerBase(BaseInterface, Device, LightpathInOutMixin):
     """
     Shared PVs and components from the LCLS2 imagers.
 
@@ -280,7 +280,7 @@ class LCLS2ImagerBase(Device, BaseInterface, LightpathInOutMixin):
         return self.target
 
 
-class PPMPowerMeter(Device, BaseInterface):
+class PPMPowerMeter(BaseInterface, Device):
     """
     Analog measurement tool for beam energy as part of the PPM assembly.
 
@@ -391,7 +391,7 @@ class XPIMFilterWheel(StatePositioner):
     set_metadata(state, dict(variety='command-enum'))
 
 
-class XPIMLED(Device):
+class XPIMLED(BaseInterface, Device):
     """
     Controllable illumination with auto-on, auto-off, and shutdown timer.
 

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -16,7 +16,7 @@ from .utils import convert_unit
 logger = logging.getLogger(__name__)
 
 
-class SyncAxesBase(PseudoPositioner, FltMvInterface):
+class SyncAxesBase(FltMvInterface, PseudoPositioner):
     """
     Synchronized Axes.
 
@@ -100,7 +100,7 @@ class SyncAxesBase(PseudoPositioner, FltMvInterface):
         return self.PseudoPosition(pseudo=self.calc_combined(real_pos))
 
 
-class DelayBase(PseudoPositioner, FltMvInterface):
+class DelayBase(FltMvInterface, PseudoPositioner):
     """
     Laser delay stage to rescale a physical axis to a time axis.
 
@@ -168,7 +168,7 @@ class SimDelayStage(DelayBase):
     motor = Cpt(FastMotor, init_pos=0, egu='mm')
 
 
-class PseudoSingleInterface(PseudoSingle, FltMvInterface):
+class PseudoSingleInterface(FltMvInterface, PseudoSingle):
     """PseudoSingle with FltMvInterface mixed in."""
     pass
 

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -13,7 +13,7 @@ from .interface import BaseInterface
 logger = logging.getLogger(__name__)
 
 
-class TurboPump(Device, BaseInterface):
+class TurboPump(BaseInterface, Device):
     """Turbo Vacuum Pump."""
     atspeed = Cpt(EpicsSignal, ':ATSPEED_DI', kind='normal')
     start = Cpt(EpicsSignal, ':START_SW', kind='normal')
@@ -29,7 +29,7 @@ class TurboPump(Device, BaseInterface):
         self.start.put(0)
 
 
-class EbaraPump(Device, BaseInterface):
+class EbaraPump(BaseInterface, Device):
     """Ebara Turbo Pump."""
     start = Cpt(EpicsSignal, ':MPSTART_SW', kind='normal')
 
@@ -44,7 +44,7 @@ class EbaraPump(Device, BaseInterface):
         self.start.put(0)
 
 
-class GammaController(Device, BaseInterface):
+class GammaController(BaseInterface, Device):
     """Ion Pump Gamma controller."""
     channel1name = Cpt(EpicsSignal, ':CHAN1NAME', kind='config')
     channel2name = Cpt(EpicsSignal, ':CHAN2NAME', kind='config')
@@ -64,7 +64,7 @@ class GammaController(Device, BaseInterface):
     tab_component_names = True
 
 
-class IonPumpBase(Device, BaseInterface):
+class IonPumpBase(BaseInterface, Device):
     """
 %s
     """

--- a/pcdsdevices/pv_positioner.py
+++ b/pcdsdevices/pv_positioner.py
@@ -6,7 +6,7 @@ from .interface import FltMvInterface
 from .signal import InternalSignal
 
 
-class PVPositionerComparator(PVPositioner, FltMvInterface):
+class PVPositionerComparator(FltMvInterface, PVPositioner):
     """
     PV Positioner with a software done signal.
 

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -42,7 +42,7 @@ class PneumaticActuator(InOutPositioner):
             self.out_cmd.put(1)
 
 
-class RTDSBase(Device, BaseInterface, LightpathInOutMixin):
+class RTDSBase(BaseInterface, Device, LightpathInOutMixin):
     """Rapid Turnaround Diagnostic Station."""
     lightpath_cpts = ['mpa1', 'mpa2', 'mpa3', 'mpa4']
     _lightpath_mixin = True

--- a/pcdsdevices/sample_delivery.py
+++ b/pcdsdevices/sample_delivery.py
@@ -10,7 +10,7 @@ from .interface import BaseInterface
 from .signal import PytmcSignal
 
 
-class M3BasePLCDevice(Device, BaseInterface):
+class M3BasePLCDevice(BaseInterface, Device):
     """
     Base device for M3 SDS PLC devices.
 
@@ -21,7 +21,7 @@ class M3BasePLCDevice(Device, BaseInterface):
     status = Cpt(PytmcSignal, ':IO:SyncUnitOK', io='i', kind='normal')
 
 
-class ViciValve(Device, BaseInterface):
+class ViciValve(BaseInterface, Device):
     """
     A Vici Valve as used in the SDS Selector.
 
@@ -93,7 +93,7 @@ class Selector(M3BasePLCDevice):
                         kind='normal')
 
 
-class CoolerShaker(Device, BaseInterface):
+class CoolerShaker(BaseInterface, Device):
     """
     A Cooler/Shaker for the sample delivery system.
 
@@ -150,7 +150,7 @@ class CoolerShaker(Device, BaseInterface):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class HPLC(Device, BaseInterface):
+class HPLC(BaseInterface, Device):
     """
     An HPLC for the sample delivery system.
 
@@ -212,7 +212,7 @@ class HPLC(Device, BaseInterface):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class PropAir(Device, BaseInterface):
+class PropAir(BaseInterface, Device):
     """
     A Proportionair pressure regulator used by the Pressure Control Module.
 
@@ -249,7 +249,7 @@ class PCM(M3BasePLCDevice):
     propair2 = Cpt(PropAir, ':PropAir:02', name='PropAir2')
 
 
-class IntegratedFlow(Device, BaseInterface):
+class IntegratedFlow(BaseInterface, Device):
     """
     A single flow for the FlowIntegrator.
 
@@ -274,7 +274,7 @@ class IntegratedFlow(Device, BaseInterface):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class FlowIntegrator(Device, BaseInterface):
+class FlowIntegrator(BaseInterface, Device):
     """
     A Flow Integrator for the sample delivery system.
 
@@ -400,7 +400,7 @@ class FlowIntegrator(Device, BaseInterface):
         super().__init__('', name=name, **kwargs)
 
 
-class ManifoldValve(Device, BaseInterface):
+class ManifoldValve(BaseInterface, Device):
     """
     A single valve as present in the SDS Gas Manifold.
 
@@ -419,7 +419,7 @@ class ManifoldValve(Device, BaseInterface):
     interlocked = Cpt(PytmcSignal, ':Ilk', io='i', kind='normal')
 
 
-class GasManifold(M3BasePLCDevice, BaseInterface):
+class GasManifold(M3BasePLCDevice):
     """
     A Gas Manifold as used in the sample delivery system.
 

--- a/pcdsdevices/sensors.py
+++ b/pcdsdevices/sensors.py
@@ -10,7 +10,7 @@ from .interface import BaseInterface
 from .signal import PytmcSignal, NotImplementedSignal
 
 
-class TwinCATThermocouple(Device, BaseInterface):
+class TwinCATThermocouple(BaseInterface, Device):
     """
     Basic twincat temperature sensor class.
 
@@ -23,7 +23,7 @@ class TwinCATThermocouple(Device, BaseInterface):
     error = Cpt(PytmcSignal, ':STC:ERR', io='i', kind='normal')
 
 
-class RTD(Device, BaseInterface):
+class RTD(BaseInterface, Device):
     """
     Resistive Temperature Device.
 

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -11,7 +11,7 @@ from .interface import BaseInterface
 logger = logging.getLogger(__name__)
 
 
-class EventSequence(Device, BaseInterface):
+class EventSequence(BaseInterface, Device):
     """Class for the event sequence of the event sequencer."""
     ec_array = Cpt(EpicsSignal, ':SEQ.A')
     bd_array = Cpt(EpicsSignal, ':SEQ.B')
@@ -145,7 +145,7 @@ class EventSequence(Device, BaseInterface):
             print(line)
 
 
-class EventSequencer(Device, MonitorFlyerMixin, FlyerInterface, BaseInterface):
+class EventSequencer(BaseInterface, Device, MonitorFlyerMixin, FlyerInterface):
     """
     Event Sequencer.
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -33,7 +33,7 @@ from .utils import schedule_task
 logger = logging.getLogger(__name__)
 
 
-class SlitsBase(Device, MvInterface, LightpathMixin):
+class SlitsBase(MvInterface, Device, LightpathMixin):
     """
     Base class for slit motion interfacing.
     """
@@ -209,7 +209,7 @@ class SlitsBase(Device, MvInterface, LightpathMixin):
         self._removed = not self._inserted
 
 
-class BadSlitPositionerBase(PVPositioner, FltMvInterface):
+class BadSlitPositionerBase(FltMvInterface, PVPositioner):
     """Base class for slit positioner with awful PV names."""
 
     readback = FCpt(EpicsSignalRO, '{prefix}:ACTUAL_{_dirlong}',

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -10,7 +10,7 @@ from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal
 
 
-class Kmono(Device, BaseInterface, LightpathMixin):
+class Kmono(BaseInterface, Device, LightpathMixin):
     """
     K-edge Monochromator: Used for Undulator tuning and other experiments.
 
@@ -97,7 +97,7 @@ class Kmono(Device, BaseInterface, LightpathMixin):
             self._transmission = 1
 
 
-class VonHamosCrystal(Device, BaseInterface):
+class VonHamosCrystal(BaseInterface, Device):
     """Pitch, yaw, and translation motors for control of a single crystal."""
     tab_component_names = True
 
@@ -106,7 +106,7 @@ class VonHamosCrystal(Device, BaseInterface):
     trans = Cpt(BeckhoffAxis, ':Translation', kind='normal')
 
 
-class VonHamosFE(Device, BaseInterface):
+class VonHamosFE(BaseInterface, Device):
     """
     von Hamos spectrometer with Focus and Energy motors.
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -21,7 +21,7 @@ from .variety import set_metadata
 logger = logging.getLogger(__name__)
 
 
-class StatePositioner(Device, PositionerBase, MvInterface):
+class StatePositioner(MvInterface, Device, PositionerBase):
     """
     Base class for state-based positioners.
 

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -4,10 +4,11 @@ Module for the SXR Test Absorbers.
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 
+from .interface import BaseInterface
 from .epics_motor import BeckhoffAxis
 
 
-class SxrTestAbsorber(Device):
+class SxrTestAbsorber(BaseInterface, Device):
     """
     SXR Test Absorber: Used for testing the sxr beamline at high pulse rates.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,9 +91,3 @@ def find_all_device_classes() -> list:
                     devices.add(obj)
 
     return list(devices)
-
-
-all_device_classes = [
-    pytest.param(cls, id=f'{cls.__module__}.{cls.__name__}')
-    for cls in find_all_device_classes()
-]

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -40,8 +40,8 @@ def test_mv(fast_motor):
 def test_umv(slow_motor):
     logger.debug('test_umv')
     slow_motor._set_position(5)
-    slow_motor.umvr(2)
-    assert slow_motor.position == 7
+    slow_motor.umvr(1)
+    assert slow_motor.position == 6
 
 
 def test_camonitor(fast_motor):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- :class:`BaseInterface` no longer inherits from :class:`ophyd.OphydObject`.
- The order of multiple inheritance for many devices using the LCLS-enhanced
  :class:`BaseInterface`, :class:`MvInterface`, and :class:`FltMvInterface` has
  been changed.
- Tab completion for many devices has been fixed. Regression tests have been
  added.

## Motivation and Context
Class hierarchy issues caused tab completion to break. The root cause was slightly more complicated than one might have expected, necessitating updating the majority of devices.

## How Has This Been Tested?
Added a fairly extensive regression test + tab completion test.

Indicates that there are still some classes that may need updating (marked with `SKIPPED`).

## Where Has This Been Documented?
Release notes + docstrings + helper exception messages.