### PR TITLE
ENH: CVMI and KTOF class, LAMP docstring fix

### DIFF
--- a/docs/source/upcoming_release_notes/744-cvmi-motion-class.rst
+++ b/docs/source/upcoming_release_notes/744-cvmi-motion-class.rst
@@ -1,0 +1,31 @@
+744 cvmi-motion-class
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- pcdsdevices.cvmi_motion.CVMI
+- pcdsdevices.cvmi_motion.KTOF
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- sheppard

--- a/docs/source/upcoming_release_notes/744-cvmi-motion-class.rst
+++ b/docs/source/upcoming_release_notes/744-cvmi-motion-class.rst
@@ -3,7 +3,8 @@
 
 API Changes
 -----------
-- N/A
+- CVMI Motion System Prefix: 'TMO:CVMI'
+- KTOF Motion System Prefix: 'TMO:KTOF'
 
 Features
 --------

--- a/pcdsdevices/cvmi_motion.py
+++ b/pcdsdevices/cvmi_motion.py
@@ -11,11 +11,11 @@ from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
 
 
-class LAMP(BaseInterface, Device):
+class CVMI(BaseInterface, Device):
     """
-    LAMP Motion Class
+    CVMI Motion Class
 
-    This class controls motors fixed to the LAMP Motion system for the IP1
+    This class controls motors fixed to the CVMI Motion system for the IP1
     endstation in TMO.
 
     Parameters
@@ -39,6 +39,29 @@ class LAMP(BaseInterface, Device):
     gas_needle_y = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
     gas_needle_z = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
 
-    sample_paddle_x = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
-    sample_paddle_y = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
-    sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')
+    sample_paddle = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
+
+
+class KTOF(BaseInterface, Device):
+    """
+    KTOF Motion Class
+
+    This class controls motors fixed to the KTOF Motion system for the IP1
+    endstation in TMO.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the LAMP motion system
+
+    name : str
+        Alias for the device
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+    tab_component_names = True
+
+    # Motor components
+    spec_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    spec_y = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+    spec_z = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Added two motion classes: `cvmi_motion.CVMI` and `cvmi_motion.KTOF` including components for the fixed Beckhoff axes of these TMO-IP1 motion systems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need motion control of the CVMI/KTOF endstation systems in order to perform Epics checkouts. The current CVMI/KTOF classes are simply a copy/paste of the LAMP class with updated in order to complete the CVMI/KTOF checkouts without modifying the LAMP system. Eventually, it seems worthwhile to restructure the TMO motion classes into a single file `tmo_ip1_motion.py` with `class IP1Base` including the Gas Jet/Gas Needle axis components that `class LAMP` and `class CVMI` could inherit from.

## How Has This Been Tested?
Local testing from psbuild-rhel7-01 using:
```
$ export PYTHONPATH=`pwd`:$PYTHONPATH
$ typhos 'pcdsdevices.cvmi_motion.CVMI[{"prefix":"TMO:CVMI"}]'
$ typhos 'pcdsdevices.cvmi_motion.CVMI[{"prefix":"TMO:KTOF"}]'
```
## Where Has This Been Documented?
Docstrings

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
