### PR TITLE
MNT: fix done running race condition in EventSequencer class

### DIFF
--- a/docs/source/upcoming_release_notes/566-seq-race.rst
+++ b/docs/source/upcoming_release_notes/566-seq-race.rst
@@ -1,0 +1,31 @@
+566 Seq Race
+############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fixed a race condition in the EventSequencer device's status objects. Waiting
+  on these statuses will now be more reliable.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -222,8 +222,9 @@ class EventSequencer(BaseInterface, Device, MonitorFlyerMixin, FlyerInterface):
         super().kickoff()
 
         # Create our status
-        def done(*args, value=None, old_value=None, **kwargs):
-            return value == 2 and old_value == 0
+        def done(*args, value=None, old_value=None, timestamp=0, **kwargs):
+            return all((value == 2, old_value == 0,
+                        timestamp > self.play_control.timestamp))
 
         # Create our status object
         return SubscriptionStatus(self.play_status, done, run=True)
@@ -263,8 +264,9 @@ class EventSequencer(BaseInterface, Device, MonitorFlyerMixin, FlyerInterface):
             return DeviceStatus(self, done=True, success=True)
 
         # Create our status
-        def done(*args, value=None, old_value=None, **kwargs):
-            return value == 0 and old_value == 2
+        def done(*args, value=None, old_value=None, timestamp=0, **kwargs):
+            return all((value == 0, old_value == 2,
+                        timestamp > self.play_control.timestamp))
 
         # Create our status object
         return SubscriptionStatus(self.play_status, done, run=True)
@@ -314,8 +316,9 @@ class EventSequencer(BaseInterface, Device, MonitorFlyerMixin, FlyerInterface):
             return DeviceStatus(self, done=True, success=True)
 
         # Otherwise we should wait for the sequencer to end
-        def done(*args, value=None, old_value=None, **kwargs):
-            return value == 0 and old_value == 2
+        def done(*args, value=None, old_value=None, timestamp=0, **kwargs):
+            return all((value == 0, old_value == 2,
+                        timestamp > self.play_control.timestamp))
 
         # Create a SubscriptionStatus
         logger.debug("EventSequencer has a determined stopping point, "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a check to make sure that the "done" transitions happen at a timestamp after the last put to `play_control`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In functions like `trigger`, we return a `SubscriptionStatus` that is to be marked as finished when we transition from state "playing" (2) to state "not playing" (0).

If the python code is running particularly fast (or the network/IOC particularly slow), it can get to the point where it sets up the `SubscriptionStatus` with local function `done`, `run=True` prior to getting an update that the sequencer has started playing (transition from 0 to 2). What happens in this case is that we get a callback with the details from the previous transition, (typically from 2 to 0), and since `run=True` we mark ourselves as `finished` immediately- after all, we just got an update that the sequencer stopped playing!

`run=True` is mandatory in case the function runs extremely slowly, so that we don't completely miss the done transition and sit there forever.

We always start the sequencer by putting 1 to the `play_control` signal, which updates the `timestamp` metadata field of that signal. Since all the timestamps are created in the python process, and since the sequencer cannot start until we ask it to, a "good" done transition must have a `timestamp` later than our last `play_control` start.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
only locally

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added release notes

<!--
## Screenshots (if appropriate):
-->
