### PR TITLE
ENH: Add SmarActTipTilt class for mirror control.

### DIFF
--- a/docs/source/upcoming_release_notes/641-SmarAct-Tip-Tilt.rst
+++ b/docs/source/upcoming_release_notes/641-SmarAct-Tip-Tilt.rst
@@ -1,0 +1,31 @@
+641 SmarAct-Tip-Tilt
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- SmarActTipTilt: Class for bundling two SmarActOpenLoop axis classes together
+  into a single device for Typhos screen generation and interactive use.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -581,7 +581,7 @@ class SmarActTipTilt(Device):
     tip = FCpt(SmarActOpenLoop, '{prefix}{self._tip_pv}', kind='normal')
     tilt = FCpt(SmarActOpenLoop, '{prefix}{self._tilt_pv}', kind='normal')
 
-    def __init__(self, prefix='', tip_pv=None, tilt_pv=None, **kwargs):
+    def __init__(self, prefix='', *, tip_pv, tilt_pv, **kwargs):
         self._tip_pv = tip_pv
         self._tilt_pv = tilt_pv
         super().__init__(prefix, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a new class, bundling two open-loop SmarAct classes together. 

## Motivation and Context
The laser system uses tip-tilt mirrors all over the place. This helps create bundled typhos screens for these axes, reducing clutter. 

Closes #641 

## How Has This Been Tested?
Tested on a tip-tilt stage in B40. 

## Where Has This Been Documented?
I wrote a docstring for the class that seems fairly comprehensive. 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
