### PR TITLE
FIX: PTMPLC wrong interlock pv causing no connection

### DIFF
--- a/docs/source/upcoming_release_notes/692-pump_PTMPLC_ILK_status_pv_fix.rst
+++ b/docs/source/upcoming_release_notes/692-pump_PTMPLC_ILK_status_pv_fix.rst
@@ -1,0 +1,30 @@
+692 pump PTMPLC ILK status pv fix
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- PTMPLC ilk pv was incorrect, changed from ILK_STATUS_RBV to ILK_OK_RBV
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ghalym

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -205,7 +205,7 @@ class PTMPLC(Device):
     alarm = Cpt(EpicsSignalRO, ':ALARM_RBV', kind='normal')
     bp_sp = Cpt(EpicsSignalWithRBV, ':BP_SP', kind='omitted')
     ip_sp = Cpt(EpicsSignalWithRBV, ':IP_SP', kind='omitted')
-    interlock_status = Cpt(EpicsSignalRO, ':ILK_STATUS_RBV', kind='normal',
+    interlock_status = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                            doc='interlock  is ok when true')
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Changes in the pump.py to the PTMPLC interlock_status pv from ILK_STATUS_RBV to ILK_OK_RBV.

## Motivation and Context
The pv was wrong causing 'no connection' error on the typhos screen.

## How Has This Been Tested?
Yes, it has been tested from my local repo.
With pv AT1K0:GAS:PTM:10
ptm.get()
PTMPLCTuple(switch_pump_on=1, reset_fault=0, run_do=1, pump_at_speed=1, pump_accelerating=0, pump_speed=542, fault=0, warn=0, alarm=0, bp_sp=0.800000011920929, ip_sp=0.019999999552965164, interlock_status=1)


## Where Has This Been Documented?
Not yet.

<!--
![image](https://user-images.githubusercontent.com/43865116/98384030-1b997f80-2002-11eb-88ab-2c2f032de9dd.png)

-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
