### PR TITLE
MNT: Slit dmov cleanup

### DIFF
--- a/docs/source/upcoming_release_notes/834-slit-dmov.rst
+++ b/docs/source/upcoming_release_notes/834-slit-dmov.rst
@@ -1,0 +1,33 @@
+834 slit-dmov
+#############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where BeckhoffSlits devices could show metadata errors on startup
+  by cleaning up the done moving handling. This would typically spam the
+  terminal in cases where we were making large numbers of PV connections in
+  the session at once, such as at the start of a hutch-python load.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -460,6 +460,10 @@ class BeckhoffSlits(SlitsBase):
 
     def __init__(self, prefix, *, name, **kwargs):
         self._started_move = False
+        self._top_done = False
+        self._bottom_done = False
+        self._north_done = False
+        self._south_done = False
         super().__init__(prefix, name=name, nominal_aperture=3, **kwargs)
 
     @exec_queue.sub_value
@@ -486,15 +490,31 @@ class BeckhoffSlits(SlitsBase):
         self.ycenter.done.put(value)
 
     @done_top.sub_value
+    def _update_top_done(self, value, *args, **kwargs):
+        self._top_done = value
+        self._update_dmov()
+
     @done_bottom.sub_value
+    def _update_bottom_done(self, value, *args, **kwargs):
+        self._bottom_done = value
+        self._update_dmov()
+
     @done_north.sub_value
+    def _update_north_done(self, value, *args, **kwargs):
+        self._north_done = value
+        self._update_dmov()
+
     @done_south.sub_value
+    def _update_south_done(self, value, *args, **kwargs):
+        self._south_done = value
+        self._update_dmove()
+
     def _update_dmov(self, *args, **kwargs):
         """When part of the dmov updates, update the done_all flag."""
-        done = all((self.done_top.get(),
-                    self.done_bottom.get(),
-                    self.done_north.get(),
-                    self.done_south.get()))
+        done = all((self._top_done,
+                    self._bottom_done,
+                    self._north_done,
+                    self._south_done))
         if done != self.done_all.get():
             self.done_all.put(done)
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -491,26 +491,36 @@ class BeckhoffSlits(SlitsBase):
 
     @done_top.sub_value
     def _update_top_done(self, value, *args, **kwargs):
+        """Update axis done flag, and then the group done if applicable"""
         self._top_done = value
         self._update_dmov()
 
     @done_bottom.sub_value
     def _update_bottom_done(self, value, *args, **kwargs):
+        """Update axis done flag, and then the group done if applicable"""
         self._bottom_done = value
         self._update_dmov()
 
     @done_north.sub_value
     def _update_north_done(self, value, *args, **kwargs):
+        """Update axis done flag, and then the group done if applicable"""
         self._north_done = value
         self._update_dmov()
 
     @done_south.sub_value
     def _update_south_done(self, value, *args, **kwargs):
+        """Update axis done flag, and then the group done if applicable"""
         self._south_done = value
         self._update_dmov()
 
     def _update_dmov(self, *args, **kwargs):
-        """When part of the dmov updates, update the done_all flag."""
+        """
+        Call this inside a callback to update the done_all signal.
+
+        Each direction's done moving signal should update its
+        individual done moving boolean in a callback and then call
+        this method to update the aggregate done_all signal.
+        """
         done = all((self._top_done,
                     self._bottom_done,
                     self._north_done,

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -507,7 +507,7 @@ class BeckhoffSlits(SlitsBase):
     @done_south.sub_value
     def _update_south_done(self, value, *args, **kwargs):
         self._south_done = value
-        self._update_dmove()
+        self._update_dmov()
 
     def _update_dmov(self, *args, **kwargs):
         """When part of the dmov updates, update the done_all flag."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ import pcdsdevices.lens
 import pcdsdevices.lxe
 from pcdsdevices.attenuator import MAX_FILTERS, Attenuator, _att_classes
 from pcdsdevices.device import UnrelatedComponent
-from pcdsdevices.mv_interface import setup_preset_paths
+from pcdsdevices.interface import setup_preset_paths
 
 MODULE_PATH = Path(__file__).parent
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Clean up the slit done moving handling so that we aren't doing any cagets inside of callbacks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Error spam in various hutch python sessions, reported in https://jira.slac.stanford.edu/browse/LCLSECSD-105
```
[2021-06-01 22:16:25,494] [ERROR ] - Subscription value callback exception (PytmcSignalRO(read_pv='SL1K4:SCATTER:TOP:DMOV_RBV', name='sl1k4_done_top', parent='sl1k4', value=1, timestamp=1621913588.808209, auto_monitor=False, string=False))
Traceback (most recent call last):
File "/reg/g/pcds/pyps/apps/dev/pythonpath/ophyd/signal.py", line 1113, in _get_with_timeout
self.wait_for_connection(timeout=connection_timeout)
File "/reg/g/pcds/pyps/apps/dev/pythonpath/ophyd/signal.py", line 1067, in wait_for_connection
self._ensure_connected(self._read_pv, timeout=timeout)
File "/reg/g/pcds/pyps/apps/dev/pythonpath/ophyd/signal.py", line 1061, in _ensure_connected
raise TimeoutError(f'Control layer {self.cl.name} failed to send connection and '
TimeoutError: Control layer pyepics failed to send connection and access rights information within 1.0 sec

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/reg/g/pcds/pyps/apps/dev/pythonpath/ophyd/ophydobj.py", line 462, in inner
cb(*args, **kwargs)
File "/reg/g/pcds/pyps/apps/dev/pythonpath/pcdsdevices/slits.py", line 494, in _update_dmov
done = all((self.done_top.get(),
File "/reg/g/pcds/pyps/apps/dev/pythonpath/ophyd/signal.py", line 1178, in get
self._read_pv, timeout, connection_timeout, as_string, form, use_monitor
File "/reg/g/pcds/pyps/apps/dev/pythonpath/ophyd/signal.py", line 1117, in _get_with_timeout
f"within {connection_timeout:.2f} sec") from err
ophyd.signal.ConnectionTimeoutError: Failed to connect to SL1K4:SCATTER:TOP:DMOV_RBV within 1.00 sec
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a few simple tests to the test suite
Tried it in tmo hutch python to verify error spam is gone

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
