### PR TITLE
target_in for IPM

### DIFF
--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -5,7 +5,6 @@ from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import EpicsSignal, EpicsSignalRO
-from ophyd.status import wait as status_wait
 
 from .doc_stubs import IPM_base, basic_positioner_init, insert_remove
 from .epics_motor import IMS
@@ -140,7 +139,7 @@ class IPMMotion(BaseInterface, Device):
     def target_in(self, target_num, moved_cb=None, timeout=None, wait=False):
         """
         Moves the target to one of the target positions. There are 4 targets
-        with different thinkness and absorbtion/signal.
+        with different thickness and absorption/signal.
         The targets move vertically. To drive them in, use presets:
         ipm.target_in(x), where x = target number
 
@@ -157,7 +156,7 @@ class IPMMotion(BaseInterface, Device):
 
         timeout : float, optional
             Maximum time for the motion. If `None` is given, the default value
-            of this positioners is used.
+            of this positioner is used.
 
         wait : bool
             If `True`, block until move is completed.
@@ -166,21 +165,8 @@ class IPMMotion(BaseInterface, Device):
         -------
         status: MoveStatus
         """
-        status = self.target.move(target_num, moved_cb=moved_cb,
-                                  timeout=timeout, wait=wait)
-
-        # Add our callback if one was given
-        if moved_cb is not None:
-            status.add_callback(moved_cb)
-
-        # Wait if instructed to do so. Stop the motors if interrupted
-        if wait:
-            try:
-                status_wait(status)
-            except KeyboardInterrupt:
-                self.target.stop()
-                raise
-        return status
+        return self.target.move(target_num, moved_cb=moved_cb,
+                                timeout=timeout, wait=wait)
 
     @property
     def transmission(self):

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -118,8 +118,8 @@ def test_ipm_motion(fake_ipm):
     assert ipm.diode.state.state.get() == 2
     # Target_in
     status = ipm.target_in(4)
-    assert ipm.target.state.get() == 4
     status.wait(timeout=1)
+    assert ipm.target.state.get() == 4
     assert status.done and status.success
     # Target_in with callback
     cb = Mock()

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -116,6 +116,21 @@ def test_ipm_motion(fake_ipm):
     # Remove IPM Diode
     ipm.diode.remove()
     assert ipm.diode.state.state.get() == 2
+    # Target_in
+    status = ipm.target_in(4)
+    assert ipm.target.state.get() == 4
+    status.wait(timeout=1)
+    assert status.done and status.success
+    # Target_in with callback
+    cb = Mock()
+    status = ipm.target_in(3, moved_cb=cb).wait(timeout=1)
+    assert(cb.called)
+    # Target_in with wait
+    ipm.target_in('TARGET2', wait=True)
+    assert(ipm.target.state.get() == 2)
+    # Target_in invalid state
+    with pytest.raises(ValueError):
+        ipm.target_in('TARGET9')
 
 
 def test_ipm_subscriptions(fake_ipm):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A `target_in` function has been added to the IPMMotion Class

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IPM Motion devices can be driven to specific states using the move function - `target_in` is taking as a parameter a "target state" and it is moving the target to that state. 
Trying to close #544

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has only been tested using the `fake_imp` device

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
