### PR TITLE
DOC: ophyd device component helper

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
 doctr
-sphinx
+sphinx >=3.2.1
 sphinx_rtd_theme

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -4,25 +4,85 @@
 
 .. autoclass:: {{ objname }}
 
-   {% block methods %}
-   {% if methods %}
-   .. rubric:: Methods
+   {% block components %}
+   {% if get_device_info(module, objname) %}
+    .. list-table:: Ophyd Device Components
+       :header-rows: 1
+       :widths: auto
 
-   .. autosummary::
-      :toctree: generated
-   {% for item in methods %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
+       *  - Attribute
+          - Class
+          - Suffix
+          - Docs
+          - Kind
+          - Notes
+   {% for cpt in get_device_info(module, objname) %}
+       *  -  {{ cpt.attr }}
+          -  {{ cpt.cls.link }}
+          -  {% if cpt.nested_components -%}
+                (See below)
+             {%- else -%}
+                {{ cpt.suffix }}
+             {%- endif %}
+          -  {{ cpt.doc }}
+          -  {{ cpt.kind }}
+          -  {% if cpt.inherited_from -%}
+            Inherited from {{ cpt.inherited_from.link }}
+            {%- endif %}
+   {% endfor %}
+
+   {% for ddc in get_device_info(module, objname) %}
+   {% if ddc.nested_components %}
+    .. list-table:: {{ objname }}.{{ ddc.attr }} Dynamic Device Components
+       :header-rows: 1
+       :widths: auto
+
+       *  - Attribute
+          - Class
+          - Suffix
+          - Docs
+          - Kind
+          - Notes
+   {% for cpt in ddc.nested_components %}
+       *  -  {{ cpt.attr }}
+          -  {{ cpt.cls.link }}
+          -  {% if cpt.nested_components -%}
+                (See below)
+             {%- else -%}
+                {{ cpt.suffix }}
+             {% endif %}
+          -  {{ cpt.doc }}
+          -  {{ cpt.kind }}
+          -  {% if cpt.inherited_from -%}
+            Inherited from {{ cpt.inherited_from.link }}
+            {%- endif %}
+   {% endfor %}
+   {% endif %}
+   {% endfor %}
+
    {% endif %}
    {% endblock %}
 
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Attributes
 
-   .. autosummary::
-   {% for item in attributes %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+    {% block methods %}
+    {% if methods %}
+    .. rubric:: Methods
+
+    .. autosummary::
+       :toctree: generated
+    {% for item in methods %}
+       ~{{ name }}.{{ item }}
+    {%- endfor %}
+    {% endif %}
+    {% endblock %}
+
+    {% block attributes %}
+    {% if attributes %}
+    .. rubric:: Attributes
+
+    .. autosummary::
+    {% for item in attributes %}
+       ~{{ name }}.{{ item }}
+    {%- endfor %}
+    {% endif %}
+    {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,19 +14,26 @@
 # serve to show the default.
 
 import datetime
+import enum
 import os
+import re
 import sys
+import typing
 
+import ophyd
 import sphinx_rtd_theme
+from docutils import statemachine
+from docutils.parsers.rst import Directive, directives
 
 import pcdsdevices
+import pcdsdevices.component
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 module_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../')
-sys.path.insert(0,module_path)
+sys.path.insert(0, module_path)
 
 
 # -- General configuration ------------------------------------------------
@@ -176,7 +183,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'PCDSDevices', 'PCDS Devices Documentation',
-     author, 'PCDSDevices', 'One line description of project.',
+     author, 'PCDSDevices', 'ophyd Devices used at the LCLS',
      'Miscellaneous'),
 ]
 
@@ -185,3 +192,218 @@ texinfo_documents = [
 intersphinx_mapping = {'ophyd': ('https://blueskyproject.io/ophyd', None),
                        'python': ('https://docs.python.org/3', None),
                        'numpy': ('https://docs.scipy.org/doc/numpy', None)}
+
+
+
+OPHYD_SKIP = {
+    # Methods
+    'add_instantiation_callback',
+    'check_value',
+    'clear_sub',
+    # 'configure',
+    # 'describe',
+    'describe_configuration',
+    'destroy',
+    'format_status_info',
+    # 'get',
+    'get_device_tuple',
+    'get_instantiated_signals',
+    'pause',
+    'put',  # prefer `set`
+    # 'read',
+    # 'read_configuration',
+    'resume',
+    'stage',
+    'status_info',
+    # 'stop',
+    'subscribe',
+    # 'summary',
+    # 'trigger',
+    'unstage',
+    'unsubscribe',
+    'unsubscribe_all',
+    'wait_for_connection',
+    'walk_components',
+    'walk_signals',
+    'walk_subdevice_classes',
+    'walk_subdevices',
+
+    # Attributes
+    'SUB_ACQ_DONE',
+    'SUB_STATE',
+    'SUB_DONE',
+    'SUB_READBACK',
+    'SUB_START',
+    'SUB_VALUE',
+    'attr_name',
+    'component_names',
+    # 'configuration_attrs',
+    # 'connected',
+    'dotted_name',
+    'event_types',
+    # 'hints',
+    'inserted',
+    # 'kind',
+    'lazy_wait_for_connection',
+    # 'lightpath_cpts',
+    'name',
+    'parent',
+    'read_attrs',
+    'removed',
+    'report',
+    'root',
+    'signal_names',
+    'tab_component_names',
+    'tab_whitelist',
+    'trigger_signals',
+}
+
+
+def skip_components_and_ophyd_stuff(app, what, name, obj, skip, options):
+    if isinstance(obj, ophyd.Component):
+        return True
+    if name.startswith('_'):
+        # It's unclear if I broke this or if it's always been broken,
+        # but for our use case we never want to document `_` items with
+        # autoclass.
+        return True
+    if name in OPHYD_SKIP:
+        return True
+    return skip
+
+
+short_component_names = {
+    ophyd.Component: '',
+    ophyd.DynamicDeviceComponent: 'DDC',
+    ophyd.FormattedComponent: 'FCpt',
+    pcdsdevices.component.UnrelatedComponent: 'UCpt',
+}
+
+
+def _get_class_info(cls):
+    if cls is None:
+        return None
+
+    return {
+        'name': cls.__name__,
+        'class': cls,
+        'link': f':class:`~{cls.__module__}.{cls.__name__}`'
+    }
+
+
+def _dynamic_device_component_to_row(base_attrs, cls, attr, cpt):
+    cpt_type = short_component_names.get(type(cpt), type(cpt).__name__)
+
+    doc = cpt.doc or ''
+    if doc.startswith('DynamicDeviceComponent attribute') :
+        doc = ''
+
+    nested_components = [
+        _component_to_row(base_attrs, cls, attr, dynamic_cpt)
+        for attr, dynamic_cpt in cpt.components.items()
+    ]
+
+    return dict(
+        component=cpt,
+        attr=attr if not cpt_type else f'{attr} ({cpt_type})',
+        cls=_get_class_info(getattr(cpt, 'cls', None)),
+        nested_components=nested_components,
+        doc=doc,
+        kind=cpt.kind.name,
+        inherited_from=_get_class_info(base_attrs.get(attr, None)),
+    )
+
+
+def _component_to_row(base_attrs, cls, attr, cpt):
+    if isinstance(cpt, ophyd.DynamicDeviceComponent):
+        return _dynamic_device_component_to_row(base_attrs, cls, attr, cpt)
+
+    cpt_type = short_component_names.get(type(cpt),
+                                              type(cpt).__name__)
+
+    doc = cpt.doc or ''
+    if doc.startswith(f'{cpt.__class__.__name__} attribute') :
+        doc = ''
+
+    return dict(
+        component=cpt,  # access to the component instance itself
+        attr=attr if not cpt_type else f'{attr} ({cpt_type})',
+        cls=_get_class_info(getattr(cpt, 'cls', None)),
+        suffix=f'``{cpt.suffix}``' if cpt.suffix else '',
+        doc=doc,
+        kind=cpt.kind.name,
+        inherited_from=_get_class_info(base_attrs.get(attr, None)),
+    )
+
+
+def _get_base_attrs(cls):
+    base_devices = [
+        base for base in reversed(cls.__bases__)
+        if hasattr(base, '_sig_attrs')
+    ]
+
+    return {
+        attr: base
+        for base in base_devices
+        for attr, cpt in base._sig_attrs.items()
+    }
+
+
+# NOTE: can't use functools.lru_cache here as it's not picklable
+_device_cache = {}
+
+
+def get_device_info(module, name):
+    class_name = f'{module}.{name}'
+    if class_name in _device_cache:
+        return _device_cache[class_name]
+
+    module_name, class_name = class_name.rsplit('.', 1)
+    module = __import__(module_name, globals(), locals(), [class_name])
+    cls = getattr(module, class_name)
+
+    if not issubclass(cls, ophyd.Device):
+        info = []
+    else:
+        base_attrs = _get_base_attrs(cls)
+
+        info = [
+            _component_to_row(base_attrs, cls, attr, cpt)
+            for attr, cpt in cls._sig_attrs.items()
+        ]
+
+    _device_cache[class_name] = info
+    return info
+
+
+autosummary_context = {
+    # Allow autosummary/class.rst to do its magic:
+    'get_device_info': get_device_info,
+}
+
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+    ],
+}
+
+
+def rstjinja(app, docname, source):
+    """
+    Render our pages as a jinja template for fancy templating goodness.
+    """
+    # Borrowed from
+    # https://www.ericholscher.com/blog/2016/jul/25/integrating-jinja-rst-sphinx/
+    # Make sure we're outputting HTML
+    if app.builder.format != 'html':
+        return
+
+    src = source[0]
+    rendered = app.builder.templates.render_string(src,
+                                                   app.config.html_context)
+    source[0] = rendered
+
+
+def setup(app):
+    app.connect('autodoc-skip-member', skip_components_and_ophyd_stuff)
+    app.connect("source-read", rstjinja)

--- a/docs/source/sample_delivery.rst
+++ b/docs/source/sample_delivery.rst
@@ -42,13 +42,7 @@ HPLC Class
 .. autoclass:: pcdsdevices.sample_delivery.HPLC
 
 
-PressureController Class
-------------------------
-
-.. autoclass:: pcdsdevices.sample_delivery.PressureController
-
-
 FlowIntegrator Class
--------------------
+--------------------
 
 .. autoclass:: pcdsdevices.sample_delivery.FlowIntegrator


### PR DESCRIPTION
(Current master for comparison: https://pcdshub.github.io/pcdsdevices/generated/generated/pcdsdevices.attenuator.AttenuatorCalculator_AT2L0.html)

Attempt 2; I think this looks much better:

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/5139267/92967213-b116f980-f42d-11ea-8afa-550fab920157.png">
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/5139267/92967228-b83e0780-f42d-11ea-9528-c80e32d40c68.png">

Retains the previous method-documenting functionality, but pares it down significantly:

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/5139267/92967343-ee7b8700-f42d-11ea-9a46-e820d343576a.png">
