### PR TITLE
MNT: add get_status_float function

### DIFF
--- a/docs/source/upcoming_release_notes/718-Add_get_status_float_function_in_utils.rst
+++ b/docs/source/upcoming_release_notes/718-Add_get_status_float_function_in_utils.rst
@@ -1,0 +1,30 @@
+718 Add get_status_float function in utils
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added a new function in `utils` to get the status value and format that value with the requested precision.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- cristinasewell

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -237,3 +237,34 @@ def get_status_value(status_info, *keys, default_value='N/A'):
         return value
     except KeyError:
         return default_value
+
+
+def get_status_float(status_info, *keys, default_value='N/A', precision=4):
+    """
+    Get the value of a dictionary key.
+
+    Format the value with the precision requested if it is a float value.
+
+    Parameters
+    ----------
+    status_info : dict
+        Dictionary to look through.
+    keys : list
+        List of keys to look through with nested dictionarie.
+    default_value : str
+        A default value to return if the item value was not found.
+    precision: int
+        Precision requested for the float values. Defaults to 4.
+
+    Returns
+    -------
+    value : dictionary item value, or `N/A`
+        Value of the last key in the `keys` list formated with precision.
+    """
+    try:
+        value = reduce(operator.getitem, keys, status_info)
+        if isinstance(value, float):
+            return ('{:.%df}' % precision).format(value)
+        return value
+    except KeyError:
+        return default_value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,3 +68,14 @@ def test_get_status_value():
     assert res == 23
     res = util.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'blah')
     assert res == 'N/A'
+
+
+def test_get_status_float():
+    dummy_dictionary = {'dict1': {'dict2': {'value': 23.34343}}}
+    res = util.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'value')
+    assert res == '23.3434'
+    res = util.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'blah')
+    assert res == 'N/A'
+    res = util.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'value',
+                                precision=3)
+    assert res == '23.343'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a new function in `utils`: `get_status_float` that is very similar to the existing one `get_status_value` except that this one is formatting the value with the precision that was requested by the user. 
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I keep having to format multiple numbers with similar precision of 4 when overriding the `format_status_info`
```
{value:.4f}
```
So this will make it simpler and has an additional check before formatting the value to make sure the value is a float in the first place.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstring
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
