### PR TITLE
ENH: attenuator 3rd harmonic print

### DIFF
--- a/docs/source/upcoming_release_notes/675-Add_3rd_Harmonic_Status_Print.rst
+++ b/docs/source/upcoming_release_notes/675-Add_3rd_Harmonic_Status_Print.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- N/A
+- Instead of creating separated devices for Fundamental Frequency and 3rd Harmonic Frequency, we are now creating Attenuators that have both frequencies.
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/675-Add_3rd_Harmonic_Status_Print.rst
+++ b/docs/source/upcoming_release_notes/675-Add_3rd_Harmonic_Status_Print.rst
@@ -1,0 +1,30 @@
+675 Add 3rd Harmonic Status Print
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added 3rd harmonic frequncy transmission info to the status print for the Attenuator.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -113,19 +113,19 @@ class AttBase(FltMvInterface, PVPositioner):
                    kind='normal')
     readback = Cpt(EpicsSignalRO, ':COM:R_CUR', auto_monitor=True,
                    kind='hinted')
-    actuate = Cpt(EpicsSignal, ':COM:GO', kind='normal')
+    actuate = Cpt(EpicsSignal, ':COM:GO', kind='omitted')
     done = Cpt(EpicsSignalRO, ':COM:STATUS', auto_monitor=True,
                kind='omitted')
 
     # Attenuator Signals
     energy = Cpt(EpicsSignalRO, ':COM:T_CALC.VALE', kind='normal')
-    trans_ceil = Cpt(EpicsSignalRO, ':COM:R_CEIL', kind='normal')
-    trans_floor = Cpt(EpicsSignalRO, ':COM:R_FLOOR', kind='normal')
-    user_energy = Cpt(EpicsSignal, ':COM:EDES', kind='normal')
-    eget_cmd = Cpt(EpicsSignal, ':COM:EACT.SCAN', kind='normal')
+    trans_ceil = Cpt(EpicsSignalRO, ':COM:R_CEIL', kind='omitted')
+    trans_floor = Cpt(EpicsSignalRO, ':COM:R_FLOOR', kind='omitted')
+    user_energy = Cpt(EpicsSignal, ':COM:EDES', kind='omitted')
+    eget_cmd = Cpt(EpicsSignal, ':COM:EACT.SCAN', kind='omitted')
 
     # Aux Signals
-    calcpend = Cpt(EpicsSignalRO, ':COM:CALCP', kind='normal')
+    calcpend = Cpt(EpicsSignalRO, ':COM:CALCP', kind='omitted')
 
     # 3rd harmonic frequency components
     # ==================================

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -327,7 +327,7 @@ Transmission for 1st harmonic (E={energy:.3} keV): {trans:.4E}
 """
 
 
-class AttBaseWith3rd(FltMvInterface, PVPositioner):
+class AttBaseWith3rdHarmonic(FltMvInterface, PVPositioner):
     """
     Base class for attenuators with 3rd harmonic frequency.
 
@@ -381,7 +381,7 @@ class FeeAtt(AttBase, PVPositionerPC):
         super().__init__(prefix, name=name, **kwargs)
 
 
-def _make_att_classes(max_filters, base, third_base, name):
+def _make_att_classes(max_filters, base, base_3rd_harmonic, name):
     """Generate all possible subclasses."""
     att_classes = {}
     for i in range(1, max_filters + 1):
@@ -391,14 +391,14 @@ def _make_att_classes(max_filters, base, third_base, name):
             att_filters['filter{}'.format(n)] = comp
 
         cls_name = '{}{}'.format(name, i)
-        cls = type(cls_name, (base, third_base,), att_filters)
+        cls = type(cls_name, (base, base_3rd_harmonic,), att_filters)
         cls.num_att = i
         att_classes[i] = cls
     return att_classes
 
 
 _att_classes = _make_att_classes(
-    MAX_FILTERS, AttBase, AttBaseWith3rd, 'Attenuator')
+    MAX_FILTERS, AttBase, AttBaseWith3rdHarmonic, 'Attenuator')
 
 
 def Attenuator(prefix, n_filters, *, name, **kwargs):

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -327,7 +327,7 @@ Transmission for 1st harmonic (E={energy:.3} keV): {trans:.4E}
 """
 
 
-class AttBaseWith3rdHarmonic(FltMvInterface, PVPositioner):
+class AttBaseWith3rdHarmonic(AttBase):
     """
     Base class for attenuators with 3rd harmonic frequency.
 
@@ -381,7 +381,7 @@ class FeeAtt(AttBase, PVPositionerPC):
         super().__init__(prefix, name=name, **kwargs)
 
 
-def _make_att_classes(max_filters, base, base_3rd_harmonic, name):
+def _make_att_classes(max_filters, base_with_3rd_harmonic, name):
     """Generate all possible subclasses."""
     att_classes = {}
     for i in range(1, max_filters + 1):
@@ -391,14 +391,14 @@ def _make_att_classes(max_filters, base, base_3rd_harmonic, name):
             att_filters['filter{}'.format(n)] = comp
 
         cls_name = '{}{}'.format(name, i)
-        cls = type(cls_name, (base, base_3rd_harmonic,), att_filters)
+        cls = type(cls_name, (base_with_3rd_harmonic,), att_filters)
         cls.num_att = i
         att_classes[i] = cls
     return att_classes
 
 
 _att_classes = _make_att_classes(
-    MAX_FILTERS, AttBase, AttBaseWith3rdHarmonic, 'Attenuator')
+    MAX_FILTERS, AttBaseWith3rdHarmonic, 'Attenuator')
 
 
 def Attenuator(prefix, n_filters, *, name, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,7 @@ from epics import PV
 from ophyd.signal import LimitError
 from ophyd.sim import FakeEpicsSignal, make_fake_device
 
-from pcdsdevices.attenuator import (MAX_FILTERS, Attenuator, _att3_classes,
-                                    _att_classes)
+from pcdsdevices.attenuator import MAX_FILTERS, Attenuator, _att_classes
 from pcdsdevices.mv_interface import setup_preset_paths
 
 MODULE_PATH = Path(__file__).parent
@@ -56,9 +55,6 @@ PV.count = property(lambda self: 1)
 
 for name, cls in _att_classes.items():
     _att_classes[name] = make_fake_device(cls)
-
-for name, cls in _att3_classes.items():
-    _att3_classes[name] = make_fake_device(cls)
 
 
 # Used in multiple test files

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -8,7 +8,7 @@ from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
 
 from pcdsdevices.attenuator import (MAX_FILTERS, AttBase, Attenuator,
-                                    _att3_classes, _att_classes)
+                                    _att_classes)
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +16,6 @@ logger = logging.getLogger(__name__)
 # Replace all the Attenuator classes with fake classes
 for name, cls in _att_classes.items():
     _att_classes[name] = make_fake_device(cls)
-
-for name, cls in _att3_classes.items():
-    _att3_classes[name] = make_fake_device(cls)
 
 
 @pytest.mark.timeout(5)
@@ -156,7 +153,7 @@ def test_attenuator_staging(fake_att):
 
 def test_attenuator_third_harmonic():
     logger.debug('test_attenuator_third_harmonic')
-    att = Attenuator('TRD:ATT', MAX_FILTERS-1, name='third', use_3rd=True)
+    att = Attenuator('TRD:ATT', MAX_FILTERS-1, name='third')
     att.wait_for_connection()
 
 

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -151,9 +151,9 @@ def test_attenuator_staging(fake_att):
         assert filt.removed
 
 
-def test_attenuator_third_harmonic():
-    logger.debug('test_attenuator_third_harmonic')
-    att = Attenuator('TRD:ATT', MAX_FILTERS-1, name='third')
+def test_attenuator():
+    logger.debug('test_attenuator')
+    att = Attenuator('TRD:ATT', MAX_FILTERS-1, name='att')
     att.wait_for_connection()
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactored the code a bit to allow creating devices with both fundamental frequency and 3rd harmonic frequency instead of creating separated classes for them as it was previously.
Add custom status printout for the Attenuator by overriding the `format_status_info` handler.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to implement #675
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
In [1]: mfx_attenuator
Out[1]:
filter # |0|1|2|3|4|5|6|7|8|9|
 OUT     | |X| | | |X|X|X|X|X|
 IN      |X| |X|X|X| | | | | |
Transmission for 1st harmonic (E=8.23e+06 keV): 2.3446E-02
Transmission for 3rd harmonic (E=2.47e+07 keV): 2.3446E-02
```

```
In [1]: at1l0
Out[1]:
filter # |0|1|2|3|4|5|6|7|8|
 OUT     |X|X|X|X|X|X|X|X|X|
 IN      | | | | | | | | | |
Transmission for 1st harmonic (E=8.23e+06 keV): 1.0000E+00
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
