### PR TITLE
MNT: wrap all status formatting in an error handler.

### DIFF
--- a/docs/source/upcoming_release_notes/703-pp-err.rst
+++ b/docs/source/upcoming_release_notes/703-pp-err.rst
@@ -1,0 +1,31 @@
+703 pp-err
+##########
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Create a default status info message for devices that have
+  errors in constructing their status.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -250,7 +250,13 @@ class BaseInterface:
             also call pp.pretty to print this object. Then cycle would be True
             and you know not to make any further recursive calls.
         """
-        pp.text(self.format_status_info(self.status_info()))
+        try:
+            status_text = self.format_status_info(self.status_info())
+        except Exception:
+            status_text = (f'{self}: Error showing status information. '
+                           'Check IOC connection and device health.')
+            logger.debug(status_text, exc_info=True)
+        pp.text(status_text)
 
     def format_status_info(self, status_info):
         """

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -226,8 +226,13 @@ class BaseInterface:
         """
         Set pretty-printing to show current status information.
 
-        We will not leverage the feature set here, we will just use it as a
-        convenient IPython entry point for rendering our device info.
+        This will also filter out errors from the ``status_info``
+        and ``format_status_info`` methods, making sure "something"
+        is printed.
+
+        We will not leverage the pretty-printing feature set here,
+        we will just use it as a convenient IPython entry point for
+        rendering our device info.
 
         The parameter set is documented here in case we change our minds,
         since I already wrote it out before deciding on a renderer-agnostic


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Wrap the pretty-print handler to cover unknown exceptions from custom status prints.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simply viewing the status of an object shouldn't break everything- we should see some information and be made aware that something has gone wrong.

In the qs loader this was causing large issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
```
In [2]: bad = IMS('BAD', name='bad')

In [3]: bad
Out[3]: IMS(BAD, name=bad): Error showing status information. Check IOC connection and device health.
```
The debug message looks like:
```
DEBUG:pcdsdevices.interface:IMS(BAD, name=bad): Error showing status information. Check IOC connection and device health.
Traceback (most recent call last):
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1078, in _get_with_timeout
    self.wait_for_connection(timeout=connection_timeout)
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1440, in wait_for_connection
    self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1011, in _ensure_connected
    raise TimeoutError(f"{pv.pvname} could not connect within "
TimeoutError: BAD.LLS could not connect within 1.0-second timeout.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/u/lu/zlentz/pydev/pcdsdevices/interface.py", line 254, in _repr_pretty_
    status_text = self.format_status_info(self.status_info())
  File "/u/lu/zlentz/pydev/pcdsdevices/epics_motor.py", line 95, in format_status_info
    switch_limits = self.check_limit_switches()
  File "/u/lu/zlentz/pydev/pcdsdevices/epics_motor.py", line 213, in check_limit_switches
    low = self.low_limit_switch.get()
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1131, in get
    self._read_pv, timeout, connection_timeout, as_string, form)
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1082, in _get_with_timeout
    f"within {connection_timeout:.2f} sec") from err
ophyd.signal.ConnectionTimeoutError: Failed to connect to BAD.LLS within 1.00 sec
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I have added a pre-release note and expanded the docstring.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
