### PR TITLE
ENH: move interface for AT2L0

### DIFF
--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -6,7 +6,6 @@ import logging
 import time
 
 import numpy as np
-
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import DynamicDeviceComponent as DDC
@@ -716,9 +715,10 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathInOutMixin):
 
     # QIcon for UX
     _icon = 'fa.barcode'
+    tab_component_names = True
 
     # Register that all blades are needed for lightpath calc
-    lightpath_cpts = ['blade_{:02}'.format(i+1) for i in range(19)]
+    lightpath_cpts = [f'blade_{idx:02}' for idx in range(1, 20)]
 
     # Summary for lightpath view
     num_in = Cpt(InternalSignal, kind='hinted')

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -697,7 +697,7 @@ class AttenuatorCalculator_AT2L0(AttenuatorCalculatorBase):
     )
 
 
-class AT2L0(BaseInterface, Device, LightpathInOutMixin):
+class AT2L0(FltMvInterface, PVPositionerPC, LightpathInOutMixin):
     """
     AT2L0 solid attenuator variant from the LCLS-II XTES project.
 
@@ -745,9 +745,30 @@ class AT2L0(BaseInterface, Device, LightpathInOutMixin):
     blade_18 = Cpt(FEESolidAttenuatorBlade, ':MMS:18')
     blade_19 = Cpt(FEESolidAttenuatorBlade, ':MMS:19')
 
-    def __init__(self, *args, **kwargs):
+    @property
+    def setpoint(self):
+        """(PVPositioner compat) - use desired transmission as setpoint."""
+        return self.calculator.desired_transmission
+
+    @property
+    def readback(self):
+        """(PVPositioner compat) - use actual transmission as readback."""
+        return self.calculator.actual_transmission
+
+    @property
+    def actuate(self):
+        """(PVPositioner compat) - use apply_config as an actuation signal."""
+        return self.calculator.apply_config
+
+    def _setup_move(self, position):
+        """(PVPositioner compat) - calculate, then move."""
+        self.calculator.calculate(position)
+        return super()._setup_move(position)
+
+    def __init__(self, *args, limits=None, **kwargs):
         UCpt.collect_prefixes(self, dict(calculator_prefix='AT2L0:CALC'))
-        super().__init__(*args, **kwargs)
+        limits = limits or (0.0, 1.0)
+        super().__init__(*args, limits=limits, **kwargs)
 
     def _set_lightpath_states(self, lightpath_values):
         info = super()._set_lightpath_states(lightpath_values)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Closes https://github.com/pcdshub/pcdsdevices/issues/511

## Motivation and Context
To close https://github.com/pcdshub/pcdsdevices/issues/511

## How Has This Been Tested?
Interactively, so far:

```python
In [1]: at2l0.position
Out[1]: 0.09998276656338201

In [2]: at2l0.move(1.0)
Out[2]: MoveStatus(done=True, pos=at2l0, elapsed=0.2, success=True, settle_time=0.0)

In [3]: at2l0.position
Out[3]: 1.0

In [4]: at2l0.mv(0.5)

In [5]: at2l0.position
Out[5]: 0.4997430366337844

In [6]: at2l0(0)

In [7]: at2l0.position
Out[7]: 1.0125629805856235e-78
```

ASCII rendering:

```python
In [1]: at2l0
Out[1]:
filter # |1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|
 OUT     |X| | | | | | | | |  |  |  |  |  |  |  |  |  |  |
 IN      | |X|X|X|X|X|X|X|X|X |X |X |X |X |X |X |X |X |X |
Transmission (E=9.5 keV): 1.0126E-78
Transmission for 3rd harmonic (E=28.5 keV): 1.6012E-03

In [2]: at2l0(0.5)

In [3]: at2l0
Out[3]:
filter # |1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|
 OUT     |X|X|X|X|X|X|X|X|X|X |X |X |X |X |X |X |  |X |X |
 IN      | | | | | | | | | |  |  |  |  |  |  |  |X |  |  |
Transmission (E=9.5 keV): 4.9974E-01
Transmission for 3rd harmonic (E=28.5 keV): 9.7535E-01

In [4]: at2l0(0.7)

In [5]: at2l0
Out[5]:
filter # |1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|
 OUT     |X|X| |X|X| |X| |X|X |X |X |X |X |X |X |X |X |X |
 IN      | | |X| | |X| |X| |  |  |  |  |  |  |  |  |  |  |
Transmission (E=9.5 keV): 6.9773E-01
Transmission for 3rd harmonic (E=28.5 keV): 9.9098E-01
```

## Lightpath
Untested with lightpath as I don't have a working setup. However, as it follows the interface, it presumably should work.