### PR TITLE
ENH: 2.2 spectrometer and stopper updates for lightpath

### DIFF
--- a/docs/source/upcoming_release_notes/817-more-lightpath.rst
+++ b/docs/source/upcoming_release_notes/817-more-lightpath.rst
@@ -1,0 +1,33 @@
+817 more-lightpath
+##################
+
+API Changes
+-----------
+- Move stoppers into stopper.py, but keep reverse imports for
+  backwards compatibility. This will be deprecated and then removed
+  at a later date.
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Update the mono spectrometer class to provide status to lightpath.
+
+New Devices
+-----------
+- Add PPSStopperL2SI for having readbacks of the new PPS stoppers inside
+  of lightpath.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -282,3 +282,9 @@ class Mono(BaseInterface, Device):
                 doc='RTD 7 [deg C]')
     rtd_8 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='normal',
                 doc='RTD 8 [deg C]')
+
+    # Lightpath constants
+    inserted = True
+    removed = False
+    transmission = 1
+    SUB_STATE = 'state'

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import IntEnum
 
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
@@ -7,7 +7,7 @@ from .inout import InOutPositioner, InOutPVStatePositioner
 from .interface import BaseInterface, LightpathMixin
 
 
-class Commands(Enum):
+class Commands(IntEnum):
     """Command aliases for opening and closing stoppers."""
     close_valve = 0
     open_valve = 1
@@ -31,7 +31,7 @@ class Stopper(InOutPVStatePositioner):
 
     Attributes
     ----------
-    commands : ~enum.Enum
+    commands : ~enum.IntEnum
         An enum with integer values for `~Commands.open_valve` and
         `~Commands.close_valve` values.
     """

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -1,0 +1,137 @@
+from enum import Enum
+
+from ophyd import Component as Cpt
+from ophyd import Device, EpicsSignal, EpicsSignalRO
+
+from .inout import InOutPositioner, InOutPVStatePositioner
+from .interface import BaseInterface, LightpathMixin
+
+
+class Commands(Enum):
+    """Command aliases for opening and closing stoppers."""
+    close_valve = 0
+    open_valve = 1
+
+
+class Stopper(InOutPVStatePositioner):
+    """
+    Controls Stopper.
+
+    A base class for a device with two limits switches controlled via an
+    external command PV. This fully encompasses the controls Stopper
+    installations as well as un-interlocked `GateValve` s.
+
+    Parameters
+    ----------
+    prefix : str
+        Full PPS Stopper PV.
+
+    name : str
+        Alias for the stopper.
+
+    Attributes
+    ----------
+    commands : ~enum.Enum
+        An enum with integer values for `~Commands.open_valve` and
+        `~Commands.close_valve` values.
+    """
+
+    # Limit-based states
+    open_limit = Cpt(EpicsSignalRO, ':OPEN', kind='normal')
+    closed_limit = Cpt(EpicsSignalRO, ':CLOSE', kind='normal')
+
+    # Information on device control
+    command = Cpt(EpicsSignal, ':CMD', kind='omitted')
+    commands = Commands
+
+    _state_logic = {'open_limit': {0: 'defer',
+                                   1: 'OUT'},
+                    'closed_limit': {0: 'defer',
+                                     1: 'IN'}}
+    # QIcon for UX
+    _icon = 'fa.times-circle'
+
+    tab_whitelist = ['open', 'close']
+
+    def __init__(self, prefix, *, name, **kwargs):
+        super().__init__(prefix, name=name, **kwargs)
+
+    def _do_move(self, state):
+        if state.name == 'IN':
+            self.command.put(self.commands.close_valve.value)
+        elif state.name == 'OUT':
+            self.command.put(self.commands.open_valve.value)
+
+    def open(self, **kwargs):
+        """Open the stopper."""
+        return self.remove(**kwargs)
+
+    def close(self, **kwargs):
+        """Close the stopper."""
+        return self.insert(**kwargs)
+
+
+class PPSStopper(InOutPositioner):
+    """
+    PPS Stopper.
+
+    Control of this device only available to PPS systems. This class merely
+    interprets the summary of limit switches to let the controls system know
+    the current position.
+
+    Because naming conventions for the states are non-uniform this class allows
+    you to enter the values at initialization.
+
+    Parameters
+    ----------
+    prefix : str
+        Full PPS Stopper PV.
+
+    name : str
+        Alias for the stopper.
+
+    in_state : str, optional
+        String associatted with in enum value.
+
+    out_state : str, optional
+        String associatted with out enum value.
+    """
+
+    state = Cpt(EpicsSignalRO, '', string=True, kind='hinted')
+    # QIcon for UX
+    _icon = 'fa.times-circle'
+
+    def __init__(self, prefix, *, in_state='IN', out_state='OUT', **kwargs):
+        # Store state information
+        self.in_states = [in_state]
+        self.out_states = [out_state]
+        self.states_list = self.in_states + self.out_states
+        # Load InOutPositioner
+        super().__init__(prefix, **kwargs)
+
+    def check_value(self, state):
+        """PPSStopper can not be commanded via EPICS."""
+        raise PermissionError("PPSStopper can not be commanded via EPICS")
+
+
+class PPSStopperL2SI(LightpathMixin, BaseInterface, Device):
+    """
+    PPS Stopper as deployed alongside L2SI.
+
+    These stoppers have IN/NOT_IN and OUT/NOT_OUT PVs with a consistent
+    pattern. We have no direct control over these from the photon side,
+    so this Device only serves as a way to check status and display in the
+    lightpath.
+    """
+    in_signal = Cpt(EpicsSignalRO, 'INSUM', kind='hinted')
+    out_signal = Cpt(EpicsSignalRO, 'OUTSUM', kind='hinted')
+
+    # QIcon for UX
+    _icon = 'fa.times-circle'
+
+    # Lightpath settings
+    lightpath_cpts = ['in_signal', 'out_signal']
+
+    def _set_lightpath_states(self, lightpath_values):
+        self._inserted = bool(lightpath_values[self.in_signal]['value'])
+        self._removed = bool(lightpath_values[self.out_signal]['value'])

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -37,11 +37,15 @@ class Stopper(InOutPVStatePositioner):
     """
 
     # Limit-based states
-    open_limit = Cpt(EpicsSignalRO, ':OPEN', kind='normal')
-    closed_limit = Cpt(EpicsSignalRO, ':CLOSE', kind='normal')
+    open_limit = Cpt(EpicsSignalRO, ':OPEN', kind='normal',
+                     doc='Reads 1 if the stopper is out, at the open limit.')
+    closed_limit = Cpt(EpicsSignalRO, ':CLOSE', kind='normal',
+                       doc=('Reads 1 if the stopper is in, '
+                            'at the closed limit.'))
 
     # Information on device control
-    command = Cpt(EpicsSignal, ':CMD', kind='omitted')
+    command = Cpt(EpicsSignal, ':CMD', kind='omitted',
+                  doc='Put here to command a stopper move.')
     commands = Commands
 
     _state_logic = {'open_limit': {0: 'defer',
@@ -97,7 +101,9 @@ class PPSStopper(InOutPositioner):
         String associatted with out enum value.
     """
 
-    state = Cpt(EpicsSignalRO, '', string=True, kind='hinted')
+    state = Cpt(EpicsSignalRO, '', string=True, kind='hinted',
+                doc=('Stopper state summary PV that tells us if it is in, '
+                     'out, or inconsistent.'))
     # QIcon for UX
     _icon = 'fa.times-circle'
 
@@ -123,8 +129,10 @@ class PPSStopperL2SI(LightpathMixin, BaseInterface, Device):
     so this Device only serves as a way to check status and display in the
     lightpath.
     """
-    in_signal = Cpt(EpicsSignalRO, 'INSUM', kind='hinted')
-    out_signal = Cpt(EpicsSignalRO, 'OUTSUM', kind='hinted')
+    in_signal = Cpt(EpicsSignalRO, 'INSUM', kind='hinted',
+                    doc='Tells us if the stopper is IN or NOT_IN')
+    out_signal = Cpt(EpicsSignalRO, 'OUTSUM', kind='hinted',
+                     doc='Tells us if the stopper is OUT or NOT_OUT')
 
     # QIcon for UX
     _icon = 'fa.times-circle'

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -2,7 +2,7 @@
 Standard classes for LCLS Gate Valves.
 """
 import logging
-from enum import Enum
+from enum import IntEnum
 
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
@@ -13,7 +13,7 @@ from .stopper import PPSStopper, Stopper  # noqa import PPS for backcompat
 logger = logging.getLogger(__name__)
 
 
-class Commands(Enum):
+class Commands(IntEnum):
     """Command aliases for opening and closing valves."""
     close_valve = 0
     open_valve = 1

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -7,8 +7,8 @@ from enum import Enum
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 
-from .inout import InOutPositioner, InOutPVStatePositioner
 from .interface import LightpathMixin
+from .stopper import PPSStopper, Stopper  # noqa import PPS for backcompat
 
 logger = logging.getLogger(__name__)
 
@@ -22,64 +22,6 @@ class Commands(Enum):
 class InterlockError(PermissionError):
     """Error when request is blocked by interlock logic."""
     pass
-
-
-class Stopper(InOutPVStatePositioner):
-    """
-    Controls Stopper.
-
-    A base class for a device with two limits switches controlled via an
-    external command PV. This fully encompasses the controls Stopper
-    installations as well as un-interlocked `GateValve` s.
-
-    Parameters
-    ----------
-    prefix : str
-        Full PPS Stopper PV.
-
-    name : str
-        Alias for the stopper.
-
-    Attributes
-    ----------
-    commands : ~enum.Enum
-        An enum with integer values for `~Commands.open_valve` and
-        `~Commands.close_valve` values.
-    """
-
-    # Limit-based states
-    open_limit = Cpt(EpicsSignalRO, ':OPEN', kind='normal')
-    closed_limit = Cpt(EpicsSignalRO, ':CLOSE', kind='normal')
-
-    # Information on device control
-    command = Cpt(EpicsSignal, ':CMD', kind='omitted')
-    commands = Commands
-
-    _state_logic = {'open_limit': {0: 'defer',
-                                   1: 'OUT'},
-                    'closed_limit': {0: 'defer',
-                                     1: 'IN'}}
-    # QIcon for UX
-    _icon = 'fa.times-circle'
-
-    tab_whitelist = ['open', 'close']
-
-    def __init__(self, prefix, *, name, **kwargs):
-        super().__init__(prefix, name=name, **kwargs)
-
-    def _do_move(self, state):
-        if state.name == 'IN':
-            self.command.put(self.commands.close_valve.value)
-        elif state.name == 'OUT':
-            self.command.put(self.commands.open_valve.value)
-
-    def open(self, **kwargs):
-        """Open the stopper."""
-        return self.remove(**kwargs)
-
-    def close(self, **kwargs):
-        """Close the stopper."""
-        return self.insert(**kwargs)
 
 
 class GateValve(Stopper):
@@ -100,6 +42,7 @@ class GateValve(Stopper):
 
     # Commands and Interlock information
     command = Cpt(EpicsSignal, ':OPN_SW', kind='omitted')
+    commands = Commands
     interlock = Cpt(EpicsSignalRO, ':OPN_OK', kind='normal')
 
     # QIcon for UX
@@ -121,49 +64,6 @@ class GateValve(Stopper):
         opening.
         """
         return not bool(self.interlock.get())
-
-
-class PPSStopper(InOutPositioner):
-    """
-    PPS Stopper.
-
-    Control of this device only available to PPS systems. This class merely
-    interprets the summary of limit switches to let the controls system know
-    the current position.
-
-    Because naming conventions for the states are non-uniform this class allows
-    you to enter the values at initialization.
-
-    Parameters
-    ----------
-    prefix : str
-        Full PPS Stopper PV.
-
-    name : str
-        Alias for the stopper.
-
-    in_state : str, optional
-        String associatted with in enum value.
-
-    out_state : str, optional
-        String associatted with out enum value.
-    """
-
-    state = Cpt(EpicsSignalRO, '', string=True, kind='hinted')
-    # QIcon for UX
-    _icon = 'fa.times-circle'
-
-    def __init__(self, prefix, *, in_state='IN', out_state='OUT', **kwargs):
-        # Store state information
-        self.in_states = [in_state]
-        self.out_states = [out_state]
-        self.states_list = self.in_states + self.out_states
-        # Load InOutPositioner
-        super().__init__(prefix, **kwargs)
-
-    def check_value(self, state):
-        """PPSStopper can not be commanded via EPICS."""
-        raise PermissionError("PPSStopper can not be commanded via EPICS")
 
 
 class ValveBase(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Drop in some "I'm always in, I never block the beam" constants to the mono spectrometer class so it behaves nice and simply inside lightpath.
- Move stoppers to stopper.py so I can find them later
- Add PPSStopperL2SI class for the new stoppers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The mono device was asked to be in the lightpath, but currently gives errors and doesn't display status.
- I always forget to look in the valve.py file for stoppers
- The new stoppers were asked to be in the lightpath, but the existing classes were not quite suitable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added docstrings and pre-release notes.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
