### PR TITLE
ENH: Slits custom status

### DIFF
--- a/docs/source/upcoming_release_notes/672-Custom_Status_Prints_for_Slits.rst
+++ b/docs/source/upcoming_release_notes/672-Custom_Status_Prints_for_Slits.rst
@@ -1,0 +1,30 @@
+672 Custom Status Prints for Slits
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added a custom status print for slits by overriding the status info handler.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/docs/source/upcoming_release_notes/672-Custom_Status_Prints_for_Slits.rst
+++ b/docs/source/upcoming_release_notes/672-Custom_Status_Prints_for_Slits.rst
@@ -8,6 +8,7 @@ API Changes
 Features
 --------
 - Added a custom status print for slits by overriding the status info handler.
+- Added a helper function in `utils.py`: `get_status_value` to support getting a value from a dictionary.
 
 Device Updates
 --------------

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -28,7 +28,7 @@ from .epics_motor import BeckhoffAxis
 from .interface import FltMvInterface, MvInterface, LightpathMixin
 from .signal import PytmcSignal, NotImplementedSignal
 from .sensors import RTD
-from .utils import schedule_task
+from .utils import schedule_task, get_status_value
 
 logger = logging.getLogger(__name__)
 
@@ -83,14 +83,13 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         hutch = self.prefix.split(':')[0].upper()
         stand = self.prefix.split(':')[1].upper()
 
-        x_width = status_info.get('xwidth', {}).get('position', 'N/A')
-        y_width = status_info.get('ywidth', {}).get('position', 'N/A')
-        x_center = status_info.get('xcenter', {}).get('position', 'N/A')
-        y_center = status_info.get('ycenter', {}).get('position', 'N/A')
-        w_units = status_info.get('ywidth', {}).get('setpoint', {}).get(
-                                  'units', 'N/A')
-        c_units = status_info.get('ycenter', {}).get('setpoint', {}).get(
-                                  'units', 'N/A')
+        x_width = get_status_value(status_info, 'xwidth', 'position')
+        y_width = get_status_value(status_info, 'ywidth', 'position')
+        x_center = get_status_value(status_info, 'xcenter', 'position')
+        y_center = get_status_value(status_info, 'ycenter', 'position')
+        w_units = get_status_value(status_info, 'ywidth', 'setpoint', 'units')
+        c_units = get_status_value(status_info, 'ycenter', 'setpoint', 'units')
+
         return f"""\
 {hutch} Slit {self.name} on {stand}
 (hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -64,25 +64,23 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
 
     def format_status_info(self, status_info):
         lines = []
-        first = self.prefix.split(':')[0].uppder()
-        second = self.prefix.split(':')[1].upper()
-        name = f'{first} Slit {self.name} on {second}'
-        try:
-            x_width = status_info['xwidth']['position']
-            y_width = status_info['ywidth']['position']
-            x_center = status_info['xcenter']['position']
-            y_center = status_info['ycenter']['position']
-            w_units = status_info['ywidth']['setpoint']['units']
-            c_units = status_info['ycenter']['setpoint']['units']
-        except KeyError as err:
-            logger.error('Key error %s', err)
-        else:
-            hg_vg = f'(hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]'
-            ho_vo = f'(ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]'
-            lines.append(name)
-            lines.append(hg_vg)
-            lines.append(ho_vo)
 
+        hutch = self.prefix.split(':')[0].upper()
+        stand = self.prefix.split(':')[1].upper()
+        name = f'{hutch} Slit {self.name} on {stand}'
+
+        x_width = status_info.get('xwidth', 'N/A').get('position', 'N/A')
+        y_width = status_info.get('ywidth', 'N/A').get('position', 'N/A')
+        x_center = status_info.get('xcenter', 'N/A').get('position', 'N/A')
+        y_center = status_info.get('ycenter', 'N/A').get('position', 'N/A')
+        w_units = status_info.get('ywidth', 'N/A').get('setpoint').get('units')
+        c_units = status_info.get('ycenter', 'N/A').get('setpoint', 'N/A').get(
+                                  'units', 'N/A')
+
+        hg_vg = f'(hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]'
+        ho_vo = f'(ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]'
+
+        lines.extend([name, hg_vg, ho_vo])
         return '\n'.join(lines)
 
     def move(self, size, wait=False, moved_cb=None, timeout=None):

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -80,6 +80,18 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         status: str
             Formatted string with all relevant status information.
         """
+        # happi metadata
+        md = self.root.md
+        try:
+            beamline = md['beamline']
+            stand = md['stand']
+            if stand is not None:
+                name = f'{beamline} Slit {self.name} on {stand}'
+            else:
+                name = f'{beamline} Slit {self.name}'
+        except AttributeError:
+            name = f'Slit: {self.prefix}'
+
         x_width = get_status_value(status_info, 'xwidth', 'position')
         y_width = get_status_value(status_info, 'ywidth', 'position')
         x_center = get_status_value(status_info, 'xcenter', 'position')
@@ -88,7 +100,7 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         c_units = get_status_value(status_info, 'ycenter', 'setpoint', 'units')
 
         return f"""\
-Slit: {self.prefix}
+{name}
 (hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]
 (ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]
 """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -63,6 +63,23 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         self.nominal_aperture.put(nominal_aperture)
 
     def format_status_info(self, status_info):
+        """
+        Override status info handler to render the slits.
+
+        Display slits status info in the ipython terminal.
+
+        Parameters
+        ----------
+        status_info: dict
+            Nested dictionary. Each level has keys name, kind, and is_device.
+            If is_device is True, subdevice dictionaries may follow. Otherwise,
+            the only other key in the dictionary will be value.
+
+        Returns
+        -------
+        status: str
+            Formatted string with all relevant status information.
+        """
         lines = []
 
         hutch = self.prefix.split(':')[0].upper()

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -80,9 +80,6 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         status: str
             Formatted string with all relevant status information.
         """
-        hutch = self.prefix.split(':')[0].upper()
-        stand = self.prefix.split(':')[1].upper()
-
         x_width = get_status_value(status_info, 'xwidth', 'position')
         y_width = get_status_value(status_info, 'ywidth', 'position')
         x_center = get_status_value(status_info, 'xcenter', 'position')
@@ -91,7 +88,7 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         c_units = get_status_value(status_info, 'ycenter', 'setpoint', 'units')
 
         return f"""\
-{hutch} Slit {self.name} on {stand}
+Slit: {self.prefix}
 (hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]
 (ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]
 """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -62,6 +62,29 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         super().__init__(*args, **kwargs)
         self.nominal_aperture.put(nominal_aperture)
 
+    def format_status_info(self, status_info):
+        lines = []
+        first = self.prefix.split(':')[0].uppder()
+        second = self.prefix.split(':')[1].upper()
+        name = f'{first} Slit {self.name} on {second}'
+        try:
+            x_width = status_info['xwidth']['position']
+            y_width = status_info['ywidth']['position']
+            x_center = status_info['xcenter']['position']
+            y_center = status_info['ycenter']['position']
+            w_units = status_info['ywidth']['setpoint']['units']
+            c_units = status_info['ycenter']['setpoint']['units']
+        except KeyError as err:
+            logger.error('Key error %s', err)
+        else:
+            hg_vg = f'(hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]'
+            ho_vo = f'(ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]'
+            lines.append(name)
+            lines.append(hg_vg)
+            lines.append(ho_vo)
+
+        return '\n'.join(lines)
+
     def move(self, size, wait=False, moved_cb=None, timeout=None):
         """
         Set the dimensions of the width/height of the gap to width paramater.

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -86,12 +86,13 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         stand = self.prefix.split(':')[1].upper()
         name = f'{hutch} Slit {self.name} on {stand}'
 
-        x_width = status_info.get('xwidth', 'N/A').get('position', 'N/A')
-        y_width = status_info.get('ywidth', 'N/A').get('position', 'N/A')
-        x_center = status_info.get('xcenter', 'N/A').get('position', 'N/A')
-        y_center = status_info.get('ycenter', 'N/A').get('position', 'N/A')
-        w_units = status_info.get('ywidth', 'N/A').get('setpoint').get('units')
-        c_units = status_info.get('ycenter', 'N/A').get('setpoint', 'N/A').get(
+        x_width = status_info.get('xwidth', {}).get('position', 'N/A')
+        y_width = status_info.get('ywidth', {}).get('position', 'N/A')
+        x_center = status_info.get('xcenter', {}).get('position', 'N/A')
+        y_center = status_info.get('ycenter', {}).get('position', 'N/A')
+        w_units = status_info.get('ywidth', {}).get('setpoint', {}).get(
+                                  'units', 'N/A')
+        c_units = status_info.get('ycenter', {}).get('setpoint', {}).get(
                                   'units', 'N/A')
 
         hg_vg = f'(hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]'

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -80,8 +80,6 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         status: str
             Formatted string with all relevant status information.
         """
-        lines = []
-
         hutch = self.prefix.split(':')[0].upper()
         stand = self.prefix.split(':')[1].upper()
         name = f'{hutch} Slit {self.name} on {stand}'
@@ -94,12 +92,11 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
                                   'units', 'N/A')
         c_units = status_info.get('ycenter', {}).get('setpoint', {}).get(
                                   'units', 'N/A')
-
-        hg_vg = f'(hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]'
-        ho_vo = f'(ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]'
-
-        lines.extend([name, hg_vg, ho_vo])
-        return '\n'.join(lines)
+        return f"""\
+{name}
+(hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]
+(ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]
+"""
 
     def move(self, size, wait=False, moved_cb=None, timeout=None):
         """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -83,14 +83,15 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         # happi metadata
         try:
             md = self.root.md
+        except AttributeError:
+            name = f'Slit: {self.prefix}'
+        else:
             beamline = get_status_value(md, 'beamline')
             stand = get_status_value(md, 'stand')
             if stand is not None:
                 name = f'{beamline} Slit {self.name} on {stand}'
             else:
                 name = f'{beamline} Slit {self.name}'
-        except AttributeError:
-            name = f'Slit: {self.prefix}'
 
         x_width = get_status_value(status_info, 'xwidth', 'position')
         y_width = get_status_value(status_info, 'ywidth', 'position')

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -81,10 +81,10 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
             Formatted string with all relevant status information.
         """
         # happi metadata
-        md = self.root.md
         try:
-            beamline = md['beamline']
-            stand = md['stand']
+            md = self.root.md
+            beamline = get_status_value(md, 'beamline')
+            stand = get_status_value(md, 'stand')
             if stand is not None:
                 name = f'{beamline} Slit {self.name} on {stand}'
             else:

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -82,7 +82,6 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         """
         hutch = self.prefix.split(':')[0].upper()
         stand = self.prefix.split(':')[1].upper()
-        name = f'{hutch} Slit {self.name} on {stand}'
 
         x_width = status_info.get('xwidth', {}).get('position', 'N/A')
         y_width = status_info.get('ywidth', {}).get('position', 'N/A')
@@ -93,7 +92,7 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         c_units = status_info.get('ycenter', {}).get('setpoint', {}).get(
                                   'units', 'N/A')
         return f"""\
-{name}
+{hutch} Slit {self.name} on {stand}
 (hg, vg): ({x_width:+.4f}, {y_width:+.4f}) [{w_units}]
 (ho, vo): ({x_center:+.4f}, {y_center:+.4f}) [{c_units}]
 """

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -4,6 +4,8 @@ import shutil
 import sys
 import threading
 import time
+import operator
+from functools import reduce
 
 import ophyd
 import pint
@@ -210,3 +212,25 @@ def schedule_task(func, args=None, kwargs=None, delay=None):
         # Do it later
         timer = threading.Timer(delay, schedule)
         timer.start()
+
+
+def get_status_value(status_info, *keys, default_value='N/A'):
+    """
+    Get the value of a dictionary key.
+
+    Parameters
+    ----------
+    status_info : dict
+        Dictionary to look through.
+    keys : list
+        List of keys to look through with nested dictionarie.
+    default_value : str
+        A default value to return if the item value was not found.
+
+    Returns
+    -------
+    value : dictionary item value
+        Value of the last key in the `keys` list.
+    """
+    value = reduce(operator.getitem, keys, status_info)
+    return value or default_value

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -232,5 +232,8 @@ def get_status_value(status_info, *keys, default_value='N/A'):
     value : dictionary item value
         Value of the last key in the `keys` list.
     """
-    value = reduce(operator.getitem, keys, status_info)
-    return value or default_value
+    try:
+        value = reduce(operator.getitem, keys, status_info)
+        return value
+    except KeyError:
+        return default_value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,3 +60,11 @@ def test_cbreak(sim_input):
     # send the ctrl+c character
     input_later(sim_input, '\x03\n')
     assert util.get_input() == '\n'
+
+
+def test_get_status_value():
+    dummy_dictionary = {'dict1': {'dict2': {'value': 23}}}
+    res = util.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'value')
+    assert res == 23
+    res = util.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'blah')
+    assert res == 'N/A'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Override the status info handler for `Slits`. 
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to implement and close #672 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
In [2]: l = LusiSlits(prefix='XCS:SB2:US:JAWS', name='s2')

In [3]: l
Out[3]:
Slit: XCS:SB2:US:JAWS
(hg, vg): (+9.9997, +9.9995) [mm]
(ho, vo): (+0.0912, -0.1137) [mm]
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
