### PR TITLE
MNT: Enum is not a valid read type, IntEnum is

### DIFF
--- a/docs/source/upcoming_release_notes/757-att-enum.rst
+++ b/docs/source/upcoming_release_notes/757-att-enum.rst
@@ -1,0 +1,31 @@
+757 att-enum
+############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where legacy attenuator classes would break bluesky scans.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer
+- zllentz

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1110,7 +1110,7 @@ Transmission for 3rd harmonic (E={energy_3} keV): {transmission_3}
 FEESolidAttenuator = AT2L0  # back-compatibility
 
 
-class BladeStateEnum(enum.Enum):
+class BladeStateEnum(enum.IntEnum):
     Unknown = 0
     OUT = 1
     IN = 2

--- a/tests/test_attenuator.py
+++ b/tests/test_attenuator.py
@@ -32,6 +32,12 @@ def test_attenuator_states(fake_att):
     assert not att.inserted
 
 
+def test_attenuator_bluesky(fake_att):
+    logger.debug('test_attenuator_bluesky')
+    fake_att.read()
+    fake_att.describe()
+
+
 def fake_move_transition(att, status, goal):
     """
     Set to the PVs sort of like it would happen in the real world and check the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
bluesky expects all items to be clearly typed, this makes this item clearly typed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #757

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see #757 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
