### PR TITLE
MNT: Lock timetool compensation to static offsets

### DIFF
--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -43,7 +43,8 @@ from .interface import FltMvInterface
 from .pseudopos import (LookupTablePositioner, PseudoSingleInterface,
                         SyncAxesBase, pseudo_position_argument,
                         real_position_argument)
-from .signal import UnitConversionDerivedSignal, NotepadLinkedSignal
+from .signal import NotepadLinkedSignal, UnitConversionDerivedSignal
+from .sim import FastMotor
 from .utils import convert_unit
 
 if typing.TYPE_CHECKING:
@@ -413,9 +414,18 @@ class LaserTimingCompensation(SyncAxesBase):
     pseudo = Cpt(PseudoSingleInterface, limits=(-10e-6, 10e-6))
     delay = UCpt(_ReversedTimeToolDelay, doc='The **reversed** txt motor')
     laser = UCpt(LaserTiming, doc='The lxt motor')
+    _offsets = {'delay': 0, 'laser': 0}
 
     def __init__(self, prefix, **kwargs):
         UCpt.collect_prefixes(self, kwargs)
         super().__init__(prefix, **kwargs)
         self.delay.name = 'txt_reversed'
         self.laser.name = 'lxt'
+
+
+class FakeLaserTimingCompensation(LaserTimingCompensation):
+    delay = Cpt(FastMotor)
+    laser = Cpt(FastMotor)
+
+    def __init__(self):
+        super().__init__('FAKE:TTC', name='fake_ttc')

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -4,11 +4,11 @@ import typing
 import numpy as np
 import ophyd
 import ophyd.pseudopos
-from ophyd.signal import EpicsSignal
 from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.pseudopos import (PseudoSingle, pseudo_position_argument,
                              real_position_argument)
+from ophyd.signal import EpicsSignal
 from scipy.constants import speed_of_light
 
 from .interface import FltMvInterface
@@ -167,6 +167,7 @@ class SyncAxesBase(FltMvInterface, PseudoPositioner):
     """
 
     pseudo = Cpt(PseudoSingleInterface)
+    _offsets = None
 
     def __init__(self, *args, **kwargs):
         if self.__class__ is SyncAxesBase:
@@ -174,7 +175,6 @@ class SyncAxesBase(FltMvInterface, PseudoPositioner):
                              'the axes to synchronize included as '
                              'components'))
         super().__init__(*args, **kwargs)
-        self._offsets = None
 
     def calc_combined(self, real_position):
         """
@@ -222,7 +222,7 @@ class SyncAxesBase(FltMvInterface, PseudoPositioner):
 
     @real_position_argument
     def inverse(self, real_pos):
-        """Combined axis readback is the mean of the composite axes."""
+        """Combined axis readback is defined in calc_combined."""
         return self.PseudoPosition(pseudo=float(self.calc_combined(real_pos)))
 
 

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -41,6 +41,12 @@ class FastMotor(FltMvInterface, SoftPositioner, Device):
             kwargs.pop(kw, None)
         super().__init__(init_pos=init_pos, **kwargs)
 
+    def set_current_position(self, position):
+        """
+        Adjust offset until the current position is the input position.
+        """
+        self._set_position(position)
+
 
 class SlowMotor(FastMotor):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Allow subclasses of `SyncAxesBase` to define static offsets. Use this in the timetool compensation construct to keep the delay and laser motors always the same value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #770 
`SyncAxesBase` sets its offsets on the first move, which is great if you've already zeroed them, otherwise this fails. It was designed to take the arbitrary set of four motors on a large stand and keep them at the same offsets as when you first started moving.

In this case, we want very similar behavior, but we always want to move the two motors to the same position, so just hardcode the offsets in the class definition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with test motors

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
WIP

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
