### PR TITLE
ENH: Smaract Open Loop Scanning

### DIFF
--- a/docs/source/upcoming_release_notes/625-SmarAct-open-loop-scanning.rst
+++ b/docs/source/upcoming_release_notes/625-SmarAct-open-loop-scanning.rst
@@ -1,0 +1,31 @@
+625 SmarAct-open-loop-scanning
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- SmarActOpenLoopPositioner: Class intended for performing Bluesky scans using
+                             open loop SmarAct motors. 
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/docs/source/upcoming_release_notes/625-SmarAct-open-loop-scanning.rst
+++ b/docs/source/upcoming_release_notes/625-SmarAct-open-loop-scanning.rst
@@ -16,7 +16,7 @@ Device Updates
 New Devices
 -----------
 - SmarActOpenLoopPositioner: Class intended for performing Bluesky scans using
-                             open loop SmarAct motors. 
+   open-loop SmarAct motors. 
 
 Bugfixes
 --------

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -558,7 +558,7 @@ class SmarActOpenLoopPositioner(PVPositionerComparator):
     open_loop = Cpt(SmarActOpenLoop, '', kind='normal')
 
     def done_comparator(self, readback, setpoint):
-        if setpoint-self.atol < readback and readback < setpoint+self.atol:
+        return setpoint-self.atol < readback < setpoint+self.atol
             return True
         else:
             return False

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -547,11 +547,11 @@ class SmarActOpenLoop(Device):
 class SmarActOpenLoopPositioner(PVPositionerComparator):
     """
     Positioner class for SmarAct open loop stages. Intended to be used in
-    BlueSky scans. Uses an integer open loop step count as the position. 
+    BlueSky scans. Uses an integer open loop step count as the position.
     """
     setpoint = Cpt(EpicsSignal, ':SET_TOTAL_STEP_COUNT')
     readback = Cpt(EpicsSignalRO, ':TOTAL_STEP_COUNT')
-    atol = 1 # step count after the move should be exact, but let's be cautious
+    atol = 1  # step count after move should be exact, but let's be cautious
 
     egu = 'steps'
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -559,9 +559,6 @@ class SmarActOpenLoopPositioner(PVPositionerComparator):
 
     def done_comparator(self, readback, setpoint):
         return setpoint-self.atol < readback < setpoint+self.atol
-            return True
-        else:
-            return False
 
 
 class SmarAct(EpicsMotorInterface):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a new class, SmarActOpenLoopPositioner for doing open loop motor scanning with SmarAct stages. 

## Motivation and Context
This allows us to scan SmarAct stages that are open loop, such as tip-tilt stages. This will be used for doing laser beam pointing/centering. 

Closes #625 

## How Has This Been Tested?
Tested on a stage in the Heinz lab. 

## Where Has This Been Documented?
The code and docstrings. 

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [X] New/changed functions and methods are covered in the test suite where possible
- [X] Test suite passes locally
- [X] Test suite passes on travis
- [X] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [X] Pre-release docs include context, functional descriptions, and contributors as appropriate
