### PR TITLE
First pass parameter manager support for IMS motors

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pcdscalc >=0.2.0
     - pcdsutils >=0.4.0
     - pint
+    - pmgr >=2.0.2
     - prettytable
     - pyepics >=3.4.2
     - pytmc >=2.7.0

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -25,6 +25,8 @@ from .pseudopos import OffsetMotorBase, delay_class_factory
 from .signal import EpicsSignalEditMD, EpicsSignalROEditMD, PytmcSignal
 from .utils import get_status_float, get_status_value
 from .variety import set_metadata
+from pmgr import pmgrAPI
+from pcdsutils.ext_scripts import get_hutch_name
 
 logger = logging.getLogger(__name__)
 
@@ -460,6 +462,9 @@ class IMS(PCDSMotorBase):
 
     tab_whitelist = ['auto_setup', 'reinitialize', 'clear_.*']
 
+    # The singleton parameter manager object.
+    _pm = pmgrAPI.pmgrAPI("ims_motor", get_hutch_name())
+
     def stage(self):
         """
         Stage the IMS motor.
@@ -567,6 +572,55 @@ class IMS(PCDSMotorBase):
             status_wait(st, timeout=timeout)
         return st
 
+    def configure(self, cfgname=None):
+        """
+        Use the parameter manager to configure the motor.
+
+        cfgname : str | None
+            The name of the configuration to apply.  If None, use the
+            configuration saved in the database.
+
+        Returns nothing.
+        """
+        self._pm.apply_config(self.prefix, cfgname)
+
+    def get_configuration(self):
+        """
+        Find the current configuration of the motor in the parameter manager.
+
+        Returns the current configuration name as a string or throws an exception.
+        """
+        return self._pm.get_config(self.prefix)
+    
+    @staticmethod
+    def find_configuration(pattern, case_insensitive=True, display=20):
+        """
+        Find parameter manager configurations that match the pattern.
+
+        pattern : str
+            The substring to match.  "." matches any character, and "*"
+            matches any string.  These maybe quoted using "\".
+
+        case_insensitive : boolean
+            True if the match should be case insensitive, False if it
+            should be case sensitive.
+
+        display : int | None
+            The maximum number of configurations to display.  If None,
+            don't display any, but return a list of all matches.
+
+        Returns a list of strings if display is None, and nothing otherwise.
+        """
+        matches = IMS._pm.match_config(pattern, ci=case_insensitive)
+        if display is None:
+            return matches
+        if len(matches) >= display:
+            print("'%s' matches %d configurations." % (pattern, len(matches)))
+            print("Use a more restrictive pattern or larger value for display (%d)." % display)
+        else:
+            print("Matches for '%s':" % pattern)
+            for m in matches:
+                  print("    %s" % m)
 
 class Newport(PCDSMotorBase):
     """


### PR DESCRIPTION

## Description
Add the ability to find and apply parameter manager configurations to IMS motors in hutch python.

This requires pmgr R2.0.2 or higher in the conda environment.  This is a first-pass at support, and a quick merge is not anticipated.

## Motivation and Context
Simplify the deployment of IMS motors by allowing the direct application of saved configurations.

## How Has This Been Tested?
Verified that the singleton pmgrAPI object is created, and configurations for a test motor can be set, retrieved, and searched for.

## Where Has This Been Documented?
Doc strings.

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
