### PR TITLE
MNT: fix pico motors on l2si ref laser

### DIFF
--- a/docs/source/upcoming_release_notes/620-ref-pico.rst
+++ b/docs/source/upcoming_release_notes/620-ref-pico.rst
@@ -1,0 +1,32 @@
+620 ref-pico
+############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issues with L2SI Reflaser Picos being unable to successfully move.
+  This was because they were using the wrong motor class, which had extra
+  PVs that would never connect.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/ref.py
+++ b/pcdsdevices/ref.py
@@ -1,7 +1,7 @@
 from ophyd import Component as Cpt
 from ophyd import Device
 
-from .epics_motor import BeckhoffAxis, PCDSMotorBase
+from .epics_motor import BeckhoffAxis, EpicsMotorInterface
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
@@ -18,11 +18,11 @@ class ReflaserL2SI(BaseInterface, Device, LightpathInOutMixin):
                  doc='In/Out control of Reflaser Mirror')
     y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal',
                   doc='Direct control of mirror motor.')
-    pico1 = Cpt(PCDSMotorBase, ':MCP:01', kind='config',
+    pico1 = Cpt(EpicsMotorInterface, ':MCP:01', kind='config',
                 doc='Laser alignment 01')
-    pico2 = Cpt(PCDSMotorBase, ':MCP:02', kind='config',
+    pico2 = Cpt(EpicsMotorInterface, ':MCP:02', kind='config',
                 doc='Laser alignment 02')
-    pico3 = Cpt(PCDSMotorBase, ':MCP:03', kind='config',
+    pico3 = Cpt(EpicsMotorInterface, ':MCP:03', kind='config',
                 doc='Laser alignment 03')
-    pico4 = Cpt(PCDSMotorBase, ':MCP:04', kind='config',
+    pico4 = Cpt(EpicsMotorInterface, ':MCP:04', kind='config',
                 doc='Laser alignment 04')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Switch the class from `PCDSMotorBase` to `EpicsMotorInterface` because these use the community motor record, unmodified.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`PCDSMotorBase` changes some PVs around, and this breaks the device.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My `typhos` screen is pretty snazzy and responsive. All the PVs connect.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I made a pre-release docs page
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
