### PR TITLE
MNT: patch wm for pseudo positioner compatibility

### DIFF
--- a/docs/source/upcoming_release_notes/557-pseudo-wm.rst
+++ b/docs/source/upcoming_release_notes/557-pseudo-wm.rst
@@ -1,0 +1,34 @@
+557 Pseudo Wm
+#############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- FltMvPositioner.wm will now return numeric values if the position
+  value is a tuple. This value is the first element of the tuple, which
+  for pseudo positioners is a value that can be passed into move and have
+  it do the right thing. This resolves consistency issues and fixes bugs
+  where mvr and umvr would fail.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -510,6 +510,13 @@ class FltMvInterface(MvInterface):
             self._presets = Presets(self)
         return self._presets
 
+    def wm(self):
+        pos = super().wm()
+        try:
+            return pos[0]
+        except Exception:
+            return pos
+
     def mvr(self, delta, timeout=None, wait=False, log=True):
         """
         Relative move from this position.

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -209,10 +209,6 @@ class LaserEnergyPositioner(FltMvInterface, LookupTablePositioner):
                                         energy=position.energy)
         return ret
 
-    def wm(self) -> float:
-        # Remove the PseudoPosition tuple for FltMvInterface compatibility
-        return super().wm[0]
-
 
 class LaserTiming(FltMvInterface, PVPositioner):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`FltMvInterface.wm()` now is aware that float movers could be pseudo positioners that return tuples, and will make sure to return a value from the first element of the tuple if it can.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This bug breaks things like mvr, umvr
closes #557 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally...
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes
<!--
## Screenshots (if appropriate):
-->
