### PR TITLE
MNT:  Fixed Target Scan - split into one file per sample

### DIFF
--- a/pcdsdevices/targets.py
+++ b/pcdsdevices/targets.py
@@ -940,13 +940,13 @@ class XYGridStage():
         self.positions_y = y_points
         return x_points, y_points
 
-    def is_target_shot(self, sample, m, n, path=None):
+    def is_target_shot(self, m, n, sample=None, path=None):
         """
         Check to see if the target position at MxN is shot.
 
         Parameters
         ----------
-        sample_name : str
+        sample_name : str, optional
             The name of the sample to get the mapped points from. To see the
             available mapped samples call the `mapped_samples()` method.
         m_point : int
@@ -961,10 +961,11 @@ class XYGridStage():
         is_shot : bool
             Indicates is target is shot or not.
         """
-        path = path or os.path.join(self._path, sample + '.yml')
-        x, y = self.compute_mapped_point(sample_name=sample, m_row=m,
-                                         n_column=n, compute_all=False,
-                                         path=path)
+        sample = sample or self.current_sample
+        path = path or self.current_sample_path
+        x, y = self.compute_mapped_point(m_row=m,
+                                         n_column=n,
+                                         sample_name=sample, path=path)
 
         data = self.get_sample_data(sample)
         xx = data.get('xx')
@@ -1057,7 +1058,6 @@ class XYGridStage():
         sample_name = self.current_sample
         if sample_name:
             n, m = self.compute_mapped_point(m_row=m, n_column=n)
-        # TODO is it safe to do this here or should i be adding some checks?
         self.x.mv(n)
         self.y.mv(m)
 
@@ -1075,8 +1075,9 @@ class XYGridStage():
         n : int
             Indicates the column on the grid.
         """
+        entry = os.path.join(self._path, sample + '.yml')
         n, m = self.compute_mapped_point(m_row=m, n_column=n,
-                                         sample_name=sample, path=None)
+                                         sample_name=sample, path=entry)
         self.x.mv(n)
         self.y.mv(m)
 

--- a/pcdsdevices/targets.py
+++ b/pcdsdevices/targets.py
@@ -620,6 +620,20 @@ class XYGridStage():
         """
         self._current_sample = str(sample_name)
 
+    @property
+    def current_sample_path(self):
+        """
+        Get the current path for the sample that is loaded.
+
+        Returns
+        -------
+        sample: dict
+        Dictionary with current sample information.
+        """
+        if self._current_sample != '':
+            return os.path.join(self._path, self._current_sample + '.yml')
+        raise ValueError('No current sample loaded, please use load() first.')
+
     def load(self, sample_name, path=None):
         """
         Get the sample information and populate these parameters.

--- a/pcdsdevices/targets.py
+++ b/pcdsdevices/targets.py
@@ -4,6 +4,7 @@ Module for common target stage stack configurations.
 import logging
 import numpy as np
 from datetime import datetime
+import os
 
 from ophyd.device import Device
 import json
@@ -587,20 +588,16 @@ class XYGridStage():
         samples : list
             List of strings of all the sample names available.
         """
+        samples = []
         path = path or self._path
-        with open(path) as sample_file:
-            try:
-                data = yaml.safe_load(sample_file)
-                if not data:
-                    logger.info('The file is empty, no samples saved yet.')
-                    return []
-                return list(data.keys())
-            except yaml.YAMLError as err:
-                logger.error('Error when loading the samples yaml file: %s',
-                             err)
-                raise err
+        with os.scandir(path) as entries:
+            for entry in entries:
+                if entry.is_file():
+                    samples.append(entry.name.split('.yml')[0])
+        return samples
 
-    def get_current_sample(self):
+    @property
+    def current_sample(self):
         """
         Get the current sample that is loaded.
 
@@ -611,7 +608,8 @@ class XYGridStage():
         """
         return self._current_sample
 
-    def set_current_sample(self, sample_name):
+    @current_sample.setter
+    def current_sample(self, sample_name):
         """
         Set the current sample.
 
@@ -622,7 +620,7 @@ class XYGridStage():
         """
         self._current_sample = str(sample_name)
 
-    def load_sample(self, sample_name, path=None):
+    def load(self, sample_name, path=None):
         """
         Get the sample information and populate these parameters.
 
@@ -638,12 +636,13 @@ class XYGridStage():
             Path where the samples yaml file exists.
         """
         path = path or self._path
+        entry = os.path.join(path, sample_name + '.yml')
         m_points, n_points, coeffs = self.get_sample_map_info(
-                                            str(sample_name), path)
+                                            str(sample_name), path=entry)
         self.m_n_points = m_points, n_points
         self.coefficients = coeffs
         # make this sample the current one
-        self.set_current_sample(str(sample_name))
+        self.current_sample = str(sample_name)
 
     def get_sample_data(self, sample_name, path=None):
         """
@@ -687,7 +686,7 @@ class XYGridStage():
         yy:
         ...}
         """
-        path = path or self._path
+        path = path or os.path.join(self._path, sample_name + '.yml')
         data = None
         with open(path) as sample_file:
             try:
@@ -720,8 +719,8 @@ class XYGridStage():
         path : str, optional
             Path to the samples yaml file.
         """
-        path = path or self._path
-        sample = self.get_sample_data(str(sample_name))
+        path = path or os.path.join(self._path, sample_name + '.yml')
+        sample = self.get_sample_data(str(sample_name), path=path)
         coeffs = []
         m_points, n_points = 0, 0
         if sample:
@@ -743,14 +742,14 @@ class XYGridStage():
 
     def save_grid(self, sample_name, path=None):
         """
-        Save a grid of mapped points for a sample.
+        Save a grid file of mapped points for a sample.
 
         This will save the date it was created, along with the sample name,
         the m and n points, the coordinates for the four corners, and the
         coefficients that will help get the x and y position on the grid.
 
         If an existing name for a sample is saved again, it will override
-        the information for that sample keeping the status of the targets.
+        the information for that samplefile keeping the status of the targets.
         When overriding a sample, this is assuming that a re-calibration was
         needed for that sample, so in case we have already shot targets from
         that sample - we want to keep track of that.
@@ -760,20 +759,21 @@ class XYGridStage():
         sample_name : str
             A name to identify the sample grid, should be snake_case style.
         path : str, optional
-            Path to the `.yml` file. Defaults to the path defined when
-            creating this object.
+            Path to the sample folder where this sample will be saved.
+            Defaults to the path defined when creating this object.
 
         Examples
         --------
         >>> save_grid('sample_1')
         """
         path = path or self._path
+        entry = os.path.join(path, sample_name + '.yml')
         now = str(datetime.now())
         top_left, top_right, bottom_right, bottom_left = [], [], [], []
-        flat_xx, flat_yy = [], []
         if self.get_presets():
             top_left, top_right, bottom_right, bottom_left = self.get_presets()
         xx, yy = self.positions_x, self.positions_y
+        flat_xx, flat_yy = [], []
         if xx and yy:
             flat_xx = [float(x) for x in xx]
             flat_yy = [float(y) for y in yy]
@@ -798,18 +798,19 @@ class XYGridStage():
         except jsonschema.exceptions.ValidationError as err:
             logger.warning('Invalid input: %s', err)
             raise err
-        # override the existing sample grids or append other grids
-        # check to see if sample exists already
-        with open(path) as sample_file:
-            yaml_dict = yaml.safe_load(sample_file) or {}
-            sample = yaml_dict.get(sample_name)
-            if sample:
+        # entry = os.path.join(path, sample_name + '.yml')
+        # if this is an existing file, overrite the info but keep the statuses
+        if os.path.isfile(entry):
+            with open(entry) as sample_file:
+                yaml_dict = yaml.safe_load(sample_file)
+                sample = yaml_dict[sample_name]
                 # when overriding the same sample, this is assuming that a
                 # re-calibration was done - so keep the previous statuses.
                 temp_xx = sample['xx']
                 temp_yy = sample['yy']
                 temp_x_status = [i['status'] for i in temp_xx]
                 temp_y_status = [i['status'] for i in temp_yy]
+                # update the current data statuses with previous ones
                 for xd, status in zip(data[sample_name]['xx'], temp_x_status):
                     xd.update((k, status)
                               for k, v in xd.items() if k == 'status')
@@ -817,11 +818,14 @@ class XYGridStage():
                     yd.update((k, status)
                               for k, v in yd.items() if k == 'status')
                 yaml_dict.update(data)
-            else:
-                yaml_dict.update(data)
-        with open(path, 'w') as sample_file:
-            yaml.safe_dump(yaml_dict, sample_file,
-                           sort_keys=False, default_flow_style=False)
+            with open(entry, 'w') as sample_file:
+                yaml.safe_dump(data, sample_file,
+                               sort_keys=False, default_flow_style=False)
+        else:
+            # create a new file
+            with open(entry, 'w') as sample_file:
+                yaml.safe_dump(data, sample_file,
+                               sort_keys=False, default_flow_style=False)
 
     def reset_statuses(self, sample_name, path=None):
         """
@@ -835,7 +839,7 @@ class XYGridStage():
             Path to the `.yml` file. Defaults to the path defined when
             creating this object.
         """
-        path = path or self._path
+        path = path or os.path.join(self._path, sample_name + '.yml')
         with open(path) as sample_file:
             yaml_dict = yaml.safe_load(sample_file) or {}
             sample = yaml_dict.get(sample_name)
@@ -922,72 +926,6 @@ class XYGridStage():
         self.positions_y = y_points
         return x_points, y_points
 
-    def compute_mapped_point(self, sample_name, m_row, n_column,
-                             compute_all=False, path=None):
-        """
-        For a given sample, compute the x, y position for M and N respecively.
-
-        If `compute_all` is True, than compute all the point positions
-        for this sample.
-
-        Parameters
-        ----------
-        sample_name : str
-            The name of the sample to get the mapped points from. To see the
-            available mapped samples call the `mapped_samples()` method.
-        m_point : int
-            Represents the row value of the point we want the position for.
-        n_point : int
-            Represents the column value of the point we want the position for.
-        compute_all : boolean, optional
-            If `True` all the point positions will be computed for this sample.
-        path : str, optional
-            Path to the samples yaml file.
-
-        Returns
-        -------
-        x, y : tuple
-            The x, y position for m n location.
-            Or, all the xx, yy values if `compute_all` is `True`.
-        """
-        # TODO: do not check the m and n if compute_all=True
-        path = path or self._path
-
-        m_points, n_points, coeffs = self.get_sample_map_info(
-                                            str(sample_name), path=path)
-        if any(v is None for v in [m_points, n_points, coeffs]):
-            raise ValueError('Some values are empty, please check the sample '
-                             f'{sample_name} in the yaml file.')
-
-        if (m_row > m_points) and (n_column > n_points):
-            raise IndexError('Index out of range, make sure the m and n values'
-                             f' are between ({m_points, n_points})')
-        if (m_row or n_column) == 0:
-            raise IndexError('Please start at 1, 1, as the initial points.')
-
-        xx_origin, yy_origin = get_unit_meshgrid(m_rows=m_points,
-                                                 n_columns=n_points)
-
-        a_coeffs = coeffs[:4]
-        b_coeffs = coeffs[4:]
-
-        if not compute_all:
-            logic_x = xx_origin[m_row - 1][n_column - 1]
-            logic_y = yy_origin[m_row - 1][n_column - 1]
-            x, y = convert_to_physical(a_coeffs, b_coeffs, logic_x, logic_y)
-            return x, y
-
-        # compute all points
-        x_points, y_points = [], []
-        for rowx, rowy in zip(xx_origin, yy_origin):
-            for x, y in zip(rowx, rowy):
-                i, j = convert_to_physical(a_coeffs=a_coeffs,
-                                           b_coeffs=b_coeffs,
-                                           logic_x=x, logic_y=y)
-                x_points.append(i)
-                y_points.append(j)
-        return x_points, y_points
-
     def is_target_shot(self, sample, m, n, path=None):
         """
         Check to see if the target position at MxN is shot.
@@ -1009,7 +947,7 @@ class XYGridStage():
         is_shot : bool
             Indicates is target is shot or not.
         """
-        path = path or self._path
+        path = path or os.path.join(self._path, sample + '.yml')
         x, y = self.compute_mapped_point(sample_name=sample, m_row=m,
                                          n_column=n, compute_all=False,
                                          path=path)
@@ -1024,12 +962,75 @@ class XYGridStage():
                              for item in xx if item['pos'] == x), None)
         return x_status
 
+    def compute_mapped_point(self, m_row, n_column, sample_name=None,
+                             path=None):
+        """
+        For a given sample, compute the x, y position for M and N respecively.
+
+        Parameters
+        ----------
+        sample_name : str
+            The name of the sample to get the mapped points from. To see the
+            available mapped samples call the `mapped_samples()` method.
+        m_point : int
+            Represents the row value of the point we want the position for.
+        n_point : int
+            Represents the column value of the point we want the position for.
+        compute_all : boolean, optional
+            If `True` all the point positions will be computed for this sample.
+        path : str, optional
+            Path to the samples yaml file.
+
+        Returns
+        -------
+        x, y : tuple
+            The x, y position for m n location.
+        """
+        path = path or self._path
+        sample_name = sample_name or self.current_sample
+
+        if sample_name is None or sample_name == '':
+            raise ValueError(
+                'Please make sure you provide a sample name or use load()')
+        # if we have a current loaded sample, use the current M, N values and
+        # current coefficients
+        if self.current_sample != '':
+            m_points, n_points = self.m_n_points
+            coeffs = self.coefficients
+        else:
+            # try to get them from the sample_name file
+            entry = os.path.join(path, sample_name + '.yml')
+            m_points, n_points, coeffs = self.get_sample_map_info(
+                str(sample_name), path=entry)
+
+        if any(v is None for v in [m_points, n_points, coeffs]):
+            raise ValueError('Some values are empty, please check the sample '
+                             f'{sample_name} in the has the M and N values as '
+                             'well as coefficients saved')
+
+        if (m_row > m_points) and (n_column > n_points):
+            raise IndexError('Index out of range, make sure the m and n values'
+                             f' are between ({m_points, n_points})')
+        if (m_row or n_column) == 0:
+            raise IndexError('Please start at 1, 1, as the initial points.')
+
+        xx_origin, yy_origin = get_unit_meshgrid(m_rows=m_points,
+                                                 n_columns=n_points)
+
+        a_coeffs = coeffs[:4]
+        b_coeffs = coeffs[4:]
+
+        logic_x = xx_origin[m_row - 1][n_column - 1]
+        logic_y = yy_origin[m_row - 1][n_column - 1]
+        x, y = convert_to_physical(a_coeffs, b_coeffs, logic_x, logic_y)
+        return x, y
+
     def move_to_sample(self, m, n):
         """
         Move x,y motors to the computed positions of n, m of current sample.
 
         Given m (row) and n (column), compute the positions for x and y based
-        on the current sample's parameters. See `get_current_sample()` and move
+        on the current sample's parameters. See `current_sample` and move
         the x and y motor to those positions.
 
         Parameters
@@ -1039,10 +1040,9 @@ class XYGridStage():
         n : int
             Indicates the column on the grid.
         """
-        sample_name = self.get_current_sample()
+        sample_name = self.current_sample
         if sample_name:
-            n, m = self.compute_mapped_point(sample_name, m_row=m, n_column=n,
-                                             compute_all=False, path=None)
+            n, m = self.compute_mapped_point(m_row=m, n_column=n)
         # TODO is it safe to do this here or should i be adding some checks?
         self.x.mv(n)
         self.y.mv(m)
@@ -1052,7 +1052,7 @@ class XYGridStage():
         Move x,y motors to the computed positions of n, m of given sample.
 
         Given m (row) and n (column), compute the positions for x and y based
-        on the current sample's parameters. See `get_current_sample()`
+        on the current sample's parameters. See `current_sample`
 
         Parameters
         ----------
@@ -1061,8 +1061,8 @@ class XYGridStage():
         n : int
             Indicates the column on the grid.
         """
-        n, m = self.compute_mapped_point(str(sample), m_row=m, n_column=n,
-                                         compute_all=False, path=None)
+        n, m = self.compute_mapped_point(m_row=m, n_column=n,
+                                         sample_name=sample, path=None)
         self.x.mv(n)
         self.y.mv(m)
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -455,3 +455,21 @@ def test_is_target_shot(fake_grid_stage, sample_file):
             are_shot.append(is_shot)
     assert are_shot == [True, True, True, True,
                         False, False, False, False]
+
+
+def test_set_status(fake_grid_stage, sample_file):
+    stage = fake_grid_stage
+    stage.load('test_sample')
+    stage.set_status(1, 1, False, 'test_sample')
+    info = stage.get_sample_data('test_sample')
+    expceted = [False, True, True, True,
+                False, False, False, False]
+    xx = info['xx']
+    res = []
+    for x in xx:
+        res.append(x['status'])
+
+    assert expceted == res
+
+    with pytest.raises(IndexError):
+        stage.set_status(1, 5, False, 'test_sample')

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -279,7 +279,6 @@ def test_move_to_sample(fake_grid_stage, sample_file):
 
 def test_move_to(fake_grid_stage):
     stage = fake_grid_stage
-    assert stage.current_sample == 'current_sample'
     assert stage.x.position == 0
     assert stage.y.position == 0
     stage.move_to('test_sample', 3, 1)
@@ -444,3 +443,15 @@ def test_reset_status(fake_grid_stage, sample_file):
         assert (yaml_dict['test_sample']['N'] ==
                 origin_info.get('N'))
         assert len(yaml_dict['test_sample']) == 10
+
+
+def test_is_target_shot(fake_grid_stage, sample_file):
+    stage = fake_grid_stage
+    stage.load('test_sample')
+    are_shot = []
+    for row in range(1, 3):
+        for column in range(1, 5):
+            is_shot = stage.is_target_shot(row, column)
+            are_shot.append(is_shot)
+    assert are_shot == [True, True, True, True,
+                        False, False, False, False]

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -103,7 +103,9 @@ def test_get_samples(fake_grid_stage, sample_file):
     xy.save_grid(sample_name='sample2', path=sample_file.parent)
     # test all mapped samples
     res = xy.get_samples(path=sample_file.parent)
-    assert res == ['sample1', 'sample2', 'test_sample']
+    for ff in res:
+        assert ff in ['sample1', 'sample2', 'test_sample']
+    assert len(res) == 3
     with pytest.raises(Exception):
         xy.get_samples(path='bad_file')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Updates a few things in the fixed target scan code. I think the main part is that it doesn't load the file on every use of most methods.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Loading a large data file every time you want to do something is very slow.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This code has been run during multiple experiments. There's still more to be done but I think this should get merged in as it's better than the previous version of the fixed target code. Also looks like tests were added and pass in Travis.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll make a pre-release notes file. Docstrings also look updated.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
