### PR TITLE
ENH: Included Exit slits class

### DIFF
--- a/docs/source/upcoming_release_notes/issue_number-add_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/issue_number-add_ExitSlits.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- ghalym

--- a/docs/source/upcoming_release_notes/issue_number-add_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/issue_number-add_ExitSlits.rst
@@ -1,0 +1,30 @@
+issue_number add ExitSlits
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/issue_number-add_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/issue_number-add_ExitSlits.rst
@@ -15,7 +15,7 @@ Device Updates
 
 New Devices
 -----------
-- N/A
+- Added `ExitSlits` device.
 
 Bugfixes
 --------

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -24,17 +24,16 @@ from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import Signal
 from ophyd.status import wait as status_wait, Status
 
-from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
-                                     PCDSAreaDetectorTyphosTrigger)
+from .areadetector.detectors import (PCDSAreaDetectorTyphosTrigger)
 
-from .epics_motor import BeckhoffAxis, EpicsMotor, PCDSMotorBase
-from .interface import BaseInterface, FltMvInterface, MvInterface,LightpathMixin, LightpathInOutMixin
+from .epics_motor import BeckhoffAxis
+from .interface import (BaseInterface, FltMvInterface, MvInterface,
+                        LightpathMixin, LightpathInOutMixin)
 from .signal import PytmcSignal, NotImplementedSignal
 from .sensors import RTD, TwinCATTempSensor
 from .utils import schedule_task, get_status_value
 
 from .pmps import TwinCATStatePMPS
-from .state import StatePositioner
 from .variety import set_metadata
 
 
@@ -502,9 +501,7 @@ class PowerSlits(BeckhoffSlits):
     fsw = Cpt(NotImplementedSignal, ':FSW', kind='normal')
 
 
-
 class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
- 
     tab_component_names = True
 
     lightpath_cpts = ['target']
@@ -513,15 +510,17 @@ class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
     target = Cpt(TwinCATStatePMPS, ':YAG:STATE', kind='hinted',
                  doc='Control of the YAG  stack via saved positions.')
     yag_motor = Cpt(BeckhoffAxis, ':MMS:YAG', kind='normal',
-                  doc='Direct control of the Yag Stack motor.')
+                    doc='Direct control of the Yag Stack motor.')
     pitch_motor = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='normal',
-                  doc='Direct control of the slits assembly pitch  motor.')
-    vert_motor = Cpt(BeckhoffAxis, ':MMS:VERT', kind='normal',
-                  doc='Direct control of the slits assembly vertical motor.')
+                      doc='Direct control of the slits assembly pitch  motor.')
+    vert_motor = Cpt(
+        BeckhoffAxis, ':MMS:VERT', kind='normal',
+        doc='Direct control of the slits assembly vertical motor.'
+    )
     roll_motor = Cpt(BeckhoffAxis, ':MMS:ROLL', kind='normal',
-                  doc='Direct control of the slits assembly roll motor.')
+                     doc='Direct control of the slits assembly roll motor.')
     gap_motor = Cpt(BeckhoffAxis, ':MMS:GAP', kind='normal',
-                  doc='Direct control of the slits gap  motor.')
+                    doc='Direct control of the slits gap  motor.')
     detector = Cpt(PCDSAreaDetectorTyphosTrigger, ':CAM:', kind='normal',
                    doc='Area detector settings and readbacks.')
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
@@ -534,12 +533,18 @@ class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
               doc='Percent of light from the dimmable illuminatior.')
     yag_thermocouple = Cpt(TwinCATTempSensor, ':RTD:YAG', kind='normal',
                            doc='Thermocouple on the YAG holder.')
-    upper_crystal_thermocouple = Cpt(TwinCATTempSensor, ':RTD:CRYSTAL_TOP', kind='normal',
-                           doc='Thermocouple on the TOP CRYSTAL.')
-    lower_crystal_thermocouple = Cpt(TwinCATTempSensor, ':RTD:CRYSTAL_BOTTOM', kind='normal',
-                           doc='Thermocouple on the BOTTOM CRYSTAL.')
-    heatsync_thermocouple = Cpt(TwinCATTempSensor, ':RTD:HeatSync', kind='normal',
-                           doc='Thermocouple on the Heat Sync.')
+    upper_crystal_thermocouple = Cpt(
+        TwinCATTempSensor, ':RTD:CRYSTAL_TOP', kind='normal',
+        doc='Thermocouple on the TOP CRYSTAL.'
+    )
+    lower_crystal_thermocouple = Cpt(
+        TwinCATTempSensor, ':RTD:CRYSTAL_BOTTOM', kind='normal',
+        doc='Thermocouple on the BOTTOM CRYSTAL.'
+    )
+    heatsync_thermocouple = Cpt(
+        TwinCATTempSensor, ':RTD:HeatSync', kind='normal',
+        doc='Thermocouple on the Heat Sync.'
+    )
     set_metadata(cam_power, dict(variety='command-enum'))
 
     @property

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -24,11 +24,19 @@ from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import Signal
 from ophyd.status import wait as status_wait, Status
 
-from .epics_motor import BeckhoffAxis
-from .interface import FltMvInterface, MvInterface, LightpathMixin
+from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
+                                     PCDSAreaDetectorTyphosTrigger)
+
+from .epics_motor import BeckhoffAxis, EpicsMotor, PCDSMotorBase
+from .interface import BaseInterface, FltMvInterface, MvInterface,LightpathMixin, LightpathInOutMixin
 from .signal import PytmcSignal, NotImplementedSignal
-from .sensors import RTD
+from .sensors import RTD, TwinCATTempSensor
 from .utils import schedule_task, get_status_value
+
+from .pmps import TwinCATStatePMPS
+from .state import StatePositioner
+from .variety import set_metadata
+
 
 logger = logging.getLogger(__name__)
 
@@ -492,3 +500,49 @@ class PowerSlits(BeckhoffSlits):
 
     rtds = DDCpt(_rtd_fields(RTD, 'rtd', range(1, 9)))
     fsw = Cpt(NotImplementedSignal, ':FSW', kind='normal')
+
+
+
+class ExitSlits(BaseInterface,Device,LightpathInOutMixin):
+ 
+    tab_component_names = True
+
+    lightpath_cpts = ['target']
+    _icon = 'fa.video-camera'
+
+    target = Cpt(TwinCATStatePMPS, ':YAG:STATE', kind='hinted',
+                 doc='Control of the YAG  stack via saved positions.')
+    yag_motor = Cpt(BeckhoffAxis, ':MMS:YAG', kind='normal',
+                  doc='Direct control of the Yag Stack motor.')
+    pitch_motor = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='normal',
+                  doc='Direct control of the slits assembly pitch  motor.')
+    vert_motor = Cpt(BeckhoffAxis, ':MMS:VERT', kind='normal',
+                  doc='Direct control of the slits assembly vertical motor.')
+    roll_motor = Cpt(BeckhoffAxis, ':MMS:ROLL', kind='normal',
+                  doc='Direct control of the slits assembly roll motor.')
+    gap_motor = Cpt(BeckhoffAxis, ':MMS:GAP', kind='normal',
+                  doc='Direct control of the slits gap  motor.')
+    detector = Cpt(PCDSAreaDetectorTyphosTrigger, ':CAM:', kind='normal',
+                   doc='Area detector settings and readbacks.')
+    cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',
+                    doc='Camera power supply controls.')
+    fan_power = Cpt(PytmcSignal, ':FAN:PWR', io='io', kind='config',
+                    doc='Fan power supply controls.')
+    led_power = Cpt(PytmcSignal, ':LED:PWR', io='io', kind='config',
+                    doc='LED power supply controls.')
+    led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config',
+              doc='Percent of light from the dimmable illuminatior.')
+    yag_thermocouple = Cpt(TwinCATTempSensor, ':RTD:YAG', kind='normal',
+                           doc='Thermocouple on the YAG holder.')
+    upper_crystal_thermocouple = Cpt(TwinCATTempSensor, ':RTD:CRYSTAL_TOP', kind='normal',
+                           doc='Thermocouple on the TOP CRYSTAL.')
+    lower_crystal_thermocouple = Cpt(TwinCATTempSensor, ':RTD:CRYSTAL_BOTTOM', kind='normal',
+                           doc='Thermocouple on the BOTTOM CRYSTAL.')
+    heatsync_thermocouple = Cpt(TwinCATTempSensor, ':RTD:HeatSync', kind='normal',
+                           doc='Thermocouple on the Heat Sync.')
+    set_metadata(cam_power, dict(variety='command-enum'))
+
+    @property
+    def y_states(self):
+        """Alias old name. Will deprecate."""
+        return self.target

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -503,7 +503,7 @@ class PowerSlits(BeckhoffSlits):
 
 
 
-class ExitSlits(BaseInterface,Device,LightpathInOutMixin):
+class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
  
     tab_component_names = True
 


### PR DESCRIPTION
New class added to slits.py for the exit slits.
## Description
New class added to slits.py for the exit slits. The class contains all the motion pvs, RTDs, Camera and CIL pvs required for the exit slits.


## How Has This Been Tested?
This has been tested from my local directory.


<!--
## Screenshots (if appropriate):
-->
![image](https://user-images.githubusercontent.com/43865116/101234012-e91a8b00-3670-11eb-9a82-ca9ef031dfc5.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
