### PR TITLE
ENH: PIM custom status

### DIFF
--- a/docs/source/upcoming_release_notes/674-PIM_Custom_Status_Print.rst
+++ b/docs/source/upcoming_release_notes/674-PIM_Custom_Status_Print.rst
@@ -1,0 +1,30 @@
+674 PIM Custom Status Print
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added a custom status print for PIM by overriding the status info handler.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -109,33 +109,31 @@ class PIM(BaseInterface, Device):
             Formatted string with all relevant status information.
         """
         lines = []
-        name = ' '.join(self.prefix.split(':'))
-        focus_str = ''
-        try:
-            focus = status_info['focus_motor']['position']
-            f_units = status_info['focus_motor']['user_setpoint']['units']
-            focus_str = f' Focus: {focus} [{f_units}]'
-        except KeyError:
-            logger.debug('No focus motor present.')
 
-        try:
-            state_pos = status_info['state']['position']
-            y_pos = status_info['state']['motor']['position']
-            y_units = status_info['state']['motor']['user_setpoint']['units']
-            zoom = status_info['zoom_motor']['position']
-            z_units = status_info['zoom_motor']['user_setpoint']['units']
-        except KeyError as err:
-            logger.error('Key error %s', err)
+        focus = status_info.get('focus_motor', {}).get('position', 'N/A')
+        f_units = status_info.get('focus_motor', {}).get(
+                                  'user_setpoint', {}).get('units', 'N/A')
+
+        state_pos = status_info.get('state', {}).get('position', 'N/A')
+        y_pos = status_info.get('state', {}).get('motor', {}).get(
+                                'position', 'N/A')
+        y_units = status_info.get('state', {}).get('motor', {}).get(
+                                  'user_setpoint', {}).get('units', 'N/A')
+        zoom = status_info.get('zoom_motor', {}).get('position', 'N/A')
+        z_units = status_info.get('zoom_motor', {}).get(
+                                  'user_setpoint', {}).get('units', 'N/A')
+
+        name = ' '.join(self.prefix.split(':'))
+        name = f'{name}: {state_pos}'
+
+        y_pos = f'Y Position: {y_pos:.4f} [{y_units}]'
+        if focus != 'N/A':
+            zoom = (f'Navitar Zoom: {zoom:.4f} [{z_units}]  '
+                    f'Focus: {focus} [{f_units}]')
         else:
-            name = f'{name}: {state_pos}'
-            y_pos = f'Y Position: {y_pos} [{y_units}]'
-            if focus_str:
-                zoom = f'Navitar Zoom: {zoom} [{z_units}] ' + focus_str
-            else:
-                zoom = f'Navitar Zoom: {zoom} [{z_units}]'
-            lines.append(name)
-            lines.append(y_pos)
-            lines.append(zoom)
+            zoom = f'Navitar Zoom: {zoom:.4f} [{z_units}]'
+
+        lines.extend([name, y_pos, zoom])
         return '\n'.join(lines)
 
     @property

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -91,6 +91,37 @@ class PIM(BaseInterface, Device):
             self._prefix_start = '{0}:{1}:'.format(prefix.split(':')[0],
                                                    prefix.split(':')[1])
 
+    def format_status_info(self, status_info):
+        lines = []
+        name = ' '.join(self.prefix.split(':'))
+        focus_str = ''
+        try:
+            focus = status_info['focus_motor']['position']
+            f_units = status_info['focus_motor']['user_setpoint']['units']
+            focus_str = f' Focus: {focus} [{f_units}]'
+        except KeyError:
+            logger.debug('No focus motor present.')
+
+        try:
+            state_pos = status_info['state']['position']
+            y_pos = status_info['state']['motor']['position']
+            y_units = status_info['state']['motor']['user_setpoint']['units']
+            zoom = status_info['zoom_motor']['position']
+            z_units = status_info['zoom_motor']['user_setpoint']['units']
+        except KeyError as err:
+            logger.error('Key error %s', err)
+        else:
+            name = f'{name}: {state_pos}'
+            y_pos = f'Y Position: {y_pos} [{y_units}]'
+            if focus_str:
+                zoom = f'Navitar Zoom: {zoom} [{z_units}] ' + focus_str
+            else:
+                zoom = f'Navitar Zoom: {zoom} [{z_units}]'
+            lines.append(name)
+            lines.append(y_pos)
+            lines.append(zoom)
+        return '\n'.join(lines)
+
     @property
     def prefix_start(self):
         """Returns the first two segments of the prefix PV."""

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -92,6 +92,22 @@ class PIM(BaseInterface, Device):
                                                    prefix.split(':')[1])
 
     def format_status_info(self, status_info):
+        """
+        Override status info handler to render the PIM.
+
+        Display pim status info in the ipython terminal.
+
+        Parameters
+        ----------
+        status_info: dict
+            Nested dictionary. Each level has keys name, kind, and is_device.
+            If is_device is True, subdevice dictionaries may follow. Otherwise,
+            the only other key in the dictionary will be value.
+        Returns
+        -------
+        status: str
+            Formatted string with all relevant status information.
+        """
         lines = []
         name = ' '.join(self.prefix.split(':'))
         focus_str = ''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Override the status info handler for pim.
 - [x] need to check about the focus...
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to implement and close #674 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not sure if I'm testing this correctly:
```
In [3]: pim_f = PIMWithFocus(prefix='CXI:DG1:PIM', name='yag')

In [4]: pim = PIM(prefix='CXI:DG1:PIM', name='yag')

In [5]: pim_f
Out[5]:
CXI DG1 PIM: OUT
Y Position: -51.9995 [mm]
Navitar Zoom: 0.6180 [%]  Focus: ERROR [None]

In [6]: pim
Out[6]:
CXI DG1 PIM: OUT
Y Position: -51.9995 [mm]
Navitar Zoom: 0.6180 [%]
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstring 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
