### PR TITLE
ENH: add AT2K2

### DIFF
--- a/docs/source/upcoming_release_notes/827-add_at2k2.rst
+++ b/docs/source/upcoming_release_notes/827-add_at2k2.rst
@@ -1,0 +1,30 @@
+827 add_at2k2
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- Added a class for the RIX ladder-style solid attenuator ``AT2K2``.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -988,6 +988,27 @@ class AT1K4(AttenuatorSXR_Ladder):
     """
 
 
+class AT2K2(AttenuatorSXR_Ladder):
+    """
+    AT2K2 solid attenuator variant from the LCLS-II L2SI project.
+
+    This has 4 blades, each with up to 8 filters each.
+    This class includes a calculator to aid in determining which filters to
+    insert for a given attenuation at a specific energy.
+
+    Parameters
+    ----------
+    prefix : str
+        Solid Attenuator base PV.
+
+    name : str
+        Alias for the Solid Attenuator.
+
+    calculator_prefix : str
+        The prefix for the calculator PVs.
+    """
+
+
 class AT2L0(FltMvInterface, PVPositionerPC, LightpathInOutMixin):
     """
     AT2L0 solid attenuator variant from the LCLS-II XTES project.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Closes #827 

## Motivation and Context
A simple addition to add the SXR solid attenuator, AT2K2.

## How Has This Been Tested?
The base class has been tested using AT1K4; this is merely an alias.

## Where Has This Been Documented?
Release notes.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
