### PR TITLE
ENH: create presets at init time

### DIFF
--- a/docs/source/upcoming_release_notes/847-init-preset.rst
+++ b/docs/source/upcoming_release_notes/847-init-preset.rst
@@ -1,0 +1,31 @@
+847 init-preset
+###############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where motor presets would not load until the first access of the
+  presets object.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -684,11 +684,9 @@ class FltMvInterface(MvInterface):
     tab_whitelist = ["mvr", "umv", "umvr", "mv_ginput", "tweak",
                      "presets", "mv_.*", "wm_.*", "umv_.*"]
 
-    @property
-    def presets(self):
-        if not hasattr(self, "_presets"):
-            self._presets = Presets(self)
-        return self._presets
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.presets = Presets(self)
 
     def wm(self):
         pos = super().wm()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix issue where motor presets would not load until the first access of the presets object by creating it during `__init__`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #847 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Diling says it works

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
