### PR TITLE
ENH: Slit interface changes and precision in status printout

### DIFF
--- a/docs/source/upcoming_release_notes/811-Slit_interface_changes_and_precision_in_status_printout.rst
+++ b/docs/source/upcoming_release_notes/811-Slit_interface_changes_and_precision_in_status_printout.rst
@@ -1,0 +1,31 @@
+811 Slit interface changes and precision in status printout
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Slits objects now have vo, vg, ho, and hg aliases.
+- Motor objects now print out values with a precision of 3 places.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZryletTC

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -22,7 +22,7 @@ from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import OffsetMotorBase, delay_class_factory
 from .signal import EpicsSignalEditMD, EpicsSignalROEditMD, PytmcSignal
-from .utils import get_status_float
+from .utils import get_status_float, get_status_value
 from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
@@ -103,10 +103,8 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
-        description = get_status_float(status_info, 'description', 'value',
-                                       precision=3)
-        units = get_status_float(status_info, 'user_setpoint', 'units',
-                                 precision=3)
+        description = get_status_value(status_info, 'description', 'value')
+        units = get_status_value(status_info, 'user_setpoint', 'units')
         dial = get_status_float(status_info, 'dial_position', 'value',
                                 precision=3)
         user = get_status_float(status_info, 'position', precision=3)

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -103,7 +103,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
-        precision = self.user_readback.metadata['precision']
+        precision = self.user_readback.metadata['precision'] or 3
         description = get_status_value(status_info, 'description', 'value')
         units = get_status_value(status_info, 'user_setpoint', 'units')
         dial = get_status_float(status_info, 'dial_position', 'value',

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -103,11 +103,12 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
+        precision = self.user_readback.metadata['precision']
         description = get_status_value(status_info, 'description', 'value')
         units = get_status_value(status_info, 'user_setpoint', 'units')
         dial = get_status_float(status_info, 'dial_position', 'value',
-                                precision=3)
-        user = get_status_float(status_info, 'position', precision=3)
+                                precision=precision)
+        user = get_status_float(status_info, 'position', precision=precision)
 
         low, high = self.limits
         switch_limits = self.check_limit_switches()
@@ -120,7 +121,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         return f"""\
 {name}
 Current position (user, dial): {user}, {dial} [{units}]
-User limits (low, high): {low:.3f}, {high:.3f} [{units}]
+User limits (low, high): {low:.{precision}f}, {high:.{precision}f} [{units}]
 Preset position: {self.presets.state()}
 Limit Switch: {switch_limits}
 """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -22,7 +22,7 @@ from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import OffsetMotorBase, delay_class_factory
 from .signal import EpicsSignalEditMD, EpicsSignalROEditMD, PytmcSignal
-from .utils import get_status_value, get_status_float
+from .utils import get_status_float
 from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
@@ -103,9 +103,12 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
-        description = get_status_float(status_info, 'description', 'value', precision=3)
-        units = get_status_float(status_info, 'user_setpoint', 'units', precision=3)
-        dial = get_status_float(status_info, 'dial_position', 'value', precision=3)
+        description = get_status_float(status_info, 'description', 'value',
+                                       precision=3)
+        units = get_status_float(status_info, 'user_setpoint', 'units',
+                                 precision=3)
+        dial = get_status_float(status_info, 'dial_position', 'value',
+                                precision=3)
         user = get_status_float(status_info, 'position', precision=3)
 
         low, high = self.limits
@@ -116,7 +119,6 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         if description:
             name = f'{description}: {self.prefix}'
 
-        # figure out how to update precision globally to 3 places. %precision doesn't seem to be working but worth investigating
         return f"""\
 {name}
 Current position (user, dial): {user}, {dial} [{units}]

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -22,7 +22,7 @@ from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import OffsetMotorBase, delay_class_factory
 from .signal import EpicsSignalEditMD, EpicsSignalROEditMD, PytmcSignal
-from .utils import get_status_value
+from .utils import get_status_value, get_status_float
 from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
@@ -103,10 +103,10 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         status: str
             Formatted string with all relevant status information.
         """
-        description = get_status_value(status_info, 'description', 'value')
-        units = get_status_value(status_info, 'user_setpoint', 'units')
-        dial = get_status_value(status_info, 'dial_position', 'value')
-        user = get_status_value(status_info, 'position')
+        description = get_status_float(status_info, 'description', 'value', precision=3)
+        units = get_status_float(status_info, 'user_setpoint', 'units', precision=3)
+        dial = get_status_float(status_info, 'dial_position', 'value', precision=3)
+        user = get_status_float(status_info, 'position', precision=3)
 
         low, high = self.limits
         switch_limits = self.check_limit_switches()
@@ -116,10 +116,11 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         if description:
             name = f'{description}: {self.prefix}'
 
+        # figure out how to update precision globally to 3 places. %precision doesn't seem to be working but worth investigating
         return f"""\
 {name}
 Current position (user, dial): {user}, {dial} [{units}]
-User limits (low, high): {low}, {high} [{units}]
+User limits (low, high): {low:.3f}, {high:.3f} [{units}]
 Preset position: {self.presets.state()}
 Limit Switch: {switch_limits}
 """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -150,8 +150,14 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
             motors.
         """
 
+        # Check for missing size
+        if width is None and height is None:
+            raise TypeError("move() missing 1 required positional "
+                            "argument: 'width'")
+        elif width is None:
+            width = height
         # Check for rectangular setpoint
-        if isinstance(width, tuple):
+        elif isinstance(width, tuple):
             (width, height) = width
         elif height is None:
             height = width

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -66,6 +66,10 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         self._has_subscribed = False
         super().__init__(*args, **kwargs)
         self.nominal_aperture.put(nominal_aperture)
+        self.hg = self.xwidth
+        self.vg = self.ywidth
+        self.ho = self.xcenter
+        self.vo = self.ycenter
 
     def format_status_info(self, status_info):
         """
@@ -115,7 +119,7 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
 (ho, vo): ({x_center}, {y_center}) [{c_units}]
 """
 
-    def move(self, size, wait=False, moved_cb=None, timeout=None):
+    def move(self, width, height=None, *, wait=False, moved_cb=None, timeout=None):
         """
         Set the dimensions of the width/height of the gap to width paramater.
 
@@ -145,10 +149,10 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         """
 
         # Check for rectangular setpoint
-        if isinstance(size, tuple):
-            (width, height) = size
-        else:
-            width, height = size, size
+        if isinstance(width, tuple):
+            (width, height) = width
+        elif height is None:
+            height = width
         # Instruct both width and height then combine the output status
         x_stat = self.xwidth.move(width, wait=False, timeout=timeout)
         y_stat = self.ywidth.move(height, wait=False, timeout=timeout)
@@ -165,6 +169,12 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
                 self.ywidth.stop()
                 raise
         return status
+
+    def __call__(self, width=None, height=None):
+        if width is None and height is None:
+            return self.wm()
+        else:
+            return self.move(width=width, height=height)
 
     @property
     def current_aperture(self):

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -119,19 +119,21 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
 (ho, vo): ({x_center}, {y_center}) [{c_units}]
 """
 
-    def move(self, width, height=None, *, wait=False, moved_cb=None, timeout=None):
+    def move(self, width, height=None, *, wait=False, moved_cb=None,
+             timeout=None):
         """
-        Set the dimensions of the width/height of the gap to width paramater.
+        Set the dimensions of the width/height of the slits gap.
 
         Parameters
         ---------
         size : float or tuple of float
-            Target size for slits in both x and y axis. Either specify as a
-            tuple for a rectangular aperture, ``(width, height)``, or set both
-            with single floating point value to use a square opening.
+            Target size for slits in both x and y axis. If a square gap is
+            desired, a single value can be entered. Otherwise, the width and
+            height can both be entered, either as separate arguments or as a
+            tuple.
 
-        wait : bool
-            If `True`, block until move is completed.
+        wait : bool, optional
+            If `True`, block until move is completed. Defaults to `False`.
 
         timeout : float, optional
             Maximum time for the motion. If `None` is given, the default value
@@ -171,6 +173,9 @@ class SlitsBase(MvInterface, Device, LightpathMixin):
         return status
 
     def __call__(self, width=None, height=None):
+        """
+        If arguments are provided, attempt a move. Otherwise, query position.
+        """
         if width is None and height is None:
             return self.wm()
         else:

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -32,6 +32,7 @@ from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
 from .pmps import TwinCATStatePMPS
 from .sensors import RTD, TwinCATTempSensor
 from .signal import NotImplementedSignal, PytmcSignal
+from .sim import FastMotor
 from .utils import get_status_float, get_status_value, schedule_task
 from .variety import set_metadata
 
@@ -578,3 +579,10 @@ class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
     def y_states(self):
         """Alias old name. Will deprecate."""
         return self.target
+
+
+class SimLusiSlits(LusiSlits):
+    xwidth = Cpt(FastMotor)
+    ywidth = Cpt(FastMotor)
+    xcenter = Cpt(FastMotor)
+    ycenter = Cpt(FastMotor)

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -75,6 +75,13 @@ def test_slit_motion(fake_slits):
     assert status.done and status.success
 
 
+def test_slit_interface(fake_slits):
+    logger.debug('test_slits_interface')
+    slits = fake_slits
+    slits(3, 5)
+    assert slits() == (3, 5)
+
+
 def test_slit_subscriptions(fake_slits):
     logger.debug('test_slit_subscriptions')
     slits = fake_slits

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -4,14 +4,14 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.slits import Slits
+from pcdsdevices.slits import LusiSlits, SimLusiSlits
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_slits():
-    FakeSlits = make_fake_device(Slits)
+    FakeSlits = make_fake_device(LusiSlits)
     slits = FakeSlits("TST:JAWS:", name='Test Slits')
     # Set centers
     slits.xcenter.readback.sim_put(0.0)
@@ -75,9 +75,9 @@ def test_slit_motion(fake_slits):
     assert status.done and status.success
 
 
-def test_slit_interface(fake_slits):
+def test_slit_interface():
     logger.debug('test_slits_interface')
-    slits = fake_slits
+    slits = SimLusiSlits('SIM:SLIT', name='sim_slits')
     slits(3, 5)
     assert slits() == (3, 5)
 
@@ -111,4 +111,4 @@ def test_slit_staging(fake_slits):
 
 @pytest.mark.timeout(5)
 def test_slits_disconnected():
-    Slits("TST:JAWS:", name='Test Slits')
+    LusiSlits("TST:JAWS:", name='Test Slits')


### PR DESCRIPTION
## Description
These are two simple changes requested by scientists in XPP/XCS that have been living in a dev checkout for a little while now. Thought it might be a good time to PR them.

First is slit interface changes. Primarily, this change allows users to do things like `s3(4,5)` and adds the aliases, `vo, vg, ho, hg`, for access to the components.

The other thing is specification of precision for the values used in motor status printouts. For now, I've hardcoded a precision of 3 decimal places, but am definitely open to other suggestions. There's probably a good way to use PREC or smth, right?

It would also be nice if we could update precision globally within an hutch-python session. `%precision` doesn't seem to be work for these printouts but might be worth further investigation.

## Motivation and Context
Scientists like their old-python conventions and unnecessarily long numbers are annoying.

## How Has This Been Tested?
Been running in dev for at least a month I think. Did some basic interactive tests when I wrote it back then. Passes Travis.

## Where Has This Been Documented?
...oops

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
