### PR TITLE
FIX: Check if context.event_thread is not None.

### DIFF
--- a/docs/source/upcoming_release_notes/661-Ophyd_utility_thread_scheduling.rst
+++ b/docs/source/upcoming_release_notes/661-Ophyd_utility_thread_scheduling.rst
@@ -1,0 +1,30 @@
+661 Ophyd utility thread scheduling
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Ensure that we only try to put into the queue if event_thread is not None.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/661-Ophyd_utility_thread_scheduling.rst
+++ b/docs/source/upcoming_release_notes/661-Ophyd_utility_thread_scheduling.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- hhslepicka

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -200,7 +200,8 @@ def schedule_task(func, args=None, kwargs=None, delay=None):
             dispatcher.schedule_utility_task(func, *args, **kwargs)
         else:
             # Put into same queue
-            context.event_thread.queue.put((func, args, kwargs))
+            if context.event_thread is not None:
+                context.event_thread.queue.put((func, args, kwargs))
 
     if delay is None:
         # Do it right away


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Ensure that we only try to add put into the queue if `event_thread` is not None.

## Motivation and Context
Closes #661 

## How Has This Been Tested?
Locally and at psbuild using PYTHONPATH pointing to my fix branch.

## Where Has This Been Documented?
N/A

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
