### PR TITLE
ENH: custom status info for DelayBase and SyncAxis

### DIFF
--- a/docs/source/upcoming_release_notes/790-delaysync-pp.rst
+++ b/docs/source/upcoming_release_notes/790-delaysync-pp.rst
@@ -19,7 +19,7 @@ New Devices
 
 Bugfixes
 --------
-- N/A
+- Fix issue where Newport motors would not show units in their status prints.
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/790-delaysync-pp.rst
+++ b/docs/source/upcoming_release_notes/790-delaysync-pp.rst
@@ -23,7 +23,8 @@ Bugfixes
 
 Maintenance
 -----------
-- N/A
+- Make unit handling in status_info more consistent to improve reliability of
+  status printouts.
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/790-delaysync-pp.rst
+++ b/docs/source/upcoming_release_notes/790-delaysync-pp.rst
@@ -20,6 +20,8 @@ New Devices
 Bugfixes
 --------
 - Fix issue where Newport motors would not show units in their status prints.
+- Fix issue where SyncAxis was not compatible with PseudoPositioners as
+  its synchronized "real" motors.
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/790-delaysync-pp.rst
+++ b/docs/source/upcoming_release_notes/790-delaysync-pp.rst
@@ -1,0 +1,30 @@
+790 delaysync-pp
+################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add custom status prints for DelayBase and SyncAxis
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -21,7 +21,7 @@ from pcdsdevices.pv_positioner import PVPositionerComparator
 from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import OffsetMotorBase, delay_class_factory
-from .signal import EpicsSignalROEditMD, PytmcSignal
+from .signal import EpicsSignalEditMD, EpicsSignalROEditMD, PytmcSignal
 from .utils import get_status_value
 from .variety import set_metadata
 
@@ -560,6 +560,8 @@ class Newport(PCDSMotorBase):
     # Override from EpicsMotor to change class for MD update
     user_readback = Cpt(EpicsSignalROEditMD, '.RBV', kind='hinted',
                         auto_monitor=True)
+    user_setpoint = Cpt(EpicsSignalEditMD, '.VAL', limits=True,
+                        auto_monitor=True)
 
     # Override from EpicsMotor to disable
     offset_freeze_switch = Cpt(Signal, kind='omitted')
@@ -596,18 +598,22 @@ class Newport(PCDSMotorBase):
     @motor_egu.sub_value
     def _update_units(self, value, **kwargs):
         self.user_readback._override_metadata(units=value)
+        self.user_setpoint._override_metadata(units=value)
 
     @high_limit_travel.sub_value
     def _update_hlt(self, value, **kwargs):
         self.user_readback._override_metadata(upper_ctrl_limit=value)
+        self.user_setpoint._override_metadata(upper_ctrl_limit=value)
 
     @low_limit_travel.sub_value
     def _update_llt(self, value, **kwargs):
         self.user_readback._override_metadata(lower_ctrl_limit=value)
+        self.user_setpoint._override_metadata(lower_ctrl_limit=value)
 
     @motor_prec.sub_value
     def _update_prec(self, value, **kwargs):
         self.user_readback._override_metadata(precision=value)
+        self.user_setpoint._override_metadata(precision=value)
 
 
 DelayNewport = delay_class_factory(Newport)

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -443,6 +443,12 @@ def device_info(device, subdevice_filter=None, devices=None):
         except Exception:
             ...
 
+    try:
+        # Best-effort try at getting the units
+        info['units'] = get_units(device)
+    except Exception:
+        pass
+
     if device not in devices:
         devices.add(device)
         for cpt_name, cpt_desc in device._sig_attrs.items():

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -553,6 +553,10 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
 
         This gives us the sync readback position.
         """
+        if isinstance(pos, tuple):
+            # Psuedo position tuple, assume first value is correct
+            # This happens if we are synchronizing pseudo motors
+            pos = pos[0]
         return (pos - self.offsets[attr]) / self.scales[attr]
 
     def is_synced(self, real_pos=None):

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -84,7 +84,9 @@ class PseudoSingleInterface(FltMvInterface, PseudoSingle):
         status: str
             Formatted string with all relevant status information.
         """
-        units = get_status_value(status_info, 'notepad_readback', 'units')
+        units = get_status_value(status_info, 'units')
+        if not units:
+            units = get_status_value(status_info, 'notepad_readback', 'units')
         position = get_status_float(
             status_info, 'position', precision=3, format='e')
         # if a dial_pos is not present we can assume that the dial position is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add custom status info for DelayBase and SyncAxis, so you'll see these on all delay motors and on lxt_ttc.

SyncAxis includes all the real motor positions:
```
In [5]: fake_lxt_ttc
Out[5]:
SyncAxis: fake_lxt_ttc
lxt position: 1e-06 [N/A]
txt position: -1e-06 [N/A]
Sync position: 1e-06
Sync limits (low, high): (-1e-05, 1e-05)
```
DelayBase is a copy of the pseudosingle delay positioner:
```
In [16]: delay
Out[16]:
Virtual Motor XPP:LAS:MMN:12:delay
Current position (user, dial): 0.000e+00, 0.000e+00 [None]
User limits (low, high): 0, 0 [None]
Preset position: Unknown

In [17]: delay.delay
Out[17]:
Virtual Motor XPP:LAS:MMN:12:delay
Current position (user, dial): 0.000e+00, 0.000e+00 [None]
User limits (low, high): 0, 0 [None]
Preset position: Unknown
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #790 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
