### PR TITLE
New VGS with two different setpoints per gauge needed for TMO

### DIFF
--- a/docs/source/upcoming_release_notes/637-vgs_2s.rst
+++ b/docs/source/upcoming_release_notes/637-vgs_2s.rst
@@ -1,0 +1,31 @@
+637 vgs_2s
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Added VGC_2S, a new valve class that extends the VGC
+  with the addition of a second setpoint and hysteresis.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ghalym

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -248,14 +248,18 @@ class VGC(VRC):
                                       doc='Downstream vacuum device used for'
                                       'interlocking this valve')
 
+
 class VGC_2S(VGC):
     """Class for Controlled Gate Valves with 2 setpoints."""
-    at_vac_setpoint_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP_DS', kind='config',
-                          doc='AT VAC Set point value for the downstream gauge')
-    setpoint_hysterisis_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS_DS', kind='config',
-                              doc='AT VAC Hysterisis for the downstream setpoint')
-    
-    
+    at_vac_setpoint_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP_DS',
+                             kind='config',
+                             doc='AT VAC Set point value '
+                                 'for the downstream gauge')
+    setpoint_hysterisis_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_HYS_DS',
+                                 kind='config',
+                                 doc='AT VAC Hysterisis for '
+                                     'the downstream setpoint')
+
 
 class VFS(Device, LightpathMixin):
     """Class for Fast Shutter Valve."""

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -248,7 +248,7 @@ class VGC(VRC):
                                       doc='Downstream vacuum device used for'
                                       'interlocking this valve')
 
-    class VGC_2S(VGC):
+class VGC_2S(VGC):
     """Class for Controlled Gate Valves with 2 setpoints."""
     at_vac_setpoint_ds = Cpt(EpicsSignalWithRBV, ':AT_VAC_SP_DS', kind='config',
                           doc='AT VAC Set point value for the downstream gauge')


### PR DESCRIPTION
## Description
A new ophyd class for the vacuum lib VGC_2S, that extends the VGC with the addition of a second setpoint and hysteresis.

## Motivation and Context
TMO requires to interlock beam line valves with 2 different setpoints instead of 1.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate