### PR TITLE
DOC: improve pre-merge checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,10 @@
 -->
 
 ## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API
+- [ ] New/changed functions and methods are covered in the test suite where possible
 - [ ] Test suite passes locally
 - [ ] Test suite passes on travis
-- [ ] Code works interactively
 - [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
+- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate


### PR DESCRIPTION
I've noticed that the PR template isn't clear enough about documentation nor complete enough to avoid "do the thing" kinds of reviews. I've updated it accordingly, including some minor re-ordering.