### PR TITLE
ENH: RIX Optics Classes

### DIFF
--- a/docs/source/upcoming_release_notes/693-rix-optics-classes.rst
+++ b/docs/source/upcoming_release_notes/693-rix-optics-classes.rst
@@ -1,0 +1,34 @@
+693 rix-optics-classes
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Renamed mirror.XOffsetMirror2 to mirror.XOffsetMirrorBend for clarity
+
+New Devices
+-----------
+- Added mirror.XOffsetMirrorSwitch
+  This is nearly identical to mirror.XOffsetMirror but with no Bender and
+  vertical axes YLEFT/YRIGHT instead of YUP/YDWN
+- Added spectrometer.Mono
+  This includes all motion axes and Pytmc signals for SP1K1-MONO system
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- jsheppard95

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -324,7 +324,7 @@ class XOffsetMirror(BaseInterface, Device):
     SUB_STATE = 'state'
 
 
-class XOffsetMirror2(XOffsetMirror):
+class XOffsetMirrorBend(XOffsetMirror):
     """
     X-ray Offset Mirror with 2 bender acutators.
 
@@ -358,6 +358,34 @@ class XOffsetMirror2(XOffsetMirror):
     # Bender RTD Cpts:
     us_rtd = Cpt(EpicsSignalRO, ':RTD:US:1_RBV', kind='normal')
     ds_rtd = Cpt(EpicsSignalRO, ':RTD:DS:1_RBV', kind='normal')
+
+
+class XOffsetMirrorSwitch(XOffsetMirror):
+    """
+    X-ray Offset Mirror with Yleft/Yright
+
+    1st and 2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+
+    # Do a dumb thing and kill inherited/unused components
+    y_up = None
+    y_dwn = None
+    bender = None
+    bender_enc_rms = None
+
+    # Motor components: can read/write positions
+    y_left = Cpt(BeckhoffAxis, ':MMS:YLEFT', kind='hinted')
+    y_right = Cpt(BeckhoffAxis, ':MMS:YRIGHT', kind='config')
 
 
 class KBOMirror(BaseInterface, Device):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -289,31 +289,47 @@ class XOffsetMirror(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='hinted')
-    x_up = Cpt(BeckhoffAxis, ':MMS:XUP', kind='hinted')
-    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='hinted')
-    bender = Cpt(BeckhoffAxis, ':MMS:BENDER', kind='normal')
-    y_dwn = Cpt(BeckhoffAxis, ':MMS:YDWN', kind='config')
-    x_dwn = Cpt(BeckhoffAxis, ':MMS:XDWN', kind='config')
+    y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='hinted',
+               doc='Yupstream master axis [um]')
+    x_up = Cpt(BeckhoffAxis, ':MMS:XUP', kind='hinted',
+               doc='Xupstream master [um]')
+    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='hinted',
+                doc='Pitch stepper and piezo axes [urad]')
+    bender = Cpt(BeckhoffAxis, ':MMS:BENDER', kind='normal',
+                 doc='Bender motor [um]')
+    y_dwn = Cpt(BeckhoffAxis, ':MMS:YDWN', kind='config',
+                doc='Ydwnstream slave axis [um]')
+    x_dwn = Cpt(BeckhoffAxis, ':MMS:XDWN', kind='config',
+                doc='Xdwnstream slave axis [um]')
 
     # Gantry components
-    gantry_x = Cpt(PytmcSignal, ':GANTRY_X', io='i', kind='normal')
-    gantry_y = Cpt(PytmcSignal, ':GANTRY_Y', io='i', kind='normal')
-    couple_y = Cpt(PytmcSignal, ':COUPLE_Y', io='o', kind='config')
-    couple_x = Cpt(PytmcSignal, ':COUPLE_X', io='o', kind='config')
-    decouple_y = Cpt(PytmcSignal, ':DECOUPLE_Y', io='o', kind='config')
-    decouple_x = Cpt(PytmcSignal, ':DECOUPLE_X', io='o', kind='config')
+    gantry_x = Cpt(PytmcSignal, ':GANTRY_X', io='i', kind='normal',
+                   doc='X gantry difference [um]')
+    gantry_y = Cpt(PytmcSignal, ':GANTRY_Y', io='i', kind='normal',
+                   doc='Y gantry difference [um]')
+    couple_y = Cpt(PytmcSignal, ':COUPLE_Y', io='o', kind='config',
+                   doc='Couple Y motors [bool]')
+    couple_x = Cpt(PytmcSignal, ':COUPLE_X', io='o', kind='config',
+                   doc='Couple X motors [bool]')
+    decouple_y = Cpt(PytmcSignal, ':DECOUPLE_Y', io='o', kind='config',
+                     doc='Decouple Y motors [bool]')
+    decouple_x = Cpt(PytmcSignal, ':DECOUPLE_X', io='o', kind='config',
+                     doc='Decouple X motors [bool]')
     couple_status_y = Cpt(PytmcSignal, ':ALREADY_COUPLED_Y', io='i',
                           kind='normal')
     couple_status_x = Cpt(PytmcSignal, ':ALREADY_COUPLED_X', io='i',
                           kind='normal')
 
     # RMS Cpts:
-    y_enc_rms = Cpt(PytmcSignal, ':ENC:Y:RMS', io='i', kind='normal')
-    x_enc_rms = Cpt(PytmcSignal, ':ENC:X:RMS', io='i', kind='normal')
-    pitch_enc_rms = Cpt(PytmcSignal, ':ENC:PITCH:RMS', io='i', kind='normal')
+    y_enc_rms = Cpt(PytmcSignal, ':ENC:Y:RMS', io='i', kind='normal',
+                    doc='Yup encoder RMS deviation [um]')
+    x_enc_rms = Cpt(PytmcSignal, ':ENC:X:RMS', io='i', kind='normal',
+                    doc='Xup encoder RMS deviation [um]')
+    pitch_enc_rms = Cpt(PytmcSignal, ':ENC:PITCH:RMS', io='i', kind='normal',
+                        doc='Pitch encoder RMS deviation [urad]')
     bender_enc_rms = Cpt(PytmcSignal, ':ENC:BENDER:RMS', io='i',
-                         kind='normal')
+                         kind='normal',
+                         doc='Bender encoder RMS deviation [um]')
 
     # Lightpath config: implement inserted, removed, transmission, subscribe
     # For now, keep it simple. Some mirrors need more than this, but it is
@@ -384,8 +400,10 @@ class XOffsetMirrorSwitch(XOffsetMirror):
     bender_enc_rms = None
 
     # Motor components: can read/write positions
-    y_left = Cpt(BeckhoffAxis, ':MMS:YLEFT', kind='hinted')
-    y_right = Cpt(BeckhoffAxis, ':MMS:YRIGHT', kind='config')
+    y_left = Cpt(BeckhoffAxis, ':MMS:YLEFT', kind='hinted',
+                 doc='Yleft master axis [um]')
+    y_right = Cpt(BeckhoffAxis, ':MMS:YRIGHT', kind='config',
+                  doc='Yright slave axis [um]')
 
 
 class KBOMirror(BaseInterface, Device):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -376,6 +376,10 @@ class XOffsetMirrorBend(XOffsetMirror):
     ds_rtd = Cpt(EpicsSignalRO, ':RTD:DS:1_RBV', kind='normal')
 
 
+# Maintain backward compatibility
+XOffsetMirror2 = XOffsetMirrorBend
+
+
 class XOffsetMirrorSwitch(XOffsetMirror):
     """
     X-ray Offset Mirror with Yleft/Yright

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -208,3 +208,51 @@ class VonHamos4Crystal(VonHamosFE):
 
     def __init__(self, prefix, *, name, **kwargs):
         super().__init__(prefix, name=name, **kwargs)
+
+
+class Mono(BaseInterface, Device):
+    """
+    L2S-I NEH 2.X Monochromator
+
+    Axilon mechatronic desig with LCLS-II Beckhoff motion architecture.
+
+    Parameters:
+    -----------
+    preifx : str
+        Base PV for the monochromator
+
+    name : str
+        Alias for the device
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+
+    # Motor components: can read/write positions
+    m_pi = Cpt(BeckhoffAxis, ':MMS:M_PI', kind='hinted') # mirror pitch, urad
+    g_pi = Cpt(BeckhoffAxis, ':MMS:G_PI', kind='hinted') # grating pitch, urad
+    m_h = Cpt(BeckhoffAxis, ':MMS:M_H', kind='hinted') # mirror horizontal, um
+    g_h = Cpt(BeckhoffAxis, ':MMS:G_H', kind='hinted') # grating horizontal, um
+    # screwdriver vertical (in/out), um
+    sd_v = Cpt(BeckhoffAxis, ':MMS:SD_V', kind='hinted')
+    # screwdriver rotation, urad
+    sd_rot = Cpt(BeckhoffAxis, ':MMS:SD_ROT', kind='hinted')
+
+    # Additional Pytmc components
+    # Upstream Encoders for pitch axes - not linked to NC axis in PLC
+    m_pi_up_enc = Cpt(PytmcSignal, ':ENC:M_PI:02', kind='hinted')
+    g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', kind='hinted')
+
+    # Flow switches
+    flow_1 = Cpt(PytmcSignal, ':FSW:01', kind='hinted')
+    flow_2 = Cpt(PytmcSignal, ':FSW:02', kind='hinted')
+    pres_1 = Cpt(PytmcSignal, ':P1', kind='hinted')
+
+    # RTDs
+    rtd_1 = Cpt(PytmcSignal, ':RTD:01', kind='hinted')
+    rtd_2 = Cpt(PytmcSignal, ':RTD:02', kind='hinted')
+    rtd_3 = Cpt(PytmcSignal, ':RTD:03', kind='hinted')
+    rtd_4 = Cpt(PytmcSignal, ':RTD:04', kind='hinted')
+    rtd_5 = Cpt(PytmcSignal, ':RTD:05', kind='hinted')
+    rtd_6 = Cpt(PytmcSignal, ':RTD:06', kind='hinted')
+    rtd_7 = Cpt(PytmcSignal, ':RTD:07', kind='hinted')
+    rtd_8 = Cpt(PytmcSignal, ':RTD:08', kind='hinted')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -228,35 +228,48 @@ class Mono(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    # mirror pitch, urad
-    m_pi = Cpt(BeckhoffAxis, ':MMS:M_PI', kind='hinted')
-    # grating pitch, urad
-    g_pi = Cpt(BeckhoffAxis, ':MMS:G_PI', kind='hinted')
-    # mirror horizontal, um
-    m_h = Cpt(BeckhoffAxis, ':MMS:M_H', kind='hinted')
-    # grating horizontal, um
-    g_h = Cpt(BeckhoffAxis, ':MMS:G_H', kind='hinted')
-    # screwdriver vertical (in/out), um
-    sd_v = Cpt(BeckhoffAxis, ':MMS:SD_V', kind='hinted')
-    # screwdriver rotation, urad
-    sd_rot = Cpt(BeckhoffAxis, ':MMS:SD_ROT', kind='hinted')
+    m_pi = Cpt(BeckhoffAxis, ':MMS:M_PI', kind='normal',
+               doc='mirror pitch [urad]')
+    g_pi = Cpt(BeckhoffAxis, ':MMS:G_PI', kind='normal',
+               doc='grating pitch [urad]')
+    m_h = Cpt(BeckhoffAxis, ':MMS:M_H', kind='normal',
+              doc='mirror horizontal [um]')
+    g_h = Cpt(BeckhoffAxis, ':MMS:G_H', kind='normal',
+              doc='grating horizontal [um]')
+    sd_v = Cpt(BeckhoffAxis, ':MMS:SD_V', kind='normal',
+               doc='screwdriver vertical (in/out) [um]')
+    sd_rot = Cpt(BeckhoffAxis, ':MMS:SD_ROT', kind='normal',
+                 doc='screwdriver rotation [urad]')
 
     # Additional Pytmc components
     # Upstream Encoders for pitch axes - not linked to NC axis in PLC
-    m_pi_up_enc = Cpt(PytmcSignal, ':ENC:M_PI:02', io='i', kind='hinted')
-    g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', io='i', kind='hinted')
+    m_pi_up_enc = Cpt(PytmcSignal, ':ENC:M_PI:02', io='i', kind='normal',
+                      doc='mirror pitch upstream encoder [urad]')
+    g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', io='i', kind='normal',
+                      doc='grating pitch upstream encoder [urad]')
 
     # Flow switches
-    flow_1 = Cpt(PytmcSignal, ':FSW:01', io='i', kind='hinted')
-    flow_2 = Cpt(PytmcSignal, ':FSW:02', io='i', kind='hinted')
-    pres_1 = Cpt(PytmcSignal, ':P1', io='i', kind='hinted')
+    flow_1 = Cpt(PytmcSignal, ':FSW:01', io='i', kind='normal',
+                 doc='flow switch 1')
+    flow_2 = Cpt(PytmcSignal, ':FSW:02', io='i', kind='normal',
+                 doc='flow switch 2')
+    pres_1 = Cpt(PytmcSignal, ':P1', io='i', kind='normal',
+                 doc='pressure sensor 1')
 
     # RTDs
-    rtd_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='hinted')
-    rtd_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='hinted')
-    rtd_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='hinted')
-    rtd_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='hinted')
-    rtd_5 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='hinted')
-    rtd_6 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='hinted')
-    rtd_7 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='hinted')
-    rtd_8 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='hinted')
+    rtd_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
+                doc='RTD 1 [deg C]')
+    rtd_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='normal',
+                doc='RTD 2 [deg C]')
+    rtd_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='normal',
+                doc='RTD 3 [deg C]')
+    rtd_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='normal',
+                doc='RTD 4 [deg C]')
+    rtd_5 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='normal',
+                doc='RTD 5 [deg C]')
+    rtd_6 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='normal',
+                doc='RTD 6 [deg C]')
+    rtd_7 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='normal',
+                doc='RTD 7 [deg C]')
+    rtd_8 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='normal',
+                doc='RTD 8 [deg C]')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -7,7 +7,7 @@ from ophyd.device import FormattedComponent as FCpt
 
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface, LightpathMixin
-from .signal import InternalSignal
+from .signal import InternalSignal, PytmcSignal
 
 
 class Kmono(BaseInterface, Device, LightpathMixin):
@@ -239,20 +239,20 @@ class Mono(BaseInterface, Device):
 
     # Additional Pytmc components
     # Upstream Encoders for pitch axes - not linked to NC axis in PLC
-    m_pi_up_enc = Cpt(PytmcSignal, ':ENC:M_PI:02', kind='hinted')
-    g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', kind='hinted')
+    m_pi_up_enc = Cpt(PytmcSignal, ':ENC:M_PI:02', io='i', kind='hinted')
+    g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', io='i', kind='hinted')
 
     # Flow switches
-    flow_1 = Cpt(PytmcSignal, ':FSW:01', kind='hinted')
-    flow_2 = Cpt(PytmcSignal, ':FSW:02', kind='hinted')
-    pres_1 = Cpt(PytmcSignal, ':P1', kind='hinted')
+    flow_1 = Cpt(PytmcSignal, ':FSW:01', io='i', kind='hinted')
+    flow_2 = Cpt(PytmcSignal, ':FSW:02', io='i', kind='hinted')
+    pres_1 = Cpt(PytmcSignal, ':P1', io='i', kind='hinted')
 
     # RTDs
-    rtd_1 = Cpt(PytmcSignal, ':RTD:01', kind='hinted')
-    rtd_2 = Cpt(PytmcSignal, ':RTD:02', kind='hinted')
-    rtd_3 = Cpt(PytmcSignal, ':RTD:03', kind='hinted')
-    rtd_4 = Cpt(PytmcSignal, ':RTD:04', kind='hinted')
-    rtd_5 = Cpt(PytmcSignal, ':RTD:05', kind='hinted')
-    rtd_6 = Cpt(PytmcSignal, ':RTD:06', kind='hinted')
-    rtd_7 = Cpt(PytmcSignal, ':RTD:07', kind='hinted')
-    rtd_8 = Cpt(PytmcSignal, ':RTD:08', kind='hinted')
+    rtd_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='hinted')
+    rtd_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='hinted')
+    rtd_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='hinted')
+    rtd_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='hinted')
+    rtd_5 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='hinted')
+    rtd_6 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='hinted')
+    rtd_7 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='hinted')
+    rtd_8 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='hinted')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -228,10 +228,14 @@ class Mono(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    m_pi = Cpt(BeckhoffAxis, ':MMS:M_PI', kind='hinted') # mirror pitch, urad
-    g_pi = Cpt(BeckhoffAxis, ':MMS:G_PI', kind='hinted') # grating pitch, urad
-    m_h = Cpt(BeckhoffAxis, ':MMS:M_H', kind='hinted') # mirror horizontal, um
-    g_h = Cpt(BeckhoffAxis, ':MMS:G_H', kind='hinted') # grating horizontal, um
+    # mirror pitch, urad
+    m_pi = Cpt(BeckhoffAxis, ':MMS:M_PI', kind='hinted')
+    # grating pitch, urad
+    g_pi = Cpt(BeckhoffAxis, ':MMS:G_PI', kind='hinted')
+    # mirror horizontal, um
+    m_h = Cpt(BeckhoffAxis, ':MMS:M_H', kind='hinted')
+    # grating horizontal, um
+    g_h = Cpt(BeckhoffAxis, ':MMS:G_H', kind='hinted')
     # screwdriver vertical (in/out), um
     sd_v = Cpt(BeckhoffAxis, ':MMS:SD_V', kind='hinted')
     # screwdriver rotation, urad


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Renamed `mirror.XOffsetMirror2` to `mirror.XOffsetMirrorBend` for clarity
- Added `mirror.XOffsetMirrorSwitch` for control of device MR1K2-SWITCH
   - This is nearly identical to `mirror.XOffsetMirror`, but with vertical axis PVs `MMS:YLEFT`/`MMS:YRIGHT` instead of `MMS:YUP`/`MMS:YDWN`
   - These changes are not ideal. It would be best to change the PVs of all mirror gantry axes to be Y1/Y2 for master/slave, allowing for the same parent class of all systems. This requires changes to each system in `lcls-plc-lfe-optics`, `lcls-plc-tmo-optics`, `lcls-plc-txi-optics`, and `lcls-plc-rixs-optics`, lots of work
   - As a first step, it would be ideal to refactor parent class `mirror.XOffsetMirror` so that child classes do not need to set unused components to `None`.

## Motivation and Context
- Python control of RIX optics MR1K1-BEND, MR1K2-SWITCH, and SP1K1-MONO

## How Has This Been Tested?
- Local testing suite
- Created `typhos` screens locally using `$ typhos mirror.XOffsetMirrorSwitch[{"prefix": "MR1K2:SWITCH"}]`, moved vertical axes without issue
- Also created local screen for Mono, but not motion testing yet

## Where Has This Been Documented?
- Docstrings
- Release notes

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [X] Test suite passes locally
- [x] Test suite passes on travis
- [X] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [X] Pre-release docs include context, functional descriptions, and contributors as appropriate
