### PR TITLE
ENH: Gon custom status

### DIFF
--- a/docs/source/upcoming_release_notes/682-Gon_Custom_Status_Print.rst
+++ b/docs/source/upcoming_release_notes/682-Gon_Custom_Status_Print.rst
@@ -1,0 +1,30 @@
+682 Gon Custom Status Print
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add custom status print for `gon` classes: `BaseGon`, `XYZStage` and `Kappa` class.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/docs/source/upcoming_release_notes/682-Gon_Custom_Status_Print.rst
+++ b/docs/source/upcoming_release_notes/682-Gon_Custom_Status_Print.rst
@@ -7,7 +7,7 @@ API Changes
 
 Features
 --------
-- Add custom status print for `gon` classes: `BaseGon`, `XYZStage` and `Kappa` class.
+- Add custom status print for `gon` classes: `BaseGon`, and `XYZStage` class.
 
 Device Updates
 --------------

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -319,5 +319,5 @@ class Kappa(BaseInterface, Device):
         return f"""\
 Kappa
 eta, kappa, phi: {eta:+.4f}, {kappa:+.4f}, {phi:+.4f} [{angle_units}]
-X, Y, Z: {x:+.4f}, {y:+.4f}, {z:+.4f} [{units}]
+x, y, z: {x:+.4f}, {y:+.4f}, {z:+.4f} [{units}]
 """

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -84,8 +84,8 @@ class BaseGon(BaseInterface, Device):
 
         return f"""\
 XPP Goniometer
-H, V: {horiz:+.4f}, {vert:+.4f} [{units}]
-Theta, Pitch, Roll: {rot:+.4f}, {tip:+.4f}, {tilt:+.4f} [{angle_units}]
+H, V: {horiz:.4f}, {vert:.4f} [{units}]
+Theta, Pitch, Roll: {rot:.4f}, {tip:.4f}, {tilt:.4f} [{angle_units}]
 """
 
 
@@ -226,7 +226,7 @@ class XYZStage(BaseInterface, Device):
 
         return f"""\
 XYZStage
-X, Y, Z: {x:+.4f}, {y:+.4f}, {z:+.4f} [{units}]
+X, Y, Z: {x:.4f}, {y:.4f}, {z:.4f} [{units}]
 """
 
 
@@ -318,6 +318,6 @@ class Kappa(BaseInterface, Device):
                                        'units')
         return f"""\
 Kappa
-eta, kappa, phi: {eta:+.4f}, {kappa:+.4f}, {phi:+.4f} [{angle_units}]
-x, y, z: {x:+.4f}, {y:+.4f}, {z:+.4f} [{units}]
+eta, kappa, phi: {eta:.4f}, {kappa:.4f}, {phi:.4f} [{angle_units}]
+x, y, z: {x:.4f}, {y:.4f}, {z:.4f} [{units}]
 """

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -6,7 +6,7 @@ from ophyd import FormattedComponent as FCpt
 
 from .epics_motor import IMS
 from .interface import BaseInterface
-from .utils import get_status_value
+from .utils import get_status_value, get_status_float
 
 
 class BaseGon(BaseInterface, Device):
@@ -72,20 +72,20 @@ class BaseGon(BaseInterface, Device):
         status: str
             Formatted string with all relevant status information.
         """
-        horiz = get_status_value(status_info, 'hor', 'position')
-        vert = get_status_value(status_info, 'ver', 'position')
+        horiz = get_status_float(status_info, 'hor', 'position')
+        vert = get_status_float(status_info, 'ver', 'position')
         units = get_status_value(status_info, 'hor', 'user_setpoint', 'units')
 
-        rot = get_status_value(status_info, 'rot', 'position')
-        tip = get_status_value(status_info, 'tip', 'position')
-        tilt = get_status_value(status_info, 'tilt', 'position')
+        rot = get_status_float(status_info, 'rot', 'position')
+        tip = get_status_float(status_info, 'tip', 'position')
+        tilt = get_status_float(status_info, 'tilt', 'position')
         angle_units = get_status_value(status_info, 'rot', 'user_setpoint',
                                        'units')
 
         return f"""\
 XPP Goniometer
-H, V: {horiz:.4f}, {vert:.4f} [{units}]
-Theta, Pitch, Roll: {rot:.4f}, {tilt:.4f}, {tip:.4f} [{angle_units}]
+H, V: {horiz}, {vert} [{units}]
+Theta, Pitch, Roll: {rot}, {tilt}, {tip} [{angle_units}]
 """
 
 
@@ -219,14 +219,14 @@ class XYZStage(BaseInterface, Device):
 
     def format_status_info(self, status_info):
         """Override status info handler to render the `XYZStage`."""
-        x = get_status_value(status_info, 'x', 'position')
-        y = get_status_value(status_info, 'y', 'position')
-        z = get_status_value(status_info, 'z', 'position')
+        x = get_status_float(status_info, 'x', 'position')
+        y = get_status_float(status_info, 'y', 'position')
+        z = get_status_float(status_info, 'z', 'position')
         units = get_status_value(status_info, 'x', 'user_setpoint', 'units')
 
         return f"""\
 XYZStage
-X, Y, Z: {x:.4f}, {y:.4f}, {z:.4f} [{units}]
+X, Y, Z: {x}, {y}, {z} [{units}]
 """
 
 

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -303,21 +303,3 @@ class Kappa(BaseInterface, Device):
         self._prefix_kappa = prefix_kappa
         self._prefix_phi = prefix_phi
         super().__init__('', name=name, **kwargs)
-
-    def format_status_info(self, status_info):
-        """Override status info handler to render the Kappa object."""
-        x = get_status_value(status_info, 'x', 'position')
-        y = get_status_value(status_info, 'y', 'position')
-        z = get_status_value(status_info, 'z', 'position')
-        units = get_status_value(status_info, 'x', 'user_setpoint', 'units')
-
-        eta = get_status_value(status_info, 'eta', 'position')
-        kappa = get_status_value(status_info, 'kappa', 'position')
-        phi = get_status_value(status_info, 'phi', 'position')
-        angle_units = get_status_value(status_info, 'eta', 'user_setpoint',
-                                       'units')
-        return f"""\
-Kappa
-eta, kappa, phi: {eta:.4f}, {kappa:.4f}, {phi:.4f} [{angle_units}]
-x, y, z: {x:.4f}, {y:.4f}, {z:.4f} [{units}]
-"""

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -6,6 +6,7 @@ from ophyd import FormattedComponent as FCpt
 
 from .epics_motor import IMS
 from .interface import BaseInterface
+from .utils import get_status_value
 
 
 class BaseGon(BaseInterface, Device):
@@ -52,6 +53,40 @@ class BaseGon(BaseInterface, Device):
         self._prefix_tip = prefix_tip
         self._prefix_tilt = prefix_tilt
         super().__init__('', name=name, **kwargs)
+
+    def format_status_info(self, status_info):
+        """
+        Override status info handler to render the xpp goniometer.
+
+        Display xpp goniometer status info in the ipython terminal.
+
+        Parameters
+        ----------
+        status_info: dict
+            Nested dictionary. Each level has keys name, kind, and is_device.
+            If is_device is True, subdevice dictionaries may follow. Otherwise,
+            the only other key in the dictionary will be value.
+
+        Returns
+        -------
+        status: str
+            Formatted string with all relevant status information.
+        """
+        horiz = get_status_value(status_info, 'hor', 'position')
+        vert = get_status_value(status_info, 'ver', 'position')
+        units = get_status_value(status_info, 'hor', 'user_setpoint', 'units')
+
+        rot = get_status_value(status_info, 'rot', 'position')
+        tip = get_status_value(status_info, 'tip', 'position')
+        tilt = get_status_value(status_info, 'tilt', 'position')
+        angle_units = get_status_value(status_info, 'rot', 'user_setpoint',
+                                       'units')
+
+        return f"""\
+XPP Goniometer
+H, V: {horiz}, {vert} [{units}]
+Theta, Pitch, Roll: {rot}, {tip}, {tilt} [{angle_units}]
+"""
 
 
 class GonWithDetArm(BaseGon):

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -84,8 +84,8 @@ class BaseGon(BaseInterface, Device):
 
         return f"""\
 XPP Goniometer
-H, V: {horiz}, {vert} [{units}]
-Theta, Pitch, Roll: {rot}, {tip}, {tilt} [{angle_units}]
+H, V: {horiz:+.4f}, {vert:+.4f} [{units}]
+Theta, Pitch, Roll: {rot:+.4f}, {tip:+.4f}, {tilt:+.4f} [{angle_units}]
 """
 
 
@@ -217,6 +217,18 @@ class XYZStage(BaseInterface, Device):
         self._prefix_z = prefix_z
         super().__init__('', name=name, **kwargs)
 
+    def format_status_info(self, status_info):
+        """Override status info handler to render the `XYZStage`."""
+        x = get_status_value(status_info, 'x', 'position')
+        y = get_status_value(status_info, 'y', 'position')
+        z = get_status_value(status_info, 'z', 'position')
+        units = get_status_value(status_info, 'x', 'user_setpoint', 'units')
+
+        return f"""\
+XYZStage
+X, Y, Z: {x:+.4f}, {y:+.4f}, {z:+.4f} [{units}]
+"""
+
 
 class SamPhi(BaseInterface, Device):
     """
@@ -291,3 +303,21 @@ class Kappa(BaseInterface, Device):
         self._prefix_kappa = prefix_kappa
         self._prefix_phi = prefix_phi
         super().__init__('', name=name, **kwargs)
+
+    def format_status_info(self, status_info):
+        """Override status info handler to render the Kappa object."""
+        x = get_status_value(status_info, 'x', 'position')
+        y = get_status_value(status_info, 'y', 'position')
+        z = get_status_value(status_info, 'z', 'position')
+        units = get_status_value(status_info, 'x', 'user_setpoint', 'units')
+
+        eta = get_status_value(status_info, 'eta', 'position')
+        kappa = get_status_value(status_info, 'kappa', 'position')
+        phi = get_status_value(status_info, 'phi', 'position')
+        angle_units = get_status_value(status_info, 'eta', 'user_setpoint',
+                                       'units')
+        return f"""\
+Kappa
+eta, kappa, phi: {eta:+.4f}, {kappa:+.4f}, {phi:+.4f} [{angle_units}]
+X, Y, Z: {x:+.4f}, {y:+.4f}, {z:+.4f} [{units}]
+"""

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -85,7 +85,7 @@ class BaseGon(BaseInterface, Device):
         return f"""\
 XPP Goniometer
 H, V: {horiz:.4f}, {vert:.4f} [{units}]
-Theta, Pitch, Roll: {rot:.4f}, {tip:.4f}, {tilt:.4f} [{angle_units}]
+Theta, Pitch, Roll: {rot:.4f}, {tilt:.4f}, {tip:.4f} [{angle_units}]
 """
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR might need some more attention, because as of now I have added a custom status for two different classes: `BaseGon`, and `XYZStage` class. 
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to tackle and close https://github.com/pcdshub/pcdsdevices/issues/682#issuecomment-733998450

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
In [1]: xpp_gon
Out[1]:
XPP Goniometer
H, V: 588.6461, 50.4013 [mm]
Theta, Pitch, Roll: -0.0468, 0.0400, 0.0282 [deg]
```
XYZStage:
```
In [5]: s
Out[5]:
XYZStage
X, Y, Z: 8.6988, -12.7856, 0.4693 [mm]
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
