### PR TITLE
MNT: clean up average signal to avoid timeout messages

### DIFF
--- a/docs/source/upcoming_release_notes/725-AvgSignal-Spam.rst
+++ b/docs/source/upcoming_release_notes/725-AvgSignal-Spam.rst
@@ -1,0 +1,32 @@
+725 AvgSignal-Spam
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- AvgSignal will no longer spam exceptions text to the terminal when the signal
+  it is averaging is disconnected. This will primarily be noticed in the
+  BeamStats class, loaded in every hutch-python session.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -12,7 +12,7 @@ if __name__ != 'pcdsdevices.signal':
 import logging
 import numbers
 import typing
-from threading import RLock, Thread
+from threading import RLock
 
 import numpy as np
 from ophyd.signal import (DerivedSignal, EpicsSignal, EpicsSignalBase,
@@ -235,18 +235,11 @@ class AvgSignal(Signal):
         self.raw_sig = signal
         self._lock = RLock()
         self.averages = averages
-        self._con = False
-        t = Thread(target=self._init_subs, args=())
-        t.start()
-
-    def _init_subs(self):
-        self.raw_sig.wait_for_connection()
         self.raw_sig.subscribe(self._update_avg)
-        self._con = True
 
     @property
     def connected(self):
-        return self._con
+        return self.raw_sig.connected
 
     @property
     def averages(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The logic in `AvgSignal` (used for gas detector) includes a `wait_for_connection` in a background thread that can time out in many cases with a large traceback.

This pull request replaces that instance with a straightforward `subscribe` call that does not time out, it just sits there and waits for the PV to be connected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm working though a `hutch-python` unit testing bug right now and these tracebacks are annoying.
```
Exception in thread Thread-16:
Traceback (most recent call last):
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/pcdsdevices/signal.py", line 243, in _init_subs
    self.raw_sig.wait_for_connection()
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1032, in wait_for_connection
    self._ensure_connected(self._read_pv, timeout=timeout)
  File "/u1/zlentz/miniconda3/envs/dev/lib/python3.6/site-packages/ophyd/signal.py", line 1011, in _ensure_connected
    raise TimeoutError(f"{pv.pvname} could not connect within "
TimeoutError: GDET:FEE1:241:ENRC could not connect within 1.0-second timeout.
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Hopefully the tests still pass, it looks pretty benign.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added a pre-release docs page

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
