### PR TITLE
ENH: WFS Class

### DIFF
--- a/docs/source/upcoming_release_notes/586-wfs.rst
+++ b/docs/source/upcoming_release_notes/586-wfs.rst
@@ -16,6 +16,7 @@ Device Updates
 New Devices
 -----------
 - Add WaveFrontSensorTarget for the wavefront sensor targets (PF1K0, PF1L0).
+- Add TwinCATTempSensor for the updated twincat FB with corrected PV pragmas.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/586-wfs.rst
+++ b/docs/source/upcoming_release_notes/586-wfs.rst
@@ -1,0 +1,30 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- Add WaveFrontSensorTarget for the wavefront sensor targets (PF1K0, PF1L0).
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -30,3 +30,4 @@ from .slits import Slits
 from .spectrometer import Kmono, VonHamos4Crystal
 from .timetool import Timetool, TimetoolWithNav
 from .valve import GateValve, Stopper
+from .wfs import WaveFrontSensorTarget

--- a/pcdsdevices/sensors.py
+++ b/pcdsdevices/sensors.py
@@ -7,7 +7,7 @@ from ophyd import Component as Cpt
 from ophyd import Device
 
 from .interface import BaseInterface
-from .signal import PytmcSignal, NotImplementedSignal
+from .signal import NotImplementedSignal, PytmcSignal
 
 
 class TwinCATThermocouple(BaseInterface, Device):
@@ -21,6 +21,19 @@ class TwinCATThermocouple(BaseInterface, Device):
     temperature = Cpt(PytmcSignal, ':STC:TEMP', io='i', kind='normal')
     sensor_connected = Cpt(PytmcSignal, ':STC:CONN', io='i', kind='normal')
     error = Cpt(PytmcSignal, ':STC:ERR', io='i', kind='normal')
+
+
+class TwinCATTempSensor(BaseInterface, Device):
+    """
+    Basic twincat temperature sensor class.
+
+    Assumes we're using the ``FB_TempSensor`` function block from
+    ``lcls-twincat-general``.
+    """
+
+    temperature = Cpt(PytmcSignal, ':TEMP', io='i', kind='normal')
+    sensor_connected = Cpt(PytmcSignal, ':CONN', io='i', kind='normal')
+    error = Cpt(PytmcSignal, ':ERR', io='i', kind='normal')
 
 
 class RTD(BaseInterface, Device):

--- a/pcdsdevices/wfs.py
+++ b/pcdsdevices/wfs.py
@@ -1,0 +1,26 @@
+from ophyd import Component as Cpt
+from ophyd import Device
+
+from .epics_motor import BeckhoffAxis
+from .inout import TwinCATInOutPositioner
+from .interface import BaseInterface, LightpathInOutMixin
+from .sensors import TwinCATThermocouple
+
+
+class WaveFrontSensorTarget(BaseInterface, Device, LightpathInOutMixin):
+    tab_component_names = True
+
+    lightpath_cpts = ['target']
+    _icon = 'fa.ellipsis-v'
+
+    target = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted',
+                 doc='Control of the diagnostic stack via saved positions.')
+    y_motor = Cpt(BeckhoffAxis, ':MMS:Y', kind='normal',
+                  doc='Direct control of the diagnostic stack motor.')
+    z_motor = Cpt(BeckhoffAxis, ':MMS:Z', kind='normal',
+                  doc='Z position of target stack for focus control.')
+
+    thermocouple1 = Cpt(TwinCATThermocouple, ':STC:01', kind='normal',
+                        doc='First thermocouple.')
+    thermocouple2 = Cpt(TwinCATThermocouple, ':STC:02', kind='normal',
+                        doc='Second thermocouple.')

--- a/pcdsdevices/wfs.py
+++ b/pcdsdevices/wfs.py
@@ -4,7 +4,7 @@ from ophyd import Device
 from .epics_motor import BeckhoffAxis
 from .inout import TwinCATInOutPositioner
 from .interface import BaseInterface, LightpathInOutMixin
-from .sensors import TwinCATThermocouple
+from .sensors import TwinCATTempSensor
 
 
 class WaveFrontSensorTarget(BaseInterface, Device, LightpathInOutMixin):
@@ -20,7 +20,7 @@ class WaveFrontSensorTarget(BaseInterface, Device, LightpathInOutMixin):
     z_motor = Cpt(BeckhoffAxis, ':MMS:Z', kind='normal',
                   doc='Z position of target stack for focus control.')
 
-    thermocouple1 = Cpt(TwinCATThermocouple, ':STC:01', kind='normal',
+    thermocouple1 = Cpt(TwinCATTempSensor, ':STC:01', kind='normal',
                         doc='First thermocouple.')
-    thermocouple2 = Cpt(TwinCATThermocouple, ':STC:02', kind='normal',
+    thermocouple2 = Cpt(TwinCATTempSensor, ':STC:02', kind='normal',
                         doc='Second thermocouple.')

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1,0 +1,12 @@
+import logging
+
+import pytest
+
+from pcdsdevices.wfs import WaveFrontSensorTarget
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.timeout(5)
+def test_wfs_disconnected():
+    WaveFrontSensorTarget('TST:WFS', name='tst')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `WaveFrontSensorTarget` class to control the wavefront sensor target
- Add `TwinCATTempSensor` class for `FB_TempSensor` from general lib

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- These exist and need to be controlled
- closes #586 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
In [2]: wfs = WaveFrontSensorTarget('PF1K0:WFS', name='pf1k0')

In [3]: wfs.get()
Out[3]: WaveFrontSensorTargetTuple(target=TwinCATInOutPositionerTuple(state=1, error=0, error_id=0, error_message='', busy=0, done=0, reset_cmd=0, config=TwinCATStateConfigAllTuple(state01=TwinCATStateConfigOneTuple(state_name='OUT', setpoint=-15.0, delta=2.0, velo=5.0, accl=200.0, dccl=25.0, move_ok=1, locked=0, valid=1), state02=TwinCATStateConfigOneTuple(state_name='TARGET1', setpoint=-39.124, delta=2.0, velo=5.0, accl=200.0, dccl=200.0, move_ok=1, locked=0, valid=1), state03=TwinCATStateConfigOneTuple(state_name='TARGET2', setpoint=-53.5, delta=2.0, velo=5.0, accl=200.0, dccl=200.0, move_ok=1, locked=0, valid=1), state04=TwinCATStateConfigOneTuple(state_name='TARGET3', setpoint=-67.874, delta=2.0, velo=5.0, accl=200.0, dccl=200.0, move_ok=1, locked=0, valid=1), state05=TwinCATStateConfigOneTuple(state_name='TARGET4', setpoint=-82.25, delta=2.0, velo=5.0, accl=200.0, dccl=200.0, move_ok=1, locked=0, valid=1))), y_motor=BeckhoffAxisTuple(user_readback=-14.00775, user_setpoint=-14.00775, user_offset=0.0, user_offset_dir=0, offset_freeze_switch=0, set_use_switch=0, velocity=20.0, acceleration=2.0, motor_egu='mm', motor_is_moving=0, motor_done_move=1, high_limit_switch=0, low_limit_switch=0, high_limit_travel=-14.0, low_limit_travel=-98.0, direction_of_travel=0, motor_stop=0, home_forward=0, home_reverse=0, disabled=0, description='Main.M8 / Axis 8 PF1K0-WFS-MMS-Y', plc=BeckhoffAxisPLCTuple(status='', err_code=0, cmd_err_reset=0), motor_spmg=3), z_motor=BeckhoffAxisTuple(user_readback=33.00075, user_setpoint=33.0008, user_offset=0.0, user_offset_dir=0, offset_freeze_switch=0, set_use_switch=0, velocity=5.0, acceleration=0.5, motor_egu='mm', motor_is_moving=0, motor_done_move=1, high_limit_switch=0, low_limit_switch=0, high_limit_travel=54.0, low_limit_travel=12.0, direction_of_travel=0, motor_stop=0, home_forward=0, home_reverse=0, disabled=0, description='Main.M9 / Axis 9 PF1K0-WFS-MMS-Z', plc=BeckhoffAxisPLCTuple(status='', err_code=0, cmd_err_reset=0), motor_spmg=3), thermocouple1=TwinCATTempSensorTuple(temperature=34.800000000000004, sensor_connected=1, error=0), thermocouple2=TwinCATTempSensorTuple(temperature=36.9, sensor_connected=1, error=0))

```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes stub added

<!--
## Screenshots (if appropriate):
-->
