### PR TITLE
ENH: custom motor status print

### DIFF
--- a/docs/source/upcoming_release_notes/670-Custom_Motor_Status_Print.rst
+++ b/docs/source/upcoming_release_notes/670-Custom_Motor_Status_Print.rst
@@ -1,0 +1,32 @@
+670 Custom Motor Status Print
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added a custom status print for motors by overriding the status info handler.
+- Added a new component for `dial_position`
+- Added a new method `check_limit_switches` to check for the limit switches.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -22,6 +22,7 @@ from .interface import FltMvInterface
 from .pseudopos import DelayBase
 from .signal import PytmcSignal
 from .variety import set_metadata
+from .utils import get_status_value
 
 logger = logging.getLogger(__name__)
 
@@ -85,11 +86,10 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
-        # return 'N/A' if can't get the values for desired keys
-        description = status_info.get('description', {}).get('value', 'N/A')
-        units = status_info.get('user_setpoint', {}).get('units', 'N/A')
-        dial = status_info.get('dial_position', {}).get('value', 'N/A')
-        user = status_info.get('position', 'N/A')
+        description = get_status_value(status_info, 'description', 'value')
+        units = get_status_value(status_info, 'user_setpoint', 'units')
+        dial = get_status_value(status_info, 'dial_position', 'value')
+        user = get_status_value(status_info, 'position')
 
         low, high = self.limits
         switch_limits = self.check_limit_switches()

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -87,9 +87,9 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         """
         lines = []
         # return 'N/A' if can't get the values for desired keys
-        description = status_info.get('description', 'N/A').get('value', 'N/A')
-        units = status_info.get('user_setpoint', 'N/A').get('units', 'N/A')
-        dial = status_info.get('dial_position', 'N/A').get('value', 'N/A')
+        description = status_info.get('description', {}).get('value', 'N/A')
+        units = status_info.get('user_setpoint', {}).get('units', 'N/A')
+        dial = status_info.get('dial_position', {}).get('value', 'N/A')
         user = status_info.get('position', 'N/A')
 
         low, high = self.limits

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -73,23 +73,28 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         # in case a .DESC value is missing, use the prefix as name
         name = ' '.join(self.prefix.split(':'))
         name = f'{name}: {self.prefix}'
-        description = status_info['description']['value']
-        if description:
-            name = f'{description}: {self.prefix}'
-        units = status_info['user_setpoint']['units']
-        dial = status_info['dial_position']['value']
-        user = status_info['position']
-        low, high = self.limits
-        switch_limits = self.check_limit_switches()[0]
-        position = f'current position (user, dial): {user}, {dial} [{units}]'
-        limits = f'user limits (low, hight): {low}, {high} [{units}]'
-        preset = f'preset position: {self.presets.name}'
-        switch = f'Limit Switch: {switch_limits}'
-        lines.append(name)
-        lines.append(position)
-        lines.append(limits)
-        lines.append(preset)
-        lines.append(switch)
+        try:
+            description = status_info['description']['value']
+            units = status_info['user_setpoint']['units']
+            dial = status_info['dial_position']['value']
+            user = status_info['position']
+        except KeyError as err:
+            logger.error('Key error %s', err)
+        else:
+            if description:
+                name = f'{description}: {self.prefix}'
+            low, high = self.limits
+            switch_limits = self.check_limit_switches()[0]
+            position = (f'Current position (user, dial): {user}, {dial}'
+                        f' [{units}]')
+            limits = f'User limits (low, hight): {low}, {high} [{units}]'
+            preset = f'Preset position: {self.presets.name}'
+            switch = f'Limit Switch: {switch_limits}'
+            lines.append(name)
+            lines.append(position)
+            lines.append(limits)
+            lines.append(preset)
+            lines.append(switch)
         return '\n'.join(lines)
 
     @property

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -205,21 +205,22 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
                                      "ignored")
 
     def check_limit_switches(self):
-        """Check the limits switches."""
+        """
+        Check the limits switches.
+
+        Returns
+        -------
+        limit_switch_indicator : str
+            Indicate which limit switch is activated.
+        """
+        if self.low_limit_switch.get() and self.high_limit_switch.get():
+            return "Low [x] High [x]"
         if self.low_limit_switch.get():
-            return (
-                "Low [x] High []",
-                "low limit switch for motor %s (pv %s) activated"
-                % (self.name, self.pvname),
-            )
+            return "Low [x] High []"
         elif self.high_limit_switch.get():
-            return (
-                "Low [] High [x]",
-                "high limit switch for motor %s (pv %s) activated"
-                % (self.name, self.pvname),
-            )
+            return "Low [] High [x]"
         else:
-            return ("Low [] High []", "")
+            return "Low [] High []"
 
 
 class PCDSMotorBase(EpicsMotorInterface):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -85,7 +85,6 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
-        lines = []
         # return 'N/A' if can't get the values for desired keys
         description = status_info.get('description', {}).get('value', 'N/A')
         units = status_info.get('user_setpoint', {}).get('units', 'N/A')
@@ -100,13 +99,13 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         if description:
             name = f'{description}: {self.prefix}'
 
-        position = f'Current position (user, dial): {user}, {dial} [{units}]'
-        limits = f'User limits (low, high): {low}, {high} [{units}]'
-        preset = f'Preset position: {self.presets.name}'
-        switch = f'Limit Switch: {switch_limits}'
-
-        lines.extend([name, position, limits, preset, switch])
-        return '\n'.join(lines)
+        return f"""\
+{name}
+Current position (user, dial): {user}, {dial} [{units}]
+User limits (low, high): {low}, {high} [{units}]
+Preset position: {self.presets.name}
+Limit Switch: {switch_limits}
+"""
 
     @property
     def low_limit(self):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -87,7 +87,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         """
         lines = []
         # return 'N/A' if can't get the values for desired keys
-        description = status_info('description', 'N/A').get('value', 'N/A')
+        description = status_info.get('description', 'N/A').get('value', 'N/A')
         units = status_info.get('user_setpoint', 'N/A').get('units', 'N/A')
         dial = status_info.get('dial_position', 'N/A').get('value', 'N/A')
         user = status_info.get('position', 'N/A')

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -103,7 +103,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
 {name}
 Current position (user, dial): {user}, {dial} [{units}]
 User limits (low, high): {low}, {high} [{units}]
-Preset position: {self.presets.name}
+Preset position: {self.presets.state()}
 Limit Switch: {switch_limits}
 """
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 - Added a custom status print for motors by overriding the status info handler.
- Added a new component for `dial_position`
- Added a new method `check_limit_switches` to check for the limit switches.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to implement and close #670 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
In [2]: ipm = Motor(prefix='XPP:SB2:MMS:03', name='name')

In [3]: ipm
Out[3]:
IPM2 Target Y: XPP:SB2:MMS:03
Current position (user, dial): 0.0, -0.0 [mm]
User limits (low, high): -200.0, 200.0 [mm]
Preset position: Unknown
Limit Switch: Low [] High []

```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstring
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
