### PR TITLE
ENH: UpdateComponent, lock down mirror offsets and others

### DIFF
--- a/docs/source/upcoming_release_notes/mirror-offsets-829.rst
+++ b/docs/source/upcoming_release_notes/mirror-offsets-829.rst
@@ -1,0 +1,35 @@
+mirror-offsets 829
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add UpdateComponent, a component class to upgrade component args
+  in subclasses.
+
+Device Updates
+--------------
+- Set various beamline component motor offset signals to read-only, using the
+  new BeckhoffAxisNoOffset class,  to prevent  accidental changes.
+  These are static components that have no need for this level of
+  customization, which tends to just cause confusion.
+
+New Devices
+-----------
+- Add BeckhoffAxisNoOffset, a varition on BeckhoffAxis that uses
+  UpdateComponent to remove write access on the user offset signals.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/atm.py
+++ b/pcdsdevices/atm.py
@@ -1,7 +1,7 @@
 from ophyd import Component as Cpt
 from ophyd import Device
 
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATTempSensor
@@ -15,7 +15,7 @@ class ArrivalTimeMonitor(BaseInterface, Device, LightpathInOutMixin):
 
     target = Cpt(TwinCATStatePMPS, ':MMS:STATE', kind='hinted',
                  doc='Control of the diagnostic stack via saved positions.')
-    y_motor = Cpt(BeckhoffAxis, ':MMS:Y', kind='normal',
+    y_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:Y', kind='normal',
                   doc='Direct control of the diagnostic stack motor.')
     x_motor = Cpt(BeckhoffAxis, ':MMS:X', kind='normal',
                   doc='X position of target stack for alignment')

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -16,7 +16,7 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal, SignalRO
 
 from . import utils
 from .device import UnrelatedComponent as UCpt
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
 from .signal import InternalSignal
@@ -449,7 +449,7 @@ class FEESolidAttenuatorBlade(BaseInterface, Device, LightpathInOutMixin):
     lightpath_cpts = ['state']
 
     state = Cpt(TwinCATInOutPositioner, ':STATE')
-    motor = Cpt(BeckhoffAxis, '')
+    motor = Cpt(BeckhoffAxisNoOffset, '')
 
 
 class GasAttenuator(BaseInterface, Device):

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -273,8 +273,8 @@ class UpdateComponent(Component):
     subclass of another device, using the same name as the component you'd like
     to update.
 
-    Pass to this component class the arguments you'd like to change from the
-    subdevice component definition.
+    Pass keyword args to this component to update the values from the parent in
+    your subclass.
 
     Some limitations:
 
@@ -300,13 +300,19 @@ class UpdateComponent(Component):
 
     def __set_name__(self, owner, attr_name):
         # Find the parent cpt of the same name and copy it
-        parent_cpt = getattr(owner.mro()[1], attr_name)
+        for cls in owner.mro()[1:]:
+            try:
+                parent_cpt = getattr(cls, attr_name)
+                break
+            except AttributeError:
+                continue
         self.copy_cpt = copy.copy(parent_cpt)
 
         # Edit this object as needed
         for key, value in self.update_kwargs.items():
             # Set the attrs if they exist
             if key == 'kind':
+                # Special handling to ensure kind is a Kind
                 value = (Kind[value.lower()] if isinstance(value, str)
                          else Kind(value))
                 self.copy_cpt.kind = value

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -306,7 +306,11 @@ class UpdateComponent(Component):
         # Edit this object as needed
         for key, value in self.update_kwargs.items():
             # Set the attrs if they exist
-            if hasattr(self.copy_cpt, key):
+            if key == 'kind':
+                value = (Kind[value.lower()] if isinstance(value, str)
+                         else Kind(value))
+                self.copy_cpt.kind = value
+            elif hasattr(self.copy_cpt, key):
                 setattr(self.copy_cpt, key, value)
             # Add to kwargs if they don't exist
             else:

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -268,6 +268,29 @@ def to_interface(device_class):
 class UpdateComponent(Component):
     """
     A component that copies and updates a parent component in a subclass.
+
+    Use this like any other component, adding it to your device that is a
+    subclass of another device, using the same name as the component you'd like
+    to update.
+
+    Pass to this component class the arguments you'd like to change from the
+    subdevice component definition.
+
+    Some limitations:
+
+    - It is not possible to use this to change the component class itself, e.g.
+      if you would like to change something from a "Component" to a
+      "FormattedComponent".
+    - All arguments to update must be provided as keyword arguments, so we know
+      which value to change in the component class.
+    - UpdateComponent will always fail isinstance checks for Component
+      subclasses.
+    - UpdateComponent is not mutable after instantiation.
+
+    Parameters
+    ----------
+    **kwargs: any, optional
+        keyword arguments to update
     """
     def __init__(self, **kwargs):
         # Store the original kwargs for use later

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -18,6 +18,7 @@ from ophyd.utils.epics_pvs import raise_if_disconnected, set_and_wait
 
 from pcdsdevices.pv_positioner import PVPositionerComparator
 
+from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init
 from .interface import FltMvInterface
 from .pseudopos import OffsetMotorBase, delay_class_factory
@@ -777,6 +778,20 @@ class BeckhoffAxis(EpicsMotorInterface):
             raise
 
         return status
+
+
+class BeckhoffAxisNoOffset(BeckhoffAxis):
+    """
+    A BeckhoffAxis with various fields read-only.
+
+    This is to prevent a user from messing themselves up by changing things
+    like user offset and user direction. This is desirable for static beamline
+    configurations.
+    """
+    user_offset = UpCpt(cls=EpicsSignalRO)
+    user_offset_dir = UpCpt(cls=EpicsSignalRO)
+    offset_freeze_switch = UpCpt(cls=EpicsSignalRO)
+    set_use_switch = UpCpt(cls=EpicsSignalRO)
 
 
 class MotorDisabledError(Exception):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -787,6 +787,9 @@ class BeckhoffAxisNoOffset(BeckhoffAxis):
     This is to prevent a user from messing themselves up by changing things
     like user offset and user direction. This is desirable for static beamline
     configurations.
+
+    Rather than removing these entirely, keep them readable in case it is
+    useful to know their values.
     """
     user_offset = UpCpt(cls=EpicsSignalRO)
     user_offset_dir = UpCpt(cls=EpicsSignalRO)

--- a/pcdsdevices/lic.py
+++ b/pcdsdevices/lic.py
@@ -1,7 +1,7 @@
 from ophyd import Component as Cpt
 from ophyd import Device
 
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 
@@ -31,5 +31,5 @@ class LaserInCoupling(BaseInterface, Device, LightpathInOutMixin):
 
     mirror = Cpt(LICMirror, ':MMS:STATE', kind='hinted',
                  doc='Control of the mirror via saved positions.')
-    y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal',
+    y_motor = Cpt(BeckhoffAxisNoOffset, ':MMS', kind='normal',
                   doc='Direct control of the mirror motor.')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -15,7 +15,7 @@ from ophyd import FormattedComponent as FCpt
 from ophyd import PVPositioner
 
 from .doc_stubs import basic_positioner_init
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
 from .interface import BaseInterface, FltMvInterface
 from .pmps import TwinCATStatePMPS
@@ -336,17 +336,17 @@ class XOffsetMirror(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    y_up = Cpt(BeckhoffAxis, ':MMS:YUP', kind='hinted',
+    y_up = Cpt(BeckhoffAxisNoOffset, ':MMS:YUP', kind='hinted',
                doc='Yupstream master axis [um]')
-    x_up = Cpt(BeckhoffAxis, ':MMS:XUP', kind='hinted',
+    x_up = Cpt(BeckhoffAxisNoOffset, ':MMS:XUP', kind='hinted',
                doc='Xupstream master [um]')
-    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='hinted',
+    pitch = Cpt(BeckhoffAxisNoOffset, ':MMS:PITCH', kind='hinted',
                 doc='Pitch stepper and piezo axes [urad]')
-    bender = Cpt(BeckhoffAxis, ':MMS:BENDER', kind='normal',
+    bender = Cpt(BeckhoffAxisNoOffset, ':MMS:BENDER', kind='normal',
                  doc='Bender motor [um]')
-    y_dwn = Cpt(BeckhoffAxis, ':MMS:YDWN', kind='config',
+    y_dwn = Cpt(BeckhoffAxisNoOffset, ':MMS:YDWN', kind='config',
                 doc='Ydwnstream slave axis [um]')
-    x_dwn = Cpt(BeckhoffAxis, ':MMS:XDWN', kind='config',
+    x_dwn = Cpt(BeckhoffAxisNoOffset, ':MMS:XDWN', kind='config',
                 doc='Xdwnstream slave axis [um]')
 
     # Gantry components
@@ -473,8 +473,8 @@ class XOffsetMirrorBend(XOffsetMirror):
     bender_enc_rms = None
 
     # Motor components: can read/write positions
-    bender_us = Cpt(BeckhoffAxis, ':MMS:US', kind='hinted')
-    bender_ds = Cpt(BeckhoffAxis, ':MMS:DS', kind='hinted')
+    bender_us = Cpt(BeckhoffAxisNoOffset, ':MMS:US', kind='hinted')
+    bender_ds = Cpt(BeckhoffAxisNoOffset, ':MMS:DS', kind='hinted')
 
     # RMS Cpts:
     bender_us_enc_rms = Cpt(PytmcSignal, ':ENC:US:RMS', io='i',
@@ -515,9 +515,9 @@ class XOffsetMirrorSwitch(XOffsetMirror):
     bender_enc_rms = None
 
     # Motor components: can read/write positions
-    y_left = Cpt(BeckhoffAxis, ':MMS:YLEFT', kind='hinted',
+    y_left = Cpt(BeckhoffAxisNoOffset, ':MMS:YLEFT', kind='hinted',
                  doc='Yleft master axis [um]')
-    y_right = Cpt(BeckhoffAxis, ':MMS:YRIGHT', kind='config',
+    y_right = Cpt(BeckhoffAxisNoOffset, ':MMS:YRIGHT', kind='config',
                   doc='Yright slave axis [um]')
 
 
@@ -539,11 +539,11 @@ class KBOMirror(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    x = Cpt(BeckhoffAxis, ':MMS:X', kind='hinted')
-    y = Cpt(BeckhoffAxis, ':MMS:Y', kind='hinted')
-    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='hinted')
-    bender_us = Cpt(BeckhoffAxis, ':MMS:BEND:US', kind='hinted')
-    bender_ds = Cpt(BeckhoffAxis, ':MMS:BEND:DS', kind='hinted')
+    x = Cpt(BeckhoffAxisNoOffset, ':MMS:X', kind='hinted')
+    y = Cpt(BeckhoffAxisNoOffset, ':MMS:Y', kind='hinted')
+    pitch = Cpt(BeckhoffAxisNoOffset, ':MMS:PITCH', kind='hinted')
+    bender_us = Cpt(BeckhoffAxisNoOffset, ':MMS:BEND:US', kind='hinted')
+    bender_ds = Cpt(BeckhoffAxisNoOffset, ':MMS:BEND:DS', kind='hinted')
 
     # RMS Cpts:
     x_enc_rms = Cpt(PytmcSignal, ':ENC:X:RMS', io='i', kind='normal')
@@ -678,9 +678,9 @@ class FFMirror(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    x = Cpt(BeckhoffAxis, ':MMS:X', kind='hinted')
-    y = Cpt(BeckhoffAxis, ':MMS:Y', kind='hinted')
-    pitch = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='hinted')
+    x = Cpt(BeckhoffAxisNoOffset, ':MMS:X', kind='hinted')
+    y = Cpt(BeckhoffAxisNoOffset, ':MMS:Y', kind='hinted')
+    pitch = Cpt(BeckhoffAxisNoOffset, ':MMS:PITCH', kind='hinted')
 
     # RMS Cpts:
     x_enc_rms = Cpt(PytmcSignal, ':ENC:X:RMS', io='i', kind='normal')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -16,7 +16,7 @@ from ophyd.signal import EpicsSignal
 
 from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
                                      PCDSAreaDetectorTyphosTrigger)
-from .epics_motor import IMS, BeckhoffAxis
+from .epics_motor import IMS, BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
@@ -318,7 +318,7 @@ class LCLS2ImagerBase(BaseInterface, Device, LightpathInOutMixin):
 
     target = Cpt(TwinCATStatePMPS, ':MMS:STATE', kind='hinted',
                  doc='Control of the diagnostic stack via saved positions.')
-    y_motor = Cpt(BeckhoffAxis, ':MMS', kind='normal',
+    y_motor = Cpt(BeckhoffAxisNoOffset, ':MMS', kind='normal',
                   doc='Direct control of the diagnostic stack motor.')
     detector = Cpt(PCDSAreaDetectorTyphosTrigger, ':CAM:', kind='normal',
                    doc='Area detector settings and readbacks.')
@@ -497,9 +497,9 @@ class XPIM(LCLS2ImagerBase):
         An identifying name for this motor, e.g. 'im3l0'.
     """
 
-    zoom_motor = Cpt(BeckhoffAxis, ':CLZ', kind='normal',
+    zoom_motor = Cpt(BeckhoffAxisNoOffset, ':CLZ', kind='normal',
                      doc='Motorized zoom.')
-    focus_motor = Cpt(BeckhoffAxis, ':CLF', kind='normal',
+    focus_motor = Cpt(BeckhoffAxisNoOffset, ':CLF', kind='normal',
                       doc='Motorized focus.')
 
     zoom_lock = Cpt(PytmcSignal, ':CLZ:LOCK', io='io', kind='config',

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -26,7 +26,7 @@ from ophyd.status import Status
 from ophyd.status import wait as status_wait
 
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
                         LightpathMixin, MvInterface)
 from .pmps import TwinCATStatePMPS
@@ -453,10 +453,10 @@ class BeckhoffSlits(SlitsBase):
     done_south = Cpt(PytmcSignal, ':SOUTH:DMOV', io='i', kind='omitted')
 
     # Raw motors
-    top = Cpt(BeckhoffAxis, ':MMS:TOP', kind='normal')
-    bottom = Cpt(BeckhoffAxis, ':MMS:BOTTOM', kind='normal')
-    north = Cpt(BeckhoffAxis, ':MMS:NORTH', kind='normal')
-    south = Cpt(BeckhoffAxis, ':MMS:SOUTH', kind='normal')
+    top = Cpt(BeckhoffAxisNoOffset, ':MMS:TOP', kind='normal')
+    bottom = Cpt(BeckhoffAxisNoOffset, ':MMS:BOTTOM', kind='normal')
+    north = Cpt(BeckhoffAxisNoOffset, ':MMS:NORTH', kind='normal')
+    south = Cpt(BeckhoffAxisNoOffset, ':MMS:SOUTH', kind='normal')
 
     def __init__(self, prefix, *, name, **kwargs):
         self._started_move = False
@@ -533,17 +533,17 @@ class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
 
     target = Cpt(TwinCATStatePMPS, ':YAG:STATE', kind='hinted',
                  doc='Control of the YAG  stack via saved positions.')
-    yag_motor = Cpt(BeckhoffAxis, ':MMS:YAG', kind='normal',
+    yag_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:YAG', kind='normal',
                     doc='Direct control of the Yag Stack motor.')
-    pitch_motor = Cpt(BeckhoffAxis, ':MMS:PITCH', kind='normal',
+    pitch_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:PITCH', kind='normal',
                       doc='Direct control of the slits assembly pitch  motor.')
     vert_motor = Cpt(
-        BeckhoffAxis, ':MMS:VERT', kind='normal',
+        BeckhoffAxisNoOffset, ':MMS:VERT', kind='normal',
         doc='Direct control of the slits assembly vertical motor.'
     )
-    roll_motor = Cpt(BeckhoffAxis, ':MMS:ROLL', kind='normal',
+    roll_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:ROLL', kind='normal',
                      doc='Direct control of the slits assembly roll motor.')
-    gap_motor = Cpt(BeckhoffAxis, ':MMS:GAP', kind='normal',
+    gap_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:GAP', kind='normal',
                     doc='Direct control of the slits gap  motor.')
     detector = Cpt(PCDSAreaDetectorTyphosTrigger, ':CAM:', kind='normal',
                    doc='Area detector settings and readbacks.')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -5,7 +5,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal, PytmcSignal
 
@@ -37,12 +37,12 @@ class Kmono(BaseInterface, Device, LightpathMixin):
                       'ret_in', 'ret_out',
                       'diode_in', 'diode_out']
 
-    xtal_angle = Cpt(BeckhoffAxis, ':XTAL_ANGLE', kind='normal')
-    xtal_vert = Cpt(BeckhoffAxis, ':XTAL_VERT', kind='normal')
-    ret_horiz = Cpt(BeckhoffAxis, ':RET_HORIZ', kind='normal')
-    ret_vert = Cpt(BeckhoffAxis, ':RET_VERT', kind='normal')
-    diode_horiz = Cpt(BeckhoffAxis, ':DIODE_HORIZ', kind='normal')
-    diode_vert = Cpt(BeckhoffAxis, ':DIODE_VERT', kind='normal')
+    xtal_angle = Cpt(BeckhoffAxisNoOffset, ':XTAL_ANGLE', kind='normal')
+    xtal_vert = Cpt(BeckhoffAxisNoOffset, ':XTAL_VERT', kind='normal')
+    ret_horiz = Cpt(BeckhoffAxisNoOffset, ':RET_HORIZ', kind='normal')
+    ret_vert = Cpt(BeckhoffAxisNoOffset, ':RET_VERT', kind='normal')
+    diode_horiz = Cpt(BeckhoffAxisNoOffset, ':DIODE_HORIZ', kind='normal')
+    diode_vert = Cpt(BeckhoffAxisNoOffset, ':DIODE_VERT', kind='normal')
 
     xtal_in = Cpt(InternalSignal, value=None, kind='omitted')
     xtal_out = Cpt(InternalSignal, value=None, kind='omitted')
@@ -101,9 +101,9 @@ class VonHamosCrystal(BaseInterface, Device):
     """Pitch, yaw, and translation motors for control of a single crystal."""
     tab_component_names = True
 
-    pitch = Cpt(BeckhoffAxis, ':Pitch', kind='normal')
-    yaw = Cpt(BeckhoffAxis, ':Yaw', kind='normal')
-    trans = Cpt(BeckhoffAxis, ':Translation', kind='normal')
+    pitch = Cpt(BeckhoffAxisNoOffset, ':Pitch', kind='normal')
+    yaw = Cpt(BeckhoffAxisNoOffset, ':Yaw', kind='normal')
+    trans = Cpt(BeckhoffAxisNoOffset, ':Translation', kind='normal')
 
 
 class VonHamosFE(BaseInterface, Device):
@@ -131,8 +131,8 @@ class VonHamosFE(BaseInterface, Device):
     tab_component_names = True
 
     # Update PVs in IOC and change here to reflect
-    f = FCpt(BeckhoffAxis, '{self._prefix_focus}', kind='normal')
-    e = FCpt(BeckhoffAxis, '{self._prefix_energy}', kind='normal')
+    f = FCpt(BeckhoffAxisNoOffset, '{self._prefix_focus}', kind='normal')
+    e = FCpt(BeckhoffAxisNoOffset, '{self._prefix_energy}', kind='normal')
 
     def __init__(self, *args, name, prefix_focus, prefix_energy, **kwargs):
         self._prefix_focus = prefix_focus
@@ -168,7 +168,7 @@ class VonHamosFER(VonHamosFE):
         The EPICS base PV of the common rotation motor.
     """
 
-    rot = FCpt(BeckhoffAxis, '{self._prefix_rot}', kind='normal')
+    rot = FCpt(BeckhoffAxisNoOffset, '{self._prefix_rot}', kind='normal')
 
     def __init__(self, *args, name, prefix_rot, prefix_focus, prefix_energy,
                  **kwargs):
@@ -229,17 +229,17 @@ class Mono(BaseInterface, Device):
     _icon = 'fa.minus-square'
 
     # Motor components: can read/write positions
-    m_pi = Cpt(BeckhoffAxis, ':MMS:M_PI', kind='normal',
+    m_pi = Cpt(BeckhoffAxisNoOffset, ':MMS:M_PI', kind='normal',
                doc='mirror pitch [urad]')
-    g_pi = Cpt(BeckhoffAxis, ':MMS:G_PI', kind='normal',
+    g_pi = Cpt(BeckhoffAxisNoOffset, ':MMS:G_PI', kind='normal',
                doc='grating pitch [urad]')
-    m_h = Cpt(BeckhoffAxis, ':MMS:M_H', kind='normal',
+    m_h = Cpt(BeckhoffAxisNoOffset, ':MMS:M_H', kind='normal',
               doc='mirror horizontal [um]')
-    g_h = Cpt(BeckhoffAxis, ':MMS:G_H', kind='normal',
+    g_h = Cpt(BeckhoffAxisNoOffset, ':MMS:G_H', kind='normal',
               doc='grating horizontal [um]')
-    sd_v = Cpt(BeckhoffAxis, ':MMS:SD_V', kind='normal',
+    sd_v = Cpt(BeckhoffAxisNoOffset, ':MMS:SD_V', kind='normal',
                doc='screwdriver vertical (in/out) [um]')
-    sd_rot = Cpt(BeckhoffAxis, ':MMS:SD_ROT', kind='normal',
+    sd_rot = Cpt(BeckhoffAxisNoOffset, ':MMS:SD_ROT', kind='normal',
                  doc='screwdriver rotation [urad]')
 
     # Additional Pytmc components

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -4,7 +4,7 @@ Module for the SXR Test Absorbers.
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathMixin
 
 
@@ -20,7 +20,7 @@ class SxrTestAbsorber(BaseInterface, LightpathMixin, Device):
 
     tab_component_names = True
 
-    absorber_vert = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    absorber_vert = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
 
     lightpath_cpts = ['absorber_vert']
 

--- a/pcdsdevices/wfs.py
+++ b/pcdsdevices/wfs.py
@@ -1,7 +1,7 @@
 from ophyd import Component as Cpt
 from ophyd import Device
 
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATTempSensor
@@ -15,9 +15,9 @@ class WaveFrontSensorTarget(BaseInterface, Device, LightpathInOutMixin):
 
     target = Cpt(TwinCATStatePMPS, ':MMS:STATE', kind='hinted',
                  doc='Control of the diagnostic stack via saved positions.')
-    y_motor = Cpt(BeckhoffAxis, ':MMS:Y', kind='normal',
+    y_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:Y', kind='normal',
                   doc='Direct control of the diagnostic stack motor.')
-    z_motor = Cpt(BeckhoffAxis, ':MMS:Z', kind='normal',
+    z_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:Z', kind='normal',
                   doc='Z position of target stack for focus control.')
 
     thermocouple1 = Cpt(TwinCATTempSensor, ':STC:01', kind='normal',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `UpdateComponent`, a `Component` subclass that allows you to inherit and update a super class's components.
- Add `BeckhoffAxisNoOffset`, a variation on `BeckhoffAxis` that uses `UpdateComponent` to set the user offset related signals to read-only.
- Apply `BeckhoffAxisNoOffset` to all static beamline motors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For the beamline Beckhoff axes, we don't want to be changing their directions or offsets accidentally. In fact these should always always always be 0/POS in 99% of cases, and some other static value in the other 1% of cases. An easy/clean way to handle this is to prevent the Python from writing to them by making them `EpicsSignalRO`. This has to be specifically targeted at specific instances, both for backcompat and for the end stations that do want to make use of the EPICS-level direction and offset controls.

Matt Seaberg originally pointed this out for the mirrors in https://jira.slac.stanford.edu/browse/LCLSPC-131, I have extended this to all beamline axes that I deemed appropriate.

To implement this, I decided to finally create the thing I've wanted for a while: an easy way to inherit/edit components inside a device definition, the `UpdateComponent`. I think this implementation minimizes the duplication of typing and feels natural to use.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only interactively, so it is possible that I have broken something- hopefully the tests will catch it.
Before merging I need to add some tests for `UpdateComponent` (which I plan to upstream to `ophyd`).

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not enough yet

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
