### PR TITLE
Added VRC_NO class to valve module

### DIFF
--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -228,41 +228,6 @@ class VRC(VVC, LightpathMixin):
         self._removed = lightpath_values[self.open_limit]['value']
 
 
-class VRCNO(Device, LightpathMixin):
-    """Gate Valve, Controlled, Normally Open."""
-
-    # Configuration for lightpath
-    lightpath_cpts = ['open_limit', 'closed_limit']
-    _icon = 'fa.hourglass'
-
-    close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',
-                        doc='Epics command to close valve')
-    close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS', kind='omitted',
-                         doc=('Epics Command for open the valve in override '
-                              'mode'))
-    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
-                      doc='Epics Command to set/reset Override mode')
-    close_ok = Cpt(EpicsSignalRO, ':CLS_OK_RBV', kind='normal',
-                   doc='used for normally open valves')
-    close_do = Cpt(EpicsSignalRO, ':CLS_DO_RBV', kind='normal',
-                   doc='PLC Output to close valve')
-
-    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal', doc='Valve state')
-
-    error_reset = Cpt(EpicsSignalWithRBV, ':ALM_RST', kind='normal',
-                      doc='Reset Error state to valid by toggling this')
-    open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
-                     doc='Open limit switch digital input')
-    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',
-                       doc='Closed limit switch digital input')
-
-    def _set_lightpath_states(self, lightpath_values):
-        """Callback for updating inserted/removed for lightpath."""
-
-        self._inserted = lightpath_values[self.closed_limit]['value']
-        self._removed = lightpath_values[self.open_limit]['value']
-
-
 class VGC(VRC):
     """Class for Controlled Gate Valves."""
     diff_press_ok = Cpt(EpicsSignalRO, ':DP_OK_RBV', kind='normal',
@@ -361,6 +326,29 @@ class VVCNO(Device):
                    doc='used for normally open valves')
     close_do = Cpt(EpicsSignalRO, ':CLS_DO_RBV', kind='normal',
                    doc='PLC Output to close valve')
+
+
+class VRCNO(VVCNO, LightpathMixin):
+    """Gate Valve, Controlled, Normally Open."""
+
+    # Configuration for lightpath
+    lightpath_cpts = ['open_limit', 'closed_limit']
+    _icon = 'fa.hourglass'
+
+    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal', doc='Valve state')
+
+    error_reset = Cpt(EpicsSignalWithRBV, ':ALM_RST', kind='normal',
+                      doc='Reset Error state to valid by toggling this')
+    open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
+                     doc='Open limit switch digital input')
+    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',
+                       doc='Closed limit switch digital input')
+
+    def _set_lightpath_states(self, lightpath_values):
+        """Callback for updating inserted/removed for lightpath."""
+
+        self._inserted = lightpath_values[self.closed_limit]['value']
+        self._removed = lightpath_values[self.open_limit]['value']
 
 
 class VCN(Device):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -170,6 +170,8 @@ class ValveBase(Device):
     """
     Base class for valves.
 
+    Valves are normally closed by default.
+
     Newer class. This and below are still missing some functionality.
     Still need to work out replacement of old classes.
     """
@@ -214,6 +216,41 @@ class VRC(VVC, LightpathMixin):
     _icon = 'fa.hourglass'
 
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal', doc='Valve state')
+    open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
+                     doc='Open limit switch digital input')
+    closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',
+                       doc='Closed limit switch digital input')
+
+    def _set_lightpath_states(self, lightpath_values):
+        """Callback for updating inserted/removed for lightpath."""
+
+        self._inserted = lightpath_values[self.closed_limit]['value']
+        self._removed = lightpath_values[self.open_limit]['value']
+
+
+class VRCNO(Device, LightpathMixin):
+    """Gate Valve, Controlled, Normally Open."""
+
+    # Configuration for lightpath
+    lightpath_cpts = ['open_limit', 'closed_limit']
+    _icon = 'fa.hourglass'
+
+    close_command = Cpt(EpicsSignalWithRBV, ':CLS_SW', kind='normal',
+                        doc='Epics command to close valve')
+    close_override = Cpt(EpicsSignalWithRBV, ':FORCE_CLS', kind='omitted',
+                         doc=('Epics Command for open the valve in override '
+                              'mode'))
+    override_on = Cpt(EpicsSignalWithRBV, ':OVRD_ON', kind='omitted',
+                      doc='Epics Command to set/reset Override mode')
+    close_ok = Cpt(EpicsSignalRO, ':CLS_OK_RBV', kind='normal',
+                   doc='used for normally open valves')
+    close_do = Cpt(EpicsSignalRO, ':CLS_DO_RBV', kind='normal',
+                   doc='PLC Output to close valve')
+
+    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal', doc='Valve state')
+
+    error_reset = Cpt(EpicsSignalWithRBV, ':ALM_RST', kind='normal',
+                      doc='Reset Error state to valid by toggling this')
     open_limit = Cpt(EpicsSignalRO, ':OPN_DI_RBV', kind='hinted',
                      doc='Open limit switch digital input')
     closed_limit = Cpt(EpicsSignalRO, ':CLS_DI_RBV', kind='hinted',


### PR DESCRIPTION

## Description
Adding a normally open class for VRC gate valves to valve module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
VRCNO exists in the vacuum library on the PLC but was not built out yet in the ophyd pcdsdevices module, Valve.py.

LAMP:ROUGH:VRC:02 is normally open, and the vacuum pydm screen would ideally reflect that.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested my new version of valve.py using flake8 and pytest. No violations were reported.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
The new class is documented in the class docstring. Additional documentation can be found in the lcls-plc-lamp-vacuum library under ST_VRC_NO.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
