### PR TITLE
DOC: component table sphinx directive

### DIFF
--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -2,9 +2,19 @@
 
 .. currentmodule:: {{ module }}
 
+.. device:: {{ module }}.{{ objname }}
+    :inherited: ignore
+    :title: :class:`{{objname}}`-defined ophyd components
+
+.. device:: {{ module }}.{{ objname }}
+    :inherited: only
+    :title: :class:`{{objname}}` inherited ophyd components
+
 .. autoclass:: {{ objname }}
 
    {% block methods %}
+   .. automethod:: __init__
+
    {% if methods %}
    .. rubric:: Methods
 

--- a/docs/source/sample_delivery.rst
+++ b/docs/source/sample_delivery.rst
@@ -42,13 +42,7 @@ HPLC Class
 .. autoclass:: pcdsdevices.sample_delivery.HPLC
 
 
-PressureController Class
-------------------------
-
-.. autoclass:: pcdsdevices.sample_delivery.PressureController
-
-
 FlowIntegrator Class
--------------------
+--------------------
 
 .. autoclass:: pcdsdevices.sample_delivery.FlowIntegrator


### PR DESCRIPTION
## Description
Mirroring some recent caproto IOC documentation work, this aims to give useful information about ophyd components in sphinx-generated documentation.

## Motivation and Context
* Current documentation exists but is cluttered with unnecessary items and lacking component information.

## How Has This Been Tested?
* Locally building docs, only

## Bugs
* I'm at a loss as to how to reference components listed in the table (looked into doing something like `    app.add_object_type('cpt', 'cpt', 'pair: %s; component')` and `.. cpt:: cpt_name` in the table, but no luck so far)
* Dynamic device components are pretty badly rendered, as I can't get the cells to render as multiple lines
* Tables can be annoyingly too big
* `autoclass` does not take custom content into account very well (or at all?) so these tables have to live outside of that section

## Screenshots (if appropriate):
<img width="1447" alt="image" src="https://user-images.githubusercontent.com/5139267/92824529-63de4d80-f383-11ea-855b-4aec6457aa1f.png">

## Other
* There may be disagreements on what we should hide/show from the base ophyd devices - but I'm sure we can agree that including it all isn't so beneficial
* Could be considered a WIP or "better than the status quo and ready enough"

## Alternatives
I still haven't settled on what's the "right" or best way:
* I did this similarly here: https://github.com/klauer/fluke_985/blob/f8cfa484af576e70878f69c1bf4a428b51c93c26/docs/source/conf.py#L201-L306
  - I like this because it makes for a simple `.. pvgroup:` directive to make the table
  - I dislike it because it's a bit strange syntactically, and a bit limited
* I did this differently here: https://github.com/caproto/caproto/blob/4033c02da7815f7145c4a42581ddf0f76da4bbca/doc/source/conf.py#L391-L435
  - I like this because it's flexible and you can customize the output pretty easily
  - I dislike this because it's flexible and requires additional markdown in each project
  - I dislike this because it requires another dependency (`tabulate` for making the table; though this could be made into a list-table just like this PR I suppose)