### PR TITLE
MNT: Workaround for error spam at XPP

### DIFF
--- a/docs/source/upcoming_release_notes/842-egu-cb-failure.rst
+++ b/docs/source/upcoming_release_notes/842-egu-cb-failure.rst
@@ -1,0 +1,31 @@
+842 egu-cb-failure
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where DelayBase subclasses could spam the terminal at
+  startup if we load too many devices at once.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -748,6 +748,12 @@ class DelayBase(FltMvInterface, PseudoPositioner):
         except ophyd.utils.DisconnectedError:
             ...
 
+    def _real_pos_update(self, *args, **kwargs):
+        try:
+            super()._real_pos_update(*args, **kwargs)
+        except TimeoutError:
+            pass
+
     @pseudo_position_argument
     def forward(self, pseudo_pos):
         """Convert delay unit to motor unit."""

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -749,6 +749,19 @@ class DelayBase(FltMvInterface, PseudoPositioner):
             ...
 
     def _real_pos_update(self, *args, **kwargs):
+        """
+        Callback on the real motor's readback.
+
+        This is used in PseudoPositioner to set some of the calculated
+        variables at startup and every time the motor's readback changes, but
+        it fails and causes spam when we have many devices because this class's
+        inverse method relies on the motor.egu variable being ready to access,
+        which may not be true when we are running many startup callbacks for
+        all devices at the same time.
+
+        For delay motors, these internal variables are not used and are safe to
+        skip at startup.
+        """
         try:
             super()._real_pos_update(*args, **kwargs)
         except TimeoutError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Ignore `TimeoutError` when doing the value update in DelayBase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This method is called at init in ophyd with `run=True`: https://github.com/bluesky/ophyd/blob/705fc9bc0fee41aaca806bb9d66caba7a7cd99e5/ophyd/pseudopos.py#L426-L427

This is a good idea in most cases, but in the case where:
- You are loading many devices at once
- And this callback needs to get an EPICS value

This will cause issues.

This logs an error in XPP during the load:
```
ERROR    Subscription readback callback exception (Newport(XPP:LAS:MMN:16, name=xpp_txt_motor))
Traceback (most recent call last):
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/signal.py", line 1115, in _get_with_timeout
    self.wait_for_connection(timeout=connection_timeout)
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/signal.py", line 1494, in wait_for_connection
    self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/signal.py", line 1061, in _ensure_connected
    raise TimeoutError(f'Control layer {self.cl.name} failed to send connection and '
TimeoutError: Control layer pyepics failed to send connection and access rights information within 1.0 sec
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/ophydobj.py", line 462, in inner
    cb(*args, **kwargs)
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/pseudopos.py", line 687, in _real_pos_update
    self._update_position()
  File "/reg/g/pcds/pyps/apps/hutch-python/xpp/dev/devpath/pcdsdevices/pseudopos.py", line 204, in _update_position
    position = super()._update_position()
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/pseudopos.py", line 671, in _update_position
    calc_pseudo_pos = self.inverse(real_cur_pos)
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/pseudopos.py", line 188, in wrapped
    return method(self, pos, **new_kwargs)
  File "/reg/g/pcds/pyps/apps/hutch-python/xpp/dev/devpath/pcdsdevices/pseudopos.py", line 763, in inverse
    meters = convert_unit(real_pos.motor, self.motor.egu, 'meters')
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/epics_motor.py", line 114, in egu
    return self.motor_egu.get()
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/signal.py", line 1179, in get
    info = self._get_with_timeout(
  File "/u1/xppopr/conda_envs/pcds-4.1.5/lib/python3.8/site-packages/ophyd/signal.py", line 1117, in _get_with_timeout
    raise ConnectionTimeoutError(
ophyd.signal.ConnectionTimeoutError: Failed to connect to XPP:LAS:MMN:16.EGU within 1.00 sec
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It made the error messages in XPP go away, and no additional bugs have been reported.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes and a huge docstring
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
