### PR TITLE
Coating state

### DIFF
--- a/docs/source/upcoming_release_notes/issue-add_coating_states_to_XOffsetMirrorState.rst
+++ b/docs/source/upcoming_release_notes/issue-add_coating_states_to_XOffsetMirrorState.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- mghaly
+- ghalym

--- a/docs/source/upcoming_release_notes/issue-add_coating_states_to_XOffsetMirrorState.rst
+++ b/docs/source/upcoming_release_notes/issue-add_coating_states_to_XOffsetMirrorState.rst
@@ -1,0 +1,30 @@
+issue add coating states to XOffsetMirrorState
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- XOffsetMirrorState for mirror coatings
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- mghaly

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -783,4 +783,3 @@ class XOffsetMirrorState(XOffsetMirror, CoatingState):
     """
     # UI representation
     _icon = 'fa.minus-square'
-    pass

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -20,6 +20,7 @@ from .inout import InOutRecordPositioner
 from .interface import BaseInterface, FltMvInterface
 from .signal import PytmcSignal
 from .utils import get_status_value
+from .pmps import TwinCATStatePMPS
 
 logger = logging.getLogger(__name__)
 
@@ -365,7 +366,6 @@ class XOffsetMirror(BaseInterface, Device):
                           kind='normal')
     couple_status_x = Cpt(PytmcSignal, ':ALREADY_COUPLED_X', io='i',
                           kind='normal')
-
     # RMS Cpts:
     y_enc_rms = Cpt(PytmcSignal, ':ENC:Y:RMS', io='i', kind='normal',
                     doc='Yup encoder RMS deviation [um]')
@@ -757,3 +757,30 @@ pitch: ({self.pitch.prefix})
     description: {p_description}
     pitch_enc_rms: {p_enc_rms}
 """
+
+
+class CoatingState(Device):
+    # Coating States
+    coating = Cpt(TwinCATStatePMPS, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
+
+
+class XOffsetMirrorState(XOffsetMirror, CoatingState):
+    """
+    X-ray Offset Mirror with Yleft/Yright
+
+    1st and 2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
+
+    With Coating State selection implemented
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+    pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Implementation of Coating State mover for the MR1L0 and MR2L0 mirrors
<!--- Describe your changes in detail -->
Since this hasn't been implemented yet to all offset mirrors additional classes have been added to e used by those two mirrors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Implementation of Coating State mover for the MR1L0 and MR2L0 mirrors
## How Has This Been Tested?
This has been tested on my local environment

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
![image](https://user-images.githubusercontent.com/43865116/112403726-2e200700-8ccc-11eb-8939-8a52bad3e8b0.png)
![image](https://user-images.githubusercontent.com/43865116/112403762-3f691380-8ccc-11eb-9205-e1cfa2a6a5c3.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
