### PR TITLE
MNT: CCM scanning issues

### DIFF
--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -79,7 +79,7 @@ class CCMCalc(FltMvInterface, PseudoPositioner):
     wavelength = Cpt(PseudoSingleInterface, egu='A', kind='normal')
     theta = Cpt(PseudoSingleInterface, egu='deg', kind='normal')
     energy_with_vernier = Cpt(PseudoSingleInterface, egu='keV',
-                              kind='omitted')
+                              kind='hinted')
 
     alio = Cpt(CCMMotor, '', kind='normal')
     energy_request = FCpt(BeamEnergyRequest, '{hutch}', kind='normal')
@@ -255,6 +255,20 @@ class CCM(InOutPositioner):
             self.x.move(self._in_pos, wait=False)
         elif value == 2:
             self.x.move(self._out_pos, wait=False)
+
+    def stage(self):
+        """
+        Do not stage subdevices, they are independent for the purposes of
+        bluesky scans.
+        """
+        return [self]
+
+    def unstage(self):
+        """
+        Do not unstage subdevices, they are independent for the purposes of
+        bluesky scans.
+        """
+        return [self]
 
 
 # Calculations between alio position and energy, with all intermediates.

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -539,7 +539,7 @@ class IMS(PCDSMotorBase):
         # Clear all flags
         self.clear_all_flags()
 
-    def reinitialize(self, wait=False):
+    def reinitialize(self, wait=False, timeout=5):
         """
         Reinitialize the IMS motor.
 
@@ -547,6 +547,9 @@ class IMS(PCDSMotorBase):
         ----------
         wait : bool
             Wait for the motor to be fully intialized.
+
+        timeout : number
+            If the re-initialization takes too long, raise an error.
 
         Returns
         -------
@@ -562,9 +565,12 @@ class IMS(PCDSMotorBase):
             return value != 3
 
         # Generate a status
-        st = SubscriptionStatus(self.error_severity,
-                                initialize_complete,
-                                settle_time=0.5)
+        st = SubscriptionStatus(
+            self.error_severity,
+            initialize_complete,
+            timeout=timeout,
+            settle_time=0.5,
+            )
         # Wait on status if requested
         if wait:
             status_wait(st)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Make the CCM stage/unstage no longer consider subdevices
- Make the IMS reinitialize have a timeout

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Scan issue where xpp ccm hung on stage because it tried to re-initialize an unneeded subdevice IMS motor that reinitialized but nothing was going to happen ever because it is disconnected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I think it should be tested more before merging

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
