### PR TITLE
MNT: bring site-specific happi name restriction to site-specific class

### DIFF
--- a/docs/source/upcoming_release_notes/happi-names-753.rst
+++ b/docs/source/upcoming_release_notes/happi-names-753.rst
@@ -1,0 +1,31 @@
+happi-names 753
+###############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Relocate happi name length restriction for lcls devices to this package
+  as a requirement on LCLSItem
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -9,6 +9,10 @@ from happi.item import OphydItem
 
 
 class LCLSItem(OphydItem):
+    name = EntryInfo(('Shorthand Python-valid name for the Python instance. '
+                      'Must be between 3 and 80 characters.'),
+                     optional=False,
+                     enforce=re.compile(r'[a-z][a-z\_0-9]{2,78}$'))
     beamline = EntryInfo('Section of beamline the device belongs',
                          optional=False, enforce=str)
     location_group = EntryInfo('LUCID grouping parameter for location',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Companion to https://github.com/pcdshub/happi/pull/211
Pulling in our name restriction to pcdsdevices

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/pcdshub/happi/issues/206

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
