### PR TITLE
MNT: edge case for timeouts on lxt moves to the same location.

### DIFF
--- a/docs/source/upcoming_release_notes/lxt-wait-752.rst
+++ b/docs/source/upcoming_release_notes/lxt-wait-752.rst
@@ -1,0 +1,31 @@
+lxt-wait 752
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- `LaserTiming` will now report done after 0.01s for infintesimal moves,
+  rather than the previous freeze-and-never-report-done.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz

--- a/docs/source/upcoming_release_notes/lxt-wait-752.rst
+++ b/docs/source/upcoming_release_notes/lxt-wait-752.rst
@@ -19,7 +19,7 @@ New Devices
 
 Bugfixes
 --------
-- `LaserTiming` will now report done after 0.01s for infintesimal moves,
+- `LaserTiming` will now report done after 0.01s for infinitesimal moves,
   rather than the previous freeze-and-never-report-done.
 
 Maintenance

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -318,10 +318,8 @@ class LaserTiming(FltMvInterface, PVPositioner):
                            position, exc_info=ex)
 
         # Trigger dmov for tiny moves since done PV doesn't work here
-        if np.isclose(position, self.setpoint.get(), atol=20e-15, rtol=0):
-            short_move = True
-        else:
-            short_move = False
+        short_move = np.isclose(position, self.setpoint.get(),
+                                atol=20e-15, rtol=0)
 
         super()._setup_move(position)
 

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -316,10 +316,16 @@ class LaserTiming(FltMvInterface, PVPositioner):
         except Exception as ex:
             self.log.debug('Failed to update notepad setpoint to position %s',
                            position, exc_info=ex)
-        super()._setup_move(position)
 
         # Trigger dmov for tiny moves since done PV doesn't work here
         if np.isclose(position, self.setpoint.get(), atol=20e-15, rtol=0):
+            short_move = True
+        else:
+            short_move = False
+
+        super()._setup_move(position)
+
+        if short_move:
             time.sleep(0.01)
             self._move_changed(value=1-self.done_value)
             self._move_changed(value=self.done_value)

--- a/tests/test_lxe.py
+++ b/tests/test_lxe.py
@@ -106,9 +106,14 @@ def test_lasertiming_dmov_fail():
     logger.debug('test_lasertiming_dmov_fail')
     FakeLaserTiming = make_fake_device(LaserTiming)
     lxt = FakeLaserTiming('FAKE:VIT', name='fstiming')
+    lxt.mv(0, wait=False)
+
     # The move should timeout if the DMOV signal is never put to
     with pytest.raises(StatusTimeoutError):
         lxt.mv(1e-6, wait=True, timeout=1)
+
+    # But we should skip dmov step on repeated moves to the same position
+    lxt.move(1e-6, wait=True, timeout=1)
 
 
 def test_laser_timing_motion(lxt):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Skip waiting for the `done` signal in cases where a move of `LaserTiming` is less than 20fs. Instead, simply sleep for 0.01s and move on.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you move the `LaserTiming` (`lxt`) device in XPP to the same location as the previous move, the `done` signal does not transition at all, it stays at `1`. Since there is never a transition from `0` to `1`, there is never any real `done` status. This is a workaround to allow scans to proceed if they are triggering tiny moves.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live on the real deal in xpp3

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
