### PR TITLE
Fix 3rd att transmission status

### DIFF
--- a/docs/source/upcoming_release_notes/742-Fix_3rd_Att_Transmission_Status.rst
+++ b/docs/source/upcoming_release_notes/742-Fix_3rd_Att_Transmission_Status.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- cristinasewell

--- a/docs/source/upcoming_release_notes/742-Fix_3rd_Att_Transmission_Status.rst
+++ b/docs/source/upcoming_release_notes/742-Fix_3rd_Att_Transmission_Status.rst
@@ -1,0 +1,30 @@
+742 Fix 3rd Att Transmission Status
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- The transmission status value for the 3rd harmonic has been fixed, it was previously using the wrong value.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -317,12 +317,13 @@ class AttBase(FltMvInterface, PVPositioner):
             status_info, 'energy_3rd', 'value', scale=1e3, precision=3)
         trans = get_status_float(
             status_info, 'position', precision=4, format='E')
+        trans_3rd = get_status_float(
+            status_info, 'readback_3rd', 'value', precision=4, format='E')
 
-        if energy != 'N/A':
-            energy = energy * 1e3
         if energy_3rd != 'N/A':
             status_3rd = (
-                f'Transmission for 3rd harmonic (E={energy_3rd} keV): {trans}'
+                f'Transmission for 3rd harmonic (E={energy_3rd} keV): '
+                f'{trans_3rd}'
             )
         else:
             status_3rd = ''

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -312,9 +312,9 @@ class AttBase(FltMvInterface, PVPositioner):
         states = '\n'.join(render_ascii_att(blade_states))
 
         energy = get_status_float(
-            status_info, 'energy', 'value', scale=1e3, precision=3)
+            status_info, 'energy', 'value', scale=1e-3, precision=3)
         energy_3rd = get_status_float(
-            status_info, 'energy_3rd', 'value', scale=1e3, precision=3)
+            status_info, 'energy_3rd', 'value', scale=1e-3, precision=3)
         trans = get_status_float(
             status_info, 'position', precision=4, format='E')
         trans_3rd = get_status_float(

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -19,7 +19,7 @@ from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
 from .signal import InternalSignal
 from .variety import set_metadata
-from .utils import get_status_value
+from .utils import get_status_value, get_status_float
 
 logger = logging.getLogger(__name__)
 MAX_FILTERS = 12
@@ -309,21 +309,24 @@ class AttBase(FltMvInterface, PVPositioner):
 
         states = '\n'.join(render_ascii_att(blade_states))
 
-        energy = get_status_value(status_info, 'energy', 'value') * 1e3
-        energy_3rd = get_status_value(status_info, 'energy_3rd', 'value')
-        trans = get_status_value(status_info, 'position')
+        energy = (get_status_float(status_info, 'energy', 'value', precision=3)
+                  * 1e3)
+        energy_3rd = get_status_float(status_info, 'energy_3rd', 'value',
+                                      precision=3)
+        trans = get_status_float(status_info, 'position')
+        trans_3rd = get_status_float(status_info, 'readback_3rd', 'value')
 
         if energy_3rd != 'N/A':
             energy_3rd = energy_3rd * 1e3
             return f"""\
 {states}
-Transmission for 1st harmonic (E={energy:.3} keV): {trans:.4E}
-Transmission for 3rd harmonic (E={energy_3rd:.3} keV): {trans:.4E}
+Transmission for 1st harmonic (E={energy} keV): {trans}
+Transmission for 3rd harmonic (E={energy_3rd} keV): {trans_3rd}
 """
         else:
             return f"""\
 {states}
-Transmission for 1st harmonic (E={energy:.3} keV): {trans:.4E}
+Transmission for 1st harmonic (E={energy} keV): {trans}
 """
 
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -309,13 +309,14 @@ class AttBase(FltMvInterface, PVPositioner):
 
         states = '\n'.join(render_ascii_att(blade_states))
 
-        energy = (get_status_float(status_info, 'energy', 'value', precision=3)
-                  * 1e3)
+        energy = get_status_float(status_info, 'energy', 'value', precision=3)
         energy_3rd = get_status_float(status_info, 'energy_3rd', 'value',
                                       precision=3)
         trans = get_status_float(status_info, 'position')
         trans_3rd = get_status_float(status_info, 'readback_3rd', 'value')
 
+        if energy != 'N/A':
+            energy = energy * 1e3
         if energy_3rd != 'N/A':
             energy_3rd = energy_3rd * 1e3
             return f"""\

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -19,7 +19,7 @@ from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
 from .signal import InternalSignal
 from .variety import set_metadata
-from .utils import get_status_value, get_status_float
+from .utils import get_status_value
 
 logger = logging.getLogger(__name__)
 MAX_FILTERS = 12
@@ -311,9 +311,8 @@ class AttBase(FltMvInterface, PVPositioner):
 
         energy = get_status_value(status_info, 'energy', 'value')
         energy_3rd = get_status_value(status_info, 'energy_3rd', 'value')
-        trans = get_status_float(status_info, 'position', precision=4)
-        trans_3rd = get_status_float(status_info, 'readback_3rd', 'value',
-                                     precision=4)
+        trans = get_status_value(status_info, 'position')
+        trans_3rd = get_status_value(status_info, 'readback_3rd', 'value')
 
         if energy != 'N/A':
             energy = energy * 1e3
@@ -321,8 +320,8 @@ class AttBase(FltMvInterface, PVPositioner):
             energy_3rd = energy_3rd * 1e3
             return f"""\
 {states}
-Transmission for 1st harmonic (E={energy:.3E} keV): {trans}
-Transmission for 3rd harmonic (E={energy_3rd:.3E} keV): {trans_3rd}
+Transmission for 1st harmonic (E={energy:.3E} keV): {trans:.4E}
+Transmission for 3rd harmonic (E={energy_3rd:.3E} keV): {trans_3rd:.4E}
 """
         else:
             return f"""\

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -309,11 +309,11 @@ class AttBase(FltMvInterface, PVPositioner):
 
         states = '\n'.join(render_ascii_att(blade_states))
 
-        energy = get_status_float(status_info, 'energy', 'value', precision=3)
-        energy_3rd = get_status_float(status_info, 'energy_3rd', 'value',
-                                      precision=3)
-        trans = get_status_float(status_info, 'position')
-        trans_3rd = get_status_float(status_info, 'readback_3rd', 'value')
+        energy = get_status_value(status_info, 'energy', 'value')
+        energy_3rd = get_status_value(status_info, 'energy_3rd', 'value')
+        trans = get_status_float(status_info, 'position', precision=4)
+        trans_3rd = get_status_float(status_info, 'readback_3rd', 'value',
+                                     precision=4)
 
         if energy != 'N/A':
             energy = energy * 1e3
@@ -321,8 +321,8 @@ class AttBase(FltMvInterface, PVPositioner):
             energy_3rd = energy_3rd * 1e3
             return f"""\
 {states}
-Transmission for 1st harmonic (E={energy} keV): {trans}
-Transmission for 3rd harmonic (E={energy_3rd} keV): {trans_3rd}
+Transmission for 1st harmonic (E={energy:.3E} keV): {trans}
+Transmission for 3rd harmonic (E={energy_3rd:.3E} keV): {trans_3rd}
 """
         else:
             return f"""\

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -326,7 +326,7 @@ Transmission for 3rd harmonic (E={energy_3rd:.3E} keV): {trans_3rd:.4E}
         else:
             return f"""\
 {states}
-Transmission for 1st harmonic (E={energy} keV): {trans}
+Transmission for 1st harmonic (E={energy:.3E} keV): {trans:.4E}
 """
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Have corrected the transmission status for the 3rd harmonic by reading this value from the `readback_3rd` which is the signal for `:COM:R3_CUR` this PV - based on a little bit of research this seems the appropriate PV to use for the transmission of the 3rd harmonic. Please see the discussion here: https://github.com/pcdshub/pcdsdevices/issues/675#issuecomment-755131529
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix the status information for the 3rd harmonic transmission value.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
happi load mfx_attenuator

In [1]: mfx_attenuator
Out[1]:
filter # |0|1|2|3|4|5|6|7|8|9|
 OUT     |X|X| | | |X|X|X|X|X|
 IN      | | |X|X|X| | | | | |
Transmission for 1st harmonic (E=13.000 keV): 4.0911E-01
Transmission for 3rd harmonic (E=39.000 keV): 9.2504E-01
```

```
happi load at1l0

In [1]: at1l0
Out[1]:
filter # |0|1|2|3|4|5|6|7|8|
 OUT     |X|X|X|X|X|X| | | |
 IN      | | | | | | |X|X|X|
Transmission for 1st harmonic (E=15.862 keV): 1.0000E+00
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
