### PR TITLE
ENH: add LED controls to the Mono

### DIFF
--- a/docs/source/upcoming_release_notes/issue_number-LED_power_add_to_Mono.rst
+++ b/docs/source/upcoming_release_notes/issue_number-LED_power_add_to_Mono.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- ghalym

--- a/docs/source/upcoming_release_notes/issue_number-LED_power_add_to_Mono.rst
+++ b/docs/source/upcoming_release_notes/issue_number-LED_power_add_to_Mono.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- N/A
+- Add LED power to the Mono device.
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/issue_number-LED_power_add_to_Mono.rst
+++ b/docs/source/upcoming_release_notes/issue_number-LED_power_add_to_Mono.rst
@@ -1,0 +1,30 @@
+issue_number LED power add to Mono
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -247,14 +247,14 @@ class Mono(BaseInterface, Device):
                       doc='mirror pitch upstream encoder [urad]')
     g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', io='i', kind='normal',
                       doc='grating pitch upstream encoder [urad]')
-    
+
     # LED PWR
     led_power_1 = Cpt(PytmcSignal, ':LED:01:PWR', io='io', kind='config',
                       doc='LED power supply controls.')
     led_power_2 = Cpt(PytmcSignal, ':LED:02:PWR', io='io', kind='config',
-                    doc='LED power supply controls.')
+                      doc='LED power supply controls.')
     led_power_3 = Cpt(PytmcSignal, ':LED:03:PWR', io='io', kind='config',
-                    doc='LED power supply controls.')
+                      doc='LED power supply controls.')
 
     # Flow switches
     flow_1 = Cpt(PytmcSignal, ':FSW:01', io='i', kind='normal',
@@ -263,7 +263,7 @@ class Mono(BaseInterface, Device):
                  doc='flow switch 2')
     pres_1 = Cpt(PytmcSignal, ':P1', io='i', kind='normal',
                  doc='pressure sensor 1')
-    
+
     # RTDs
     rtd_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
                 doc='RTD 1 [deg C]')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -247,6 +247,14 @@ class Mono(BaseInterface, Device):
                       doc='mirror pitch upstream encoder [urad]')
     g_pi_up_enc = Cpt(PytmcSignal, ':ENC:G_PI:02', io='i', kind='normal',
                       doc='grating pitch upstream encoder [urad]')
+    
+    # LED PWR
+    led_power_1 = Cpt(PytmcSignal, ':LED:01:PWR', io='io', kind='config',
+                    doc='LED power supply controls.')
+    led_power_2 = Cpt(PytmcSignal, ':LED:02:PWR', io='io', kind='config',
+                    doc='LED power supply controls.')
+    led_power_3 = Cpt(PytmcSignal, ':LED:03:PWR', io='io', kind='config',
+                    doc='LED power supply controls.')
 
     # Flow switches
     flow_1 = Cpt(PytmcSignal, ':FSW:01', io='i', kind='normal',
@@ -255,7 +263,7 @@ class Mono(BaseInterface, Device):
                  doc='flow switch 2')
     pres_1 = Cpt(PytmcSignal, ':P1', io='i', kind='normal',
                  doc='pressure sensor 1')
-
+    
     # RTDs
     rtd_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
                 doc='RTD 1 [deg C]')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -250,7 +250,7 @@ class Mono(BaseInterface, Device):
     
     # LED PWR
     led_power_1 = Cpt(PytmcSignal, ':LED:01:PWR', io='io', kind='config',
-                    doc='LED power supply controls.')
+                      doc='LED power supply controls.')
     led_power_2 = Cpt(PytmcSignal, ':LED:02:PWR', io='io', kind='config',
                     doc='LED power supply controls.')
     led_power_3 = Cpt(PytmcSignal, ':LED:03:PWR', io='io', kind='config',


### PR DESCRIPTION
Three LED controls have been added to the Mono
## Description
Three LED controls have been added to the Mono. They can be controlled on/ off.



## How Has This Been Tested?
Yes, this have been tested from my local directory


<!--
## Screenshots (if appropriate):
-->
![image](https://user-images.githubusercontent.com/43865116/101234592-968f9d80-3675-11eb-83ba-96e45254d3fe.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
