### PR TITLE
ENH: Add camera viewer to PCDSAreaDetectorTyphos

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - periodictable
     - happi
     - schema
+    - pcdsutils
 
 test:
   imports:

--- a/docs/source/upcoming_release_notes/627-Typhos-cam-viewer.rst
+++ b/docs/source/upcoming_release_notes/627-Typhos-cam-viewer.rst
@@ -1,0 +1,32 @@
+627 Typhos-cam-viewer
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- PCDSAreaDetectorTyphos: Added a camera viewer button to the class to open a
+  python camera viewer for the camera. Removed the old 'cam_image' viewer in
+  favor of this new viewer. 
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -19,6 +19,8 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from pcdsdevices.variety import set_metadata
 
+from pcdsdaq.ext_scripts import hutch_name
+
 from .plugins import (ColorConvPlugin, HDF5Plugin, ImagePlugin, JPEGPlugin,
                       NetCDFPlugin, NexusPlugin, OverlayPlugin, ProcessPlugin,
                       ROIPlugin, StatsPlugin, TIFFPlugin, TransformPlugin)
@@ -213,19 +215,21 @@ class PCDSAreaDetectorTyphos(Device):
                     num_dimensions='ndimensions',
                     kind='normal')
 
+    # Eventually I want to typhos-ify into a button. I couldn't figure out
+    # how to do that, so I will settle for this for now. 
     def viewer(self):
+        """
+        Launch the python camera viewer for this camera.
+        """
         arglist = ['/reg/g/pcds/pyps/apps/camviewer/latest/run_viewer.sh',
                    '--instrument',
-                   'las',
-                   '--oneline']
-
-        oneline = 'GE:16,{0}:IMAGE1;{0},,{0}'
-
-        # Remove terminating colon weirdness of AD ophyd device prefix
-        arglist.append(oneline.format(self.prefix[0:-1]))
+                   '{0}'.format(get_hutch().lower()),
+                   '--oneline',
+                   'GE:16,{0}:IMAGE1;{0},,{0}'.format(self.prefix[0:-1])]
 
         subprocess.run(arglist, stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE, check=True)
+
 
 class PCDSAreaDetectorTyphosBeamStats(PCDSAreaDetectorTyphos):
     """

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -19,7 +19,7 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO, AttributeSignal
 
 from pcdsdevices.variety import set_metadata
 
-#from pcdsutils.ext_scripts import get_hutch_name
+from pcdsutils.ext_scripts import get_hutch_name
 
 from .plugins import (ColorConvPlugin, HDF5Plugin, ImagePlugin, JPEGPlugin,
                       NetCDFPlugin, NexusPlugin, OverlayPlugin, ProcessPlugin,
@@ -202,18 +202,19 @@ class PCDSAreaDetectorTyphos(Device):
     acquire_rbv = Cpt(EpicsSignalRO, 'DetectorState_RBV', kind='normal')
     image_counter = Cpt(EpicsSignalRO, 'NumImagesCounter_RBV', kind='normal')
 
+    # TJ: removing from the class for now. May be useful later. 
     # Image data
-    ndimensions = Cpt(EpicsSignalRO, 'IMAGE2:NDimensions_RBV', kind='omitted')
-    width = Cpt(EpicsSignalRO, 'IMAGE2:ArraySize0_RBV', kind='omitted')
-    height = Cpt(EpicsSignalRO, 'IMAGE2:ArraySize1_RBV', kind='omitted')
-    depth = Cpt(EpicsSignalRO, 'IMAGE2:ArraySize2_RBV', kind='omitted')
-    array_data = Cpt(EpicsSignal, 'IMAGE2:ArrayData', kind='omitted')
-    cam_image = Cpt(NDDerivedSignal, derived_from='array_data',
-                    shape=('height',
-                           'width',
-                           'depth'),
-                    num_dimensions='ndimensions',
-                    kind='normal')
+#    ndimensions = Cpt(EpicsSignalRO, 'IMAGE2:NDimensions_RBV', kind='omitted')
+#    width = Cpt(EpicsSignalRO, 'IMAGE2:ArraySize0_RBV', kind='omitted')
+#    height = Cpt(EpicsSignalRO, 'IMAGE2:ArraySize1_RBV', kind='omitted')
+#    depth = Cpt(EpicsSignalRO, 'IMAGE2:ArraySize2_RBV', kind='omitted')
+#    array_data = Cpt(EpicsSignal, 'IMAGE2:ArrayData', kind='omitted')
+#    cam_image = Cpt(NDDerivedSignal, derived_from='array_data',
+#                    shape=('height',
+#                           'width',
+#                           'depth'),
+#                    num_dimensions='ndimensions',
+#                    kind='normal')
 
     def open_viewer(self):
         """
@@ -221,7 +222,7 @@ class PCDSAreaDetectorTyphos(Device):
         """
         arglist = ['/reg/g/pcds/pyps/apps/camviewer/latest/run_viewer.sh',
                    '--instrument',
-                   'las',
+                   '{}.format(get_hutch_name())',
                    '--oneline',
                    'GE:16,{0}:IMAGE1;{0},,{0}'.format(self.prefix[0:-1])]
 

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -7,6 +7,8 @@ functions needed by all instances of a detector are added here.
 import logging
 import warnings
 
+import subprocess
+
 from ophyd import Device
 from ophyd.areadetector import cam
 from ophyd.areadetector.base import (ADComponent, EpicsSignalWithRBV,
@@ -14,6 +16,8 @@ from ophyd.areadetector.base import (ADComponent, EpicsSignalWithRBV,
 from ophyd.areadetector.detectors import DetectorBase
 from ophyd.device import Component as Cpt
 from ophyd.signal import EpicsSignal, EpicsSignalRO
+
+from pcdsdevices.variety import set_metadata
 
 from .plugins import (ColorConvPlugin, HDF5Plugin, ImagePlugin, JPEGPlugin,
                       NetCDFPlugin, NexusPlugin, OverlayPlugin, ProcessPlugin,
@@ -209,6 +213,19 @@ class PCDSAreaDetectorTyphos(Device):
                     num_dimensions='ndimensions',
                     kind='normal')
 
+    def viewer(self):
+        arglist = ['/reg/g/pcds/pyps/apps/camviewer/latest/run_viewer.sh',
+                   '--instrument',
+                   'las',
+                   '--oneline']
+
+        oneline = 'GE:16,{0}:IMAGE1;{0},,{0}'
+
+        # Remove terminating colon weirdness of AD ophyd device prefix
+        arglist.append(oneline.format(self.prefix[0:-1]))
+
+        subprocess.run(arglist, stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, check=True)
 
 class PCDSAreaDetectorTyphosBeamStats(PCDSAreaDetectorTyphos):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 pint
 scipy
 schema
+pcdsutils


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
I added a method to PCDSAreaDetectorTyphos to launch the camera viewer for that camera.  This method is available on Typhos screens via a button. 

## Motivation and Context
The camera viewer is pretty fully featured, and the LCLS staff are used to it. It would be nice to have this easily accessible from automatically generated Typhos screens. 

Closes #627.

## How Has This Been Tested?
Tested on a camera in the Heinz lab. This method uses the get_hutch_name script from engineering_tools, which in its latest release does not include the las or hpl subnets. There is a PR in the rectify this, and will be fixed with the next release of engineering tools. The code still works, though on the las/hpl subnets the viewer is instantiated as 'unknown_hutch' for the --instrument flag. This is fine for now, and will be fixed on the next release of engineering_tools.

## Where Has This Been Documented?
The code. 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
