### PR TITLE
ENH: Sync features for lxt_ttc

### DIFF
--- a/docs/source/upcoming_release_notes/775-sync-refactor.rst
+++ b/docs/source/upcoming_release_notes/775-sync-refactor.rst
@@ -1,0 +1,34 @@
+775 sync-refactor
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add ``SyncAxis`` to replace deprecated ``SyncAxesBase`` with expanded
+  feature set, more sensible defaults, and more solid foundation.
+- Add ``set_current_position`` to all ``PseudoPositioner`` classes.
+- Add ``invert`` parameter to ``DelayBase`` for inverting any delay stage.
+- Add ``set_position`` as an alias to ``set_current_position``
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -9,7 +9,8 @@ from .beam_stats import BeamEnergyRequest
 from .epics_motor import IMS, EpicsMotorInterface
 from .inout import InOutPositioner
 from .interface import FltMvInterface
-from .pseudopos import PseudoPositioner, PseudoSingleInterface, SyncAxesBase
+from .pseudopos import (PseudoPositioner, PseudoSingleInterface, SyncAxis,
+                        SyncAxisOffsetMode)
 from .pv_positioner import PVPositionerIsClose
 
 logger = logging.getLogger(__name__)
@@ -155,11 +156,12 @@ class CCMCalc(FltMvInterface, PseudoPositioner):
                                    energy_with_vernier=energy)
 
 
-class CCMX(SyncAxesBase):
+class CCMX(SyncAxis):
     """Combined motion of the CCM X motors."""
     down = FCpt(IMS, '{self.down_prefix}')
     up = FCpt(IMS, '{self.up_prefix}')
 
+    offset_mode = SyncAxisOffsetMode.AUTO_FIXED
     tab_component_names = True
 
     def __init__(self, down_prefix, up_prefix, *args, **kwargs):
@@ -168,12 +170,13 @@ class CCMX(SyncAxesBase):
         super().__init__(down_prefix, *args, **kwargs)
 
 
-class CCMY(SyncAxesBase):
+class CCMY(SyncAxis):
     """Combined motion of the CCM Y motors."""
     down = FCpt(IMS, '{self.down_prefix}')
     up_north = FCpt(IMS, '{self.up_north_prefix}')
     up_south = FCpt(IMS, '{self.up_south_prefix}')
 
+    offset_mode = SyncAxisOffsetMode.AUTO_FIXED
     tab_component_names = True
 
     def __init__(self, down_prefix, up_north_prefix, up_south_prefix,

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -20,7 +20,7 @@ from pcdsdevices.pv_positioner import PVPositionerComparator
 
 from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
-from .pseudopos import DelayBase, OffsetMotorBase
+from .pseudopos import OffsetMotorBase, delay_class_factory
 from .signal import PytmcSignal
 from .utils import get_status_value
 from .variety import set_metadata
@@ -566,8 +566,7 @@ class Newport(PCDSMotorBase):
                                   "motors")
 
 
-class DelayNewport(DelayBase):
-    motor = Cpt(Newport, '')
+DelayNewport = delay_class_factory(Newport)
 
 
 class OffsetMotor(OffsetMotorBase):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -40,7 +40,8 @@ Device_whitelist = ["read_attrs", "configuration_attrs", "summary",
                     "wait_for_connection", "stop", "get", "configure"]
 Signal_whitelist = ["value", "put"]
 Positioner_whitelist = ["settle_time", "timeout", "egu", "limits", "move",
-                        "position", "moving"]
+                        "position", "moving", "set_position",
+                        "set_current_position"]
 
 
 class _TabCompletionHelper:
@@ -810,6 +811,14 @@ class FltMvInterface(MvInterface):
         """
 
         return tweak_base(self)
+
+    def set_position(self, position):
+        """
+        Alias for set_current_position.
+
+        Will fail if the motor does not have set_current_position.
+        """
+        self.set_current_position(position)
 
 
 def setup_preset_paths(**paths):

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -37,14 +37,12 @@ from ophyd import Component as Cpt
 from ophyd import EpicsSignal, PVPositioner
 from scipy.constants import speed_of_light
 
-from .component import UnrelatedComponent as UCpt
 from .epics_motor import DelayNewport, EpicsMotorInterface
 from .interface import FltMvInterface
-from .pseudopos import (LookupTablePositioner, PseudoSingleInterface,
-                        SyncAxesBase, pseudo_position_argument,
-                        real_position_argument)
-from .signal import UnitConversionDerivedSignal, NotepadLinkedSignal
-from .utils import convert_unit, get_status_value, get_status_float
+from .pseudopos import (LookupTablePositioner, PseudoSingleInterface, SyncAxis,
+                        pseudo_position_argument, real_position_argument)
+from .signal import NotepadLinkedSignal, UnitConversionDerivedSignal
+from .utils import convert_unit, get_status_float, get_status_value
 
 if typing.TYPE_CHECKING:
     import matplotlib  # noqa
@@ -446,7 +444,7 @@ class _ReversedTimeToolDelay(DelayNewport):
                                            + self.user_offset.get()))
 
 
-class LaserTimingCompensation(SyncAxesBase):
+class LaserTimingCompensation(SyncAxis):
     """
     LaserTimingCompensation (``lxt_ttc``) synchronously moves
     :class:`LaserTiming` (``lxt``) with :class:`TimeToolDelay` (``txt``) to
@@ -458,13 +456,6 @@ class LaserTimingCompensation(SyncAxesBase):
     ``delay`` and ``laser`` are intentionally renamed to non-ophyd-style
     ``txt`` and ``lxt``, respectively.
     """
-    tab_component_names = True
-    pseudo = Cpt(PseudoSingleInterface, limits=(-10e-6, 10e-6))
-    delay = UCpt(_ReversedTimeToolDelay, doc='The **reversed** txt motor')
-    laser = UCpt(LaserTiming, doc='The lxt motor')
+    sync = Cpt(PseudoSingleInterface, limits=(-10e-6, 10e-6))
 
-    def __init__(self, prefix, **kwargs):
-        UCpt.collect_prefixes(self, kwargs)
-        super().__init__(prefix, **kwargs)
-        self.delay.name = 'txt_reversed'
-        self.laser.name = 'lxt'
+    warn_deadband = 1e-14

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -491,7 +491,7 @@ class FakeLxtTtc(LxtTtcExample):
     lxt = Cpt(FastMotor)
     txt = Cpt(FastMotor)
 
-    scale = {'txt': -1}
+    scales = {'txt': -1}
 
     def __init__(self):
         super().__init__('FAKE:LXT:TTC', name='fake_lxt_ttc')

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -38,11 +38,11 @@ from ophyd import EpicsSignal, PVPositioner
 from scipy.constants import speed_of_light
 
 from .component import UnrelatedComponent as UCpt
-from .epics_motor import DelayNewport, EpicsMotorInterface, Newport
+from .epics_motor import DelayNewport, EpicsMotorInterface
 from .interface import FltMvInterface
-from .pseudopos import (DelayMotor, LookupTablePositioner,
-                        PseudoSingleInterface, SyncAxesBase, SyncAxis,
-                        pseudo_position_argument, real_position_argument)
+from .pseudopos import (LookupTablePositioner, PseudoSingleInterface,
+                        SyncAxesBase, SyncAxis, pseudo_position_argument,
+                        real_position_argument)
 from .signal import NotepadLinkedSignal, UnitConversionDerivedSignal
 from .sim import FastMotor
 from .utils import convert_unit, get_status_float, get_status_value
@@ -478,11 +478,12 @@ class LxtTtcExample(SyncAxis):
     XPP's config on March 4, 2021
     """
     lxt = Cpt(LaserTiming, 'LAS:FS11')
-    txt = Cpt(DelayMotor, 'XPP:LAS:MMN:16', motor_class=Newport,
-              n_bounces=14, invert=True)
+    txt = Cpt(DelayNewport, 'XPP:LAS:MMN:16',
+              n_bounces=14)
 
     tab_component_names = True
-    warn_deadband = 1e-14
+    scales = {'txt': -1}
+    warn_deadband = 5e-14
     fix_sync_keep_still = 'lxt'
     sync_limits = (-10e-6, 10e-6)
 
@@ -490,8 +491,6 @@ class LxtTtcExample(SyncAxis):
 class FakeLxtTtc(LxtTtcExample):
     lxt = Cpt(FastMotor)
     txt = Cpt(FastMotor)
-
-    scales = {'txt': -1}
 
     def __init__(self):
         super().__init__('FAKE:LXT:TTC', name='fake_lxt_ttc')

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -44,6 +44,7 @@ from .pseudopos import (DelayMotor, LookupTablePositioner,
                         PseudoSingleInterface, SyncAxesBase, SyncAxis,
                         pseudo_position_argument, real_position_argument)
 from .signal import NotepadLinkedSignal, UnitConversionDerivedSignal
+from .sim import FastMotor
 from .utils import convert_unit, get_status_float, get_status_value
 
 if typing.TYPE_CHECKING:
@@ -484,3 +485,13 @@ class LxtTtcExample(SyncAxis):
     warn_deadband = 1e-14
     fix_sync_keep_still = 'lxt'
     sync_limits = (-10e-6, 10e-6)
+
+
+class FakeLxtTtc(LxtTtcExample):
+    lxt = Cpt(FastMotor)
+    txt = Cpt(FastMotor)
+
+    scale = {'txt': -1}
+
+    def __init__(self):
+        super().__init__('FAKE:LXT:TTC', name='fake_lxt_ttc')

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -38,11 +38,11 @@ from ophyd import EpicsSignal, PVPositioner
 from scipy.constants import speed_of_light
 
 from .component import UnrelatedComponent as UCpt
-from .epics_motor import DelayNewport, EpicsMotorInterface
+from .epics_motor import DelayNewport, EpicsMotorInterface, Newport
 from .interface import FltMvInterface
-from .pseudopos import (LookupTablePositioner, PseudoSingleInterface,
-                        SyncAxesBase, pseudo_position_argument,
-                        real_position_argument)
+from .pseudopos import (DelayMotor, LookupTablePositioner,
+                        PseudoSingleInterface, SyncAxesBase, SyncAxis,
+                        pseudo_position_argument, real_position_argument)
 from .signal import NotepadLinkedSignal, UnitConversionDerivedSignal
 from .utils import convert_unit, get_status_float, get_status_value
 
@@ -468,3 +468,18 @@ class LaserTimingCompensation(SyncAxesBase):
         super().__init__(prefix, **kwargs)
         self.delay.name = 'txt_reversed'
         self.laser.name = 'lxt'
+
+
+class LxtTtcExample(SyncAxis):
+    """
+    Example of one way to set up the lxt_ttc construct using SyncAxis
+
+    XPP's config on March 4, 2021
+    """
+    lxt = Cpt(LaserTiming, 'LAS:FS11')
+    txt = Cpt(DelayMotor, Newport, 'XPP:LAS:MMN:16',
+              n_bounces=14, invert=True)
+
+    tab_component_names = True
+    fix_sync_keep_still = 'lxt'
+    sync_limits = (-10e-6, 10e-6)

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -481,5 +481,6 @@ class LxtTtcExample(SyncAxis):
               n_bounces=14, invert=True)
 
     tab_component_names = True
+    warn_deadband = 1e-14
     fix_sync_keep_still = 'lxt'
     sync_limits = (-10e-6, 10e-6)

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -477,7 +477,7 @@ class LxtTtcExample(SyncAxis):
     XPP's config on March 4, 2021
     """
     lxt = Cpt(LaserTiming, 'LAS:FS11')
-    txt = Cpt(DelayMotor, Newport, 'XPP:LAS:MMN:16',
+    txt = Cpt(DelayMotor, 'XPP:LAS:MMN:16', motor_class=Newport,
               n_bounces=14, invert=True)
 
     tab_component_names = True

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -750,7 +750,7 @@ def delay_class_factory(motor_class):
 
 
 def delay_instance_factory(
-        motor_class, prefix, egu='s', n_bounces=2, invert=False, **kwargs
+        prefix, motor_class, egu='s', n_bounces=2, invert=False, **kwargs
         ):
     cls = delay_class_factory(motor_class)
     return cls(prefix, egu=egu, n_bounces=n_bounces, invert=invert, **kwargs)

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -485,11 +485,13 @@ class DelayBase(FltMvInterface, PseudoPositioner):
                       notepad_metadata={'record': 'ao', 'default_value': 0.0})
     motor = None
 
-    def __init__(self, *args, egu='s', n_bounces=2, **kwargs):
+    def __init__(self, *args, egu='s', n_bounces=2, invert=False, **kwargs):
         if self.__class__ is DelayBase:
             raise TypeError(('DelayBase must be subclassed with '
                              'a "motor" component, the real motor to move.'))
         self.n_bounces = n_bounces
+        if invert:
+            self.n_bounces *= -1
         super().__init__(*args, egu=egu, **kwargs)
 
     @pseudo_position_argument   # TODO: upstream this fix

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -453,24 +453,22 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
                     ) from None
         self._check_info_dict(self.offsets, 'offsets')
         self._check_info_dict(self.scales, 'scales')
-        if self.fix_sync_keep_still is not None:
-            try:
-                getattr(self.__class__, self.fix_sync_keep_still)
-            except AttributeError:
-                raise ValueError(
-                    'Invalid fix_sync_keep_still. Must match a motor.'
-                    ) from None
+        if (self.fix_sync_keep_still is not None
+                and self.fix_sync_keep_still not in self.component_names):
+            raise ValueError(
+                f'Invalid fix_sync_keep_still == {self.fix_sync_keep_still}. '
+                'Must match a motor.'
+                )
 
     def _check_info_dict(self, setting, info_kind):
         """Helper function to check that all keys in the dict are Cpts"""
         if setting is not None:
-            try:
-                for attr, _ in setting.items():
-                    getattr(self.__class__, attr)
-            except AttributeError:
-                raise ValueError(
-                    f'Invalid key {attr} in {info_kind}. Must match a motor.'
-                    ) from None
+            for attr, _ in setting.items():
+                if attr not in self.component_names:
+                    raise ValueError(
+                        f'Invalid key {attr} in {info_kind}. '
+                        'Must match a motor.'
+                        )
 
     def _fill_info_dict(self, setting, default, info_kind):
         """Helper function to fill default values into the dict"""

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -221,7 +221,7 @@ class SyncAxesBase(FltMvInterface, PseudoPositioner):
     """
     Synchronized Axes.
 
-    This class is deprecated. Use SyncAxis instead.
+    This class is deprecated. Use `SyncAxis` instead.
 
     This will move all axes in a coordinated way, retaining offsets.
 
@@ -528,7 +528,7 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
 
         This gives us the real motor setpoint value for one axis.
         """
-        return pos * self.scales[attr] + self.offset[attr]
+        return pos * self.scales[attr] + self.offsets[attr]
 
     @real_position_argument
     def inverse(self, real_pos):
@@ -563,7 +563,7 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
 
         This gives us the sync readback position.
         """
-        return (pos - self.offset[attr]) / self.scale[attr]
+        return (pos - self.offsets[attr]) / self.scales[attr]
 
     def consistency_warning(self):
         """

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -12,6 +12,7 @@ from ophyd.device import FormattedComponent as FCpt
 from ophyd.pseudopos import (PseudoSingle, pseudo_position_argument,
                              real_position_argument)
 from ophyd.signal import EpicsSignal
+from ophyd.sim import fake_device_cache
 from scipy.constants import speed_of_light
 
 from .interface import FltMvInterface
@@ -758,6 +759,7 @@ def delay_instance_factory(
 
 delay_instance_factory.__doc__ = DelayBase.__doc__
 DelayMotor = delay_instance_factory
+fake_device_cache[DelayMotor] = FastMotor
 
 
 class SimDelayStage(DelayBase):

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -742,7 +742,7 @@ def delay_class_factory(motor_class):
     except KeyError:
         cls = type(
             'Delay' + motor_class.__name__,
-            DelayBase,
+            (DelayBase,),
             {'motor': Cpt(motor_class, '')}
         )
         delay_classes[motor_class] = cls

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -480,8 +480,7 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
             raise ValueError(
                 f'Invalid {info_kind}: {setting}, must be dict or None')
         for attr in self._real_attrs:
-            if attr not in setting:
-                setting[attr] = default
+            setting.setdefault(attr, default)
         return setting
 
     def _setup_offsets(self):

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -4,11 +4,11 @@ import typing
 import numpy as np
 import ophyd
 import ophyd.pseudopos
-from ophyd.signal import EpicsSignal
 from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.pseudopos import (PseudoSingle, pseudo_position_argument,
                              real_position_argument)
+from ophyd.signal import EpicsSignal
 from scipy.constants import speed_of_light
 
 from .interface import FltMvInterface
@@ -111,6 +111,7 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
     * Adds support for NotepadLinkedSignal.
     * Makes scalar ``RealPosition`` and ``PseudoPosition`` easily convert
       to floating point values.
+    * Adds a set_current_position helper method
 
     """ + ophyd.pseudopos.PseudoPositioner.__doc__
 
@@ -195,6 +196,22 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         position = super()._update_position()
         self._update_notepad_ioc(position, 'notepad_readback')
         return position
+
+    def set_current_position(self, position):
+        """
+        Adjust all offsets so that the pseudo position matches the input.
+
+        This will raise an AttributeError if any of the real motors is missing
+        a ``set_current_position`` method.
+
+        Parameters
+        ----------
+        position : PseudoPos
+            The position
+        """
+        real_pos = self.forward(position)
+        for motor, pos in zip(self._real, real_pos):
+            motor.set_current_position(pos)
 
 
 class SyncAxesBase(FltMvInterface, PseudoPositioner):

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -426,13 +426,13 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
 
     def __init__(self, *args, **kwargs):
         self._check_settings()
-        super().__init__(*args, **kwargs)
+        self._has_setup = False
         self._real_attrs = [attr for attr, _ in self._get_real_positioners()]
         self.scales = self._fill_info_dict(
             self.scales, self.default_scale, 'scales')
+        super().__init__(*args, **kwargs)
         if self.sync_limits is not None:
             self.sync._limits = tuple(self.sync_limits)
-        self._has_setup = False
 
     def _check_settings(self):
         """Mostly just a typo check."""
@@ -553,7 +553,8 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
         pick_answer = pseudo_calcs[0]
         if self.warn_inconsistent:
             for calc in pseudo_calcs:
-                if not np.isclose(pick_answer, calc, atol=self.warn_deadband):
+                if not np.isclose(pick_answer, calc,
+                                  atol=self.warn_deadband, rtol=0):
                     self.consistency_warning()
                     break
         return self.PseudoPosition(sync=pick_answer)
@@ -594,7 +595,7 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
         logger.info('Planning to perform the following moves:')
         moves = {}
 
-        for attr, pos in goal._asdict.items():
+        for attr, pos in goal._asdict().items():
             if attr == anchor:
                 logger.info(f'Keep {attr} at {anchor_pos}')
             else:
@@ -605,7 +606,7 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
             logger.info('Automatically doing moves because confirm=False')
             do_moves = True
         else:
-            do_moves = input('Confirm? y/n').lower().startswith('y')
+            do_moves = input('Confirm? (y/n): ').lower().startswith('y')
 
         if do_moves:
             statuses = []

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -23,7 +23,7 @@ class SynMotor(FltMvInterface, SynAxis):
         return super().set(position)
 
 
-ignore_kwargs = ('atol',)
+ignore_kwargs = ('atol', 'n_bounces', 'invert')
 
 
 class FastMotor(FltMvInterface, SoftPositioner, Device):
@@ -40,6 +40,9 @@ class FastMotor(FltMvInterface, SoftPositioner, Device):
         for kw in ignore_kwargs:
             kwargs.pop(kw, None)
         super().__init__(init_pos=init_pos, **kwargs)
+
+    def set_current_position(self, position):
+        self._set_position(position)
 
 
 class SlowMotor(FastMotor):

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -128,6 +128,37 @@ def test_sync_axis_crazy():
         sync.move(20)
 
 
+def test_sync_axis_class_checks():
+    logger.debug('test_sync_axis_class_checks')
+
+    class BadSync(SyncAxisDefault):
+        def __init__(self):
+            super().__init__('Bad', name='bad')
+
+    # Original
+    BadSync()
+    # Bad offset_mode
+    BadSync.offset_mode = 'potatoes'
+    with pytest.raises(ValueError):
+        BadSync()
+    BadSync.offset_mode = SyncAxisOffsetMode.STATIC_FIXED
+    # Bad offsets
+    BadSync.offsets = {'seven_billion': 3}
+    with pytest.raises(ValueError):
+        BadSync()
+    BadSync.offsets = None
+    # Bad scales
+    BadSync.scales = {'longcat': 100000000}
+    with pytest.raises(ValueError):
+        BadSync()
+    BadSync.scales = None
+    # Bad fix_sync_keep_still
+    BadSync.fix_sync_keep_still = 'zoomer'
+    with pytest.raises(ValueError):
+        BadSync()
+    BadSync.fix_sync_keep_still = None
+
+
 def test_delay_basic():
     logger.debug('test_delay_basic')
     stage_s = SimDelayStage('prefix', name='name', egu='s', n_bounces=2)

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -132,10 +132,14 @@ def test_delay_basic():
     logger.debug('test_delay_basic')
     stage_s = SimDelayStage('prefix', name='name', egu='s', n_bounces=2)
     stage_ns = SimDelayStage('prefix', name='name', egu='ns', n_bounces=2)
+    stage_inv = SimDelayStage('prefix', name='name', egu='s', n_bounces=2,
+                              invert=True)
     approx_c = 3e8
     stage_s.move(1e-9)
     stage_ns.move(1)
-    for pos in stage_s.motor.position, stage_ns.motor.position:
+    stage_inv.move(-1e-9)
+    for pos in (stage_s.motor.position, stage_ns.motor.position,
+                stage_inv.motor.position):
         assert abs(pos*1e-3 - 1e-9 * approx_c / 2) < 0.01
 
     stage_s.set_current_position(1.0e-6)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR handles many of the requests for `lxt_ttc` by expanding the sync motor handling. To go through them one by one:

- Fix issues where `lxt_ttc` could have inconsistent offset behavior by allowing the `SyncAxis` to define static offsets (which is going to be the default). Since I'm changing a default, I've decided to deprecate the previous `SyncAxesBase`. (closes #770)
- Add `set_current_position` to all pcdsdevices `PseudoPositioner`s (closes #772)
- Add a warning when any `SyncAxis` subclass has motor positions that do not match each other properly, and provide a method (`fix_sync`) to re-synchronize them (closes #776) 
- Provide an example of a clean way to implement `lxt_ttc` per instrument so that the scientists can reconfigure it as needed (closes #777)
- Add direction inversion directly to `DelayBase` instead of requiring a special inversion class. (closes #778)
- Add `set_position` as an alias to `set_current_position` (no issue number, but I remember this from the meeting)

Obsoletes the following PRs:
- closes #771
- closes #773

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`lxt_ttc` had issues recently that made the code unusable, we want to:
- fix the issues
- use a more stable and configurable base
- allow the scientists to configure `lxt_ttc` themselves, as it will change between experiments
- add requested features

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some unit tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release docs

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
