### PR TITLE
ENH: Include LAMP motion class

### DIFF
--- a/docs/source/upcoming_release_notes/614-LAMP_motion_system_class.rst
+++ b/docs/source/upcoming_release_notes/614-LAMP_motion_system_class.rst
@@ -1,5 +1,5 @@
 614 LAMP motion system class
-#################
+############################
 
 API Changes
 -----------
@@ -15,7 +15,7 @@ Device Updates
 
 New Devices
 -----------
-- LAMP motion Class for the LAMP endstation TMO. This indluces the following motion axes:
+- LAMP motion Class for the LAMP endstation TMO. This includes the following motion axes:
  - Gas Jet X/Y/Z Axes
  - Gas Needle X/Y/Z Axes
  - Sample Paddle X/Y/Z Axes 

--- a/docs/source/upcoming_release_notes/614-LAMP_motion_system_class.rst
+++ b/docs/source/upcoming_release_notes/614-LAMP_motion_system_class.rst
@@ -1,0 +1,33 @@
+614 LAMP motion system class
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- LAMP Class: TMO-LAMP Motion system class:
+ - Gas Jet X/Y/Z Axes
+ - Gas Needle X/Y/Z Axes
+ - Sample Paddle X/Y/Z Axes 
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- jsheppard95

--- a/docs/source/upcoming_release_notes/614-LAMP_motion_system_class.rst
+++ b/docs/source/upcoming_release_notes/614-LAMP_motion_system_class.rst
@@ -15,7 +15,7 @@ Device Updates
 
 New Devices
 -----------
-- LAMP Class: TMO-LAMP Motion system class:
+- LAMP motion Class for the LAMP endstation TMO. This indluces the following motion axes:
  - Gas Jet X/Y/Z Axes
  - Gas Needle X/Y/Z Axes
  - Sample Paddle X/Y/Z Axes 

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -27,6 +27,7 @@ class LAMP(BaseInterface, Device):
     """
     # UI representation
     _icon = 'fa.minus-square'
+    tab_component_names = True
 
     # Motor components
     gas_jet_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -16,6 +16,14 @@ class LAMP(BaseInterface, Device):
     LAMP Motion Class
 
     This class controls motors fixed to the LAMP Motion system
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the LAMP motion system
+
+    name : str
+        Alias for the device
     """
     # UI representation
     _icon = 'fa.minus-square'

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -1,0 +1,34 @@
+"""
+LAMP Motion Classes
+
+This module contains classes related to the TMO-LAMP Motion System
+"""
+
+import logging
+from ophyd import Component as Cpt
+from ophyd import Device
+
+from .epics_motor import BeckhoffAxis
+from .interface import BaseInterface
+
+class LAMP(BaseInterface, Device):
+    """
+    LAMP Motion Class
+
+    This class controls motors fixed to the LAMP Motion system
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+
+    # Motor components
+    gas_jet_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    gas_jet_y = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+    gas_jet_z = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
+
+    gas_needle_x = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
+    gas_needle_y = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+    gas_needle_z = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
+
+    sample_paddle_x = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
+    sample_paddle_y = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
+    sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -4,12 +4,12 @@ LAMP Motion Classes
 This module contains classes related to the TMO-LAMP Motion System
 """
 
-import logging
 from ophyd import Component as Cpt
 from ophyd import Device
 
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
+
 
 class LAMP(BaseInterface, Device):
     """

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -15,7 +15,8 @@ class LAMP(BaseInterface, Device):
     """
     LAMP Motion Class
 
-    This class controls motors fixed to the LAMP Motion system
+    This class controls motors fixed to the LAMP Motion system for the LAMP
+    endstation in TMO.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added class `lamp_motion.LAMP` which contains motion components for each LAMP stepper motor:
- Gas Jet X/Y/Z (in air)
- Gas Needle X/Y/Z (in air)
- Sample Paddle X/Y/Z (in vacuum)

## Motivation and Context
This class is required for a Python interface to the LAMP motion system.

## How Has This Been Tested?
- Ran test suite locally (no failed tests)
- Instantiated object in Ipython section/inspected components
- Opened test typhos screen

## Where Has This Been Documented?
- Docstring for `lamp_motion.LAMP`


## Pre-merge checklist
- [X] Test suite passes locally
- [x] Test suite passes on travis
- [X] Code works interactively
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
