### PR TITLE
MNT: fix states on mirror coating

### DIFF
--- a/docs/source/upcoming_release_notes/812-mirror-states.rst
+++ b/docs/source/upcoming_release_notes/812-mirror-states.rst
@@ -1,0 +1,31 @@
+812 mirror-states
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where the mirror coating states were expecting the default
+  'OUT' position, which does not exist on the real device.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -18,9 +18,9 @@ from .doc_stubs import basic_positioner_init
 from .epics_motor import BeckhoffAxis
 from .inout import InOutRecordPositioner
 from .interface import BaseInterface, FltMvInterface
+from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
 from .utils import get_status_value
-from .pmps import TwinCATStatePMPS
 
 logger = logging.getLogger(__name__)
 
@@ -759,9 +759,21 @@ pitch: ({self.pitch.prefix})
 """
 
 
+class TwinCATMirrorStripe(TwinCATStatePMPS):
+    # Select auto mode: get states from EPICS, every state is IN
+    states_list = []
+    in_states = []
+    out_states = []
+    _in_if_not_out = True
+
+    @property
+    def transmission(self):
+        return 1
+
+
 class CoatingState(Device):
     # Coating States
-    coating = Cpt(TwinCATStatePMPS, ':COATING:STATE', kind='hinted',
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')
 
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -760,7 +760,16 @@ pitch: ({self.pitch.prefix})
 
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):
-    # Select auto mode: get states from EPICS, every state is IN
+    """
+    Subclass of TwinCATStatePMPS for the mirror coatings.
+
+    Unless most TwinCATStatePMPS, we have:
+    - Only in_states
+    - No in_states block the beam
+
+    We also clear the states_list and set _in_if_not_out to True
+    to automatically pick up the coatings from each mirror enum.
+    """
     states_list = []
     in_states = []
     out_states = []
@@ -768,11 +777,16 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
 
     @property
     def transmission(self):
+        """The mirror coating never blocks the beam."""
         return 1
 
 
 class CoatingState(Device):
-    # Coating States
+    """
+    Extra parent class to put "coating" as the first device in order.
+
+    This makes it appear at the top of the screen in typhos.
+    """
     coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Twincat mirror coating doesn't have the default in/out states, it has only in states and these are at varying materials.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #812 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively:
```
$ happi load mr1l0_homs
[2021-04-06 09:36:35] - INFO -  Creating shell with devices ['mr1l0_homs']
Python 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:22:27)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [2]: mr1l0_homs.coating.position
Out[2]: 'B4C'

In [3]: mr1l0_homs.coating.out_states
Out[3]: []

In [4]: mr1l0_homs.coating.inserted
Out[4]: True

In [5]: mr1l0_homs.coating.states_list
Out[5]: ['Unknown', 'B4C', 'B4C_Ni']

```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
oops, forgot to do the pre-release notes, will revisit in a moment

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
