### PR TITLE
ENH: New lcls object to query machine status

### DIFF
--- a/docs/source/upcoming_release_notes/619-New_Lcls_object_to_query_machine_status.rst
+++ b/docs/source/upcoming_release_notes/619-New_Lcls_object_to_query_machine_status.rst
@@ -3,7 +3,7 @@
 
 API Changes
 -----------
-- N/A
+- The `SxrGmD` device has been removed from `beam_stats` module. SXR has been disassembled and the GMD was moved into the EBD. Its MJ PVs was not working anymore.
 
 Features
 --------
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- The `SxrGmD` device has been removed from `beam_stats` module. SXR has been disassembled and the GMD was moved into the EBD. Its MJ PVs was not working anymore.
+- N/A
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/619-New_Lcls_object_to_query_machine_status.rst
+++ b/docs/source/upcoming_release_notes/619-New_Lcls_object_to_query_machine_status.rst
@@ -1,0 +1,31 @@
+619 New Lcls object to query machine status
+###########################################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A 
+
+Device Updates
+--------------
+- The `SxrGmD` device has been removed from `beam_stats` module. SXR has been disassembled and the GMD was moved into the EBD. Its MJ PVs was not working anymore.
+
+New Devices
+-----------
+- A new Lcls class has been added to the `beam_stats` module.
+- This new class contains PVs related to the Lcls Linac Status, as well as a few functions to support with checking the BYKIK status, turning that On and Off, and setting the period.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -80,7 +80,9 @@ class BeamEnergyRequest(PVPositionerDone):
 
 
 class Lcls(BaseInterface, Device):
-    """Lcls Linac Status."""
+    """
+    Object to query machine Lcls Linac status.
+    """
 
     tab_component_names = True
 

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,5 +1,3 @@
-import time
-import numpy as np
 import logging
 
 from ophyd.device import Component as Cpt
@@ -15,20 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 class BeamStats(BaseInterface, Device):
+    # Pulse energy (in mJ)
     mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted')
+    # Photon Energy (in eV)
     ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal')
+    # LCLSBEAM Event Rate (in Hz)
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE', kind='normal')
+    # ECS: BEAM_OWNER ID
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID', kind='omitted')
-
-    # Bunch charge
-    bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal')
-    # estimated FEL Pulse Duration (FWHM)
-    bunch_length = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO820', kind='normal')
-    # Peak current after BC2 (A)
-    peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195', kind='normal')
-    # Last Eloss sxray energy
-    eloss_energy = Cpt(EpicsSignalRO, 'PHYS:SYS0:1:ELOSSENERGY', kind='normal')
-    # Vernier energy?  FBCK:FB04:LG01:DL2VERNIER
 
     mj_avg = Cpt(AvgSignal, 'mj', averages=120, kind='normal')
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages', kind='config')
@@ -94,279 +86,96 @@ class BeamEnergyRequest(PVPositionerDone):
                          **kwargs)
 
 
-class LclsEvent(Device):
-    def __init__(self, prefix='', name='lcls_event', **kwargs):
+class Lcls(BaseInterface, Device):
+    '''
+    LCLS LINAC STATUS
+    bunch charge: 180 [pC]
+    repetition rate: 120 [Hz]
+    ebeam energy: 10.75 [GeV]
+    Vernier energy: -35 [MeV]
+    Photon Energy: 9.91 [keV]
+    BC2 peak current: 3201 [A]
+    electron bunch length: 23 [fs]
+    Last eLoss Scan: 0.93 [mJ]
+    '''
+    # Bunch Charge nC: FBCK:BCI0:1:CHRG	no desc
+    # Hard e-Energy GeV/c: BEND:DMPH:400:BDES - Desired B-Field
+    # Soft e-Energ GeV/c: BEND:DMPS:400:BDES - Desired B-Field
+    # Bunch Length fs: SIOC:SYS0:ML00:AO820 estimated FEL Pulse Duration (FWHM)
+
+    # BC2 IPK:	 FBCK:FB04:LG01:S5DES	BC2 Current set point
+
+    # Bunch charge (units: nC)
+    bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal')
+    # also have this one  FBCK:BCI0:1:CHRG (nC)
+    # estimated FEL Pulse Duration (FWHM) (units: fs)
+    bunch_length = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO820', kind='normal')
+    # BLEN:LI21:265:WIDTH - not found
+    # Width of pulse (bunch length) Fsec
+
+    # Peak current after BC2 (units: A)
+    peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195', kind='normal')
+    # Last Eloss sxray energy (units: mJ)
+    eloss_energy = Cpt(EpicsSignalRO, 'PHYS:SYS0:1:ELOSSENERGY', kind='normal')
+    # Fast Feedback 6x6 Vernier (units: MeV)
+    vernier_energy = Cpt(EpicsSignalRO, 'FBCK:FB04:LG01:DL2VERNIER',
+                         kind='normal')
+
+    # FBCK Vernier SIOC:SYS0:ML00:CALC209 (units: MeV)
+    # DL2 Energy - FBCK:FB04:LG01:DL2VERNIER
+    # Vernier Limit (% of Bend Energy):	SIOC:SYS0:ML01:AO151 Vernier Scan Range
+    # Vernier Limit: SIOC:SYS0:ML01:CALC034 - Vernier Limit
+    # Vernie Crtrl w/limits: SIOC:SYS0:ML01:CALC033	- Vernier Ctrl w/ limits
+
+    # LCLSBEAM Event Rate (units: Hz)
+    beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
+                          kind='normal')
+    # Photon eV HXR (units: eV)
+    photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627', kind='normal')
+
+    # Abort Active Status
+    # [ 0] Disable [ 1] Enable
+    bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT', kind='normal')
+
+    # Abort Period in  beam shots
+    bykik_period = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTPRD',
+                       kind='normal')
+    # undulator k value - not the correct PV i think
+    undulator_k = Cpt(EpicsSignal, 'USEG:UND1:150:KACT', kind='normal')
+
+    def bykik_status(self):
+        """
+        Returns status of bykik abort
+        """
+        status = self.bykik_abort.get()
+        if status == 0:
+            return 'Disable'
+        else:
+            return 'Enable'
+
+    def bykik_disable(self):
+        """
+        Disables bykik abort
+        """
+        return self.bykik_abort.put(0)
+
+    def bykik_enable(self):
+        """
+        Enables bykik abort
+        """
+        return self.bykik_abort.put(1)
+
+    def bykik_get_period(self):
+        """
+        Gets the number of events between bykik aborts
+        """
+        return self.bykik_period.get()
+
+    def bykik_set_period(self, period):
+        """
+        Sets the number of events between bykik aborts
+        """
+        return self.bykik_period.put(period)
+
+    def __init__(self, prefix='', name='lcls', **kwargs):
         super().__init__(prefix=prefix, name=name, **kwargs)
-
-        # Abort Active Status
-        # [ 0] Disable [ 1] Enable
-        self.bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT',
-                               kind='normal')
-        # Abort Period in  beam shots
-        self.bykik_period = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTPRD',
-                                kind='normal')
-
-        def bykik_status(self):
-            """
-            Returns status of bykik abort
-            """
-            status = self.bykik_abort.get()
-            if status == 0:
-                return 'Disable'
-            else:
-                return 'Enable'
-
-        def bykik_disable(self):
-            """
-            Disables bykik abort
-            """
-            return self.bykik_abort.put(0)
-
-        def bykik_enable(self):
-            """
-            Enables bykik abort
-            """
-            return self.bykik_abort.put(1)
-
-        def bykik_get_period(self):
-            """
-            Gets the number of events between bykik aborts
-            """
-            return self.bykik_period.get()
-
-        def bykik_set_period(self, period):
-            """
-            Sets the number of events between bykik aborts
-            """
-            return self.bykik_period.put(period)
-
-
-class Linac(Device):
-    """
-    Contains methods to view and change parameters from the
-    lcls event/timing system screen
-    """
-    def __init__(self, prefix='', name='linac', **kwargs):
-        super().__init__(prefix=prefix, name=name, **kwargs)
-
-        # Photon eV HXR (units: eV)
-        self.photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627',
-                                 kind='normal')
-        # BeTpv
-        #  Actual Ratio
-        self.actual_ratio = Cpt(EpicsSignalRO, 'SATT:FEE1:320:RACT',
-                                kind='normal')
-        # BeMilspv
-        # Sum All
-        self.sum_all = Cpt(EpicsSignalRO, 'SATT:FEE1:320:TACT',
-                           kind='normal')
-
-        # LCLSBEAM Event Rate (units: Hz)
-        self.beam_event_rate = Cpt(EpicsSignalRO,
-                                   'EVNT:SYS0:1:LCLSBEAMRATE',
-                                   kind='normal')
-        # Request BYKIK Burst Mode
-        # [ 0] No [ 1] Yes
-        self.is_bykik_burst_mode_en = Cpt(EpicsSignalRO,
-                                          'IOC:BSY0:MP01:REQBYKIKBRST',
-                                          kind='normal')
-        # Request Pockels Cell Burst Mode
-        # [ 0] No [ 1] Yes
-        self.is_pockels_cell_burst_mode_en = Cpt(EpicsSignalRO,
-                                                 'IOC:BSY0:MP01:REQPCBRST',
-                                                 kind='normal')
-        # Maximum Pulses to Inhibit
-        self.max_pulses_to_inhibit = Cpt(EpicsSignal,
-                                         'PATT:SYS0:1:MPSBURSTCNTMAX',
-                                         kind='normal')
-        # MPSBURST Control
-        self.mps_burst_control = Cpt(EpicsSignal,
-                                     'PATT:SYS0:1:MPSBURSTCTRL',
-                                     kind='normal')
-        # Actual Count
-        self.burst_count = Cpt(EpicsSignalRO, 'PATT:SYS0:1:MPSBURSTCNT',
-                               kind='norml')
-        # aximum Pulses to Inhibit
-        self.test_burst_count = Cpt(EpicsSignal,
-                                    'PATT:SYS0:1:TESTBURSTCNTMAX',
-                                    kind='normal')
-        # Rate to Inhibit Pulses
-        self.rate_to_inhibit_pulses = Cpt(EpicsSignal,
-                                          'PATT:SYS0:1:MPSBURSTRATE',
-                                          kind='normal')
-        # Rate to Inhibit Pulses
-        self.test_burst_rate = Cpt(EpicsSignal,
-                                   'PATT:SYS0:1:TESTBURSTRATE',
-                                   kind='normal')
-        # Set Pattern Check Parameters
-        self.test_burst = Cpt(EpicsSignal, 'PATT:SYS0:1:TESTBURST.N',
-                              kind='normal')
-        # undulator k value - not the correct PV i think
-        self.undulator_k = Cpt(EpicsSignal, 'USEG:UND1:150:KACT',
-                               kind='normal')
-        # MPSBURST Control
-        # [ 0] Off [ 1] Burst - why declared twice?
-        self.burst_delivered = Cpt(EpicsSignalRO, 'PATT:SYS0:1:MPSBURSTCTRL',
-                                   kind='normal')
-
-        self.dict_rate_to_enum = {0.5: 5, 1: 4, 5: 3, 10: 2, 30: 1,
-                                  120: 0, 0: 0}
-
-        self.freqs = {'Full': 0, 'full': 0, '30Hz': 1, '10Hz': 2,
-                      '5Hz': 3, '1Hz': 4, '0.5Hz': 5}
-
-    def get_BeL(self):
-        return self.sum_all.get() / 1e3 * 25.4e-3
-
-    def get_BeT(self):
-        return self.actual_ratio.get()
-
-    def get_fee_att_t(self):
-        return self.actual_ratio.get()
-
-    def get_xray_eV(self):
-        return self.photon_ev_hxr.get()
-
-    def is_burst_enabled(self):
-        """
-        Checks if the burst is enabled
-        """
-        is_burst_en = (self.is_bykik_burst_mode_en.get() == 1 or
-                       self.is_pockels_cell_burst_mode_en.get() == 1)
-        return True if is_burst_en else False
-
-    def is_legal_rate(self, rate):
-        return rate in self.dict_rate_to_enum
-
-    def set_num_burst(self, num):
-        if num == "forever":
-            num = -1
-        self.max_pulses_to_inhibit.put(int(num))
-
-    def get_num_bursts(self):
-        return self.burst_count.get()
-
-    def get_burst(self, num=None, wait=False):
-        if num is not None:
-            self.set_num_burst(num)
-            time.sleep(0.03)
-            # make sure the PV is written before executing
-            self.start_burst()
-
-    def get_shot(self):
-        self.set_num_burst(1)
-        time.sleep(0.03)
-        # make sure PV is written before executing
-        # return self.mps_burst_control.put(1)
-        self.start_burst()
-
-    def start_burst(self):
-        return self.mps_burst_control.put(1)
-
-    def stop_burst(self):
-        self.mps_burst_control.put(0)
-        self.set_num_burst(1)
-
-    def stop(self):
-        self.stop_burst()
-
-    def burst_forever(self):
-        self.set_num_burst(-1)
-        time.sleep(0.1)
-        self.start_burst()
-
-    def set_test_nburst(self, num):
-        if num == "forever":
-            num = -1
-        self.test_burst_count.put(int(num))
-
-    def set_fburst(self, f='Full'):
-        f.replace(' ', '')
-        # remove spaces
-        if not (f in self.freqs):
-            logger.error('Frequency should be one of: %s',
-                         list(self.dict_rate_to_enum.keys()))
-            return
-        self.rate_to_inhibit_pulses.put(self.freqs[f])
-
-    def set_burst_rate(self, rate):
-        if not (rate in self.dict_rate_to_enum):
-            logger.error('Rate should be one of: %s',
-                         list(self.dict_rate_to_enum.keys()))
-            return
-        self.test_burst.put(0)
-        self.test_burst_rate.put(self.dict_rate_to_enum[rate])
-
-    def get_fburst(self):
-        rate = self.rate_to_inhibit_pulses.get()
-        if rate == 0:
-            return self.get_ebeam_rate()
-        elif rate == 1:
-            return 30.0
-        elif rate == 2:
-            return 10.0
-        elif rate == 3:
-            return 5.0
-        elif rate == 4:
-            return 1.0
-        elif rate == 5:
-            return 0.5
-        else:
-            return 0.0
-
-    def get_test_burst(self):
-        rate = self.test_burst_rate.get()
-        if rate == 0:
-            return self.get_ebeam_rate()
-        elif rate == 1:
-            return 30.0
-        elif rate == 2:
-            return 10.0
-        elif rate == 3:
-            return 5.0
-        elif rate == 4:
-            return 1.0
-        elif rate == 5:
-            return 0.5
-        else:
-            return 0.0
-
-    def get_ebeam_rate(self):
-        return self.beam_event_rate.get()
-
-    def get_xray_beam_rate(self):
-        if self.is_bykik_burst_mode_en():
-            return self.get_fburst()
-        else:
-            return self.get_ebeam_rate()
-
-    def wait_burst(self, timeout=1.0):
-        self.burst_delivered.wait_for_value(1, float(timeout))
-        time.sleep(0.2)
-        # This is commented out in the old code too
-        # while(self.mps_burst_control.get() != 0):
-        #     time.sleep(0.02)
-        #     logger.info('Wait...')
-
-    def wait_for_shot(self, verbose=False, timeout=None):
-        """
-        Waits for the burst to be over to make sure the PV is
-        written, otherwise a sequence get_shot(); wait_for_shot() may fail
-        """
-        time.sleep(0.03)
-        t0 = time.time()
-        self.burst_delivered.wait_for_value(0, timeout)
-        if verbose:
-            logger.info("waited %.3f secs for shots" % (time.time() - t0))
-
-    def GeV_to_keV(self, electron_in_GeV):
-        und_period = 3
-        # in cm
-        und_K = self.undulator_k_k.get()
-        return 0.95 * electron_in_GeV ** 2 / (1 + und_K ** 2 / 2) / und_period
-
-    def KeV_to_GeV(self, exray_in_keV):
-        und_period = 3
-        # in cm
-        und_K = self.undulator_k.get()
-        return np.sqrt((1 + und_K ** 2 / 2) * und_period * exray_in_keV / 0.95)

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -103,7 +103,7 @@ class Lcls(BaseInterface, Device):
 
     bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal',
                        doc='Bunch charge [nC]')
-    bunch_charge_2 = Cpt(EpicsSignalRO, 'Bunch Charge nC: FBCK:BCI0:1:CHRG',
+    bunch_charge_2 = Cpt(EpicsSignalRO, 'FBCK:BCI0:1:CHRG',
                          kind='normal', doc='Bunch Charge [nC]')
     beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
                           kind='normal', doc='LCLSBEAM Event Rate [Hz]')

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,3 +1,7 @@
+import time
+import numpy as np
+import logging
+
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
@@ -7,11 +11,24 @@ from .pv_positioner import PVPositionerDone
 from .signal import AvgSignal
 
 
+logger = logging.getLogger(__name__)
+
+
 class BeamStats(BaseInterface, Device):
     mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted')
     ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal')
     rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE', kind='normal')
     owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID', kind='omitted')
+
+    # Bunch charge
+    bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal')
+    # estimated FEL Pulse Duration (FWHM)
+    bunch_length = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO820', kind='normal')
+    # Peak current after BC2 (A)
+    peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195', kind='normal')
+    # Last Eloss sxray energy
+    eloss_energy = Cpt(EpicsSignalRO, 'PHYS:SYS0:1:ELOSSENERGY', kind='normal')
+    # Vernier energy?  FBCK:FB04:LG01:DL2VERNIER
 
     mj_avg = Cpt(AvgSignal, 'mj', averages=120, kind='normal')
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages', kind='config')
@@ -75,3 +92,281 @@ class BeamEnergyRequest(PVPositionerDone):
             self.atol = atol
         super().__init__(prefix, name=name, skip_small_moves=skip_small_moves,
                          **kwargs)
+
+
+class LclsEvent(Device):
+    def __init__(self, prefix='', name='lcls_event', **kwargs):
+        super().__init__(prefix=prefix, name=name, **kwargs)
+
+        # Abort Active Status
+        # [ 0] Disable [ 1] Enable
+        self.bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT',
+                               kind='normal')
+        # Abort Period in  beam shots
+        self.bykik_period = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTPRD',
+                                kind='normal')
+
+        def bykik_status(self):
+            """
+            Returns status of bykik abort
+            """
+            status = self.bykik_abort.get()
+            if status == 0:
+                return 'Disable'
+            else:
+                return 'Enable'
+
+        def bykik_disable(self):
+            """
+            Disables bykik abort
+            """
+            return self.bykik_abort.put(0)
+
+        def bykik_enable(self):
+            """
+            Enables bykik abort
+            """
+            return self.bykik_abort.put(1)
+
+        def bykik_get_period(self):
+            """
+            Gets the number of events between bykik aborts
+            """
+            return self.bykik_period.get()
+
+        def bykik_set_period(self, period):
+            """
+            Sets the number of events between bykik aborts
+            """
+            return self.bykik_period.put(period)
+
+
+class Linac(Device):
+    """
+    Contains methods to view and change parameters from the
+    lcls event/timing system screen
+    """
+    def __init__(self, prefix='', name='linac', **kwargs):
+        super().__init__(prefix=prefix, name=name, **kwargs)
+
+        # Photon eV HXR (units: eV)
+        self.photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627',
+                                 kind='normal')
+        # BeTpv
+        #  Actual Ratio
+        self.actual_ratio = Cpt(EpicsSignalRO, 'SATT:FEE1:320:RACT',
+                                kind='normal')
+        # BeMilspv
+        # Sum All
+        self.sum_all = Cpt(EpicsSignalRO, 'SATT:FEE1:320:TACT',
+                           kind='normal')
+
+        # LCLSBEAM Event Rate (units: Hz)
+        self.beam_event_rate = Cpt(EpicsSignalRO,
+                                   'EVNT:SYS0:1:LCLSBEAMRATE',
+                                   kind='normal')
+        # Request BYKIK Burst Mode
+        # [ 0] No [ 1] Yes
+        self.is_bykik_burst_mode_en = Cpt(EpicsSignalRO,
+                                          'IOC:BSY0:MP01:REQBYKIKBRST',
+                                          kind='normal')
+        # Request Pockels Cell Burst Mode
+        # [ 0] No [ 1] Yes
+        self.is_pockels_cell_burst_mode_en = Cpt(EpicsSignalRO,
+                                                 'IOC:BSY0:MP01:REQPCBRST',
+                                                 kind='normal')
+        # Maximum Pulses to Inhibit
+        self.max_pulses_to_inhibit = Cpt(EpicsSignal,
+                                         'PATT:SYS0:1:MPSBURSTCNTMAX',
+                                         kind='normal')
+        # MPSBURST Control
+        self.mps_burst_control = Cpt(EpicsSignal,
+                                     'PATT:SYS0:1:MPSBURSTCTRL',
+                                     kind='normal')
+        # Actual Count
+        self.burst_count = Cpt(EpicsSignalRO, 'PATT:SYS0:1:MPSBURSTCNT',
+                               kind='norml')
+        # aximum Pulses to Inhibit
+        self.test_burst_count = Cpt(EpicsSignal,
+                                    'PATT:SYS0:1:TESTBURSTCNTMAX',
+                                    kind='normal')
+        # Rate to Inhibit Pulses
+        self.rate_to_inhibit_pulses = Cpt(EpicsSignal,
+                                          'PATT:SYS0:1:MPSBURSTRATE',
+                                          kind='normal')
+        # Rate to Inhibit Pulses
+        self.test_burst_rate = Cpt(EpicsSignal,
+                                   'PATT:SYS0:1:TESTBURSTRATE',
+                                   kind='normal')
+        # Set Pattern Check Parameters
+        self.test_burst = Cpt(EpicsSignal, 'PATT:SYS0:1:TESTBURST.N',
+                              kind='normal')
+        # undulator k value - not the correct PV i think
+        self.undulator_k = Cpt(EpicsSignal, 'USEG:UND1:150:KACT',
+                               kind='normal')
+        # MPSBURST Control
+        # [ 0] Off [ 1] Burst - why declared twice?
+        self.burst_delivered = Cpt(EpicsSignalRO, 'PATT:SYS0:1:MPSBURSTCTRL',
+                                   kind='normal')
+
+        self.dict_rate_to_enum = {0.5: 5, 1: 4, 5: 3, 10: 2, 30: 1,
+                                  120: 0, 0: 0}
+
+        self.freqs = {'Full': 0, 'full': 0, '30Hz': 1, '10Hz': 2,
+                      '5Hz': 3, '1Hz': 4, '0.5Hz': 5}
+
+    def get_BeL(self):
+        return self.sum_all.get() / 1e3 * 25.4e-3
+
+    def get_BeT(self):
+        return self.actual_ratio.get()
+
+    def get_fee_att_t(self):
+        return self.actual_ratio.get()
+
+    def get_xray_eV(self):
+        return self.photon_ev_hxr.get()
+
+    def is_burst_enabled(self):
+        """
+        Checks if the burst is enabled
+        """
+        is_burst_en = (self.is_bykik_burst_mode_en.get() == 1 or
+                       self.is_pockels_cell_burst_mode_en.get() == 1)
+        return True if is_burst_en else False
+
+    def is_legal_rate(self, rate):
+        return rate in self.dict_rate_to_enum
+
+    def set_num_burst(self, num):
+        if num == "forever":
+            num = -1
+        self.max_pulses_to_inhibit.put(int(num))
+
+    def get_num_bursts(self):
+        return self.burst_count.get()
+
+    def get_burst(self, num=None, wait=False):
+        if num is not None:
+            self.set_num_burst(num)
+            time.sleep(0.03)
+            # make sure the PV is written before executing
+            self.start_burst()
+
+    def get_shot(self):
+        self.set_num_burst(1)
+        time.sleep(0.03)
+        # make sure PV is written before executing
+        # return self.mps_burst_control.put(1)
+        self.start_burst()
+
+    def start_burst(self):
+        return self.mps_burst_control.put(1)
+
+    def stop_burst(self):
+        self.mps_burst_control.put(0)
+        self.set_num_burst(1)
+
+    def stop(self):
+        self.stop_burst()
+
+    def burst_forever(self):
+        self.set_num_burst(-1)
+        time.sleep(0.1)
+        self.start_burst()
+
+    def set_test_nburst(self, num):
+        if num == "forever":
+            num = -1
+        self.test_burst_count.put(int(num))
+
+    def set_fburst(self, f='Full'):
+        f.replace(' ', '')
+        # remove spaces
+        if not (f in self.freqs):
+            logger.error('Frequency should be one of: %s',
+                         list(self.dict_rate_to_enum.keys()))
+            return
+        self.rate_to_inhibit_pulses.put(self.freqs[f])
+
+    def set_burst_rate(self, rate):
+        if not (rate in self.dict_rate_to_enum):
+            logger.error('Rate should be one of: %s',
+                         list(self.dict_rate_to_enum.keys()))
+            return
+        self.test_burst.put(0)
+        self.test_burst_rate.put(self.dict_rate_to_enum[rate])
+
+    def get_fburst(self):
+        rate = self.rate_to_inhibit_pulses.get()
+        if rate == 0:
+            return self.get_ebeam_rate()
+        elif rate == 1:
+            return 30.0
+        elif rate == 2:
+            return 10.0
+        elif rate == 3:
+            return 5.0
+        elif rate == 4:
+            return 1.0
+        elif rate == 5:
+            return 0.5
+        else:
+            return 0.0
+
+    def get_test_burst(self):
+        rate = self.test_burst_rate.get()
+        if rate == 0:
+            return self.get_ebeam_rate()
+        elif rate == 1:
+            return 30.0
+        elif rate == 2:
+            return 10.0
+        elif rate == 3:
+            return 5.0
+        elif rate == 4:
+            return 1.0
+        elif rate == 5:
+            return 0.5
+        else:
+            return 0.0
+
+    def get_ebeam_rate(self):
+        return self.beam_event_rate.get()
+
+    def get_xray_beam_rate(self):
+        if self.is_bykik_burst_mode_en():
+            return self.get_fburst()
+        else:
+            return self.get_ebeam_rate()
+
+    def wait_burst(self, timeout=1.0):
+        self.burst_delivered.wait_for_value(1, float(timeout))
+        time.sleep(0.2)
+        # This is commented out in the old code too
+        # while(self.mps_burst_control.get() != 0):
+        #     time.sleep(0.02)
+        #     logger.info('Wait...')
+
+    def wait_for_shot(self, verbose=False, timeout=None):
+        """
+        Waits for the burst to be over to make sure the PV is
+        written, otherwise a sequence get_shot(); wait_for_shot() may fail
+        """
+        time.sleep(0.03)
+        t0 = time.time()
+        self.burst_delivered.wait_for_value(0, timeout)
+        if verbose:
+            logger.info("waited %.3f secs for shots" % (time.time() - t0))
+
+    def GeV_to_keV(self, electron_in_GeV):
+        und_period = 3
+        # in cm
+        und_K = self.undulator_k_k.get()
+        return 0.95 * electron_in_GeV ** 2 / (1 + und_K ** 2 / 2) / und_period
+
+    def KeV_to_GeV(self, exray_in_keV):
+        und_period = 3
+        # in cm
+        und_K = self.undulator_k.get()
+        return np.sqrt((1 + und_K ** 2 / 2) * und_period * exray_in_keV / 0.95)

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -79,7 +79,7 @@ class BeamEnergyRequest(PVPositionerDone):
                          **kwargs)
 
 
-class Lcls(BaseInterface, Device):
+class LCLS(BaseInterface, Device):
     """
     Object to query machine Lcls Linac status.
     """

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 class BeamStats(BaseInterface, Device):
-    # Pulse energy (in mJ)
-    mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted')
-    # Photon Energy (in eV)
-    ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal')
-    # LCLSBEAM Event Rate (in Hz)
-    rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE', kind='normal')
-    # ECS: BEAM_OWNER ID
-    owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID', kind='omitted')
+    mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted',
+             doc='Pulse energy [mJ]')
+    ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal',
+             doc='Photon Energy [eV]')
+    rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE', kind='normal',
+               doc='LCLSBEAM Event Rate [Hz]')
+    owner = Cpt(EpicsSignalRO, 'ECS:SYS0:0:BEAM_OWNER_ID', kind='omitted',
+                doc='BEAM_OWNER ID')
 
     mj_avg = Cpt(AvgSignal, 'mj', averages=120, kind='normal')
     mj_buffersize = Cpt(AttributeSignal, 'mj_avg.averages', kind='config')
@@ -32,6 +32,7 @@ class BeamStats(BaseInterface, Device):
 
 
 class SxrGmd(Device):
+    # TODO: this PV => not found
     mj = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse', kind='hinted')
 
     def __init__(self, prefix='', name='sxr_gmd', **kwargs):
@@ -98,72 +99,70 @@ class Lcls(BaseInterface, Device):
     electron bunch length: 23 [fs]
     Last eLoss Scan: 0.93 [mJ]
     '''
-    # Bunch Charge nC: FBCK:BCI0:1:CHRG	no desc
-    # Hard e-Energy GeV/c: BEND:DMPH:400:BDES - Desired B-Field
-    # Soft e-Energ GeV/c: BEND:DMPS:400:BDES - Desired B-Field
-    # Bunch Length fs: SIOC:SYS0:ML00:AO820 estimated FEL Pulse Duration (FWHM)
 
-    # BC2 IPK:	 FBCK:FB04:LG01:S5DES	BC2 Current set point
+    tab_component_names = True
 
-    # Bunch charge (units: nC)
-    bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal')
-    # also have this one  FBCK:BCI0:1:CHRG (nC)
-    # estimated FEL Pulse Duration (FWHM) (units: fs)
-    bunch_length = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO820', kind='normal')
-    # BLEN:LI21:265:WIDTH - not found
-    # Width of pulse (bunch length) Fsec
+    tab_whitelist = ['bykik_status', 'bykik_disable', 'bykik_enable',
+                     'bykik_get_period', 'bykik_set_period']
 
-    # Peak current after BC2 (units: A)
-    peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195', kind='normal')
-    # Last Eloss sxray energy (units: mJ)
-    eloss_energy = Cpt(EpicsSignalRO, 'PHYS:SYS0:1:ELOSSENERGY', kind='normal')
-    # Fast Feedback 6x6 Vernier (units: MeV)
+    # TODO: - these PVs are not necessarily the ones we'll end up using...
+
+    bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal',
+                       doc='Bunch charge [nC]')
+    bunch_length = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO820', kind='normal',
+                       doc='estimated FEL Pulse Duration (FWHM) [fs]')
+    peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195', kind='normal',
+                       doc='Peak current after BC2 [A]')
+    eloss_energy = Cpt(EpicsSignalRO, 'PHYS:SYS0:1:ELOSSENERGY', kind='normal',
+                       doc='Last Eloss sxray energy [mJ]')
     vernier_energy = Cpt(EpicsSignalRO, 'FBCK:FB04:LG01:DL2VERNIER',
-                         kind='normal')
-
+                         kind='normal', doc='Fast Feedback 6x6 Vernier [MeV]')
+    beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
+                          kind='normal', doc='LCLSBEAM Event Rate [Hz]')
+    photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627', kind='normal',
+                        doc='Photon eV HXR (units: eV)')
+    # [ 0] Disable [ 1] Enable
+    bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT', kind='normal',
+                      doc='BYKIK: Abort Active')
+    bykik_period = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTPRD',
+                       kind='normal', doc='BYKIK: Abort Period [beam shots]')
+    undulator_k_line = Cpt(EpicsSignalRO, 'USEG:UNDS:2650:KAct', kind='normal',
+                           doc='Most upstream undulator K value (K-line)')
+    undulator_l_line = Cpt(EpicsSignalRO, 'USEG:UNDH:1850:KAct', kind='normal',
+                           doc='Most upstream undulator K value (L-line)')
+    # TODO: remove these below, just pasted here for reference - might end up
+    # using some of these PVs...
     # FBCK Vernier SIOC:SYS0:ML00:CALC209 (units: MeV)
     # DL2 Energy - FBCK:FB04:LG01:DL2VERNIER
     # Vernier Limit (% of Bend Energy):	SIOC:SYS0:ML01:AO151 Vernier Scan Range
     # Vernier Limit: SIOC:SYS0:ML01:CALC034 - Vernier Limit
     # Vernie Crtrl w/limits: SIOC:SYS0:ML01:CALC033	- Vernier Ctrl w/ limits
-
-    # LCLSBEAM Event Rate (units: Hz)
-    beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
-                          kind='normal')
-    # Photon eV HXR (units: eV)
-    photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627', kind='normal')
-
-    # Abort Active Status
-    # [ 0] Disable [ 1] Enable
-    bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT', kind='normal')
-
-    # Abort Period in  beam shots
-    bykik_period = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTPRD',
-                       kind='normal')
-    # undulator k value - not the correct PV i think
-    undulator_k = Cpt(EpicsSignal, 'USEG:UND1:150:KACT', kind='normal')
+    # Bunch Charge nC: FBCK:BCI0:1:CHRG	no desc
+    # Hard e-Energy GeV/c: BEND:DMPH:400:BDES - Desired B-Field
+    # Soft e-Energ GeV/c: BEND:DMPS:400:BDES - Desired B-Field
+    # Bunch Length fs: SIOC:SYS0:ML00:AO820 estimated FEL Pulse Duration (FWHM)
+    # BC2 IPK:	 FBCK:FB04:LG01:S5DES	BC2 Current set point
+    # BLEN:LI21:265:WIDTH - not found
+    # Width of pulse (bunch length) Fsec
+    # also have this one  FBCK:BCI0:1:CHRG (nC)
 
     def bykik_status(self):
         """
         Returns status of bykik abort
         """
-        status = self.bykik_abort.get()
-        if status == 0:
-            return 'Disable'
-        else:
-            return 'Enable'
+        return self.bykik_abort.get(as_string=True)
 
     def bykik_disable(self):
         """
         Disables bykik abort
         """
-        return self.bykik_abort.put(0)
+        return self.bykik_abort.put(value='Disable')
 
     def bykik_enable(self):
         """
         Enables bykik abort
         """
-        return self.bykik_abort.put(1)
+        return self.bykik_abort.put(value='Enable')
 
     def bykik_get_period(self):
         """

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -80,26 +80,12 @@ class BeamEnergyRequest(PVPositionerDone):
 
 
 class Lcls(BaseInterface, Device):
-    """
-    Lcls Linac Status.
-
-    Desired Status Output.
-    bunch charge: 180 [pC]
-    repetition rate: 120 [Hz]
-    ebeam energy: 10.75 [GeV]
-    Vernier energy: -35 [MeV]
-    Photon Energy: 9.91 [keV]
-    BC2 peak current: 3201 [A]
-    electron bunch length: 23 [fs]
-    Last eLoss Scan: 0.93 [mJ]
-    """
+    """Lcls Linac Status."""
 
     tab_component_names = True
 
     tab_whitelist = ['bykik_status', 'bykik_disable', 'bykik_enable',
                      'bykik_get_period', 'bykik_set_period']
-
-    # TODO: - these PVs are not necessarily the ones we'll end up using...
 
     bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal',
                        doc='Bunch charge [nC]')
@@ -121,7 +107,7 @@ class Lcls(BaseInterface, Device):
     vernier_energy = Cpt(EpicsSignalRO, 'FBCK:FB04:LG01:DL2VERNIER',
                          kind='normal', doc='Fast Feedback 6x6 Vernier [MeV]')
     photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627', kind='normal',
-                        doc='Photon eV HXR (units: eV)')
+                        doc='Photon eV HXR [eV]')
     # [ 0] Disable [ 1] Enable
     bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT', kind='normal',
                       string=True, doc='BYKIK: Abort Active')

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -31,14 +31,6 @@ class BeamStats(BaseInterface, Device):
         super().__init__(prefix=prefix, name=name, **kwargs)
 
 
-class SxrGmd(Device):
-    # TODO: this PV => not found
-    mj = Cpt(EpicsSignalRO, 'SXR:GMD:BLD:milliJoulesPerPulse', kind='hinted')
-
-    def __init__(self, prefix='', name='sxr_gmd', **kwargs):
-        super().__init__(prefix=prefix, name=name, **kwargs)
-
-
 class BeamEnergyRequest(PVPositionerDone):
     """
     Positioner to request beam color changes from ACR in eV.
@@ -88,8 +80,10 @@ class BeamEnergyRequest(PVPositionerDone):
 
 
 class Lcls(BaseInterface, Device):
-    '''
-    LCLS LINAC STATUS
+    """
+    Lcls Linac Status.
+
+    Desired Status Output.
     bunch charge: 180 [pC]
     repetition rate: 120 [Hz]
     ebeam energy: 10.75 [GeV]
@@ -98,7 +92,7 @@ class Lcls(BaseInterface, Device):
     BC2 peak current: 3201 [A]
     electron bunch length: 23 [fs]
     Last eLoss Scan: 0.93 [mJ]
-    '''
+    """
 
     tab_component_names = True
 
@@ -109,70 +103,80 @@ class Lcls(BaseInterface, Device):
 
     bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal',
                        doc='Bunch charge [nC]')
+    bunch_charge_2 = Cpt(EpicsSignalRO, 'Bunch Charge nC: FBCK:BCI0:1:CHRG',
+                         kind='normal', doc='Bunch Charge [nC]')
+    beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
+                          kind='normal', doc='LCLSBEAM Event Rate [Hz]')
+    ebeam_energy = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO500', kind='normal',
+                       doc='Final electron energy [ GeV]')
+    ebeam_energy_user_req = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML01:CALC036',
+                                kind='normal',
+                                doc='Beam energy request from Users [GeV]')
     bunch_length = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO820', kind='normal',
                        doc='estimated FEL Pulse Duration (FWHM) [fs]')
-    peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195', kind='normal',
-                       doc='Peak current after BC2 [A]')
+    bc2_peak_current = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO195',
+                           kind='normal', doc='Peak current after BC2 [A]')
     eloss_energy = Cpt(EpicsSignalRO, 'PHYS:SYS0:1:ELOSSENERGY', kind='normal',
                        doc='Last Eloss sxray energy [mJ]')
     vernier_energy = Cpt(EpicsSignalRO, 'FBCK:FB04:LG01:DL2VERNIER',
                          kind='normal', doc='Fast Feedback 6x6 Vernier [MeV]')
-    beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
-                          kind='normal', doc='LCLSBEAM Event Rate [Hz]')
     photon_ev_hxr = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO627', kind='normal',
                         doc='Photon eV HXR (units: eV)')
     # [ 0] Disable [ 1] Enable
     bykik_abort = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTACT', kind='normal',
-                      doc='BYKIK: Abort Active')
+                      string=True, doc='BYKIK: Abort Active')
     bykik_period = Cpt(EpicsSignal, 'IOC:IN20:EV01:BYKIK_ABTPRD',
                        kind='normal', doc='BYKIK: Abort Period [beam shots]')
     undulator_k_line = Cpt(EpicsSignalRO, 'USEG:UNDS:2650:KAct', kind='normal',
                            doc='Most upstream undulator K value (K-line)')
     undulator_l_line = Cpt(EpicsSignalRO, 'USEG:UNDH:1850:KAct', kind='normal',
                            doc='Most upstream undulator K value (L-line)')
-    # TODO: remove these below, just pasted here for reference - might end up
-    # using some of these PVs...
-    # FBCK Vernier SIOC:SYS0:ML00:CALC209 (units: MeV)
-    # DL2 Energy - FBCK:FB04:LG01:DL2VERNIER
-    # Vernier Limit (% of Bend Energy):	SIOC:SYS0:ML01:AO151 Vernier Scan Range
-    # Vernier Limit: SIOC:SYS0:ML01:CALC034 - Vernier Limit
-    # Vernie Crtrl w/limits: SIOC:SYS0:ML01:CALC033	- Vernier Ctrl w/ limits
-    # Bunch Charge nC: FBCK:BCI0:1:CHRG	no desc
-    # Hard e-Energy GeV/c: BEND:DMPH:400:BDES - Desired B-Field
-    # Soft e-Energ GeV/c: BEND:DMPS:400:BDES - Desired B-Field
-    # Bunch Length fs: SIOC:SYS0:ML00:AO820 estimated FEL Pulse Duration (FWHM)
-    # BC2 IPK:	 FBCK:FB04:LG01:S5DES	BC2 Current set point
-    # BLEN:LI21:265:WIDTH - not found
-    # Width of pulse (bunch length) Fsec
-    # also have this one  FBCK:BCI0:1:CHRG (nC)
+    fbck_vernier = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:CALC209', kind='normal',
+                       doc='FBCK Vernier [MeV]')
+    dl2_energy = Cpt(EpicsSignalRO, 'FBCK:FB04:LG01:DL2VERNIER', kind='normal',
+                     doc='DL2 Energy [MeV]')
+    vernier_percent_of_bend_energy = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML01:AO151',
+                                         kind='normal',
+                                         doc='Vernier Scan Range [%]')
+    vernier_limit = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML01:CALC034', kind='normal',
+                        doc='Vernier Limit [MeV]')
+    vernier_ctrl_with_limits = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML01:CALC033',
+                                   kind='normal',
+                                   doc='Vernier Ctrl w/ limits [MeV]')
+    hard_e_energy = Cpt(EpicsSignalRO, 'BEND:DMPH:400:BDES', kind='normal',
+                        doc='Desired B-Field, Hard e-Energy [GeV/c]')
+    soft_e_energy = Cpt(EpicsSignalRO, 'BEND:DMPS:400:BDES', kind='normal',
+                        doc='Desired B-Field, Soft e-Energy [GeV/c]')
 
     def bykik_status(self):
         """
-        Returns status of bykik abort
+        Get status of bykik abort.
+
+        Returns
+        -------
+            Bykik Abort Status
         """
-        return self.bykik_abort.get(as_string=True)
+        return self.bykik_abort.get()
 
     def bykik_disable(self):
-        """
-        Disables bykik abort
-        """
+        """Disable bykik abort."""
         return self.bykik_abort.put(value='Disable')
 
     def bykik_enable(self):
-        """
-        Enables bykik abort
-        """
+        """Enable bykik abort."""
         return self.bykik_abort.put(value='Enable')
 
     def bykik_get_period(self):
-        """
-        Gets the number of events between bykik aborts
-        """
+        """Get the number of events between bykik aborts."""
         return self.bykik_period.get()
 
     def bykik_set_period(self, period):
         """
-        Sets the number of events between bykik aborts
+        Set the number of events between bykik aborts.
+
+        Parameters
+        ----------
+        period : number
         """
         return self.bykik_period.put(period)
 

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -3,7 +3,7 @@ from .analog_signals import Acromag
 from .areadetector.detectors import PCDSAreaDetector
 from .atm import ArrivalTimeMonitor
 from .attenuator import Attenuator
-from .beam_stats import BeamStats, SxrGmd
+from .beam_stats import BeamStats
 from .ccm import CCM
 from .dc_devices import ICT
 from .epics_motor import (IMS, PMC100, BeckhoffAxis, DelayNewport, EpicsMotor,

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.beam_stats import BeamStats, Lcls
+from pcdsdevices.beam_stats import BeamStats, LCLS
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ def test_beam_stats_disconnected():
 
 @pytest.fixture(scope='function')
 def fake_lcls():
-    FakeLcls = make_fake_device(Lcls)
+    FakeLcls = make_fake_device(LCLS)
     lcls = FakeLcls()
     lcls.bykik_period.sim_put(200)
     return lcls

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -63,9 +63,9 @@ def test_lcls(fake_lcls):
 
 def test_bykik_status(fake_lcls):
     lcls = fake_lcls
-    lcls.bykik_abort.put(1)
+    lcls.bykik_abort.put('Enable')
     assert lcls.bykik_status() == 'Enable'
-    lcls.bykik_abort.put(0)
+    lcls.bykik_abort.put('Disable')
     assert lcls.bykik_status() == 'Disable'
 
 

--- a/tests/test_beam_stats.py
+++ b/tests/test_beam_stats.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.beam_stats import BeamStats
+from pcdsdevices.beam_stats import BeamStats, Lcls
 
 logger = logging.getLogger(__name__)
 
@@ -45,3 +45,44 @@ def test_beam_stats_avg(fake_beam_stats):
 @pytest.mark.timeout(5)
 def test_beam_stats_disconnected():
     BeamStats()
+
+
+@pytest.fixture(scope='function')
+def fake_lcls():
+    FakeLcls = make_fake_device(Lcls)
+    lcls = FakeLcls()
+    lcls.bykik_period.sim_put(200)
+    return lcls
+
+
+def test_lcls(fake_lcls):
+    lcls = fake_lcls
+    lcls.read()
+    lcls.hints
+
+
+def test_bykik_status(fake_lcls):
+    lcls = fake_lcls
+    lcls.bykik_abort.put(1)
+    assert lcls.bykik_status() == 'Enable'
+    lcls.bykik_abort.put(0)
+    assert lcls.bykik_status() == 'Disable'
+
+
+def test_bykik_disable(fake_lcls):
+    lcls = fake_lcls
+    lcls.bykik_disable()
+    assert lcls.bykik_status() == 'Disable'
+
+
+def test_bykik_enable(fake_lcls):
+    lcls = fake_lcls
+    lcls.bykik_enable()
+    assert lcls.bykik_status() == 'Enable'
+
+
+def test_get_set_period(fake_lcls):
+    lcls = fake_lcls
+    assert lcls.bykik_get_period() == 200
+    lcls.bykik_set_period(100)
+    assert lcls.bykik_get_period() == 100


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A new Lcls class has been added to the `beam_stats` module.

<!--- Describe your changes in detail -->
- The Lcls class will be used to query machine status. 
- The `SxrGmd` has been removed from this module because the SXR has been disassembled and the GMD was moved into the EBD, the mj PV was not working anymore.
- This class will have to be revised, because as of now there are probably way too many PVs and we might not care for some of them. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is supposed to close https://github.com/pcdshub/Bug-Reports-and-Requests/issues/33

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A few tests have been added to test the functionality of the new methods. 
## Where Has This Been Documented?
Locally only
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
