### PR TITLE
MNT: establish ureg only once, it is a slow process

### DIFF
--- a/docs/source/upcoming_release_notes/558-slow-ureg.rst
+++ b/docs/source/upcoming_release_notes/558-slow-ureg.rst
@@ -1,0 +1,31 @@
+558 Slow Ureg
+#############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where converting units could incur time penalties of up to
+  7 seconds. This should take around 10ms now.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zlentz

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -88,6 +88,9 @@ def get_input():
         return inp
 
 
+ureg = pint.UnitRegistry()
+
+
 def convert_unit(value, unit, new_unit):
     """
     One-line unit conversion.
@@ -109,7 +112,6 @@ def convert_unit(value, unit, new_unit):
         The starting value, but converted to the new unit.
     """
 
-    ureg = pint.UnitRegistry()
     expr = ureg.parse_expression(unit)
     return (value * expr).to(new_unit).magnitude
 

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -88,7 +88,7 @@ def get_input():
         return inp
 
 
-ureg = pint.UnitRegistry()
+ureg = None
 
 
 def convert_unit(value, unit, new_unit):
@@ -111,6 +111,10 @@ def convert_unit(value, unit, new_unit):
     new_value : float
         The starting value, but converted to the new unit.
     """
+
+    global ureg
+    if ureg is None:
+        ureg = pint.UnitRegistry()
 
     expr = ureg.parse_expression(unit)
     return (value * expr).to(new_unit).magnitude


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Create the `pint.UnitRegistry` at first use only instead of at every conversion call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The function call is slow, and only needs to be done once.
Contributes to #526, might be related to #550 

Here is the line_profiler output for this method from a software-only motor move:
```
Total time: 6.7158 s
File: /u/lu/zlentz/pydev/pcdsdevices/utils.py
Function: convert_unit at line 91

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    91                                           def convert_unit(value, unit, new_unit):
    92                                               """
    93                                               One-line unit conversion.
    94
    95                                               Parameters
    96                                               ----------
    97                                               value : float
    98                                                   The starting value for the conversion.
    99
   100                                               unit : str
   101                                                   The starting unit for the conversion.
   102
   103                                               new_unit : str
   104                                                   The desired unit for the conversion.
   105
   106                                               Returns
   107                                               -------
   108                                               new_value : float
   109                                                   The starting value, but converted to the new unit.
   110                                               """
   111
   112         8       6705.0    838.1     99.8      ureg = pint.UnitRegistry()
   113         8          4.1      0.5      0.1      expr = ureg.parse_expression(unit)
   114         8          6.7      0.8      0.1      return (value * expr).to(new_unit).magnitude
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally only with simulated hardware- all slowdowns after this are due to the hardware classes and should be investigated too.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes added
<!--
## Screenshots (if appropriate):
-->
