### PR TITLE
DEV: Release helper

### DIFF
--- a/docs/source/upcoming_release_notes/aggregate.py
+++ b/docs/source/upcoming_release_notes/aggregate.py
@@ -1,0 +1,73 @@
+import collections
+import pathlib
+
+
+def parse(text: str) -> dict:
+    results = collections.OrderedDict()
+    category = None
+    lines = list(text.splitlines())
+
+    for idx, (line, next_line) in enumerate(zip(lines, lines[1:] + ['']), 1):
+        if not line.strip():
+            ...
+        elif set(next_line.strip()) == {'-'}:
+            category = line.strip()
+        elif set(line.strip()) == {'-'}:
+            ...
+        elif category is not None:
+            if line.strip() != '- N/A':
+                if category not in results:
+                    results[category] = []
+                results[category].append(line)
+        elif idx > 2 and category is not None:
+            raise ValueError(
+                f'Malformed RST? Line outside of category: '
+                f'line={idx} {line!r}'
+            )
+
+        previous_line = line
+
+    return results
+
+
+def aggregate() -> dict:
+    information = {
+        'API Changes': [],
+        'Features': [],
+        'Device Updates': [],
+        'New Devices': [],
+        'Bugfixes': [],
+        'Maintenance': [],
+        'Contributors': [],
+    }
+
+    skip = {'template-full.rst', 'template-short.rst'}
+
+    for fn in sorted(pathlib.Path('.').glob('*.rst')):
+        if fn.name in skip:
+            continue
+
+        with open(fn, 'rt') as f:
+            raw = f.read()
+
+        try:
+            for category, info in parse(raw).items():
+                if category not in information:
+                    information[category] = []
+
+                information[category].extend(info)
+        except Exception:
+            print('Failed on', fn)
+            raise
+    return information
+
+
+for category, info in aggregate().items():
+    print()
+    print(category)
+    print('-' * len(category))
+    if category == 'Contributors':
+        info = list(sorted(set(info)))
+
+    for line in info:
+        print(line)


### PR DESCRIPTION
Using the template effectively means we can automate things even more.

As a development helper tool, this doesn't need to be merged. It can save a bit of time with big releases, though, like this upcoming one.

Results:
```rst

API Changes
-----------
- :class:`BaseInterface` no longer inherits from :class:`ophyd.OphydObject`.
- The order of multiple inheritance for many devices using the LCLS-enhanced
  :class:`BaseInterface`, :class:`MvInterface`, and :class:`FltMvInterface` has
  been changed.
- Added :class:`pcdsdevices.interface.TabCompletionHelperClass` to help hold
  tab completion information state and also allow for tab-completion
  customization on a per-instance level.

Features
--------
- Moves using mv and umv will log their moves at info level for interactive
  use to keep track of the sessions.
- Add ``user_offset`` to :class:`~pcdsdevices.signal.UnitConversionDerivedSignal`,
  allowing for an arbitrary user offset in user-facing units.
- Add ``user_offset`` signal to the :class:`pcdsdevices.lxe.LaserTiming`, by
  way of :class:`~pcdsdevices.signal.UnitConversionDerivedSignal`, offset
  support.
- Epics motors can now have local limits updated per-session, rather than
  only having the option of the EPICS limits. Setting limits attributes will
  update the python limits, putting to the limits PVs will update the limits
  PVs.
- Add PVPositionerDone, a setpoint-only PVPositioner class that is done moving
  immediately. This is not much more useful than just using a PV, but it is
  compatibile with pseudopositioners and has a built-in filter for ignoring
  small moves.

Device Updates
--------------
- CCM energy limited to the range of 4 to 25 keV
- CCM theta2fine done moving tolerance raised to 0.01
- Beam request default move start tolerance dropped to 5eV

New Devices
-----------

Bugfixes
--------
- Tweak will feel less "janky" now and give useful feedback.
- Tweak now accepts + and - as valid inputs for changing the step size.
- Tweak properly clears lines between prints.
- Adds hints to the :class:`pcdsdevices.lxe.LaserTiming` class for
  ``LiveTable`` support.
- Fix issue where putting to the limits property would update live PVs,
  contrary to the behavior of all other limits attributes in ophyd.
- Fix issue where doing a getattr on the limits properties would fetch
  live PVs, which can cause slowdowns and instabilities.
- Tab completion for many devices has been fixed. Regression tests have been
  added.
- Rework BeamEnergyPositioner to be setpoint-only to work properly
  with the behavior of the energy PVs.
- umv will now properly display position and completion status after a move.
- FltMvPositioner.wm will now return numeric values if the position
  value is a tuple. This value is the first element of the tuple, which
  for pseudo positioners is a value that can be passed into move and have
  it do the right thing. This resolves consistency issues and fixes bugs
  where mvr and umvr would fail.
- Fix issue where converting units could incur time penalties of up to
  7 seconds. This should take around 10ms now.
- Fix bug on beam request where you could not override the tolerance
  via init kwarg, despite docstring's indication.
- Fix bug in PulsePickerInOut where it would grab only the first section of
  of the PV instead of the first two
- Fixed a race condition in the EventSequencer device's status objects. Waiting
  on these statuses will now be more reliable.
- Preset methods are now visible when not in engineering mode. (#576)

Maintenance
-----------
- Establish DOC conventions for accumulating release notes from every
  pull request.
- Tweak refactored for maintainability.
- Use more of the built-in ophyd mechanisms for limits rather than
  relying on local overrides.

Contributors
------------
- klauer
- pennebak
- zlentz
- zllentz
- zrylettc
```
