### PR TITLE
STY: Epics_motor metadata

### DIFF
--- a/docs/source/upcoming_release_notes/695-Epics-Motor-Metadata.rst
+++ b/docs/source/upcoming_release_notes/695-Epics-Motor-Metadata.rst
@@ -1,0 +1,31 @@
+695 Epics-Motor-Metadata
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- EpicsMotorInterface: Add metadata to various upstream Ophyd methods to clean
+  up screens generated via Typhos.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/docs/source/upcoming_release_notes/695-Epics-Motor-Metadata.rst
+++ b/docs/source/upcoming_release_notes/695-Epics-Motor-Metadata.rst
@@ -3,7 +3,8 @@
 
 API Changes
 -----------
-- N/A
+- SmarActOpenLoop: Combined scan_move_cmd and scan_pos into single EpicsSignal,
+  scan_move, with separate read and write PVs. 
 
 Features
 --------

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -62,27 +62,22 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     tab_whitelist = ["set_current_position", "home", "velocity",
                      "enable", "disable"]
 
-    set_metadata(EpicsMotor.home_forward, dict(variety='command-proc', value=1))
+    set_metadata(EpicsMotor.home_forward, dict(variety='command-proc',
+                                               value=1))
     EpicsMotor.home_forward.kind = Kind.normal
-    set_metadata(EpicsMotor.home_reverse, dict(variety='command-proc', value=1))
+    set_metadata(EpicsMotor.home_reverse, dict(variety='command-proc',
+                                               value=1))
     EpicsMotor.home_reverse.kind = Kind.normal
     set_metadata(EpicsMotor.low_limit_switch, dict(variety='bitmask', bits=1))
     EpicsMotor.low_limit_switch.kind = Kind.normal
     set_metadata(EpicsMotor.high_limit_switch, dict(variety='bitmask', bits=1))
     EpicsMotor.high_limit_switch.kind = Kind.normal
     set_metadata(EpicsMotor.motor_done_move, dict(variety='bitmask', bits=1))
-    EpicsMotor.motor_done_move.kind = Kind.config
+    EpicsMotor.motor_done_move.kind = Kind.omitted
     set_metadata(EpicsMotor.motor_is_moving, dict(variety='bitmask', bits=1))
-    # Had no joy here or anywhere else with enums. I still get the <val> <egu> 
-    # "0 mm" readback. Maybe I'm doing it wrong?
-#    set_metadata(EpicsMotor.motor_is_moving, dict(variety='enum',
-#                                                  enum_strings=['No', 'Yes']))
     EpicsMotor.motor_is_moving.kind = Kind.normal
     set_metadata(EpicsMotor.motor_stop, dict(variety='command-proc', value=1))
     EpicsMotor.motor_stop.kind = Kind.normal
-    # Had no luck with text either, same as enums above. 
-#    set_metadata(EpicsMotor.direction_of_travel, dict(variety='text',
-#                                                      enum_strings=['Rev', 'Fwd']))
     EpicsMotor.direction_of_travel.kind = Kind.normal
 
     def __init__(self, *args, **kwargs):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -14,6 +14,7 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
 from ophyd.status import DeviceStatus, SubscriptionStatus
 from ophyd.status import wait as status_wait
 from ophyd.utils import LimitError
+from ophyd.ophydobj import Kind
 
 from pcdsdevices.pv_positioner import PVPositionerComparator
 
@@ -54,11 +55,35 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
 
     # Enable/Disable puts
     disabled = Cpt(EpicsSignal, ".DISP", kind='omitted')
+    set_metadata(disabled, dict(variety='command-enum'))
     # Description is valuable
     description = Cpt(EpicsSignal, '.DESC', kind='normal')
 
     tab_whitelist = ["set_current_position", "home", "velocity",
                      "enable", "disable"]
+
+    set_metadata(EpicsMotor.home_forward, dict(variety='command-proc', value=1))
+    EpicsMotor.home_forward.kind = Kind.normal
+    set_metadata(EpicsMotor.home_reverse, dict(variety='command-proc', value=1))
+    EpicsMotor.home_reverse.kind = Kind.normal
+    set_metadata(EpicsMotor.low_limit_switch, dict(variety='bitmask', bits=1))
+    EpicsMotor.low_limit_switch.kind = Kind.normal
+    set_metadata(EpicsMotor.high_limit_switch, dict(variety='bitmask', bits=1))
+    EpicsMotor.high_limit_switch.kind = Kind.normal
+    set_metadata(EpicsMotor.motor_done_move, dict(variety='bitmask', bits=1))
+    EpicsMotor.motor_done_move.kind = Kind.config
+    set_metadata(EpicsMotor.motor_is_moving, dict(variety='bitmask', bits=1))
+    # Had no joy here or anywhere else with enums. I still get the <val> <egu> 
+    # "0 mm" readback. Maybe I'm doing it wrong?
+#    set_metadata(EpicsMotor.motor_is_moving, dict(variety='enum',
+#                                                  enum_strings=['No', 'Yes']))
+    EpicsMotor.motor_is_moving.kind = Kind.normal
+    set_metadata(EpicsMotor.motor_stop, dict(variety='command-proc', value=1))
+    EpicsMotor.motor_stop.kind = Kind.normal
+    # Had no luck with text either, same as enums above. 
+#    set_metadata(EpicsMotor.direction_of_travel, dict(variety='text',
+#                                                      enum_strings=['Rev', 'Fwd']))
+    EpicsMotor.direction_of_travel.kind = Kind.normal
 
     def __init__(self, *args, **kwargs):
         # Locally defined limit overrides, note can only make limits narrower
@@ -551,11 +576,9 @@ class SmarActOpenLoop(Device):
                          doc='Clear the current step count')
     set_metadata(step_clear_cmd, dict(variety='command-proc', value=1))
     # Scan move
-    scan_move_cmd = Cpt(EpicsSignal, ':SCAN_MOVE', kind='omitted',
-                        doc='Set current piezo voltage (in 16 bit ADC steps)')
-    # Scan pos
-    scan_pos = Cpt(EpicsSignal, ':SCAN_POS', kind='omitted',
-                   doc='Current piezo voltage (in 16 bit ADC steps)')
+    scan_move = Cpt(EpicsSignal, ':SCAN_POS', write_pv=':SCAN_MOVE',
+                    kind='config',
+                    doc='Set current piezo voltage (in 16 bit ADC steps)')
 
 
 class SmarActTipTilt(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds some metadata and updates kind for some motor record fields. Small update to SmarActOpenLoop to clean up the open loop position control because I couldn't resist. 

## Motivation and Context
Closes #695, more details there. 

## How Has This Been Tested?
Tested on a stage in TMO. 

## Where Has This Been Documented?
Just the code. 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/29102919/100551388-f4b31f80-3234-11eb-87de-dfef3e6b576b.png)

![image](https://user-images.githubusercontent.com/29102919/100551402-0bf20d00-3235-11eb-94c6-bd13a1234c56.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
