### PR TITLE
Vcn limit 

### DIFF
--- a/docs/source/upcoming_release_notes/739-add_upper_limit_threshold_to_vcn.rst
+++ b/docs/source/upcoming_release_notes/739-add_upper_limit_threshold_to_vcn.rst
@@ -1,4 +1,4 @@
-issue_number add upper limit threshold to vcn
+739 add upper limit threshold to vcn
 #################
 
 API Changes
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- N/A
+- VCN upper limit can be changed from epics.
 
 New Devices
 -----------
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- mghaly

--- a/docs/source/upcoming_release_notes/issue_number-add_upper_limit_threshold_to_vcn.rst
+++ b/docs/source/upcoming_release_notes/issue_number-add_upper_limit_threshold_to_vcn.rst
@@ -1,0 +1,30 @@
+issue_number add upper limit threshold to vcn
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -330,6 +330,9 @@ class VCN(Device):
     position_control = Cpt(EpicsSignalWithRBV, ':POS_REQ', kind='normal',
                            doc=('requested positition to control the valve '
                                 '0-100%'))
+    upper_limit = Cpt(EpicsSignalWithRBV, ':Limit', kind='normal',
+                      doc=('max upper limit position to open the valve '
+                           '0-100%'))
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock ok status')
     open_command = Cpt(EpicsSignalWithRBV, ':OPN_SW', kind='normal',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The upper limit of the VCN ( how much the VCN can open) can now be set from epics. This adds another way to safely operate the vcn.

## Motivation and Context
The VCN can be set to fully open, which can lead to vacuum events. Now, the Upper limit can be set from epics to prevent the operator from fully opening the VCN unintentionally.

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/43865116/104241138-0da51800-5412-11eb-8a6a-3441b0f14245.png)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43865116/104241328-59f05800-5412-11eb-9a55-2f59632a4763.png)

-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
