### PR TITLE
MNT: fix issue with epics setpoint limits being (None, None)

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -91,7 +91,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
 
     def _get_epics_limits(self):
         limits = self.user_setpoint.limits
-        if limits is None:
+        if limits is None or limits == (None, None):
             # Not initialized
             return (0, 0)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Extend the check to also check `(None, None)` and not just `None`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
LXE is not initializing because its newport is initializing to limits `(None, None)`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
LXE initializes now

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Patches bug that was introduced after to the last tag, so I'll overlook it
<!--
## Screenshots (if appropriate):
-->
