### PR TITLE
ENH: PPSStopper2PV

### DIFF
--- a/docs/source/upcoming_release_notes/835-st1k2-pps.rst
+++ b/docs/source/upcoming_release_notes/835-st1k2-pps.rst
@@ -1,0 +1,34 @@
+835 st1k2-pps
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Rename PPSStopperL2SI to PPSStopper2PV and generalize to all PPS stoppers
+  whose states are determined by the combination of two PVs. The old name and
+  old defaults are retained for backcompatibility and have not yet been
+  deprecated. This was done to support the PVs for ST1K2 which do not follow
+  any existing pattern.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Convert `PPSStopperL2SI` into `PPSStopper2PV`: a generalized form to support PPS stoppers with two separate PVs that must be checked to determine the PPS state, to support the reality where PPS stoppers have no fixed pattern in their EPICS interfaces.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ST1K2 does not fit the existing PPS stopper PV patterns in any way.
closes #835 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check to make sure an existing stopper still works with default arguments:
```
$ happi load st3k4_pps
[2021-06-03 10:18:52] - INFO -  Creating shell with devices ['st3k4_pps']
Python 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:22:27)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: st3k4_pps.get()
Out[1]: PPSStopper2PVTuple(in_signal=1, out_signal=0)
```

Check that st1k2's setup works too. Note that the real device shows an inconsistent state right now, just like the class does:
```
$ ipython
Python 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:22:27)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from pcdsdevices.stopper import PPSStopper2PV

In [2]: st1k2 = PPSStopper2PV('STPR:NEH1:2200:ST1K2', in_suffix='IN', out_suffix='OUT', in_value=1, out_value=0, name='st1k2')

In [3]: st1k2.get()
Out[3]: PPSStopper2PVTuple(in_signal=1, out_signal=0)

In [4]: st1k2.inserted
Out[4]: True

In [5]: st1k2.removed
Out[5]: True
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
