### PR TITLE
MNT: rework beam energy positioner to be setpoint-only

### DIFF
--- a/docs/source/upcoming_release_notes/546-beam-req.rst
+++ b/docs/source/upcoming_release_notes/546-beam-req.rst
@@ -1,0 +1,34 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add PVPositionerDone, a setpoint-only PVPositioner class that is done moving
+  immediately. This is not much more useful than just using a PV, but it is
+  compatibile with pseudopositioners and has a built-in filter for ignoring
+  small moves.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Rework BeamEnergyPositioner to be setpoint-only to work properly
+  with the behavior of the energy PVs.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -37,7 +37,7 @@ class BeamEnergyRequest(PVPositionerDone):
     fulfilled by moving the Vernier but can also be a more involved process.
 
     Motion is immedately considered "done", but will not execute unless the
-    requested position is larger than the current position. The default
+    requested position delta is larger than the tolerance. The default
     tolerance here is 30 eV, but this can be changed on a per-instance basis
     by passing ``atol`` into the initializer, or on a per-subclass basis by
     overriding the default.

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -74,11 +74,7 @@ def make_fake_ccm():
     init_pos(fake_ccm.y.up_north)
     init_pos(fake_ccm.y.up_south)
 
-    def init_pvpos(mot, pos=0):
-        mot.setpoint.sim_put(0)
-        mot.readback.sim_put(0)
-
-    init_pvpos(fake_ccm.calc.energy_request)
+    fake_ccm.calc.energy_request.setpoint.sim_put(0)
 
     return fake_ccm
 
@@ -165,43 +161,32 @@ def test_ccm_main(fake_ccm):
 def test_vernier(fake_ccm):
     logger.debug('test_vernier')
 
-    def finish_energy_move():
-        # Satisfy the isclose positioner's done condition
-        setpoint = fake_ccm.calc.energy_request.setpoint.get()
-        fake_ccm.calc.energy_request.readback.sim_put(setpoint)
-
     # Moving with vernier should move the energy request motor too
     fake_ccm.calc.energy_with_vernier.move(7, wait=False)
-    finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 7)
     assert fake_ccm.calc.energy_request.position == 7000
 
     fake_ccm.calc.energy_with_vernier.move(8, wait=False)
-    finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 8)
     assert fake_ccm.calc.energy_request.position == 8000
 
     fake_ccm.calc.energy_with_vernier.move(9, wait=False)
-    finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 9)
     assert fake_ccm.calc.energy_request.position == 9000
 
     # Small moves (less than 30eV) should be skipped on the energy request
     fake_ccm.calc.energy_with_vernier.move(9.001, wait=False)
-    finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 9.001)
     assert fake_ccm.calc.energy_request.position == 9000
 
     # Unless we set the option for not skipping them
     fake_ccm.calc.energy_request.skip_small_moves = False
     fake_ccm.calc.energy_with_vernier.move(9.002, wait=False)
-    finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 9.002)
     assert fake_ccm.calc.energy_request.position == 9002
 
     # Normal moves should ignore the vernier PV
     fake_ccm.calc.energy.move(10, wait=False)
-    finish_energy_move()
     assert np.isclose(fake_ccm.calc.energy.position, 10)
     assert fake_ccm.calc.energy_request.position == 9002
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The beam energy positioner only has a setpoint. The readback I had originally picked was not appropriate for the use case for various reasons. I have resolved this by making a new base class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #546 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes old tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Oops, I'll go write the pre-release docs
<!--
## Screenshots (if appropriate):
-->
