### PR TITLE
MNT: RTDSK0 is just 2 actuators for now (4 channels total)

### DIFF
--- a/docs/source/upcoming_release_notes/814-rtdsk0-mpas.rst
+++ b/docs/source/upcoming_release_notes/814-rtdsk0-mpas.rst
@@ -1,0 +1,31 @@
+814 rtdsk0-mpas
+###############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Remove mpa3 and mpa4 from rtdsk0, they do not have filters and are always
+  in invalid states that confuse the lightpath.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -57,14 +57,22 @@ class RTDSBase(BaseInterface, Device, LightpathInOutMixin):
 
 
 class RTDSL0(RTDSBase):
-    """RTDS Configuration on the HXR Line."""
+    """
+    RTDS Configuration on the HXR Line.
+
+    mpa4 is an available but unused channel, showing invalid data.
+    """
     lightpath_cpts = ['mpa1', 'mpa2', 'mpa3']
 
     mpa4 = None
 
 
 class RTDSK0(RTDSBase):
-    """RTDS Configuration on the SXR Line."""
+    """
+    RTDS Configuration on the SXR Line.
+
+    mpa3 and mpa4 are available but unused channels, showing invalid data.
+    """
     lightpath_cpts = ['mpa1', 'mpa2']
 
     mpa3 = None

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -1,4 +1,5 @@
-from ophyd import Device, Signal, Component as Cpt
+from ophyd import Component as Cpt
+from ophyd import Device, Signal
 
 from .inout import InOutPositioner
 from .interface import BaseInterface, LightpathInOutMixin
@@ -64,4 +65,7 @@ class RTDSL0(RTDSBase):
 
 class RTDSK0(RTDSBase):
     """RTDS Configuration on the SXR Line."""
-    pass
+    lightpath_cpts = ['mpa1', 'mpa2']
+
+    mpa3 = None
+    mpa4 = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove the 2 unused actuators from RTDSK0 so their "INVALID" state has no bearing on the lightpath.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting up KFE lightpath today and we're going for accuracy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I will add pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
