### PR TITLE
MNT: pass the object's class to the cpt init so pseudopos work correctly

### DIFF
--- a/docs/source/upcoming_release_notes/819-objcpt-cls.rst
+++ b/docs/source/upcoming_release_notes/819-objcpt-cls.rst
@@ -1,0 +1,31 @@
+819 objcpt-cls
+##############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where ``ObjectComponent`` instances did not have proper class
+  information.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -130,7 +130,7 @@ class ObjectComponent(Component):
         self._override_kind = kind
         if kind is None:
             kind = Kind.normal
-        super().__init__(object, kind=kind)
+        super().__init__(obj.__class__, kind=kind)
         self.obj = obj
 
     def create_component(self, instance):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In `ObjectComponent`, instead of just passing `object` as the `cls`, pass the class of the object we're using.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some classes like `PseudoPositioner` check the `cls` fields of their components as part of the initialization process. This aims to make the `cls` field for an `ObjectComponent` more similar to a normal component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in xpp's beamline file

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
will add pre-release docs

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
