### PR TITLE
MNT: Fix umv and tweak issues

### DIFF
--- a/docs/source/upcoming_release_notes/527-tweak-fixes.rst
+++ b/docs/source/upcoming_release_notes/527-tweak-fixes.rst
@@ -1,0 +1,32 @@
+527 Tweak tweaks
+################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Tweak will feel less "janky" now and give useful feedback.
+- Tweak now accepts + and - as valid inputs for changing the step size.
+- Tweak properly clears lines between prints.
+
+Maintenance
+-----------
+- Tweak refactored for maintainability.
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/553-umv-fixes.rst
+++ b/docs/source/upcoming_release_notes/553-umv-fixes.rst
@@ -1,0 +1,30 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- umv will now properly display position and completion status after a move.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/553-umv-fixes.rst
+++ b/docs/source/upcoming_release_notes/553-umv-fixes.rst
@@ -1,5 +1,5 @@
-IssueNumber Title
-#################
+553 Umv Fixes
+#############
 
 API Changes
 -----------

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1173,14 +1173,25 @@ def tweak_base(*args):
     print()
 
 
+loglist = []
+
+
 class AbsProgressBar(ProgressBar):
     """Progress bar that displays the absolute position as well."""
+    def __init__(self, status_objs, delay_draw=1.0):
+        self._last_position = None
+        super().__init__(status_objs, delay_draw=delay_draw)
+
     def update(self, *args, name=None, current=None, **kwargs):
-        if None not in (name, current):
-            super().update(*args, name='{} ({:.3f})'.format(name, current),
-                           current=current, **kwargs)
-        else:
-            super().update(*args, name=name, current=current, **kwargs)
+        try:
+            name = '{} ({:.3f})'.format(name, current)
+            self._last_position = current
+        except Exception:
+            name = name or 'motor'
+
+        current = current or self._last_position
+        loglist.append((name, current, kwargs))
+        super().update(*args, name=name, current=current, **kwargs)
 
 
 class LightpathMixin(OphydObject):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1204,25 +1204,24 @@ def tweak_base(*args):
             logger.error('Error in tweak move: %s', exc)
             logger.debug('', exc_info=True)
 
+    start_text = ['{} at {:.4f}'.format(mot.name, mot.wm()) for mot in args]
+    logger.info('Started tweak of ' + ', '.join(start_text))
+
     # Loop takes in user key input and stops when 'q' is pressed
-    if len(args) == 1:
-        logger.info('Started tweak of %s', args[0])
-    else:
-        logger.info('Started tweak of %s', [mot.name for mot in args])
     is_input = True
     while is_input is True:
         show_status()
         inp = utils.get_input()
         if inp in ('q', None):
             is_input = False
+        elif inp in move_keys:
+            movement(scale, inp)
+        elif inp in scale_keys:
+            scale = edit_scale(scale, inp)
         else:
-            if inp in move_keys:
-                movement(scale, inp)
-            elif inp in scale_keys:
-                scale = edit_scale(scale, inp)
-            else:
-                usage()
+            usage()
     print()
+    logger.info('Tweak complete')
 
 
 class AbsProgressBar(ProgressBar):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -539,11 +539,12 @@ class FltMvInterface(MvInterface):
 
         self._log_move(position)
         status = self.move(position, timeout=timeout, wait=False)
-        AbsProgressBar([status])
+        pgb = AbsProgressBar([status])
         try:
             status_wait(status)
         except KeyboardInterrupt:
             self.stop()
+            pgb.no_more_updates()
         print()
 
     def umvr(self, delta, timeout=None):
@@ -1179,6 +1180,7 @@ class AbsProgressBar(ProgressBar):
     def __init__(self, status_objs, **kwargs):
         self._last_position = None
         self._name = None
+        self._no_more = False
         super().__init__(status_objs, **kwargs)
 
         # Extra call when status is complete
@@ -1189,6 +1191,8 @@ class AbsProgressBar(ProgressBar):
         self.update(pos, name=self._name, current=self._last_position)
 
     def update(self, *args, name=None, current=None, **kwargs):
+        if self._no_more:
+            return
         current = current or self._last_position
         self._name = self._name or name
 
@@ -1199,6 +1203,9 @@ class AbsProgressBar(ProgressBar):
             name = name or self._name or 'motor'
 
         super().update(*args, name=name, current=current, **kwargs)
+
+    def no_more_updates(self):
+        self._no_more = True
 
 
 class LightpathMixin(OphydObject):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1173,24 +1173,30 @@ def tweak_base(*args):
     print()
 
 
-loglist = []
-
-
 class AbsProgressBar(ProgressBar):
     """Progress bar that displays the absolute position as well."""
-    def __init__(self, status_objs, delay_draw=1.0):
+    def __init__(self, status_objs, **kwargs):
         self._last_position = None
-        super().__init__(status_objs, delay_draw=delay_draw)
+        self._name = None
+        super().__init__(status_objs, **kwargs)
+
+        # Extra call when status is complete
+        for i, obj in enumerate(status_objs):
+            obj.add_callback(functools.partial(self._status_cb, i))
+
+    def _status_cb(self, pos, status):
+        self.update(pos, name=self._name, current=self._last_position)
 
     def update(self, *args, name=None, current=None, **kwargs):
+        current = current or self._last_position
+        self._name = self._name or name
+
         try:
             name = '{} ({:.3f})'.format(name, current)
             self._last_position = current
         except Exception:
-            name = name or 'motor'
+            name = name or self._name or 'motor'
 
-        current = current or self._last_position
-        loglist.append((name, current, kwargs))
         super().update(*args, name=name, current=current, **kwargs)
 
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -544,6 +544,7 @@ class FltMvInterface(MvInterface):
             status_wait(status)
         except KeyboardInterrupt:
             self.stop()
+        print()
 
     def umvr(self, delta, timeout=None):
         """

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1185,7 +1185,8 @@ class AbsProgressBar(ProgressBar):
 
         # Extra call when status is complete
         for i, obj in enumerate(status_objs):
-            obj.add_callback(functools.partial(self._status_cb, i))
+            if not obj.done:
+                obj.add_callback(functools.partial(self._status_cb, i))
 
     def _status_cb(self, pos, status):
         self.update(pos, name=self._name, current=self._last_position)

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -47,7 +47,10 @@ class SlowMotor(FastMotor):
 
     def _setup_move(self, position, status):
         if self.position is None:
-            return self._set_position(position)
+            # Initialize position during __init__'s set call
+            self._set_position(position)
+            self._done_moving(success=True)
+            return
 
         def update_thread(positioner, goal):
             positioner._moving = True
@@ -58,7 +61,7 @@ class SlowMotor(FastMotor):
                     positioner._set_position(positioner.position - 1)
                 else:
                     positioner._set_position(goal)
-                    positioner._done_moving()
+                    positioner._done_moving(success=True)
                     return
                 time.sleep(0.1)
             positioner._done_moving(success=False)

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -32,6 +32,8 @@ ctrl_arrow_up = '\x1b[1;5A'
 ctrl_arrow_down = '\x1b[1;5B'
 ctrl_arrow_right = '\x1b[1;5C'
 ctrl_arrow_left = '\x1b[1;5D'
+plus = '+'
+minus = '-'
 
 
 def is_input():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -39,9 +39,10 @@ def test_mv(fast_motor):
 @pytest.mark.timeout(5)
 def test_umv(slow_motor):
     logger.debug('test_umv')
-    slow_motor._set_position(5)
-    slow_motor.umvr(1)
-    assert slow_motor.position == 6
+    start_position = slow_motor.position
+    delta = 2
+    slow_motor.umvr(delta)
+    assert slow_motor.position == start_position + delta
 
 
 def test_camonitor(fast_motor):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- umv displays position at the end of the move
- umv displays complete instead of not complete at the end of the move
- umv and tweak agree on an output format
- tweak doesn't tweak out, it has measured, consistent output
- tweak accepts + and - for increasing or decreasing the scaling
- tweak properly clears lines between prints
- tweak code refactored a bit for cleanliness

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #553 (umv)
The progress bar / position bar was not guaranteed an update on status completion. This guarantees such an update. Otherwise, you can get stuck with a progress bar that says "move in progress, no real information, blah blah blah"

closes #527 (tweak)
closes #281 (tweak)

Partially addresses https://github.com/pcdshub/Bug-Reports-and-Requests/issues/16 by adding the + and - keystrokes

also closes #481. I tracked down the race condition because it was extremely annoying.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally
```
In [4]: mot.umv(100)
mot (100.000) [Complete.]
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
In the pre-release docs section
<!--
## Screenshots (if appropriate):
-->
