### PR TITLE
MNT: make doc helper script more user-friendly

### DIFF
--- a/docs/pre-release-notes.sh
+++ b/docs/pre-release-notes.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 
 ISSUE=$1
-DESCRIPTION=$2
+shift
+DESCRIPTION=$*
 
 if [[ -z "$ISSUE" || -z "$DESCRIPTION" ]]; then
-    echo "Usage: $0 (ISSUE) '(DESCRIPTION)'"
+    echo "Usage: $0 (ISSUE NUMBER) (DESCRIPTION)"
     exit 1
 fi
 
-FILENAME=source/upcoming_release_notes/${ISSUE}-${DESCRIPTION}.rst
+echo "Issue: $ISSUE"
+echo "Description: $DESCRIPTION"
 
-pushd "$(dirname "$0")"
-cp source/upcoming_release_notes/template-short.rst ${FILENAME}
+FILENAME=source/upcoming_release_notes/${ISSUE}-${DESCRIPTION// /_}.rst
+
+pushd "$(dirname "$0")" || exit 1
+
+sed -e "s/IssueNumber Title/${ISSUE} ${DESCRIPTION}/" \
+    "source/upcoming_release_notes/template-short.rst" > "${FILENAME}"
+
 if ${EDITOR} "${FILENAME}"; then
     echo "Adding ${FILENAME} to the git repository..."
-    git add ${FILENAME}
+    git add "${FILENAME}"
 fi
 
 popd


### PR DESCRIPTION
Minor tweaks to the release notes helper script.

* Allows for spaces in the description (`filename ~= s/ /_/g`)
* Auto sets title so you don't forget