### PR TITLE
MNT: add 'confirm' tag to home commands

### DIFF
--- a/docs/source/upcoming_release_notes/722-add_confirm_tag.rst
+++ b/docs/source/upcoming_release_notes/722-add_confirm_tag.rst
@@ -1,0 +1,32 @@
+722 add_confirm_tag
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add "confirm" variety metadata tag to ``EpicsMotorInterface`` and
+  ``BeckhoffAxisPLC`` home commands, requiring user confirmation prior to
+  performing the homing motion in auto-generated Typhos screens.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -66,9 +66,11 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
                      "set_low_limit", "get_high_limit", "set_high_limit"]
 
     set_metadata(EpicsMotor.home_forward, dict(variety='command-proc',
+                                               tags={"confirm"},
                                                value=1))
     EpicsMotor.home_forward.kind = Kind.normal
     set_metadata(EpicsMotor.home_reverse, dict(variety='command-proc',
+                                               tags={"confirm"},
                                                value=1))
     EpicsMotor.home_reverse.kind = Kind.normal
     set_metadata(EpicsMotor.low_limit_switch, dict(variety='bitmask', bits=1))
@@ -706,7 +708,9 @@ class BeckhoffAxisPLC(Device):
 
     set_metadata(err_code, dict(variety='scalar', display_format='hex'))
     set_metadata(cmd_err_reset, dict(variety='command', value=1))
-    set_metadata(cmd_home, dict(variety='command-proc', value=1))
+    set_metadata(cmd_home, dict(variety='command-proc',
+                                value=1,
+                                tags={"confirm"}))
 
 
 class BeckhoffAxis(EpicsMotorInterface):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Implements my suggestion of the "confirm" tag for homing commands.

## Motivation and Context
Closes #722

## How Has This Been Tested?
Interactively, once, with a simulation motor. See screenshot.

## Where Has This Been Documented?
If acceptable, pre-release docs will follow.

## Screenshots (if appropriate):
<img width="815" alt="image" src="https://user-images.githubusercontent.com/5139267/114433239-71a4bd00-9b76-11eb-91d1-36ccccfb4413.png">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
