### PR TITLE
FIX: import laser devices; implicitly test interface through find_all_device_classes

### DIFF
--- a/docs/source/upcoming_release_notes/647-import_lasers.rst
+++ b/docs/source/upcoming_release_notes/647-import_lasers.rst
@@ -1,0 +1,31 @@
+647 import lasers
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Add laser imports to :mod:`pcdsdevices.device_types`.  Test fixtures now
+  verify imported laser devices' tab completion settings.
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -14,6 +14,11 @@ from .gon import BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi, XYZStage
 from .inout import Reflaser, TTReflaser
 from .ipm import IPM, IPM_IPIMB, IPM_Wave8
 from .jet import BeckhoffJet
+from .lasers.ek9000 import El3174AiCh, EnvironmentalMonitor
+from .lasers.elliptec import Ell6, Ell9, EllBase, EllLinear, EllRotation
+from .lasers.qmini import QminiSpectrometer
+from .lasers.thorlabsWFS import ThorlabsWfs40
+from .lasers.zoomtelescope import ZoomTelescope
 from .lens import XFLS, Prefocus
 from .lic import LaserInCoupling
 from .lodcm import LODCM

--- a/pcdsdevices/lasers/__init__.py
+++ b/pcdsdevices/lasers/__init__.py
@@ -1,0 +1,10 @@
+from . import ek9000, elliptec, qmini, thorlabsWFS, tuttifrutti, zoomtelescope
+
+__all__ = [
+    'ek9000',
+    'elliptec',
+    'qmini',
+    'thorlabsWFS',
+    'tuttifrutti',
+    'zoomtelescope',
+]


### PR DESCRIPTION
## Description
* Add laser imports to `pcdsdevices.device_types`
* `test_interfaces` will now pick up laser classes and check their tab completion settings

It may be worthwhile to do an alternative PR to this, moving laser classes to the top level. I think we at least discussed that possibility or we may have had an issue on that at some point?

## Motivation and Context
Related to #647 , but does not close it.

## How Has This Been Tested?
Locally, noting that laser devices are imported and run through `test_interfaces`.

## Where Has This Been Documented?
Release notes

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate