### PR TITLE
DOC: Pre-release docs page fix

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
 doctr
-sphinx >=3.2.1
+sphinx >=3.3.1
 sphinx_rtd_theme

--- a/docs/source/upcoming_release_notes/720-add_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/720-add_ExitSlits.rst
@@ -1,4 +1,4 @@
-issue_number LED power add to Mono
+720 add ExitSlits
 #################
 
 API Changes
@@ -11,11 +11,11 @@ Features
 
 Device Updates
 --------------
-- Add LED power to the Mono device.
+- N/A
 
 New Devices
 -----------
-- N/A
+- Added `ExitSlits` device.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/721-LED_power_add_to_Mono.rst
+++ b/docs/source/upcoming_release_notes/721-LED_power_add_to_Mono.rst
@@ -1,5 +1,5 @@
-issue_number add ExitSlits
-#################
+721 LED power add to Mono
+#########################
 
 API Changes
 -----------
@@ -11,11 +11,11 @@ Features
 
 Device Updates
 --------------
-- N/A
+- Add LED power to the Mono device.
 
 New Devices
 -----------
-- Added `ExitSlits` device.
+- N/A
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/723-update_ExitSlits.rst
+++ b/docs/source/upcoming_release_notes/723-update_ExitSlits.rst
@@ -1,5 +1,5 @@
-issue_number update ExitSlits
-#################
+723 update ExitSlits
+####################
 
 API Changes
 -----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Bump Sphinx requirement to the one I built correctly with locally
- Add missing title information from exit slit pre-release docs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed that the pre-release docs page is empty:
https://pcdshub.github.io/pcdsdevices/v3.3.0/upcoming_changes.html

So I tried to figure out why this could be. These are the only two anomalies I noticed.
My local docs build correctly with this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is docs

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
