### PR TITLE
DEV: added GHCPLC class.

### DIFF
--- a/docs/source/upcoming_release_notes/749-GHC.rst
+++ b/docs/source/upcoming_release_notes/749-GHC.rst
@@ -1,0 +1,32 @@
+749 GHC
+#######
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- Add GHCPLC (Hot Cathode) class as a counterpart to the GCCPLC (Cold Cathode)
+  class.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- adpai
+- zllentz

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -198,9 +198,25 @@ class GaugePLC(Device):
 class GCCPLC(GaugePLC):
     """Class for a Cold Cathode Gauge controlled by PLC."""
     high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='normal',
-                          doc='command to switch the hight voltage on')
+                          doc='command to switch the high voltage on')
     high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_DO_RBV', kind='normal',
                                doc=('enables the high voltage on the cold '
+                                    'cathode gauge'))
+    protection_setpoint = Cpt(EpicsSignalWithRBV, ':PRO_SP', kind='normal',
+                              doc=('Protection setpoint for ion gauges at '
+                                   'which the gauge turns off'))
+    setpoint_hysterisis = Cpt(EpicsSignalWithRBV, ':SP_HYS', kind='config',
+                              doc='Protection setpoint hysteresis')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+                       doc='Interlock is ok')
+
+
+class GHCPLC(GaugePLC):
+    """Class for a Hot Cathode Gauge controlled by PLC."""
+    high_voltage_on = Cpt(EpicsSignalWithRBV, ':HV_SW', kind='normal',
+                          doc='command to switch the high voltage on')
+    high_voltage_disable = Cpt(EpicsSignalRO, ':HV_DIS_DO_RBV', kind='normal',
+                               doc=('enables the high voltage on the hot '
                                     'cathode gauge'))
     protection_setpoint = Cpt(EpicsSignalWithRBV, ':PRO_SP', kind='normal',
                               doc=('Protection setpoint for ion gauges at '


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
the GCCPLC class was copied and the word cold was switched out for hot.

## Motivation and Context
Currently the Hot cathodes does not have an expert screen. The stop gap measure was the use a cold cathode expert screen

## How Has This Been Tested?
Yes, the screenshot shows that the expert screen has been tested . Flake8 has already been checked.

## Where Has This Been Documented?
There is a comment under the GHCPLC class

<!--
## Screenshots (if appropriate):
-->
![image](https://user-images.githubusercontent.com/42284230/106974618-dcb2bd00-6709-11eb-9746-9b3e0914a416.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
