### PR TITLE
BUG: Fix pulsepicker so it gets its PV like it says it does

### DIFF
--- a/docs/source/upcoming_release_notes/565-pp-inout-pvfix.rst
+++ b/docs/source/upcoming_release_notes/565-pp-inout-pvfix.rst
@@ -1,0 +1,31 @@
+565 PP InOut PVFix
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix bug in PulsePickerInOut where it would grab only the first section of
+  of the PV instead of the first two
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- pennebak

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -199,7 +199,7 @@ class PulsePickerInOut(PulsePicker):
     def __init__(self, prefix, **kwargs):
         # inout follows naming convention
         parts = prefix.split(':')
-        self._inout = ':'.join(parts[:1] + ['PP', 'Y'])
+        self._inout = ':'.join(parts[:2] + ['PP', 'Y'])
         super().__init__(prefix, **kwargs)
 
     def _do_move(self, state):


### PR DESCRIPTION
## Description
The `PulsePickerInOut` class is meant to grab the first two segments of its PV to use for its in-out motion. At it is currently written, it only grabs the first segment of the PV instead of the first two.

## Motivation and Context
Wanted to implement a `PulsePickerInOut`. It didn't work.

## How Has This Been Tested?
```
In [40]: pp.prefix.split(':')[:1]
Out[40]: ['XCS']

In [41]: pp.prefix.split(':')[:2]
Out[41]: ['XCS', 'SB2']
```

## Where Has This Been Documented?
🤷‍♂️