### PR TITLE
ENH: Metadata for the SL1K2-Exit LED control - slider widget

### DIFF
--- a/docs/source/upcoming_release_notes/issue_number-update_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/issue_number-update_ExitSlits.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- ghalym

--- a/docs/source/upcoming_release_notes/issue_number-update_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/issue_number-update_ExitSlits.rst
@@ -1,0 +1,30 @@
+issue_number update ExitSlits
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/issue_number-update_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/issue_number-update_ExitSlits.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- N/A
+- led metadata scalar range
 
 New Devices
 -----------

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -531,6 +531,10 @@ class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
                     doc='LED power supply controls.')
     led = Cpt(PytmcSignal, ':CAM:CIL:PCT', io='io', kind='config',
               doc='Percent of light from the dimmable illuminatior.')
+    set_metadata(led, dict(variety='scalar-range',
+                           range={'value': (0, 100),
+                                  'source': 'value'}
+                           ))
     yag_thermocouple = Cpt(TwinCATTempSensor, ':RTD:YAG', kind='normal',
                            doc='Thermocouple on the YAG holder.')
     upper_crystal_thermocouple = Cpt(


### PR DESCRIPTION
Included meta data to the SL1K2-Exit Led control
## Description
Included meta data to the SL1K2-Exit Led control

## Motivation and Context
The LED has an analog control, with the meta data the user can control the output via a slide bar.

## How Has This Been Tested?
This has been tested from my local directory

## Where Has This Been Documented?


<!--
![image](https://user-images.githubusercontent.com/43865116/101416644-21071580-389f-11eb-974a-bdb3bd86261d.png)

-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
