### PR TITLE
FIX: pass through derived 'units' in SUB_META callbacks

### DIFF
--- a/docs/source/upcoming_release_notes/767-fix_ucds_unit_md_callback.rst
+++ b/docs/source/upcoming_release_notes/767-fix_ucds_unit_md_callback.rst
@@ -1,0 +1,33 @@
+767 fix_ucds_unit_md_callback
+#############################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- :class:`~pcdsdevices.signal.UnitConversionDerivedSignal` will now pass
+  through the ``units`` keyword argument in its metadata (``SUB_META`` or
+  ``'meta'``) callbacks.  It will be included even if the original signal
+  did not include ``units`` in metadata callbacks. (#767)
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -2,6 +2,7 @@ import logging
 import threading
 from unittest.mock import Mock
 
+import pytest
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
 from ophyd.sim import FakeEpicsSignal
 
@@ -52,40 +53,79 @@ def test_avg_signal():
     assert cb.called
 
 
-def test_unit_conversion_signal():
+class MockCallbackHelper:
+    """
+    Simple helper for getting a callback, setting an event, and checking args.
+
+    Use __call__ as the hook and inspect/verify ``mock`` or ``call_kwargs``.
+    """
+
+    def __init__(self):
+        self.event = threading.Event()
+        self.mock = Mock()
+
+    def __call__(self, *args, **kwargs):
+        self.mock(*args, **kwargs)
+        self.event.set()
+
+    def wait(self, timeout=1.0):
+        """Wait for the callback to be called."""
+        self.event.wait(timeout)
+
+    @property
+    def call_kwargs(self):
+        """Call keyword arguments."""
+        _, kwargs = self.mock.call_args
+        return kwargs
+
+
+@pytest.fixture(scope='function')
+def unit_conv_signal():
     orig = FakeEpicsSignal('sig', name='orig')
+    if 'units' not in orig.metadata_keys:
+        # HACK: This will need to be fixed upstream in ophyd as part of
+        # upstreaming UnitConversionDerivedSignal
+        orig._metadata_keys = orig.metadata_keys + ('units', )
+
     orig.sim_put(5)
 
-    converted = UnitConversionDerivedSignal(
+    return UnitConversionDerivedSignal(
         derived_from=orig,
         original_units='m',
         derived_units='mm',
         name='converted',
     )
 
-    assert converted.original_units == 'm'
-    assert converted.derived_units == 'mm'
-    assert converted.describe()[converted.name]['units'] == 'mm'
 
-    assert converted.get() == 5_000
-    converted.put(10_000, wait=True)
-    assert orig.get() == 10
+def test_unit_conversion_signal_units(unit_conv_signal):
+    assert unit_conv_signal.original_units == 'm'
+    assert unit_conv_signal.derived_units == 'mm'
+    assert unit_conv_signal.describe()[unit_conv_signal.name]['units'] == 'mm'
 
-    event = threading.Event()
-    cb = Mock()
 
-    def callback(**kwargs):
-        cb(**kwargs)
-        event.set()
+def test_unit_conversion_signal_get_put(unit_conv_signal):
+    assert unit_conv_signal.get() == 5_000
+    unit_conv_signal.put(10_000, wait=True)
+    assert unit_conv_signal.derived_from.get() == 10
 
-    converted.subscribe(callback, run=False)
-    orig.put(20, wait=True)
-    event.wait(1)
-    cb.assert_called_once()
 
-    args, kwargs = cb.call_args
-    assert kwargs['value'] == 20_000
-    assert converted.get() == 20_000
+def test_unit_conversion_signal_value_sub(unit_conv_signal):
+    helper = MockCallbackHelper()
+    unit_conv_signal.subscribe(helper, run=False)
+    unit_conv_signal.derived_from.put(20, wait=True)
+    helper.wait(1)
+    helper.mock.assert_called_once()
+
+    assert helper.call_kwargs['value'] == 20_000
+    assert unit_conv_signal.get() == 20_000
+
+
+def test_unit_conversion_signal_metadata_sub(unit_conv_signal):
+    helper = MockCallbackHelper()
+    unit_conv_signal.subscribe(helper, run=True, event_type='meta')
+    helper.wait(1)
+    helper.mock.assert_called_once()
+    assert helper.call_kwargs['units'] == 'mm'
 
 
 def test_optional_epics_signal(monkeypatch):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Metadata callbacks did not include appropriate units for UnitConversionDerivedSignal.

## Motivation and Context
Closes #767 

Also ensures that `units` will be included, even if the original signal did not include them in metadata callbacks.
This is, in fact, a bug in upstream ophyd's `FakeEpicsSignal`.

Consider this a pre-requisite to upstreaming the signal class to ophyd.

## How Has This Been Tested?
See new-and-improved test suite.

## Where Has This Been Documented?
Pre-release docs incoming

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
