### PR TITLE
ENH: add support for AT1K4 and some status table utilities

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - schema
     - pcdsutils
     - pcdscalc
+    - prettytable
 
 test:
   imports:

--- a/docs/source/upcoming_release_notes/736-sxr_solid_attenuators.rst
+++ b/docs/source/upcoming_release_notes/736-sxr_solid_attenuators.rst
@@ -4,7 +4,7 @@
 API Changes
 -----------
 - Added ``format`` and ``scale`` arguments to
-  :func:`~pcdsdevices.utils.get_status_float`, which are affect floating point
+  :func:`~pcdsdevices.utils.get_status_float`, which affect floating point
   formatting of values available in the ``status_info`` dictionary.
 
 Features

--- a/docs/source/upcoming_release_notes/736-sxr_solid_attenuators.rst
+++ b/docs/source/upcoming_release_notes/736-sxr_solid_attenuators.rst
@@ -1,0 +1,43 @@
+736 sxr_solid_attenuators
+#########################
+
+API Changes
+-----------
+- Added ``format`` and ``scale`` arguments to
+  :func:`~pcdsdevices.utils.get_status_float`, which are affect floating point
+  formatting of values available in the ``status_info`` dictionary.
+
+Features
+--------
+- Added :func:`~pcdsdevices.utils.format_status_table` for ease of generating
+  status tables from ``status_info`` dictionaries.
+- Added :func:`~pcdsdevices.utils.combine_status_info` to simplify joining
+  status information of child components.
+
+Device Updates
+--------------
+- Added the ``active`` component to
+  :class:`~pcdsdevices.attenuator.AttenuatorCalculatorFilter`, indicating
+  whether or not the filter should be used in calculations.
+
+New Devices
+-----------
+- Added :class:`~pcdsdevices.attenuator.AT1K4` and supporting SXR solid
+  attenuator classes, including
+  :class:`~pcdsdevices.attenuator.AttenuatorCalculatorSXR_Blade`,
+  :class:`~pcdsdevices.attenuator.AttenuatorCalculatorSXR_FourBlade`, and
+  :class:`~pcdsdevices.attenuator.AttenuatorSXR_Ladder`.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Updated AT2L0 to use newer status formatting utilities.
+- Added prettytable as an explicit dependency.  It was previously assumed to
+  be installed with a sub-dependency.
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -20,7 +20,7 @@ from .epics_motor import BeckhoffAxis
 from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
 from .signal import InternalSignal, _OptionalEpicsSignal
-from .utils import get_status_value
+from .utils import get_status_float, get_status_value
 from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
@@ -901,19 +901,23 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
         """
         Override status info handler to render the attenuator.
         """
-        transmission = get_status_value(
-            status_info, 'calculator', 'actual_transmission', 'value',
-            default_value=0.0,
+        calc_status = status_info.get('calculator', {})
+        transmission = get_status_float(
+            calc_status, 'actual_transmission', 'value',
+            format='E', precision=3,
         )
-        transmission_3 = get_status_value(
-            status_info, 'calculator', 'actual_transmission_3omega', 'value',
-            default_value=0.0,
+        transmission_3 = get_status_float(
+            calc_status, 'actual_transmission_3omega', 'value',
+            format='E', precision=3,
         )
-        energy = get_status_value(
-            status_info, 'calculator', 'energy_actual', 'value',
-            default_value=0.0,
-        ) / 1e3
-
+        energy = get_status_float(
+            calc_status, 'energy_actual', 'value',
+            scale=1e-3,
+        )
+        energy_3 = get_status_float(
+            calc_status, 'energy_actual', 'value',
+            scale=3 * 1e-3,
+        )
         cpt_states = [
             get_status_value(
                 status_info, cpt, 'state', 'state', 'value',
@@ -931,8 +935,8 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
 
         return f"""
 {table}
-Transmission (E={energy:.3} keV): {transmission:.4E}
-Transmission for 3rd harmonic (E={energy * 3.0:.3} keV): {transmission_3:.4E}
+Transmission (E={energy} keV): {transmission}
+Transmission for 3rd harmonic (E={energy_3} keV): {transmission_3}
 """
 
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -888,7 +888,10 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
 
     def _setup_move(self, position):
         """(PVPositioner compat) - calculate, then move."""
-        self.calculator.calculate(position)
+        # Do not call `calculator.calculate()` here to respect the current
+        # calculator settings:
+        self.calculator.desired_transmission.put(position)
+        self.calculator.run_calculation.put(1, wait=True)
         return super()._setup_move(position)
 
     def _set_lightpath_states(self, lightpath_values):
@@ -1027,7 +1030,10 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathInOutMixin):
 
     def _setup_move(self, position):
         """(PVPositioner compat) - calculate, then move."""
-        self.calculator.calculate(position)
+        # Do not call `calculator.calculate()` here to respect the current
+        # calculator settings:
+        self.calculator.desired_transmission.put(position)
+        self.calculator.run_calculation.put(1, wait=True)
         return super()._setup_move(position)
 
     def __init__(self, *args, limits=None, **kwargs):

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -808,16 +808,16 @@ class AttenuatorCalculatorSXR_FourBlade(AttenuatorCalculatorBase):
     # Not using "DDC" here, so the parent is `self`:
     _filter_parent = None
     _filter_index_to_attr = {
-        1: 'axis_01',
-        2: 'axis_02',
-        3: 'axis_03',
-        4: 'axis_04',
+        1: 'blade_01',
+        2: 'blade_02',
+        3: 'blade_03',
+        4: 'blade_04',
     }
 
-    axis_01 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:01:', index=1)
-    axis_02 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:02:', index=2)
-    axis_03 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:03:', index=3)
-    axis_04 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:04:', index=4)
+    blade_01 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:01:', index=1)
+    blade_02 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:02:', index=2)
+    blade_03 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:03:', index=3)
+    blade_04 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:04:', index=4)
 
     def format_status_info(self, status_info):
         """

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1096,6 +1096,44 @@ class BladeStateEnum(enum.Enum):
         }.get(self, '?')
 
 
+class LadderBladeState(enum.IntEnum):
+    """
+    SXR attenuator ladder motion states.
+    """
+    # 'Moving' is also: "unknown" or "between states"
+    Moving = 0
+
+    # 'Out' is fixed at 1:
+    Out = 1
+
+    # And any "in" states follow:
+    In_01 = 2
+    In_02 = 3
+    In_03 = 4
+    In_04 = 5
+    In_05 = 6
+    In_06 = 7
+    In_07 = 8
+    In_08 = 9
+
+    @property
+    def filter_index(self):
+        """The one-based filter index, if inserted."""
+        if not self.is_inserted:
+            return None
+        return self.value - 1
+
+    @property
+    def is_inserted(self):
+        """Is a filter inserted?"""
+        return self not in {LadderBladeState.Moving, LadderBladeState.Out}
+
+    @property
+    def is_moving(self) -> bool:
+        """Is the blade moving?"""
+        return self == LadderBladeState.Moving
+
+
 def get_blade_enum(value):
     try:
         return BladeStateEnum[value]

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -728,15 +728,15 @@ class AttenuatorCalculatorSXR_Blade(AttenuatorCalculatorFilter):
     A single blade, holding up to 8 filters.
     """
     tab_component_names = True
-    filter_01 = Cpt(AttenuatorCalculatorFilter, ':FILTER:01:', index=1)
-    filter_02 = Cpt(AttenuatorCalculatorFilter, ':FILTER:02:', index=2)
-    filter_03 = Cpt(AttenuatorCalculatorFilter, ':FILTER:03:', index=3)
-    filter_04 = Cpt(AttenuatorCalculatorFilter, ':FILTER:04:', index=4)
-    filter_05 = Cpt(AttenuatorCalculatorFilter, ':FILTER:05:', index=5)
-    filter_06 = Cpt(AttenuatorCalculatorFilter, ':FILTER:06:', index=6)
-    filter_07 = Cpt(AttenuatorCalculatorFilter, ':FILTER:07:', index=7)
-    filter_08 = Cpt(AttenuatorCalculatorFilter, ':FILTER:08:', index=8)
-    inserted_filter_index = Cpt(EpicsSignalRO, ':InsertedFilter_RBV',
+    filter_01 = Cpt(AttenuatorCalculatorFilter, 'FILTER:01:', index=1)
+    filter_02 = Cpt(AttenuatorCalculatorFilter, 'FILTER:02:', index=2)
+    filter_03 = Cpt(AttenuatorCalculatorFilter, 'FILTER:03:', index=3)
+    filter_04 = Cpt(AttenuatorCalculatorFilter, 'FILTER:04:', index=4)
+    filter_05 = Cpt(AttenuatorCalculatorFilter, 'FILTER:05:', index=5)
+    filter_06 = Cpt(AttenuatorCalculatorFilter, 'FILTER:06:', index=6)
+    filter_07 = Cpt(AttenuatorCalculatorFilter, 'FILTER:07:', index=7)
+    filter_08 = Cpt(AttenuatorCalculatorFilter, 'FILTER:08:', index=8)
+    inserted_filter_index = Cpt(EpicsSignalRO, 'InsertedFilter_RBV',
                                 kind='normal')
 
     _filter_index_to_attr = {
@@ -776,11 +776,12 @@ class AttenuatorCalculatorSXR_Blade(AttenuatorCalculatorFilter):
             row_identifier='Filter',
         )
 
-        if inserted_filter is not None and inserted_filter > 0:
+        if inserted_filter is not None and inserted_filter > 1:
+            # Subtract 1 from the filter to match state -> filter index
             inserted_info = (
-                f'Inserted filter: #{inserted_filter}'
-                f'{material} {thickness} um (T={transmission} '
-                f'T3={transmission3})'
+                f'Inserted filter: #{inserted_filter - 1} ('
+                f'{material} {thickness} um T={transmission} '
+                f'at 3 omega={transmission3})'
             )
         else:
             inserted_info = 'Inserted filter: None'
@@ -815,10 +816,10 @@ class AttenuatorCalculatorSXR_FourBlade(AttenuatorCalculatorBase):
         4: 'axis_04',
     }
 
-    axis_01 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:01', index=1)
-    axis_02 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:02', index=2)
-    axis_03 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:03', index=3)
-    axis_04 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:04', index=4)
+    axis_01 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:01:', index=1)
+    axis_02 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:02:', index=2)
+    axis_03 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:03:', index=3)
+    axis_04 = Cpt(AttenuatorCalculatorSXR_Blade, ':AXIS:04:', index=4)
 
     def format_status_info(self, status_info):
         """

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -717,6 +717,26 @@ class AttenuatorCalculator_AT2L0(AttenuatorCalculatorBase):
          }
     )
 
+    def format_status_info(self, status_info):
+        """
+        Override status info handler to render the attenuator.
+        """
+        table = utils.format_status_table(
+            status_info.get('filters', {}),
+            row_to_key=self._filter_index_to_attr,
+            column_to_key={
+                'Active': 'active',
+                'Material': 'material',
+                'Thickness [um]': 'thickness',
+                'Stuck': 'is_stuck',
+                'Transmission': 'transmission',
+                'Transmission 3 Omega': 'transmission_3omega',
+            },
+            row_identifier='Filter',
+        )
+
+        return str(table)
+
 
 class AttenuatorCalculatorSXR_Blade(AttenuatorCalculatorFilter):
     # TODO FltMvInterface?
@@ -764,7 +784,7 @@ class AttenuatorCalculatorSXR_Blade(AttenuatorCalculatorFilter):
             column_to_key={
                 'Active': 'active',
                 'Material': 'material',
-                'Thickness': 'thickness',
+                'Thickness [um]': 'thickness',
                 'Stuck': 'is_stuck',
                 'Transmission': 'transmission',
                 'Transmission 3 Omega': 'transmission_3omega',

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -19,7 +19,7 @@ from .component import UnrelatedComponent as UCpt
 from .epics_motor import BeckhoffAxis
 from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
-from .signal import InternalSignal, _OptionalEpicsSignal
+from .signal import InternalSignal
 from .utils import get_status_float, get_status_value
 from .variety import set_metadata
 
@@ -478,9 +478,7 @@ class AttenuatorCalculatorFilter(BaseInterface, Device):
         doc='Thickness in micron',
     )
     active = Cpt(
-        # TODO: this is *new* API. I want to unify AT2L0/AT1K4, but need
-        # time to get there.
-        _OptionalEpicsSignal, 'Active', kind='normal',
+        EpicsSignal, 'Active', kind='normal',
         doc='Should the filter be used in calculations?',
     )
     is_stuck = Cpt(

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -777,7 +777,7 @@ class AttenuatorCalculatorSXR_Blade(AttenuatorCalculatorFilter):
             inserted_info = (
                 f'Inserted filter: #{inserted_filter - 1} ('
                 f'{material} {thickness} um T={transmission} '
-                f'at 3 omega={transmission3})'
+                f'T3={transmission3})'
             )
         else:
             inserted_info = 'Inserted filter: None'

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -261,6 +261,7 @@ class BaseInterface:
             status_text = (f'{self}: Error showing status information. '
                            'Check IOC connection and device health.')
             logger.debug(status_text, exc_info=True)
+            raise
         pp.text(status_text)
 
     def format_status_info(self, status_info):

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -1,14 +1,15 @@
+import operator
 import os
 import select
 import shutil
 import sys
 import threading
 import time
-import operator
 from functools import reduce
 
 import ophyd
 import pint
+import prettytable
 
 try:
     import termios
@@ -268,3 +269,63 @@ def get_status_float(status_info, *keys, default_value='N/A', precision=4):
         return value
     except KeyError:
         return default_value
+
+
+def format_status_table(status_info, row_to_key, column_to_key,
+                        row_identifier='Index'):
+    """
+    Create a PrettyTable based on status information.
+
+    Parameters
+    ----------
+    status_info : dict
+        The status information dictionary.
+
+    row_to_key : dict
+        Dictionary of the form ``{'display_text': 'status_key'}``.
+
+    column_to_key : dict
+        Dictionary of the form ``{'display_text': 'status_key'}``.
+
+    row_identifier : str, optional
+        What to show for the first column, likely an 'Index' or 'Component'.
+    """
+
+    table = prettytable.PrettyTable()
+    table.field_names = [row_identifier] + list(column_to_key)
+    for row_name, row_key in row_to_key.items():
+        row = [
+            get_status_value(status_info, row_key, key, 'value')
+            for key in column_to_key.values()
+        ]
+        table.add_row([str(row_name)] + row)
+
+    return table
+
+
+def combine_status_info(obj, status_info, attrs, separator='\n= {attr} ='):
+    """
+    Combine status information from the given attributes.
+
+    Parameters
+    ----------
+    obj : OphydObj
+        The parent ophyd object.
+
+    status_info : dict
+        The status information dictionary.
+
+    attrs : sequence of str
+        The attribute names.
+
+    separator : str, optional
+        The separator line between the statuses.  May be formatted
+        with variables ``attr``, ``parent``, or ``child``.
+    """
+    lines = []
+    for attr in attrs:
+        child = getattr(obj, attr)
+        lines.append(separator.format(attr=attr, parent=obj, child=child))
+        lines.append(child.format_status_info(status_info[attr]))
+
+    return '\n'.join(lines)

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -240,7 +240,8 @@ def get_status_value(status_info, *keys, default_value='N/A'):
         return default_value
 
 
-def get_status_float(status_info, *keys, default_value='N/A', precision=4):
+def get_status_float(status_info, *keys, default_value='N/A', precision=4,
+                     format='f', scale=1.0):
     """
     Get the value of a dictionary key.
 
@@ -254,8 +255,12 @@ def get_status_float(status_info, *keys, default_value='N/A', precision=4):
         List of keys to look through with nested dictionarie.
     default_value : str
         A default value to return if the item value was not found.
-    precision: int
+    precision : int
         Precision requested for the float values. Defaults to 4.
+    format : str
+        Format specifier to use for the floating point value. Defaults to 'f'.
+    scale : float
+        Scale to apply to value prior to formatting.
 
     Returns
     -------
@@ -264,8 +269,9 @@ def get_status_float(status_info, *keys, default_value='N/A', precision=4):
     """
     try:
         value = reduce(operator.getitem, keys, status_info)
-        if isinstance(value, float):
-            return ('{:.%df}' % precision).format(value)
+        if isinstance(value, (int, float)):
+            value = float(value) * scale
+            return ('{:.%d%s}' % (precision, format)).format(value)
         return value
     except KeyError:
         return default_value

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scipy
 schema
 pcdsutils
 pcdscalc
+prettytable


### PR DESCRIPTION
## Description
Preliminary working AT1K4 support (and other 4-blade, <= 8 filter L2SI attenuators).

## Motivation and Context
Closes #736 
Closes #732 (semi-related as prettytable is used here)

Naming was OK'd before making this ready to review, though we all agree that `SXR_` is a bit unsightly.

## How Has This Been Tested?
* Interactive testing. 
* Test suite

## Where Has This Been Documented?
Docstrings.

## Screenshots (if appropriate):
Table and status joining utilities:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/5139267/104227590-826e5700-53fe-11eb-9b1c-3b5c7977e9f5.png">

Previous ascii art table sadly wasn't enough when you have a bunch of filters per blade. Added new one:
<img width="384" alt="image" src="https://user-images.githubusercontent.com/5139267/104227627-90bc7300-53fe-11eb-809a-00dc020e8a4f.png">

And WIP typhos screen:

<img width="617" alt="image" src="https://user-images.githubusercontent.com/5139267/104530386-b2fdee80-55c0-11eb-9e85-fe6ba6a73809.png">

## Cross-references
IOC support: https://github.com/pcdshub/solid-attenuator/
Screens: https://github.com/pcdshub/typhos/pull/416

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
- [x] Excessive screenshots included