### PR TITLE
REF: tab completion state in a separate class

### DIFF
--- a/docs/source/upcoming_release_notes/576-tab_completion.rst
+++ b/docs/source/upcoming_release_notes/576-tab_completion.rst
@@ -1,0 +1,32 @@
+576 Tab Completion
+##################
+
+API Changes
+-----------
+- Added :class:`pcdsdevices.interface.TabCompletionHelperClass` to help hold
+  tab completion information state and also allow for tab-completion
+  customization on a per-instance level.
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Preset methods are now visible when not in engineering mode. (#576)
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -43,6 +43,10 @@ Positioner_whitelist = ["settle_time", "timeout", "egu", "limits", "move",
 
 
 class _TabCompletionHelper:
+    """
+    Base class for `TabCompletionHelperClass`, `TabCompletionHelperInstance`.
+    """
+
     _includes: typing.Set[str]
     _regex: typing.Optional[typing.Pattern]
 
@@ -92,6 +96,7 @@ class TabCompletionHelperClass(_TabCompletionHelper):
         super().__init__()
 
     def reset(self):
+        """Reset the attribute includes to those annotated in the class."""
         super().reset()
         whitelist = []
         for parent in self.cls.mro():
@@ -105,6 +110,14 @@ class TabCompletionHelperClass(_TabCompletionHelper):
         self._includes = set(whitelist)
 
     def new_instance(self, instance) -> 'TabCompletionHelperInstance':
+        """
+        Create a new :class:`TabCompletionHelperInstance` for the given object.
+
+        Parameters
+        ----------
+        instance : object
+            The instance of `self.cls`.
+        """
         return TabCompletionHelperInstance(instance, self)
 
 
@@ -134,10 +147,12 @@ class TabCompletionHelperInstance(_TabCompletionHelper):
         super().__init__()
 
     def reset(self):
+        """Reset the attribute includes to that defined by the class."""
         super().reset()
         self._includes = set(self.class_helper._includes)
 
     def get_filtered_dir_list(self) -> typing.List[str]:
+        """Get the dir list, filtered based on the whitelist."""
         if self._regex is None:
             self.build_regex()
 
@@ -148,9 +163,7 @@ class TabCompletionHelperInstance(_TabCompletionHelper):
         ]
 
     def get_dir(self) -> typing.List[str]:
-        """
-        Get the dir list based on the engineering mode settings.
-        """
+        """Get the dir list based on the engineering mode settings."""
         if get_engineering_mode():
             return self.super_dir()
         return self.get_filtered_dir_list()

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -189,6 +189,9 @@ class BaseInterface:
                      Device_whitelist + Signal_whitelist +
                      Positioner_whitelist)
 
+    _class_tab: TabCompletionHelperClass
+    _tab: TabCompletionHelperInstance
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         mro = cls.mro()

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -987,6 +987,8 @@ class Presets:
         logger.debug('register method %s to %s', method_name, obj.name)
         self._methods.append((obj, method_name))
         setattr(obj, method_name, MethodType(method, obj))
+        if hasattr(obj, '_tab'):
+            obj._tab.add(method_name)
 
     def _make_add(self, preset_type):
         """
@@ -1117,6 +1119,8 @@ class Presets:
                 delattr(obj, method_name)
             except AttributeError:
                 pass
+            if hasattr(obj, '_tab'):
+                obj._tab.remove(method_name)
         self._methods = []
         self.positions = SimpleNamespace()
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -217,7 +217,7 @@ def test_tab_completion(cls):
     if BaseInterface not in cls.mro():
         pytest.skip(f'{cls} does not inherit from the interface')
 
-    regex = cls._tab_regex
+    regex = cls._class_tab.build_regex()
     if getattr(cls, 'tab_component_names', False):
         for name in cls.component_names:
             if getattr(cls, name).kind != ophyd.Kind.omitted:


### PR DESCRIPTION
An alternative to holding tab completion state in `BaseInterface`, pulling it out to allow for class or instance-level modification.

If this is deemed acceptable, we can build functionality on top of it for https://github.com/pcdshub/pcdsdevices/issues/576

If not, we can patch in that requested functionality in each subclass.

8d64558 closes #576