### PR TITLE
REF/FIX: Noisy limits and EpicsMotor limit clamping

### DIFF
--- a/docs/source/upcoming_release_notes/555-Fix_EpicsMotor_limit_clamping.rst
+++ b/docs/source/upcoming_release_notes/555-Fix_EpicsMotor_limit_clamping.rst
@@ -1,0 +1,33 @@
+555 Fix EpicsMotor limit clamping
+#################################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Allow setting of :class:`~ophyd.EpicsMotor` limits when unset in the motor
+  record (i.e., ``(0, 0)``) when using
+  :class:`~pcdsdevices.epics_motor.EpicsMotorInterface`.
+
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/docs/source/upcoming_release_notes/591-Catch_LimitError.rst
+++ b/docs/source/upcoming_release_notes/591-Catch_LimitError.rst
@@ -1,0 +1,34 @@
+591 Catch LimitError
+####################
+
+API Changes
+-----------
+- User-facing move functions will not be able to catch the
+  :class:`~ophyd.utils.LimitError` exception.  These interactive methods are
+  not meant to be used in scans, as that is the role of bluesky.
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Catch :class:`~ophyd.utils.LimitError` in all
+  :class:`pcdsdevices.interface.MvInterface` moves, reporting a simple error by
+  way of the interface module-level logger.
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -65,7 +65,10 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     @property
     def low_limit(self):
         """The lower soft limit for the motor."""
-        return max(self._limits[0], self._get_epics_limits()[0])
+        epics_low, epics_high = self._get_epics_limits()
+        if epics_low != epics_high:
+            return max(self._limits[0], epics_low)
+        return self._limits[0]
 
     @low_limit.setter
     def low_limit(self, value):
@@ -74,7 +77,10 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     @property
     def high_limit(self):
         """The higher soft limit for the motor."""
-        return min(self._limits[1], self._get_epics_limits()[1])
+        epics_low, epics_high = self._get_epics_limits()
+        if epics_low != epics_high:
+            return min(self._limits[1], epics_high)
+        return self._limits[1]
 
     @high_limit.setter
     def high_limit(self, value):
@@ -94,8 +100,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         if limits is None or limits == (None, None):
             # Not initialized
             return (0, 0)
-        else:
-            return limits
+        return limits
 
     def enable(self):
         """

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -535,10 +535,16 @@ class MvInterface(BaseInterface):
     def _log_move_end(self):
         logger.info('%s reached position %s', self.name, self.wm())
 
-    def move(self, position, *args, **kwargs):
+    def move(self, *args, **kwargs):
         try:
-            st = super().move(position, *args, **kwargs)
+            st = super().move(*args, **kwargs)
         except ophyd.utils.LimitError as ex:
+            # Pick out the position either in kwargs or args
+            try:
+                position = kwargs['position']
+            except KeyError:
+                position = args[0]
+
             self._log_move_limit_error(position, ex)
             raise
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -14,6 +14,7 @@ from threading import Event
 from types import MethodType, SimpleNamespace
 from weakref import WeakSet
 
+import ophyd
 import yaml
 from bluesky.utils import ProgressBar
 from ophyd.device import Device
@@ -524,14 +525,23 @@ class MvInterface(BaseInterface):
         self._last_status.set_finished()
         super().__init__(*args, **kwargs)
 
+    def _log_move_limit_error(self, position, ex):
+        logger.error('Failed to move %s from %s to %s: %s', self.name,
+                     self.wm(), position, ex)
+
     def _log_move(self, position):
         logger.info('Moving %s from %s to %s', self.name, self.wm(), position)
 
     def _log_move_end(self):
         logger.info('%s reached position %s', self.name, self.wm())
 
-    def move(self, *args, **kwargs):
-        st = super().move(*args, **kwargs)
+    def move(self, position, *args, **kwargs):
+        try:
+            st = super().move(position, *args, **kwargs)
+        except ophyd.utils.LimitError as ex:
+            self._log_move_limit_error(position, ex)
+            raise
+
         self._last_status = st
         return st
 
@@ -561,7 +571,12 @@ class MvInterface(BaseInterface):
         """
         if log:
             self._log_move(position)
-        self.move(position, timeout=timeout, wait=wait)
+
+        try:
+            self.move(position, timeout=timeout, wait=wait)
+        except ophyd.utils.LimitError:
+            return
+
         if wait and log:
             self._log_move_end()
 
@@ -694,7 +709,11 @@ class FltMvInterface(MvInterface):
 
         if log:
             self._log_move(position)
-        status = self.move(position, timeout=timeout, wait=False)
+        try:
+            status = self.move(position, timeout=timeout, wait=False)
+        except ophyd.utils.LimitError:
+            return
+
         pgb = AbsProgressBar([status])
         try:
             status.wait()
@@ -758,7 +777,10 @@ class FltMvInterface(MvInterface):
                 limit_plot.append(x)
             plt.plot(limit_plot)
         pos = plt.ginput(1)[0][0]
-        self.move(pos, timeout=timeout)
+        try:
+            self.move(pos, timeout=timeout)
+        except ophyd.utils.LimitError:
+            return
 
     def tweak(self):
         """

--- a/tests/test_epics_motor.py
+++ b/tests/test_epics_motor.py
@@ -111,6 +111,8 @@ def test_epics_motor_soft_limits(fake_epics_motor):
         m.move(40)
     # Try with no limits set, e.g. (0, 0)
     m.user_setpoint.sim_set_limits((0, 0))
+    # And of course, clear our soft limits as well:
+    m.limits = (0, 0)
     m.check_value(42)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
```
- User-facing move functions will not be able to catch the
  :class:`~ophyd.utils.LimitError` exception.  These interactive methods are
  not meant to be used in scans, as that is the role of bluesky.
- Catch :class:`~ophyd.utils.LimitError` in all
  :class:`pcdsdevices.interface.MvInterface` moves, reporting a simple error by
  way of the interface module-level logger.
- Allow setting of :class:`~ophyd.EpicsMotor` limits when unset in the motor
  record (i.e., ``(0, 0)``) when using
  :class:`~pcdsdevices.epics_motor.EpicsMotorInterface`.
```

## Motivation and Context
Closes #555 
Closes #591 

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
Release notes.