### PR TITLE
MNT: set epics motor soft limit kinds to config for typhos

### DIFF
--- a/docs/source/upcoming_release_notes/793-config-soft-limits.rst
+++ b/docs/source/upcoming_release_notes/793-config-soft-limits.rst
@@ -1,0 +1,30 @@
+793 config-soft-limits
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Set EpicsMotor soft limit kinds to "config" for use in typhos.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -81,6 +81,8 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     EpicsMotor.motor_is_moving.kind = Kind.normal
     set_metadata(EpicsMotor.motor_stop, dict(variety='command-proc', value=1))
     EpicsMotor.motor_stop.kind = Kind.normal
+    EpicsMotor.high_limit_travel.kind = Kind.config
+    EpicsMotor.low_limit_travel.kind = Kind.config
     EpicsMotor.direction_of_travel.kind = Kind.normal
 
     def format_status_info(self, status_info):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Set the soft limit kinds to config

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We'd like to see these in typhos
closes #793

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Opened a screen

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
