### PR TITLE
Update gon.py

### DIFF
--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -521,8 +521,9 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
         Checks for the motor step, and ask the user for confirmation if
         movement step is greater than default one.
         """
-        if self.check_motor_step(position.e_eta, position.e_chi,
-                                 position.e_phi):
+        position_k = self.e_to_k(position.e_eta, position.e_chi, position.e_phi)
+        if self.check_motor_step(position_k.eta, position_k.chi,
+                                 position_k.phi):
             return super().move(position, wait=wait, timeout=timeout,
                                 moved_cb=moved_cb)
         else:


### PR DESCRIPTION
check_motor_step currently takes 'real motor positions', rather than the Euler angles. This is one of the issues that led to the print out giving wrong target position values even though the motion largely did the right thing. Also, phi motor was moving right amount, but status of kappa.e_phi shows the wrong value. Thus when moving, e.g. kappa.e_chi(5), from (0,0,0), at the end of motion, it looks like the motors moved the right mount/direction, but kappa.e_phi show 2X value as kappa.phi, rather than 0.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
