### PR TITLE
MNT: revert to old ccm energy calculation

### DIFF
--- a/docs/source/upcoming_release_notes/570-Old_CCM_Energy_Calculation_Reversion.rst
+++ b/docs/source/upcoming_release_notes/570-Old_CCM_Energy_Calculation_Reversion.rst
@@ -1,0 +1,31 @@
+570 Old CCM Energy Calculation Reversion
+#################
+
+API Changes
+-----------
+ - The calculations for `alio_to_theta` and `theta_to_alio` in `ccm.py` 
+   have been reverted to the old calculations. 
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+cristinasewell

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -282,16 +282,9 @@ def alio_to_theta(alio, theta0, gr, gd):
     """
     Converts alio position (mm) to theta angle (rad).
 
-    This is an empirical inversion via binary search. If you decide to spend
-    time trying to find the analytic solution here, please update this
-    docstring, either to indicate your success or to increment the hours
-    counter below.
-
     Conversion function
     theta_angle = f(x) = 2arctan * [(sqrt(x^2 + D^2 + 2Rx) - D)/(2R + x)]
     Note that for x = −R, θ = 2 arctan(−R/D)
-
-    total hours spent here: 2
     """
     return theta0 + 2 * np.arctan(
          (np.sqrt(alio ** 2 + gd ** 2 + 2 * gr * alio) - gd) / (2 * gr + alio)

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -15,12 +15,11 @@ from .pv_positioner import PVPositionerIsClose
 logger = logging.getLogger(__name__)
 
 # Constants
-
 si_111_dspacing = 3.1356011499587773
 si_511_dspacing = 1.0452003833195924
 
 # Defaults
-default_theta0 = 14.9792
+default_theta0 = 14.9792 * np.pi/180
 default_dspacing = si_111_dspacing
 default_gr = 3.175
 default_gd = 231.303
@@ -266,14 +265,16 @@ def theta_to_alio(theta, theta0, gr, gd):
     Delta_Theta:   the effective scattering angle (adjusted with Alio stage)
     R = 0.003175m: radius of the sapphire ball connected to the Alio stage
     D = 0.232156m: distance between the Theta_B rotation axis and the center
-                   of the saphire sphere located on the Alio stage
+                   of the saphire sphere located on the Alio stage.
+                   note: The current value that we're using for D is 0.231303 -
+                   possibly measured by metrology
 
     Theta_B = Theta_0 + Delta_Theta
     Conversion formula:
     x = f(Delta_Theta) = D * tan(Delta_Theta)+(R/cos(Delta_Theda))-R
     Note that for ∆θ = 0, x = R
     """
-    t_rad = (theta - theta0) * np.pi / 180.0
+    t_rad = theta - theta0
     return gr * (1 / np.cos(t_rad) - 1) + gd * np.tan(t_rad)
 
 
@@ -292,19 +293,19 @@ def alio_to_theta(alio, theta0, gr, gd):
 
     total hours spent here: 2
     """
-    return theta0 + 180 / np.pi * 2 * np.arctan(
-        (np.sqrt(alio ** 2 + gd ** 2 + 2 * gr * alio) - gd) / (2 * gr + alio)
-    )
+    return theta0 + 2 * np.arctan(
+         (np.sqrt(alio ** 2 + gd ** 2 + 2 * gr * alio) - gd) / (2 * gr + alio)
+     )
 
 
 def wavelength_to_theta(wavelength, dspacing):
     """Converts wavelength (A) to theta angle (rad)."""
-    return 180.0 / np.pi * np.arcsin(wavelength / 2 / dspacing)
+    return np.arcsin(wavelength/2/dspacing)
 
 
 def theta_to_wavelength(theta, dspacing):
     """Converts theta angle (rad) to wavelength (A)."""
-    return 2 * dspacing * np.sin(theta / 180 * np.pi)
+    return 2*dspacing*np.sin(theta)
 
 
 def energy_to_wavelength(energy):

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import numpy as np
 from ophyd.device import Component as Cpt
@@ -16,11 +15,12 @@ from .pv_positioner import PVPositionerIsClose
 logger = logging.getLogger(__name__)
 
 # Constants
+
 si_111_dspacing = 3.1356011499587773
 si_511_dspacing = 1.0452003833195924
 
 # Defaults
-default_theta0 = 14.9792 * np.pi/180
+default_theta0 = 14.9792
 default_dspacing = si_111_dspacing
 default_gr = 3.175
 default_gd = 231.303
@@ -257,8 +257,24 @@ class CCM(InOutPositioner):
 
 # Calculations between alio position and energy, with all intermediates.
 def theta_to_alio(theta, theta0, gr, gd):
-    """Converts theta angle (rad) to alio position (mm)."""
-    return gr * (1/np.cos(theta)-1) + gd * np.tan(theta - theta0)
+    """
+    Converts theta angle (rad) to alio position (mm).
+
+    Theta_B:       scattering angle, the angle reduces when rotating clockwise
+                   (Bragg angle)
+    Theta_0:       scattering angle offset of the Si (111) first crystal
+    Delta_Theta:   the effective scattering angle (adjusted with Alio stage)
+    R = 0.003175m: radius of the sapphire ball connected to the Alio stage
+    D = 0.232156m: distance between the Theta_B rotation axis and the center
+                   of the saphire sphere located on the Alio stage
+
+    Theta_B = Theta_0 + Delta_Theta
+    Conversion formula:
+    x = f(Delta_Theta) = D * tan(Delta_Theta)+(R/cos(Delta_Theda))-R
+    Note that for ∆θ = 0, x = R
+    """
+    t_rad = (theta - theta0) * np.pi / 180.0
+    return gr * (1 / np.cos(t_rad) - 1) + gd * np.tan(t_rad)
 
 
 def alio_to_theta(alio, theta0, gr, gd):
@@ -270,33 +286,25 @@ def alio_to_theta(alio, theta0, gr, gd):
     docstring, either to indicate your success or to increment the hours
     counter below.
 
+    Conversion function
+    theta_angle = f(x) = 2arctan * [(sqrt(x^2 + D^2 + 2Rx) - D)/(2R + x)]
+    Note that for x = −R, θ = 2 arctan(−R/D)
+
     total hours spent here: 2
     """
-
-    low = -1.0
-    high = 1.0
-    timeout = 1.0
-    start = time.time()
-    while time.time() - start < timeout:
-        theta_guess = (low+high)/2
-        alio_calc = theta_to_alio(theta_guess, theta0, gr, gd)
-        if np.isclose(alio, alio_calc):
-            break
-        elif alio_calc > alio:
-            high = theta_guess
-        else:
-            low = theta_guess
-    return theta_guess
+    return theta0 + 180 / np.pi * 2 * np.arctan(
+        (np.sqrt(alio ** 2 + gd ** 2 + 2 * gr * alio) - gd) / (2 * gr + alio)
+    )
 
 
 def wavelength_to_theta(wavelength, dspacing):
     """Converts wavelength (A) to theta angle (rad)."""
-    return np.arcsin(wavelength/2/dspacing)
+    return 180.0 / np.pi * np.arcsin(wavelength / 2 / dspacing)
 
 
 def theta_to_wavelength(theta, dspacing):
     """Converts theta angle (rad) to wavelength (A)."""
-    return 2*dspacing*np.sin(theta)
+    return 2 * dspacing * np.sin(theta / 180 * np.pi)
 
 
 def energy_to_wavelength(energy):

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -18,11 +18,11 @@ SAMPLE_WAVELENGTH = 1.5  # hard xray
 # Make sure the calcs are properly inverted
 def test_theta_alio_inversion():
     logger.debug('test_theta_alio_inversion')
-
     theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.default_theta0, ccm.default_gr,
                               ccm.default_gd)
     alio_calc = ccm.theta_to_alio(theta, ccm.default_theta0, ccm.default_gr,
                                   ccm.default_gd)
+    # Unlike the other inversions, this is just an approximation
     assert np.isclose(alio_calc, SAMPLE_ALIO)
 
 

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -19,17 +19,10 @@ SAMPLE_WAVELENGTH = 1.5  # hard xray
 def test_theta_alio_inversion():
     logger.debug('test_theta_alio_inversion')
 
-    alio_res = ccm.theta_to_alio(SAMPLE_ALIO, ccm.default_theta0,
-                                 ccm.default_gr, ccm.default_gd)
-    theta_res = ccm.alio_to_theta(alio_res, ccm.default_theta0,
-                                  ccm.default_gr, ccm.default_gd)
-
     theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.default_theta0, ccm.default_gr,
                               ccm.default_gd)
     alio_calc = ccm.theta_to_alio(theta, ccm.default_theta0, ccm.default_gr,
                                   ccm.default_gd)
-
-    assert np.isclose(theta_res, SAMPLE_ALIO)
     assert np.isclose(alio_calc, SAMPLE_ALIO)
 
 

--- a/tests/test_ccm.py
+++ b/tests/test_ccm.py
@@ -18,11 +18,18 @@ SAMPLE_WAVELENGTH = 1.5  # hard xray
 # Make sure the calcs are properly inverted
 def test_theta_alio_inversion():
     logger.debug('test_theta_alio_inversion')
+
+    alio_res = ccm.theta_to_alio(SAMPLE_ALIO, ccm.default_theta0,
+                                 ccm.default_gr, ccm.default_gd)
+    theta_res = ccm.alio_to_theta(alio_res, ccm.default_theta0,
+                                  ccm.default_gr, ccm.default_gd)
+
     theta = ccm.alio_to_theta(SAMPLE_ALIO, ccm.default_theta0, ccm.default_gr,
                               ccm.default_gd)
     alio_calc = ccm.theta_to_alio(theta, ccm.default_theta0, ccm.default_gr,
                                   ccm.default_gd)
-    # Unlike the other inversions, this is just an approximation
+
+    assert np.isclose(theta_res, SAMPLE_ALIO)
     assert np.isclose(alio_calc, SAMPLE_ALIO)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The def `theta_to_alio` and def `alio_to_theta` functions have been reverted to use the `old` calculations.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to close #570
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has only been tested with a `fake_ccm`. 
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
