### PR TITLE
Von hamos beckhoff

### DIFF
--- a/docs/source/upcoming_release_notes/636-VonHamos_motion_system_class.rst
+++ b/docs/source/upcoming_release_notes/636-VonHamos_motion_system_class.rst
@@ -1,0 +1,30 @@
+636 VonHamos_motion_system_class
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- Von Hamos Spectrometer (HXX-VON_HAMOS)
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- sheppard

--- a/pcdsdevices/vonhamos_beckhoff_motion.py
+++ b/pcdsdevices/vonhamos_beckhoff_motion.py
@@ -1,0 +1,34 @@
+"""
+LAMP Motion Classes
+
+This module contains classes related to the TMO-LAMP Motion System
+"""
+
+from ophyd import Component as Cpt
+from ophyd import Device
+
+from .epics_motor import BeckhoffAxis
+from .interface import BaseInterface
+
+
+class VonHamosBeckhoff(BaseInterface, Device):
+    """
+    Von Hamos Beckhoff Motion Class
+
+    This class controls Beckhoff motors fixed to the Von Hamos Spectrometer
+    used in HXR hutches.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the Von Hamos motion system
+
+    name : str
+        Alias for the device
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+    tab_component_names = True
+
+    # Motor components
+    von_hamos_y = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')

--- a/pcdsdevices/vonhamos_motion.py
+++ b/pcdsdevices/vonhamos_motion.py
@@ -1,7 +1,7 @@
 """
-LAMP Motion Classes
+Von Hamos Motion Classes
 
-This module contains classes related to the TMO-LAMP Motion System
+This module contains classes related to the Von Hamos Spectrometer Motion System
 """
 
 from ophyd import Component as Cpt
@@ -11,7 +11,7 @@ from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
 
 
-class VonHamosBeckhoff(BaseInterface, Device):
+class VonHamos(BaseInterface, Device):
     """
     Von Hamos Beckhoff Motion Class
 
@@ -31,4 +31,4 @@ class VonHamosBeckhoff(BaseInterface, Device):
     tab_component_names = True
 
     # Motor components
-    von_hamos_y = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    y = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Added class `vonhamos_motion.VonHamos`. Currently, this just contains a single vertical axis, with the rest of the Von Hamos system using LCLS-I style dumb motors with MForce Chassis.
- Currently feels like overkill to have separate class for one Beckhoff axis, but eventually all LCLS-I dumb motors will be converted to Beckhoff axes and can be included in this class

## Motivation and Context
- Need to control Von Hamos Y axis. This originally was a dumb motor but it needed to be replaced. Thus, the decision was made to start the Beckhoff conversion with this single axis.

## How Has This Been Tested?
- Ran `pcdsdevices` test suite, no failed tests.
- Instantiated object in Ipython session/inspected components
- Opened test typhos screen

## Where Has This Been Documented?
- Docstrings

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [X] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
