### PR TITLE
Fixing a typo in KBO Mirror class for DS Bender RMS PV

### DIFF
--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -551,7 +551,7 @@ class KBOMirror(BaseInterface, Device):
     pitch_enc_rms = Cpt(PytmcSignal, ':ENC:PITCH:RMS', io='i', kind='normal')
     bender_us_enc_rms = Cpt(PytmcSignal, ':ENC:BEND:US:RMS', io='i',
                             kind='normal')
-    bender_ds_enc_rms = Cpt(PytmcSignal, ':ENC:BENDER:DS:RMS', io='i',
+    bender_ds_enc_rms = Cpt(PytmcSignal, ':ENC:BEND:DS:RMS', io='i',
                             kind='normal')
 
     # Bender RTD Cpts:


### PR DESCRIPTION
A typo in KBO Mirror class for DS Bender RMS. Broken PV of DS RMS value for RIX and TMO

## Pre-merge checklist
- [x] Code works interactively
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate


![Screen Shot 2021-06-07 at 4 56 21 PM](https://user-images.githubusercontent.com/10403658/121101872-8934a680-c7b1-11eb-80f8-1604f9912012.png)
![Screen Shot 2021-06-07 at 4 57 05 PM](https://user-images.githubusercontent.com/10403658/121101880-8cc82d80-c7b1-11eb-8aca-7db553fc1310.png)

