### PR TITLE
MNT: Elliptec 'stop' signal conflict

### DIFF
--- a/docs/source/upcoming_release_notes/645-elliptec-stop-fix.rst
+++ b/docs/source/upcoming_release_notes/645-elliptec-stop-fix.rst
@@ -1,0 +1,30 @@
+645 elliptec-stop-fix
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- lasers/elliptec.py: Fix conflict with BlueSky interface and 'stop' signal. 
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson 

--- a/pcdsdevices/lasers/elliptec.py
+++ b/pcdsdevices/lasers/elliptec.py
@@ -131,12 +131,9 @@ class EllLinear(EllBase):
                  kind='omitted')
     set_metadata(clean, dict(variety='command-proc', value=1))
 
-    # Only the linear and rotation stages have extended optimization and
-    # cleaning procedures; the sliders finish almost immediately. This stops
-    # these long procedures prematurely.
-    stop = FCpt(EpicsSignal, '{prefix}:M{self._channel}:STOP',
-                kind='omitted')
-    set_metadata(stop, dict(variety='command-proc', value=1))
+    stop_optimize = FCpt(EpicsSignal, '{prefix}:M{self._channel}:STOP',
+                         kind='omitted')
+    set_metadata(stop_optimize, dict(variety='command-proc', value=1))
 
     current_egu = FCpt(EpicsSignal, '{prefix}:M{self._channel}:CURPOS.EGU',
                        kind='omitted')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Changed the 'stop' signal to 'stop_optimize' in the elliptec module.

## Motivation and Context
This resolves a conflict with the BlueSky interface. 

Closes #645 

## How Has This Been Tested?
Tested interactively using a stage in the Heinz lab. 

## Where Has This Been Documented?
The code. 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
