### PR TITLE
MNT: pmgr CI fixes

### DIFF
--- a/docs/source/upcoming_release_notes/846-pmgr-ci.rst
+++ b/docs/source/upcoming_release_notes/846-pmgr-ci.rst
@@ -1,0 +1,33 @@
+846 pmgr
+########
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add pmgr support to the `IMS` class! There are three new methods on IMS
+  for interacting with pmgr: ``configure``, ``get_configuration``, and
+  ``find_configuration``.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- mcb64
+- ZLLentz

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ happi
 ophyd>=1.2.0
 bluesky>=1.2.0
 periodictable
+pmgr>=2.0.2
 pyepics
 pytmc
 pyyaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Create the pmgr singleton only on first instance of IMS class, we don't need to do it if we aren't using IMS
- Allow us to move on if the pmgr singleton fails to be created
- flake8 edits for style consistency (line length, import sorting)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fails travis on import because we are running a script that only exists on NFS when we load the IMS class
- Fails the flake8 check in travis

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally and hopefully travis passes now

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll make a release snippit

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
