### PR TITLE
ENH: make sim devices hinted for bec

### DIFF
--- a/docs/source/upcoming_release_notes/822-sim-kind.rst
+++ b/docs/source/upcoming_release_notes/822-sim-kind.rst
@@ -1,0 +1,31 @@
+822 sim-kind
+############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Make sim devices hinted by default so they show up in the
+  best-effort callback in bluesky.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -3,6 +3,7 @@ import time
 
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
+from ophyd.ophydobj import Kind
 from ophyd.positioner import SoftPositioner
 from ophyd.signal import AttributeSignal
 from ophyd.sim import SynAxis
@@ -36,10 +37,10 @@ class FastMotor(FltMvInterface, SoftPositioner, Device):
 
     user_readback = Cpt(AttributeSignal, 'position')
 
-    def __init__(self, *args, init_pos=0, **kwargs):
+    def __init__(self, *args, init_pos=0, kind=Kind.hinted, **kwargs):
         for kw in ignore_kwargs:
             kwargs.pop(kw, None)
-        super().__init__(init_pos=init_pos, **kwargs)
+        super().__init__(init_pos=init_pos, kind=kind, **kwargs)
 
     def set_current_position(self, position):
         self._set_position(position)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make the simulated motor utilities hinted by default 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows them to show up in the bec LiveTable and LivePlot when instantiated standalone

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
