### PR TITLE
MNT: set_current_position error handling

### DIFF
--- a/docs/source/upcoming_release_notes/845-scp-cleanup.rst
+++ b/docs/source/upcoming_release_notes/845-scp-cleanup.rst
@@ -1,0 +1,31 @@
+845 scp-cleanup
+###############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where an epics motor could get stuck with a bad state of its
+  set_use_switch after a call to set_current_position with a bad value.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -297,9 +297,8 @@ Limit Switch: {switch_limits}
 
         Parameters
         ----------
-        pos
+        pos : number
            Position to set.
-
         '''
         self.set_use_switch.put(1, wait=True)
         try:

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -289,6 +289,24 @@ Limit Switch: {switch_limits}
         self.high_limit_travel.put(0)
         self.low_limit_travel.put(0)
 
+    @raise_if_disconnected
+    def set_current_position(self, pos):
+        '''Configure the motor user position to the given value
+
+        Override ophyd's method temporarily for error handling.
+
+        Parameters
+        ----------
+        pos
+           Position to set.
+
+        '''
+        self.set_use_switch.put(1, wait=True)
+        try:
+            self.user_setpoint.put(pos, wait=True, force=True)
+        finally:
+            self.set_use_switch.put(0, wait=True)
+
 
 class PCDSMotorBase(EpicsMotorInterface):
     """
@@ -426,8 +444,10 @@ class PCDSMotorBase(EpicsMotorInterface):
         correctly to wait=True on the VAL field while SET/USE is set to SET.
         """
         self.set_use_switch.put(1, wait=True)
-        set_and_wait(self.user_setpoint, pos, timeout=1)
-        self.set_use_switch.put(0, wait=True)
+        try:
+            set_and_wait(self.user_setpoint, pos, timeout=1)
+        finally:
+            self.set_use_switch.put(0, wait=True)
 
 
 class IMS(PCDSMotorBase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If the user puts in a bad value to `EpicsMotor.set_current_position`, this method can abort before restoring the `.SET` field (`set_use_switch`) to the normal value of `0` (`Use`), leaving it at the value of `1` (`Set`). This can cause confusion when someone tries to move a motor manually later, only for the position to be set instead of used.

This is just a simple try/finally block, we still raise the exception caused by the bad input but we clean up after ourselves.

This is a copy of https://github.com/bluesky/ophyd/pull/999 for use until it ends up in a tag

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TMO accidentally fed a string into this method, causing set/use to be set to use, causing much confusion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll make a doc

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
