### PR TITLE
MNT: Fix Kappa Things

### DIFF
--- a/docs/source/upcoming_release_notes/762-kappa-fix.rst
+++ b/docs/source/upcoming_release_notes/762-kappa-fix.rst
@@ -1,0 +1,33 @@
+762 kappa-fix
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where the Kappa had an incorrect e_phi calculation
+  in certain situations.
+- Fix issue where the Kappa used the calculated motors for the
+  safety check instead of the real motors.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -442,7 +442,7 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
         if kappa is None:
             kappa = self.kappa.position
         if phi is None:
-            phi = -self.phi.position
+            phi = self.phi.position
 
         kappa_ang = self.kappa_ang * np.pi / 180
 
@@ -451,7 +451,7 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
         e_eta = -eta * np.pi / 180 - delta
         e_chi = 2.0 * np.arcsin(np.sin(kappa * np.pi / 180 / 2.0)
                                 * np.sin(kappa_ang))
-        e_phi = phi * np.pi / 180 - delta
+        e_phi = -phi * np.pi / 180 - delta
         e_eta = e_eta * 180 / np.pi
         e_chi = e_chi * 180 / np.pi
         e_phi = e_phi * 180 / np.pi

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -517,24 +517,6 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
                                       pseudo_pos.e_phi)
         return self.RealPosition(eta=eta, kappa=kappa, phi=phi)
 
-    @pseudo_position_argument
-    def move(self, position, wait=True, timeout=None, moved_cb=None):
-        """
-        Move to a specified position, optionally waiting for motion to
-        complete.
-
-        Checks for the motor step, and ask the user for confirmation if
-        movement step is greater than default one.
-        """
-        try:
-            return super().move(position, wait=wait, timeout=timeout,
-                                moved_cb=moved_cb)
-        except KappaMoveAbort as exc:
-            logger.warning('Aborting moving for safety.')
-            status = DeviceStatus(self)
-            status.set_exception(exc)
-            return status
-
     @real_position_argument
     def inverse(self, real_pos):
         """
@@ -553,6 +535,24 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
         e_eta, e_chi, e_phi = self.k_to_e(real_pos.eta, real_pos.kappa,
                                           real_pos.phi)
         return self.PseudoPosition(e_eta=e_eta, e_chi=e_chi, e_phi=e_phi)
+
+    @pseudo_position_argument
+    def move(self, position, wait=True, timeout=None, moved_cb=None):
+        """
+        Move to a specified position, optionally waiting for motion to
+        complete.
+
+        Checks for the motor step, and ask the user for confirmation if
+        movement step is greater than default one.
+        """
+        try:
+            return super().move(position, wait=wait, timeout=timeout,
+                                moved_cb=moved_cb)
+        except KappaMoveAbort as exc:
+            logger.warning('Aborting moving for safety.')
+            status = DeviceStatus(self)
+            status.set_exception(exc)
+            return status
 
     def check_value(self, position):
         """

--- a/tests/test_gon.py
+++ b/tests/test_gon.py
@@ -168,6 +168,7 @@ def test_check_motor_step(fake_kappa):
     assert res is False
 
 
+@pytest.mark.timeout(5)
 def test_moving(fake_kappa):
     eta_pos, kappa_pos, phi_pos = fake_kappa.e_to_k(e_eta=3, e_chi=5, e_phi=7)
     with patch('builtins.input', return_value='y'):
@@ -185,11 +186,16 @@ def test_moving(fake_kappa):
     assert fake_kappa.eta.position == eta_pos
     assert fake_kappa.kappa.position == kappa_pos
     assert fake_kappa.phi.position == phi_pos
+    status.wait()
     assert status.done
     assert status.success
 
     with patch('builtins.input', return_value='n'):
         status = fake_kappa.move(0, 0, 0)
+    try:
+        status.wait()
+    except Exception:
+        pass
     assert status.done
     assert not status.success
 

--- a/tests/test_gon.py
+++ b/tests/test_gon.py
@@ -178,19 +178,20 @@ def test_moving(fake_kappa):
     assert fake_kappa.kappa.position == kappa_pos
     assert fake_kappa.phi.position == phi_pos
 
-    eta_pos, kappa_pos, phi_pos = fake_kappa.e_to_k(e_eta=4, e_chi=6, e_phi=8)
+    eta_pos, kappa_pos, phi_pos = fake_kappa.e_to_k(e_eta=45, e_chi=45,
+                                                    e_phi=45)
     with patch('builtins.input', return_value='y'):
-        status = fake_kappa.move(4, 6, 8)
+        status = fake_kappa.move(45, 45, 45)
     assert fake_kappa.eta.position == eta_pos
     assert fake_kappa.kappa.position == kappa_pos
     assert fake_kappa.phi.position == phi_pos
-    assert status.done is True
-    assert status.success is True
+    assert status.done
+    assert status.success
 
     with patch('builtins.input', return_value='n'):
-        status = fake_kappa.move(4, 6, 8)
-    assert status.done is False
-    assert status.success is False
+        status = fake_kappa.move(0, 0, 0)
+    assert status.done
+    assert not status.success
 
 
 @pytest.mark.parametrize("eta,kappa,phi", [

--- a/tests/test_gon.py
+++ b/tests/test_gon.py
@@ -1,22 +1,20 @@
 import logging
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from ophyd.sim import make_fake_device
-from unittest.mock import patch
 
 from pcdsdevices.gon import (BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi,
-                             XYZStage, SimKappa)
+                             SimKappa, XYZStage)
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_kappa():
-    FakeKappa = make_fake_device(SimKappa)
-    fake_kap = FakeKappa(name='test', prefix_x='x', prefix_y='y', prefix_z='z',
-                         prefix_eta='eta', prefix_kappa='kappa',
-                         prefix_phi='phi', eta_max_step=2, kappa_max_step=2,
-                         phi_max_step=2, kappa_ang=50)
+    fake_kap = SimKappa()
+
     # set current positions
     fake_kap.eta.move(10)
     fake_kap.kappa.move(20)
@@ -73,8 +71,8 @@ def test_gon_disconnected():
 
 
 def test_k_to_e(fake_kappa):
-    # expected result based on old code
-    expected_res = (-27.51268029508058, 10.713563480515766, 41.48731970491941)
+    # modified test based on calculation fixes
+    expected_res = (-27.51268029508058, 10.713563480515766, -50.51268029508058)
     result = fake_kappa.k_to_e(eta=23, kappa=14, phi=46)
     assert np.isclose(expected_res, result).all()
     # test with constructor's params
@@ -89,7 +87,7 @@ def test_e_to_k(fake_kappa):
     result = fake_kappa.e_to_k(e_eta=23, e_chi=14, e_phi=46)
     assert np.isclose(expected_res, result).all()
     # test with constructor's params
-    # when positions are: eat = 10, kappa = 20, phi = 30, angle = 50
+    # when positions are: eta = 10, kappa = 20, phi = 30, angle = 50
     # the coordinates are:
     # (-16.466354394274497, 15.288540112588864, -36.46635439427449)
     expected_res = (10, 20, 30)
@@ -109,7 +107,7 @@ def test_forward(fake_kappa):
 
 
 def test_inverse(fake_kappa):
-    inverse = fake_kappa.inverse(eta=10, kappa=20, phi=-30)
+    inverse = fake_kappa.inverse(eta=10, kappa=20, phi=30)
     # original pseudo coord: eta=-16.466354394274497, kappa=15.288540112588864,
     # phi=-36.46635439427449
     assert np.isclose(inverse.e_eta, -16.466354394274497)
@@ -193,3 +191,16 @@ def test_moving(fake_kappa):
         status = fake_kappa.move(4, 6, 8)
     assert status.done is False
     assert status.success is False
+
+
+@pytest.mark.parametrize("eta,kappa,phi", [
+    (0, 0, 0), (1, 2, 3), (10, 20, 30), (45, 45, 45),
+    (6, 2, 6), (42, 0, 0), (0, 42, 0), (0, 0, 42),
+    (7, 7, 7), (-1, -2, -3), (-10, 25, -30), (9, -1, 1)
+    ])
+def test_kappa_calculations(fake_kappa, eta, kappa, phi):
+    e_eta, e_chi, e_phi = fake_kappa.k_to_e(eta, kappa, phi)
+    k_eta, k_kap, k_phi = fake_kappa.e_to_k(e_eta, e_chi, e_phi)
+    assert np.isclose(eta, k_eta)
+    assert np.isclose(kappa, k_kap)
+    assert np.isclose(phi, k_phi)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix issue where position check used the e motors instead of the k motors
- Fix issue where misplaced minus sign was breaking certain calculations
- Some minor cleanup (do all move checking in check_move, test for None more succinctly, etc.)
- Extend the move table to help me test
- Edit the fake Kappa class to help me test

closes #761 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before:
```
In [4]: sim.e_chi.move(10)
Do you really intend to do the following motions?
 +-------+------------------+-----+------------------------+
| Motor | Current position |  to |    Target position     |
+-------+------------------+-----+------------------------+
|  eta  |        0         | --> |  -4.2099681189703455   |
| kappa |        0         | --> |   13.065802839493314   |
|  phi  |        0         | --> |  -4.2099681189703455   |
| e_eta |       0.0        | --> | -7.951386703658792e-16 |
| e_chi |       0.0        | --> |          10.0          |
| e_phi |       0.0        | --> |   -8.419936237940691   |
+-------+------------------+-----+------------------------+
```
Something is clearly wrong if moving to (0, 10, 0) puts us at (0, 10, -8.42)

After:
```
In [4]: sim.e_chi.move(10)

Do you really intend to do the following motions?
 +-------+------------------+-----+------------------------+
| Motor | Current position |  to |    Target position     |
+-------+------------------+-----+------------------------+
|  eta  |        0         | --> |  -4.2099681189703455   |
| kappa |        0         | --> |   13.065802839493314   |
|  phi  |        0         | --> |  -4.2099681189703455   |
| e_eta |       0.0        | --> | -7.951386703658792e-16 |
| e_chi |       0.0        | --> |          10.0          |
| e_phi |       0.0        | --> | -7.951386703658792e-16 |
+-------+------------------+-----+------------------------+
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added and updated unit tests.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release documentation.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
