### PR TITLE
ENH: allow waiting on in-progress moves without caching status object

### DIFF
--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -410,8 +410,8 @@ class MvInterface(BaseInterface):
     def _log_move_end(self):
         logger.info('%s reached position %s', self.name, self.wm())
 
-    def move(self, position, timeout=None, **kwargs):
-        st = super().move(position, timeout=timeout, **kwargs)
+    def move(self, *args, **kwargs):
+        st = super().move(*args, **kwargs)
         self._last_status = st
         return st
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -18,7 +18,7 @@ from bluesky.utils import ProgressBar
 from ophyd.device import Device
 from ophyd.ophydobj import Kind, OphydObject
 from ophyd.signal import AttributeSignal, Signal
-from ophyd.status import wait as status_wait
+from ophyd.status import Status
 
 from . import utils
 from .signal import NotImplementedSignal
@@ -399,14 +399,24 @@ class MvInterface(BaseInterface):
     tab_whitelist = ["mv", "wm", "camonitor", "wm_update"]
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self._mov_ev = Event()
+        self._last_status = Status()
+        self._last_status.set_finished()
+        super().__init__(*args, **kwargs)
 
     def _log_move(self, position):
         logger.info('Moving %s from %s to %s', self.name, self.wm(), position)
 
     def _log_move_end(self):
         logger.info('%s reached position %s', self.name, self.wm())
+
+    def move(self, position, timeout=None, **kwargs):
+        st = super().move(position, timeout=timeout, **kwargs)
+        self._last_status = st
+        return st
+
+    def wait(self, timeout=None):
+        self._last_status.wait(timeout=timeout)
 
     def mv(self, position, timeout=None, wait=False, log=True):
         """
@@ -567,7 +577,7 @@ class FltMvInterface(MvInterface):
         status = self.move(position, timeout=timeout, wait=False)
         pgb = AbsProgressBar([status])
         try:
-            status_wait(status)
+            status.wait()
             # Avoid race conditions involving the final update
             pgb.manual_update()
             pgb.no_more_updates()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
After a call to any move command, you will be able to call `.wait()` later as a proxy to `status.wait()` for the motor's most recently generated `MoveStatus` object, bypassing the need to keep track of this object yourself.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The weird interactive move shortcuts that were requested of us do not return status objects, so if you don't pass `wait=True` you miss your chance forever. This is used in the "move the whole beamline between pink and mono" script I was asked to write, which heavily leverages the presets system, which doesn't return status objects.

An alternate approach here may have been to add extra presets methods that do return status objects... but this seemed easier to figure out.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## How Has This Been Documented
You got me there