### PR TITLE
MNT: fix set position bug

### DIFF
--- a/docs/source/upcoming_release_notes/805-set-position-bug.rst
+++ b/docs/source/upcoming_release_notes/805-set-position-bug.rst
@@ -1,0 +1,34 @@
+805 set-position-bug
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where calling ``set_current_position`` on certain motors would
+  cause the ipython session to freeze, leaving the motor in the ``set`` state
+  instead of bringing it back to the ``use`` state.
+- Hacky workaround for IMS motor part number strings being unable to be read
+  through pyepics when they contain invalid utf-8 characters.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -20,7 +20,7 @@ def make_new_bts(old_bts):
         try:
             return old_bts(st1)
         except UnicodeDecodeError:
-            return new_bts(st1[1:])
+            return st1.decode("utf-8", "ignore")
     return new_bts
 
 

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,4 +1,5 @@
-# Hacky ophyd hotfix
+# Hacky ophyd and pyepics hotfixes
+import epics.ca
 from ophyd.device import Device
 
 from ._version import get_versions
@@ -11,6 +12,26 @@ def __contains__(self, value):
 Device.OphydAttrList.__contains__ = __contains__
 del Device
 del __contains__
+
+
+# Fix handling of often corrupt IMS PN fields
+def make_new_bts(old_bts):
+    def new_bts(st1):
+        try:
+            return old_bts(st1)
+        except UnicodeDecodeError:
+            return new_bts(st1[1:])
+    return new_bts
+
+
+try:
+    epics.ca.BYTES2STR = make_new_bts(epics.ca.BYTES2STR)
+    epics.ca.bytes2str = make_new_bts(epics.ca.bytes2str)
+except AttributeError:
+    pass
+
+del epics.ca
+del make_new_bts
 
 __version__ = get_versions()['version']
 del get_versions

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -418,7 +418,7 @@ class PCDSMotorBase(EpicsMotorInterface):
         This is a re-implementation of the ophyd set_current_position, which
         does not work on some legacy PCDS motors because they do not use the
         standard motor record. This non-standard record does not respond
-        correctly to wait=True on the VAL field with SET/USE set to USE.
+        correctly to wait=True on the VAL field while SET/USE is set to SET.
         """
         self.set_use_switch.put(1, wait=True)
         set_and_wait(self.user_setpoint, pos, timeout=1)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -14,7 +14,7 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
 from ophyd.status import DeviceStatus, MoveStatus, SubscriptionStatus
 from ophyd.status import wait as status_wait
 from ophyd.utils import LimitError
-from ophyd.utils.epics_pvs import raise_if_disconnected
+from ophyd.utils.epics_pvs import raise_if_disconnected, set_and_wait
 
 from pcdsdevices.pv_positioner import PVPositionerComparator
 
@@ -310,6 +310,9 @@ class PCDSMotorBase(EpicsMotorInterface):
         motor record.  This is a reduced version of the standard EPICS
         'SPMG' field.  Setting to 'STOP', 'PAUSE' and 'GO'  will respectively
         stop motor movement, pause a move in progress, or resume a paused move.
+        3. In some cases, puts to the setpoint PV cannot be waited on. In fact
+        this seems to brick the whole python session, requiring a slightly
+        modified set_current_position method.
     """
 
     # Disable missing field that our EPICS motor record lacks
@@ -406,6 +409,20 @@ class PCDSMotorBase(EpicsMotorInterface):
             return
         arg = self.prefix
         os.system(executable + ' ' + arg)
+
+    @raise_if_disconnected
+    def set_current_position(self, pos):
+        """
+        Change the offset such that pos is the current position.
+
+        This is a re-implementation of the ophyd set_current_position, which
+        does not work on some legacy PCDS motors because they do not use the
+        standard motor record. This non-standard record does not respond
+        correctly to wait=True on the VAL field with SET/USE set to USE.
+        """
+        self.set_use_switch.put(1, wait=True)
+        set_and_wait(self.user_setpoint, pos, timeout=1)
+        self.set_use_switch.put(0, wait=True)
 
 
 class IMS(PCDSMotorBase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix an issue where calling ``set_current_position`` on certain motors would cause the ipython session to freeze, leaving the motor in the ``set`` state instead of bringing it back to the ``use`` state.
- Hacky workaround for IMS motor part number strings being unable to be read through pyepics when they contain invalid utf-8 characters. (Is there a better way to do this? Perhaps by picking a different character set for the pyepics string interpretation? There's something I half remember about this)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #805 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on `XPP:USR:PRT:MMS:25`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
