### PR TITLE
MNT: alternate calc mode for large kappa angle from Diling

### DIFF
--- a/docs/source/upcoming_release_notes/764-kappa-180.rst
+++ b/docs/source/upcoming_release_notes/764-kappa-180.rst
@@ -1,0 +1,30 @@
+764 kappa-180
+#############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix Kappa behavior for kappa angles above 180 degrees.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -486,12 +486,20 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
 
         kappa_ang = self.kappa_ang * np.pi / 180
 
-        delta = np.arcsin(-np.tan(e_chi * np.pi / 180
-                                  / 2.0) / np.tan(kappa_ang))
-        k_eta = -(e_eta * np.pi / 180 - delta)
-        k_kap = 2.0 * np.arcsin(np.sin(e_chi * np.pi
-                                       / 180 / 2.0) / np.sin(kappa_ang))
-        k_phi = e_phi * np.pi / 180 - delta
+        if self.kappa.position < 180:
+            delta = np.arcsin(-np.tan(e_chi * np.pi/180/2)
+                              / np.tan(kappa_ang))
+            k_eta = -(e_eta * np.pi / 180 - delta)
+            k_kap = 2 * np.arcsin(np.sin(e_chi * np.pi/180/2)
+                                  / np.sin(kappa_ang))
+            k_phi = e_phi * np.pi / 180 - delta
+        else:
+            delta = np.arcsin(-np.tan(e_chi * np.pi/180/2)
+                              / np.tan(kappa_ang))
+            k_eta = (e_eta * np.pi / 180 - delta) - np.pi
+            k_kap = 2 * np.pi - 2 * np.arcsin(np.sin(e_chi * np.pi/180/2)
+                                              / np.sin(kappa_ang))
+            k_phi = -e_phi * np.pi / 180 - delta
 
         k_eta = k_eta * 180 / np.pi
         k_kap = k_kap * 180 / np.pi

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -445,20 +445,18 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
             phi = self.phi.position
 
         kappa_ang = self.kappa_ang * np.pi / 180
+        delta = np.arctan(np.tan(kappa * np.pi / 180 / 2)
+                          * np.cos(kappa_ang))
 
-        if self.kappa.position < 180:
-            delta = np.arctan(np.tan(kappa * np.pi / 180 / 2)
-                              * np.cos(kappa_ang))
-            e_eta = -eta * np.pi / 180 - delta
-            e_chi = 2 * np.arcsin(np.sin(kappa * np.pi / 180 / 2)
-                                  * np.sin(kappa_ang))
-            e_phi = -phi * np.pi / 180 - delta
-        else:
-            delta = np.arctan(np.tan(kappa * np.pi / 180 / 2)
-                              * np.cos(kappa_ang))
-            e_eta = np.pi - (-eta * np.pi / 180 - delta)
-            e_chi = 2 * np.arcsin(np.sin(kappa * np.pi / 180 / 2)
-                                  * np.sin(kappa_ang))
+        e_eta = -eta * np.pi / 180 - delta
+        e_chi = 2 * np.arcsin(np.sin(kappa * np.pi / 180 / 2)
+                              * np.sin(kappa_ang))
+        e_phi = -phi * np.pi / 180 - delta
+
+        # Phase shift for flipped kappa
+        if self.kappa.position > 180:
+            e_eta = np.pi - e_eta
+            e_chi = e_chi
             e_phi = phi * np.pi / 180 - delta
 
         e_eta = e_eta * 180 / np.pi

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -492,20 +492,17 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
             e_phi = self.e_phi_coord
 
         kappa_ang = self.kappa_ang * np.pi / 180
+        delta = np.arcsin(-np.tan(e_chi * np.pi / 180 / 2)
+                          / np.tan(kappa_ang))
+        k_eta = -(e_eta * np.pi / 180 - delta)
+        k_kap = 2 * np.arcsin(np.sin(e_chi * np.pi / 180 / 2)
+                              / np.sin(kappa_ang))
+        k_phi = e_phi * np.pi / 180 - delta
 
-        if self.kappa.position < 180:
-            delta = np.arcsin(-np.tan(e_chi * np.pi/180/2)
-                              / np.tan(kappa_ang))
-            k_eta = -(e_eta * np.pi / 180 - delta)
-            k_kap = 2 * np.arcsin(np.sin(e_chi * np.pi/180/2)
-                                  / np.sin(kappa_ang))
-            k_phi = e_phi * np.pi / 180 - delta
-        else:
-            delta = np.arcsin(-np.tan(e_chi * np.pi/180/2)
-                              / np.tan(kappa_ang))
-            k_eta = (e_eta * np.pi / 180 - delta) - np.pi
-            k_kap = 2 * np.pi - 2 * np.arcsin(np.sin(e_chi * np.pi/180/2)
-                                              / np.sin(kappa_ang))
+        # Phase shift for flipped kappa
+        if self.kappa.position > 180:
+            k_eta = -k_eta - np.pi
+            k_kap = 2 * np.pi - k_kap
             k_phi = -e_phi * np.pi / 180 - delta
 
         k_eta = k_eta * 180 / np.pi

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -446,12 +446,21 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
 
         kappa_ang = self.kappa_ang * np.pi / 180
 
-        delta = np.arctan(np.tan(kappa * np.pi / 180 / 2.0)
-                          * np.cos(kappa_ang))
-        e_eta = -eta * np.pi / 180 - delta
-        e_chi = 2.0 * np.arcsin(np.sin(kappa * np.pi / 180 / 2.0)
-                                * np.sin(kappa_ang))
-        e_phi = -phi * np.pi / 180 - delta
+        if self.kappa.position < 180:
+            delta = np.arctan(np.tan(kappa * np.pi / 180 / 2)
+                              * np.cos(kappa_ang))
+            e_eta = -eta * np.pi / 180 - delta
+            e_chi = 2 * np.arcsin(np.sin(kappa * np.pi / 180 / 2)
+                                  * np.sin(kappa_ang))
+            e_phi = -phi * np.pi / 180 - delta
+        else:
+            delta = np.arctan(np.tan(kappa * np.pi / 180 / 2)
+                              * np.cos(kappa_ang))
+            e_eta = np.pi - (-eta * np.pi / 180 - delta)
+            e_chi = 2 * np.arcsin(np.sin(kappa * np.pi / 180 / 2)
+                                  * np.sin(kappa_ang))
+            e_phi = phi * np.pi / 180 - delta
+
         e_eta = e_eta * 180 / np.pi
         e_chi = e_chi * 180 / np.pi
         e_phi = e_phi * 180 / np.pi
@@ -660,9 +669,9 @@ class SimSampleStage(KappaXYZStage):
 class SimKappa(Kappa):
     """Test version of the Kappa object."""
     sample_stage = Cpt(SimSampleStage, name='')
-    eta = Cpt(FastMotor, limits=(-100, 100))
-    kappa = Cpt(FastMotor, limits=(-100, 100))
-    phi = Cpt(FastMotor, limits=(-100, 100))
+    eta = Cpt(FastMotor, limits=(-180, 180))
+    kappa = Cpt(FastMotor, limits=(-360, 360))
+    phi = Cpt(FastMotor, limits=(-180, 180))
 
     def __init__(self):
         super().__init__(name='SimKappa', prefix_x='X', prefix_y='Y',

--- a/tests/test_gon.py
+++ b/tests/test_gon.py
@@ -203,9 +203,23 @@ def test_moving(fake_kappa):
 @pytest.mark.parametrize("eta,kappa,phi", [
     (0, 0, 0), (1, 2, 3), (10, 20, 30), (45, 45, 45),
     (6, 2, 6), (42, 0, 0), (0, 42, 0), (0, 0, 42),
-    (7, 7, 7), (-1, -2, -3), (-10, 25, -30), (9, -1, 1)
+    (7, 7, 7), (-1, -2, -3), (-10, 25, -30), (9, -1, 1),
     ])
 def test_kappa_calculations(fake_kappa, eta, kappa, phi):
+    e_eta, e_chi, e_phi = fake_kappa.k_to_e(eta, kappa, phi)
+    k_eta, k_kap, k_phi = fake_kappa.e_to_k(e_eta, e_chi, e_phi)
+    assert np.isclose(eta, k_eta)
+    assert np.isclose(kappa, k_kap)
+    assert np.isclose(phi, k_phi)
+
+
+@pytest.mark.parametrize("eta,kappa,phi", [
+    (0, 225, 0), (1, 227, 3), (10, 245, 30), (45, 270, 45),
+    (6, 227, 6), (42, 225, 0), (0, 267, 0), (0, 225, 42),
+    (7, 232, 7), (-1, 223, -3), (-10, 250, -30), (9, 224, 1),
+    ])
+def test_kappa_calculations_big_kap(fake_kappa, eta, kappa, phi):
+    fake_kappa.kappa.move(225, wait=True)
     e_eta, e_chi, e_phi = fake_kappa.k_to_e(eta, kappa, phi)
     k_eta, k_kap, k_phi = fake_kappa.e_to_k(e_eta, e_chi, e_phi)
     assert np.isclose(eta, k_eta)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- If kappa is currently > 180 deg, do the calculation differently
- Code copied/adapted from @dlzhu
- Basically a phase shift
- Add regression tests for this range
- Simplify the calculations a bit

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The original calculations aren't quite correct for large kappa angles, because it makes the eta rotate in the positive direction and collide with the test setup
- In normal operation, the kappa will be set to the correct operating range prior to being used scientifically, so it is sufficient to do the current position check

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release documentation

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
