### PR TITLE
MNT: various CCM tolerances and limits

### DIFF
--- a/docs/source/upcoming_release_notes/560-tol-lims.rst
+++ b/docs/source/upcoming_release_notes/560-tol-lims.rst
@@ -1,0 +1,33 @@
+560 CCM Tols and Lims
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- CCM energy limited to the range of 4 to 25 keV
+- CCM theta2fine done moving tolerance raised to 0.01
+- Beam request default move start tolerance dropped to 5eV
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix bug on beam request where you could not override the tolerance
+  via init kwarg, despite docstring's indication.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -64,8 +64,8 @@ class BeamEnergyRequest(PVPositionerDone):
         skip moves using the skip_small_moves parameter.
     """
 
-    # Default tolerance from Vernier in legacy XCS python
-    atol = 30
+    # Default vernier tolerance
+    atol = 5
 
     setpoint = Cpt(EpicsSignal, ':USER:MCC:EPHOT', kind='hinted')
 

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -69,6 +69,9 @@ class BeamEnergyRequest(PVPositionerDone):
 
     setpoint = Cpt(EpicsSignal, ':USER:MCC:EPHOT', kind='hinted')
 
-    def __init__(self, prefix, *, name, skip_small_moves=True, **kwargs):
+    def __init__(self, prefix, *, name, skip_small_moves=True, atol=None,
+                 **kwargs):
+        if atol is not None:
+            self.atol = atol
         super().__init__(prefix, name=name, skip_small_moves=skip_small_moves,
                          **kwargs)

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -75,7 +75,8 @@ class CCMCalc(FltMvInterface, PseudoPositioner):
     description instead of giving a partial and possibly incorrect summary.
     """
 
-    energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted')
+    energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted',
+                 limits=(4, 25))
     wavelength = Cpt(PseudoSingleInterface, egu='A', kind='normal')
     theta = Cpt(PseudoSingleInterface, egu='deg', kind='normal')
     energy_with_vernier = Cpt(PseudoSingleInterface, egu='keV',

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -195,7 +195,7 @@ class CCM(InOutPositioner):
     """
 
     calc = FCpt(CCMCalc, '{self.alio_prefix}', kind='hinted')
-    theta2fine = FCpt(CCMMotor, '{self.theta2fine_prefix}')
+    theta2fine = FCpt(CCMMotor, '{self.theta2fine_prefix}', atol=0.01)
     theta2coarse = FCpt(CCMPico, '{self.theta2coarse_prefix}')
     chi2 = FCpt(CCMPico, '{self.chi2_prefix}')
     x = FCpt(CCMX,

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -23,6 +23,8 @@ class SynMotor(FltMvInterface, SynAxis):
         return super().set(position)
 
 
+ignore_kwargs = ('atol',)
+
 class FastMotor(FltMvInterface, SoftPositioner, Device):
     """
     Instant motor with `FltMvInterface`.
@@ -34,6 +36,8 @@ class FastMotor(FltMvInterface, SoftPositioner, Device):
     user_readback = Cpt(AttributeSignal, 'position')
 
     def __init__(self, *args, init_pos=0, **kwargs):
+        for kw in ignore_kwargs:
+            kwargs.pop(kw, None)
         super().__init__(init_pos=init_pos, **kwargs)
 
 

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -25,6 +25,7 @@ class SynMotor(FltMvInterface, SynAxis):
 
 ignore_kwargs = ('atol',)
 
+
 class FastMotor(FltMvInterface, SoftPositioner, Device):
     """
     Instant motor with `FltMvInterface`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Implement the following fixes as requested by the scientists:
- CCM energy limited to the range of 4 to 25 keV
- CCM theta2fine done moving tolerance raised to 0.01
- beam request default move start tolerance dropped to 5eV
- Fix bug on beam request where you could not override the tolerance via init kwarg (though we will not use this feature here)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- energy limits avoid accidents because the alio has no limits
- theta2fine's tolerance value from old python was wrong
- beam request's move start tolerance from old python was wrong

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ happi load xcs_ccm
[2020-08-31 16:11:52] - INFO -  Creating shell with devices ['xcs_ccm']
/reg/neh/home/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/dask/config.py:168: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(f.read()) or {}
/reg/neh/home/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/distributed/config.py:20: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  defaults = yaml.load(f)
Python 3.6.11 | packaged by conda-forge | (default, Jul 23 2020, 22:18:32)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: xcs_ccm.calc.energy_request.atol
Out[1]: 5

In [2]: xcs_ccm.theta2fine.atol
Out[2]: 0.01

In [3]: xcs_ccm.calc.energy.limits
Out[3]: (4, 25)
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Adding pre-release doc notes
<!--
## Screenshots (if appropriate):
-->
