### PR TITLE
ENH: GroupDevice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS=""
 
-jobs:
-  allow_failures:
-    - name: "Python 3.8 - PIP"
-    - name: "Python 3.9"
-
 import:
   # This import enables a set of standard python jobs including:
   # - Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    - PIP_EXTRAS=""
+    - PIP_EXTRAS="PyQt5"
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS="PyQt5 -e ./"
 
-jobs:
-  allow_failures:
-    - name: "Python 3.7"
-    - name: "Python 3.8"
-
 import:
   # This import enables a set of standard python jobs including:
   # - Build
@@ -40,10 +35,10 @@ import:
   #   - Python Linter
   #   - Package Linter
   #   - Documentation
-  #   - Python 3.6 - PIP based
-  #   - Python 3.6, 3.7 & 3.8 - Conda base
+  #   - Python - PIP based
+  #   - Python 3.9 - Conda base
   # - Deploy
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
   #   - PyPI
-  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml
+  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    - PIP_EXTRAS="PyQt5"
+    - PIP_EXTRAS="PyQt5 -e ./"
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS=""
 
+jobs:
+  allow_failures:
+    - name: "Python 3.7"
+    - name: "Python 3.8"
+
 import:
   # This import enables a set of standard python jobs including:
   # - Build

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
   build:
-    - python >=3.6
+    - python >=3.9
     - setuptools
   run:
-    - python >=3.6
+    - python >=3.9
     - bluesky >=1.6.4
     - happi
     - jsonschema

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - pyyaml
     - schema
     - scipy
+  run_constrained:
+    - pmgr >=2.0.2
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - pcdscalc >=0.2.0
     - pcdsutils >=0.4.0
     - pint
-    - pmgr >=2.0.2
     - prettytable
     - pyepics >=3.4.2
     - pytmc >=2.7.0

--- a/docs/source/upcoming_release_notes/859-group_device.rst
+++ b/docs/source/upcoming_release_notes/859-group_device.rst
@@ -15,54 +15,54 @@ Device Updates
 
   - Acromag
   - ArrivalTimeMonitor
-  - CCM
-  - CVMI
-  - KTOF
-  - ICT
   - BaseGon
-  - XYZStage
-  - SamPhi
-  - Kappa
-  - IPMDiode
-  - IPMMotion
-  - IPIMB
-  - Wave8
-  - Injector
+  - BeckhoffJet
   - BeckhoffJetManipulator
   - BeckhoffJetSlits
-  - BeckhoffJet
+  - CCM
+  - CrystalTower1
+  - CrystalTower2
+  - CVMI
+  - DiagnosticTower
+  - ExitSlits
+  - FFMirror
+  - FlowIntegrator
+  - GasManifold
+  - ICT
+  - Injector
+  - IPIMB
+  - IPMDiode
+  - IPMMotion
+  - Kappa
+  - KBOMirror
+  - KMono
+  - KTOF
   - LAMP
   - LAMPMagneticBottle
   - LaserInCoupling
-  - CrystalTower1
-  - CrystalTower2
-  - DiagnosticTower
-  - LODCMEnergySi
-  - LODCMEnergyC
+  - LCLS2ImagerBase
   - LODCM
-  - OffsetMirror
-  - XOffsetMirror
-  - KBOMirror
-  - FFMirror
+  - LODCMEnergyC
+  - LODCMEnergySi
+  - Mono
   - MPODApalisModule
   - MRCO
+  - OffsetMirror
+  - PCM
   - PIM
-  - LCLS2ImagerBase
   - PulsePickerInOut
   - ReflaserL2SI
   - RTDSBase
+  - SamPhi
   - Selector
-  - PCM
-  - FlowIntegrator
-  - GasManifold
   - SlitsBase
-  - ExitSlits
-  - KMono
+  - StateRecordPositionerBase
   - VonHamosCrystal
   - VonHamosFE
-  - Mono
-  - StateRecordPositionerBase
+  - Wave8
   - WaveFrontSensorTarget
+  - XOffsetMirror
+  - XYZStage
 
 - Clean up pmgr loading a bit on IMS (my previous edit to Mike's setup was a bit rough)
 - Edit stage/unstage on PIMY to be compatible with GroupDevice

--- a/docs/source/upcoming_release_notes/859-group_device.rst
+++ b/docs/source/upcoming_release_notes/859-group_device.rst
@@ -79,7 +79,7 @@ Bugfixes
 
 Maintenance
 -----------
-- Move PVstateSignal from state.py to signal.py to avoid a circular import
+- Move PVStateSignal from state.py to signal.py to avoid a circular import
 - Make the tests importable and runnable on Windows
 - Require Python 3.9 for type annotations
 - Make pmgr optional, but if installed make sure it has a compatible version.

--- a/docs/source/upcoming_release_notes/859-group_device.rst
+++ b/docs/source/upcoming_release_notes/859-group_device.rst
@@ -1,0 +1,91 @@
+859 group_device
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add GroupDevice: A device that is a group of components that will act independently.
+
+Device Updates
+--------------
+- The following devices have become group devices:
+
+  - Acromag
+  - ArrivalTimeMonitor
+  - CCM
+  - CVMI
+  - KTOF
+  - ICT
+  - BaseGon
+  - XYZStage
+  - SamPhi
+  - Kappa
+  - IPMDiode
+  - IPMMotion
+  - IPIMB
+  - Wave8
+  - Injector
+  - BeckhoffJetManipulator
+  - BeckhoffJetSlits
+  - BeckhoffJet
+  - LAMP
+  - LAMPMagneticBottle
+  - LaserInCoupling
+  - CrystalTower1
+  - CrystalTower2
+  - DiagnosticTower
+  - LODCMEnergySi
+  - LODCMEnergyC
+  - LODCM
+  - OffsetMirror
+  - XOffsetMirror
+  - KBOMirror
+  - FFMirror
+  - MPODApalisModule
+  - MRCO
+  - PIM
+  - LCLS2ImagerBase
+  - PulsePickerInOut
+  - ReflaserL2SI
+  - RTDSBase
+  - Selector
+  - PCM
+  - FlowIntegrator
+  - GasManifold
+  - SlitsBase
+  - ExitSlits
+  - KMono
+  - VonHamosCrystal
+  - VonHamosFE
+  - Mono
+  - StateRecordPositionerBase
+  - WaveFrontSensorTarget
+
+- Clean up pmgr loading a bit on IMS (my previous edit to Mike's setup was a bit rough)
+- Edit stage/unstage on PIMY to be compatible with GroupDevice
+- Edit stage/unstage and the class definition on SlitsBase to be compatible with GroupDevice
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix some race conditions in FuncPositioner
+- Fix a race condition in schedule_task that could cause a task to never be run
+
+Maintenance
+-----------
+- Move PVstateSignal from state.py to signal.py to avoid a circular import
+- Make the tests importable and runnable on Windows
+- Require Python 3.9 for type annotations
+- Make pmgr optional, but if installed make sure it has a compatible version.
+- Update to 3.9-only CI
+- Fix the CI PIP test build
+
+Contributors
+------------
+- ZLLentz

--- a/pcdsdevices/analog_signals.py
+++ b/pcdsdevices/analog_signals.py
@@ -5,10 +5,11 @@ from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 
 from . import utils as key_press
+from .device import GroupDevice
 from .interface import BaseInterface
 
 
-class Acromag(BaseInterface, Device):
+class Acromag(BaseInterface, GroupDevice):
     """
     Class for Acromag analog input/ouput signals.
 

--- a/pcdsdevices/atm.py
+++ b/pcdsdevices/atm.py
@@ -1,13 +1,13 @@
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATTempSensor
 
 
-class ArrivalTimeMonitor(BaseInterface, Device, LightpathInOutMixin):
+class ArrivalTimeMonitor(BaseInterface, GroupDevice, LightpathInOutMixin):
     tab_component_names = True
 
     lightpath_cpts = ['target']

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,9 +1,9 @@
 import logging
 
 from ophyd.device import Component as Cpt
+from ophyd.device import Device
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 
-from .device import GroupDevice
 from .interface import BaseInterface
 from .pv_positioner import PVPositionerDone
 from .signal import AvgSignal
@@ -11,7 +11,7 @@ from .signal import AvgSignal
 logger = logging.getLogger(__name__)
 
 
-class BeamStats(BaseInterface, GroupDevice):
+class BeamStats(BaseInterface, Device):
     mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted',
              doc='Pulse energy [mJ]')
     ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal',
@@ -78,7 +78,7 @@ class BeamEnergyRequest(PVPositionerDone):
                          **kwargs)
 
 
-class LCLS(BaseInterface, GroupDevice):
+class LCLS(BaseInterface, Device):
     """
     Object to query machine Lcls Linac status.
     """

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,18 +1,17 @@
 import logging
 
 from ophyd.device import Component as Cpt
-from ophyd.device import Device
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 
+from .device import GroupDevice
 from .interface import BaseInterface
 from .pv_positioner import PVPositionerDone
 from .signal import AvgSignal
 
-
 logger = logging.getLogger(__name__)
 
 
-class BeamStats(BaseInterface, Device):
+class BeamStats(BaseInterface, GroupDevice):
     mj = Cpt(EpicsSignalRO, 'GDET:FEE1:241:ENRC', kind='hinted',
              doc='Pulse energy [mJ]')
     ev = Cpt(EpicsSignalRO, 'BLD:SYS0:500:PHOTONENERGY', kind='normal',
@@ -79,7 +78,7 @@ class BeamEnergyRequest(PVPositionerDone):
                          **kwargs)
 
 
-class LCLS(BaseInterface, Device):
+class LCLS(BaseInterface, GroupDevice):
     """
     Object to query machine Lcls Linac status.
     """

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -6,6 +6,7 @@ from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO, Signal
 
 from .beam_stats import BeamEnergyRequest
+from .device import GroupDevice
 from .epics_motor import IMS, EpicsMotorInterface
 from .inout import InOutPositioner
 from .interface import FltMvInterface
@@ -187,7 +188,7 @@ class CCMY(SyncAxis):
         super().__init__(down_prefix, *args, **kwargs)
 
 
-class CCM(InOutPositioner):
+class CCM(InOutPositioner, GroupDevice):
     """
     The full CCM assembly.
 

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -217,6 +217,8 @@ class CCM(InOutPositioner, GroupDevice):
     _transmission = {'IN': 0.9}
 
     tab_component_names = True
+    # When we move the top-level CCM, it moves X
+    stage_group = [x]
 
     def __init__(self, alio_prefix, theta2fine_prefix, theta2coarse_prefix,
                  chi2_prefix, x_down_prefix, x_up_prefix,

--- a/pcdsdevices/cvmi_motion.py
+++ b/pcdsdevices/cvmi_motion.py
@@ -5,13 +5,13 @@ This module contains classes related to the TMO-LAMP Motion System
 """
 
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
 
 
-class CVMI(BaseInterface, Device):
+class CVMI(BaseInterface, GroupDevice):
     """
     CVMI Motion Class
 
@@ -42,7 +42,7 @@ class CVMI(BaseInterface, Device):
     sample_paddle = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
 
 
-class KTOF(BaseInterface, Device):
+class KTOF(BaseInterface, GroupDevice):
     """
     KTOF Motion Class
 

--- a/pcdsdevices/dc_devices.py
+++ b/pcdsdevices/dc_devices.py
@@ -6,6 +6,7 @@ import logging
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 
+from .device import GroupDevice
 from .interface import BaseInterface
 
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ class ICTBus(Device):
         return self.bus_voltage.get()
 
 
-class ICT(BaseInterface, Device):
+class ICT(BaseInterface, GroupDevice):
     """Complete ICT device with access to all buses and channels."""
     bus_A = FCpt(ICTBus, '{self.prefix}', bus='A')
     bus_B = FCpt(ICTBus, '{self.prefix}', bus='B')

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -371,14 +371,14 @@ class GroupDevice(Device):
       (Note: at time of writing, this hypothetical ``GroupDevice``
       ui template does not yet exist).
     - Certain devices will completely break if we remove their subdevice
-      references: for example, consider the PsuedoPositioner class.
+      references: for example, consider the ``PsuedoPositioner`` class.
       For classes like these, we'll need to keep the parent references
-      for the PseudoSingle instances. For the full list of classes that
+      for the ``PseudoSingle`` instances. For the full list of classes that
       need to retain their ``parent`` attribute, see
       ``GroupDevice.needs_parent``.
     """
     stage_group: list[Component] = None
-    needs_parent: list[OphydObject] = [
+    needs_parent: list[type] = [
         PseudoSingle,
         AttributeSignal,
         PVStateSignal,

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -416,7 +416,7 @@ class GroupDevice(Device):
 
     def unstage(self) -> list[OphydObject]:
         unstaged = [self]
-        for obj in reversed(self.stage_group_instances()):
+        for obj in reversed(list(self.stage_group_instances())):
             if hasattr(obj, 'unstage'):
                 unstaged.extend(obj.unstage())
         return unstaged

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -394,6 +394,9 @@ class GroupDevice(Device):
                 cpt._parent = None
         if self.stage_group is None:
             self.stage_group = []
+        else:
+            # Avoid potential issues from shared mutable class attribute
+            self.stage_group = list(self.stage_group)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -355,6 +355,10 @@ class GroupDevice(Device):
     - ``GroupDevice`` instances by default do nothing when staged.
       You can add specific subdevices to the stage list by setting the
       ``stage_group`` class attribute to a list of components.
+    - Following from the previous point, note that ``GroupDevice``
+      instances cannot process top-level ``stage_sigs``. If you need
+      top-level ``stage_sigs``, you should instead contain them in a
+      subdevice that is not a ``GroupDevice``.
     - ``GroupDevice`` instances that implement ``set`` are required
       to specify a ``stage_group`` to help remind you that these classes
       really do need to stage "something" before scanning. If your
@@ -393,20 +397,20 @@ class GroupDevice(Device):
                 "is a movable device. See the GroupDevice docs."
                 )
 
-    def stage_group_instances(self) -> Iterator[Device]:
+    def stage_group_instances(self) -> Iterator[OphydObject]:
         """Yields an iterator of subdevices that should be staged."""
         return (getattr(self, cpt.attr) for cpt in self.stage_group)
 
-    def stage(self) -> list[Device]:
+    def stage(self) -> list[OphydObject]:
         staged = [self]
         for obj in self.stage_group_instances():
             if hasattr(obj, 'stage'):
                 staged.extend(obj.stage())
         return staged
 
-    def unstage(self) -> list[Device]:
+    def unstage(self) -> list[OphydObject]:
         unstaged = [self]
-        for obj in self.stage_group_instances():
+        for obj in reversed(self.stage_group_instances()):
             if hasattr(obj, 'unstage'):
                 unstaged.extend(obj.unstage())
         return unstaged

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -374,7 +374,8 @@ class GroupDevice(Device):
         super().__init_subclass__(**kwargs)
         if issubclass(cls, PseudoPositioner):
             raise TypeError(
-                "GroupDevice cannot be applied to a PseudoPositioner"
+                f"Cannot apply GroupDevice to {cls.__name__} because it is "
+                "a PseudoPositioner."
                 )
 
     def stage(self):

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -395,11 +395,13 @@ class GroupDevice(Device):
     def stage(self) -> list[Device]:
         staged = [self]
         for obj in self.stage_group_instances():
-            staged.extend(obj.stage())
+            if hasattr(obj, 'stage'):
+                staged.extend(obj.stage())
         return staged
 
     def unstage(self) -> list[Device]:
         unstaged = [self]
         for obj in self.stage_group_instances():
-            unstaged.extend(obj.unstage())
+            if hasattr(obj, 'unstage'):
+                unstaged.extend(obj.unstage())
         return unstaged

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -378,7 +378,7 @@ class GroupDevice(Device):
       ``GroupDevice.needs_parent``.
     """
     stage_group: list[Component] = None
-    needs_parent: list[type] = [
+    needs_parent: list[type[OphydObject]] = [
         PseudoSingle,
         AttributeSignal,
         PVStateSignal,

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -413,7 +413,7 @@ class GroupDevice(Device):
                         f"{cls.__name__}! Only Component types are allowed!"
                     )
                 subcls_cpt = getattr(cls, cpt.attr, None)
-                if not issubclass(subcls_cpt, Component):
+                if not isinstance(subcls_cpt, Component):
                     raise TypeError(
                         f"In stage_group for {cls.__name__}, {cpt.attr} "
                         f"referenced {subcls_cpt}, which is not a Component! "

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -405,6 +405,20 @@ class GroupDevice(Device):
                 f"Must specify a stage_group in {cls.__name__} because it "
                 "is a movable device. See the GroupDevice docs."
                 )
+        if cls.stage_group is not None:
+            for cpt in cls.stage_group:
+                if not isinstance(cpt, Component):
+                    raise TypeError(
+                        f"Found non-Component {cpt} in stage_group for "
+                        f"{cls.__name__}! Only Component types are allowed!"
+                    )
+                subcls_cpt = getattr(cls, cpt.attr, None)
+                if not issubclass(subcls_cpt, Component):
+                    raise TypeError(
+                        f"In stage_group for {cls.__name__}, {cpt.attr} "
+                        f"referenced {subcls_cpt}, which is not a Component! "
+                        "Only Component types are allowed!"
+                    )
 
     def stage_group_instances(self) -> Iterator[OphydObject]:
         """Yields an iterator of subdevices that should be staged."""

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -6,6 +6,8 @@ from ophyd.ophydobj import Kind, OphydObject
 from ophyd.pseudopos import PseudoSingle
 from ophyd.signal import AttributeSignal
 
+from .signal import PVStateSignal
+
 
 class UnrelatedComponent(Component):
     """
@@ -376,7 +378,11 @@ class GroupDevice(Device):
       ``GroupDevice.needs_parent``.
     """
     stage_group: list[Component] = None
-    needs_parent: list[OphydObject] = [PseudoSingle, AttributeSignal]
+    needs_parent: list[OphydObject] = [
+        PseudoSingle,
+        AttributeSignal,
+        PVStateSignal,
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -1,10 +1,11 @@
 import copy
 from collections.abc import Iterator
 
+from ophyd.areadetector.plugins import PluginBase
 from ophyd.device import Component, Device
 from ophyd.ophydobj import Kind, OphydObject
 from ophyd.pseudopos import PseudoSingle
-from ophyd.signal import AttributeSignal
+from ophyd.signal import AttributeSignal, DerivedSignal
 
 from .signal import PVStateSignal
 
@@ -379,8 +380,10 @@ class GroupDevice(Device):
     """
     stage_group: list[Component] = None
     needs_parent: list[type[OphydObject]] = [
-        PseudoSingle,
         AttributeSignal,
+        DerivedSignal,
+        PluginBase,
+        PseudoSingle,
         PVStateSignal,
         ]
 

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -344,13 +344,17 @@ class GroupDevice(Device):
 
     This has the following implications:
     - Components will have no references to this parent device. If
-      accessed and used out of context, the device will be as if it
-      was instantited completely separately.
+      accessed and used out of context, the components will be as if
+      they were instantited completely separately.
     - If a component is staged in a bluesky plan, it will not stage
-      the entire device tree. If you'd like to stage everything, then this
-      group device must participate in the scan.
-    - When represented in typhos, we'd rather see the GroupDevice screen than
-      the default device screens. (Note: at time of writing, this GroupDevice
+      the ``GroupDevice``, and therefore will not stage the entire
+      device tree.
+    - ``GroupDevice`` instances cannot in themselves be staged.
+      This would necessarily create a redundant staging error when
+      used in a bluesky scan alongside the more useful subdevices.
+    - When represented in typhos, we'll see the GroupDevice screen
+      instead of the default device screens.
+      (Note: at time of writing, this hypothetical ``GroupDevice``
       ui template does not yet exist).
     """
     def __init__(self, *args, **kwargs):
@@ -359,3 +363,15 @@ class GroupDevice(Device):
         for cpt_name in self.component_names:
             cpt = getattr(self, cpt_name)
             cpt.parent = None
+
+    def stage(self):
+        raise RuntimeError(
+            "Group devices cannot be staged and should not be "
+            "used in a bluesky plan."
+            )
+
+    def unstage(self):
+        raise RuntimeError(
+            "Group devices cannot be unstaged and should not be "
+            "used in a bluesky plan."
+            )

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -336,3 +336,26 @@ class UpdateComponent(Component):
     def create_component(self, instance):
         # Use our hostage component from __set_name__
         return self.copy_cpt.create_component(instance)
+
+
+class GroupDevice(Device):
+    """
+    A device that is a group of components that will act independently.
+
+    This has the following implications:
+    - Components will have no references to this parent device. If
+      accessed and used out of context, the device will be as if it
+      was instantited completely separately.
+    - If a component is staged in a bluesky plan, it will not stage
+      the entire device tree. If you'd like to stage everything, then this
+      group device must participate in the scan.
+    - When represented in typhos, we'd rather see the GroupDevice screen than
+      the default device screens. (Note: at time of writing, this GroupDevice
+      ui template does not yet exist).
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Remove references to parent (in this case, self)
+        for cpt_name in self.component_names:
+            cpt = getattr(self, cpt_name)
+            cpt.parent = None

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -1,4 +1,5 @@
 import copy
+from collections.abc import Iterator
 
 from ophyd.device import Component, Device
 from ophyd.ophydobj import Kind
@@ -367,7 +368,7 @@ class GroupDevice(Device):
       For classes like these, we'll need to keep the parent references
       for the PseudoSingle instances.
     """
-    stage_group = None
+    stage_group: list[Component] = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -387,17 +388,17 @@ class GroupDevice(Device):
                 "is a movable device. See the GroupDevice docs."
                 )
 
-    def stage_group_instances(self):
+    def stage_group_instances(self) -> Iterator[Device]:
         """Yields an iterator of subdevices that should be staged."""
         return (getattr(self, cpt.attr) for cpt in self.stage_group)
 
-    def stage(self):
+    def stage(self) -> list[Device]:
         staged = [self]
         for obj in self.stage_group_instances():
             staged.extend(obj.stage())
         return staged
 
-    def unstage(self):
+    def unstage(self) -> list[Device]:
         unstaged = [self]
         for obj in self.stage_group_instances():
             unstaged.extend(obj.unstage())

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -366,7 +366,7 @@ class GroupDevice(Device):
       really do need to stage "something" before scanning. If your
       movable device really does not need this, you can set ``stage_group``
       to an empty list.
-    - When represented in typhos, we'll see the GroupDevice screen
+    - When represented in typhos, we'll see the ``GroupDevice`` screen
       instead of the default device screens.
       (Note: at time of writing, this hypothetical ``GroupDevice``
       ui template does not yet exist).

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -362,6 +362,9 @@ class GroupDevice(Device):
       For classes like these, we'll raise an exception at class definition
       time. We can't just ignore it since we make other changes here that
       would make it impossible to scan these objects.
+    - Certain devices will completely break if we change their staging
+      behavior: for example, any motor. These will also raise an Exception
+      at class definition time.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -376,6 +379,11 @@ class GroupDevice(Device):
             raise TypeError(
                 f"Cannot apply GroupDevice to {cls.__name__} because it is "
                 "a PseudoPositioner."
+                )
+        if hasattr(cls, 'set'):
+            raise TypeError(
+                f"Cannot apply GroupDevice to {cls.__name__} because it is "
+                "a Movable device according to bluesky."
                 )
 
     def stage(self):

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -390,7 +390,7 @@ class GroupDevice(Device):
         for cpt_name in self.component_names:
             cpt = getattr(self, cpt_name)
             # The following types break without parents
-            if not isinstance(cpt, self.needs_parent):
+            if not isinstance(cpt, tuple(self.needs_parent)):
                 cpt._parent = None
         if self.stage_group is None:
             self.stage_group = []

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -390,7 +390,7 @@ class GroupDevice(Device):
         for cpt_name in self.component_names:
             cpt = getattr(self, cpt_name)
             # The following types break without parents
-            if not any(isinstance(cpt, cls) for cls in self.needs_parent):
+            if not isinstance(cpt, self.needs_parent):
                 cpt._parent = None
         if self.stage_group is None:
             self.stage_group = []

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -10,6 +10,7 @@ from ophyd.device import Component as Cpt
 from ophyd.status import DeviceStatus
 from prettytable import PrettyTable
 
+from .device import GroupDevice
 from .epics_motor import IMS
 from .interface import BaseInterface
 from .pseudopos import (PseudoPositioner, PseudoSingleInterface,
@@ -20,7 +21,7 @@ from .utils import get_status_float, get_status_value
 logger = logging.getLogger(__name__)
 
 
-class BaseGon(BaseInterface, Device):
+class BaseGon(BaseInterface, GroupDevice):
     """
     Basic goniometer, as present in XPP.
 
@@ -201,7 +202,7 @@ def Goniometer(**kwargs):
         return BaseGon(**kwargs)
 
 
-class XYZStage(BaseInterface, Device):
+class XYZStage(BaseInterface, GroupDevice):
     """
     Sample XYZ stage.
 
@@ -256,7 +257,7 @@ class KappaXYZStage(XYZStage):
                          **kwargs)
 
 
-class SamPhi(BaseInterface, Device):
+class SamPhi(BaseInterface, GroupDevice):
     """
     Sample Phi stage.
 

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -4,7 +4,6 @@ Module for goniometers and sample stages used with them.
 import logging
 
 import numpy as np
-from ophyd import Device
 from ophyd import FormattedComponent as FCpt
 from ophyd.device import Component as Cpt
 from ophyd.status import DeviceStatus
@@ -289,7 +288,7 @@ class KappaMoveAbort(ValueError):
     pass
 
 
-class Kappa(BaseInterface, PseudoPositioner, Device):
+class Kappa(BaseInterface, PseudoPositioner, GroupDevice):
     """
     Kappa stage, control the Kappa diffractometer in spherical coordinates.
 
@@ -372,8 +371,10 @@ class Kappa(BaseInterface, PseudoPositioner, Device):
     e_eta = FCpt(PseudoSingleInterface, kind='normal', name='gon_kappa_e_eta')
     e_chi = FCpt(PseudoSingleInterface, kind='normal', name='gon_kappa_e_chi')
     e_phi = FCpt(PseudoSingleInterface, kind='normal', name='gon_kappa_e_phi')
-    tab_component_names = True
 
+    # Only stage the motors involved in the coordinate transform
+    stage_group = [eta, kappa, phi]
+    tab_component_names = True
     tab_whitelist = ['stop', 'wait', 'k_to_e', 'e_to_k', 'check_motor_step']
 
     def __init__(self, *, name, prefix_x, prefix_y, prefix_z,

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -8,6 +8,7 @@ from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 
+from .device import GroupDevice
 from .doc_stubs import IPM_base, basic_positioner_init, insert_remove
 from .epics_motor import IMS
 from .evr import Trigger
@@ -68,7 +69,7 @@ class IPMTarget(InOutRecordPositioner):
         self.y_motor = self.motor
 
 
-class IPMDiode(BaseInterface, Device):
+class IPMDiode(BaseInterface, GroupDevice):
     """
     Diode of a standard intensity position monitor.
 
@@ -118,7 +119,7 @@ class IPMDiode(BaseInterface, Device):
     remove.__doc__ += insert_remove
 
 
-class IPMMotion(BaseInterface, Device):
+class IPMMotion(BaseInterface, GroupDevice):
     """
     Standard intensity position monitor.
 
@@ -289,7 +290,7 @@ class IPIMBChannel(BaseInterface, Device):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class IPIMB(BaseInterface, Device):
+class IPIMB(BaseInterface, GroupDevice):
     """
     Class for an IPIMB box.
 
@@ -382,7 +383,7 @@ class Wave8Channel(BaseInterface, Device):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class Wave8(BaseInterface, Device):
+class Wave8(BaseInterface, GroupDevice):
     """
     Class for a wave8.
 

--- a/pcdsdevices/jet.py
+++ b/pcdsdevices/jet.py
@@ -2,14 +2,14 @@
 Module for the liquid jet classes.
 """
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .device import UnrelatedComponent as UCpt
 from .epics_motor import IMS, BeckhoffAxis
 from .interface import BaseInterface
 
 
-class Injector(BaseInterface, Device):
+class Injector(BaseInterface, GroupDevice):
     """
     Positioner for liquid jet Injector.
 
@@ -69,7 +69,7 @@ class InjectorWithFine(Injector):
     fine_z = UCpt(IMS)
 
 
-class BeckhoffJetManipulator(BaseInterface, Device):
+class BeckhoffJetManipulator(BaseInterface, GroupDevice):
     """Jet Manipulator controlled by Beckhoff PLC."""
 
     tab_component_names = True
@@ -79,7 +79,7 @@ class BeckhoffJetManipulator(BaseInterface, Device):
     z = Cpt(BeckhoffAxis, ':Z', kind='normal')
 
 
-class BeckhoffJetSlits(BaseInterface, Device):
+class BeckhoffJetSlits(BaseInterface, GroupDevice):
     """Pair of Beckhoff-controlled slits where each blade has X & Y motors."""
     tab_component_names = True
 
@@ -89,7 +89,7 @@ class BeckhoffJetSlits(BaseInterface, Device):
     bot_y = Cpt(BeckhoffAxis, ':BOT_Y', kind='normal')
 
 
-class BeckhoffJet(BaseInterface, Device):
+class BeckhoffJet(BaseInterface, GroupDevice):
     """
     Full liquid jet setup controlled by a Beckhoff PLC.
 

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -5,13 +5,13 @@ This module contains classes related to the TMO-LAMP Motion System
 """
 
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
 
 
-class LAMP(BaseInterface, Device):
+class LAMP(BaseInterface, GroupDevice):
     """
     LAMP Motion Class
 
@@ -44,7 +44,7 @@ class LAMP(BaseInterface, Device):
     sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')
 
 
-class LAMPMagneticBottle(BaseInterface, Device):
+class LAMPMagneticBottle(BaseInterface, GroupDevice):
     """
     LAMPMagneticBottle Motion Class
 

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -11,6 +11,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 from pcdscalc import be_lens_calcs as calcs
 
+from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .inout import CombinedInOutRecordPositioner, InOutRecordPositioner
@@ -78,7 +79,7 @@ class Prefocus(CombinedInOutRecordPositioner):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class LensStackBase(BaseInterface, PseudoPositioner):
+class LensStackBase(BaseInterface, PseudoPositioner, GroupDevice):
     """
     Class for Be lens macros and safe operations.
 

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -11,7 +11,6 @@ from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 from pcdscalc import be_lens_calcs as calcs
 
-from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .inout import CombinedInOutRecordPositioner, InOutRecordPositioner
@@ -79,7 +78,7 @@ class Prefocus(CombinedInOutRecordPositioner):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class LensStackBase(BaseInterface, PseudoPositioner, GroupDevice):
+class LensStackBase(BaseInterface, PseudoPositioner):
     """
     Class for Be lens macros and safe operations.
 

--- a/pcdsdevices/lic.py
+++ b/pcdsdevices/lic.py
@@ -1,6 +1,6 @@
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
@@ -20,7 +20,7 @@ class LICMirror(TwinCATStatePMPS):
     }
 
 
-class LaserInCoupling(BaseInterface, Device, LightpathInOutMixin):
+class LaserInCoupling(BaseInterface, GroupDevice, LightpathInOutMixin):
     """
     Device to bring the optical laser to the sample via mirrors.
     """

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -769,6 +769,8 @@ class LODCMEnergySi(FltMvInterface, PseudoPositioner, GroupDevice):
 
     energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted')
 
+    stage_group = [dr, th1Si, th2Si, z1Si, z2Si]
+
     def __init__(self, prefix, *args, **kwargs):
         self._prefix = prefix
         self._hutch_prefix = ''
@@ -984,6 +986,8 @@ class LODCMEnergyC(FltMvInterface, PseudoPositioner, GroupDevice):
                doc='Z2 motor offset for C [mm]')
 
     energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted')
+
+    stage_group = [dr, th1C, th2C, z1C, z2C]
 
     def __init__(self, prefix, *args, **kwargs):
         self._prefix = prefix

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -729,7 +729,7 @@ navitar zoom [{yag_zoom_units}]  {yag_zoom_user} ({yag_zoom_dial})
 """
 
 
-class LODCMEnergySi(FltMvInterface, PseudoPositioner, GroupDevice):
+class LODCMEnergySi(FltMvInterface, PseudoPositioner):
     """
     Energy calculations for the Si material.
 
@@ -945,7 +945,7 @@ Photon Energy: {energy} [keV]
 """
 
 
-class LODCMEnergyC(FltMvInterface, PseudoPositioner, GroupDevice):
+class LODCMEnergyC(FltMvInterface, PseudoPositioner):
     """
     Energy calculations for the C material.
 

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -13,16 +13,16 @@ import logging
 
 import numpy as np
 from ophyd.device import Component as Cpt
-from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import EpicsSignalRO
 from ophyd.sim import NullStatus
 from ophyd.status import wait as status_wait
 from pcdscalc import common, diffraction
 
-from pcdsdevices.epics_motor import OffsetMotor, OffsetIMSWithPreset
+from pcdsdevices.epics_motor import OffsetIMSWithPreset, OffsetMotor
 from pcdsdevices.sim import FastMotor
 
+from .device import GroupDevice
 from .doc_stubs import insert_remove
 from .epics_motor import IMS
 from .inout import InOutRecordPositioner
@@ -104,7 +104,7 @@ class Y2(InOutRecordPositioner):
     out_states = []
 
 
-class CrystalTower1(BaseInterface, Device):
+class CrystalTower1(BaseInterface, GroupDevice):
     """
     LODCM Crystal Tower 1.
 
@@ -366,7 +366,7 @@ hp [{hp_units}]  {hp_user} ({hp_dial})
 """
 
 
-class CrystalTower2(BaseInterface, Device):
+class CrystalTower2(BaseInterface, GroupDevice):
     """
     LODCM Crystal Tower 2.
 
@@ -619,7 +619,7 @@ diode [{diode_units}]  {diode_user} ({diode_dial})
 """
 
 
-class DiagnosticsTower(BaseInterface, Device):
+class DiagnosticsTower(BaseInterface, GroupDevice):
     """
     LODCM Diagnostic Tower.
 
@@ -729,7 +729,7 @@ navitar zoom [{yag_zoom_units}]  {yag_zoom_user} ({yag_zoom_dial})
 """
 
 
-class LODCMEnergySi(FltMvInterface, PseudoPositioner):
+class LODCMEnergySi(FltMvInterface, PseudoPositioner, GroupDevice):
     """
     Energy calculations for the Si material.
 
@@ -945,7 +945,7 @@ Photon Energy: {energy} [keV]
 """
 
 
-class LODCMEnergyC(FltMvInterface, PseudoPositioner):
+class LODCMEnergyC(FltMvInterface, PseudoPositioner, GroupDevice):
     """
     Energy calculations for the C material.
 
@@ -1160,7 +1160,7 @@ Photon Energy: {energy} [keV]
 """
 
 
-class LODCM(BaseInterface, Device):
+class LODCM(BaseInterface, GroupDevice):
     """
     Large Offset Dual Crystal Monochromator.
 

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -729,7 +729,7 @@ navitar zoom [{yag_zoom_units}]  {yag_zoom_user} ({yag_zoom_dial})
 """
 
 
-class LODCMEnergySi(FltMvInterface, PseudoPositioner):
+class LODCMEnergySi(FltMvInterface, PseudoPositioner, GroupDevice):
     """
     Energy calculations for the Si material.
 
@@ -945,7 +945,7 @@ Photon Energy: {energy} [keV]
 """
 
 
-class LODCMEnergyC(FltMvInterface, PseudoPositioner):
+class LODCMEnergyC(FltMvInterface, PseudoPositioner, GroupDevice):
     """
     Energy calculations for the C material.
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -284,6 +284,8 @@ class PointingMirror(InOutRecordPositioner, OffsetMirror):
 
     # Reverse state order as PointingMirror is non-standard
     states_list = ['OUT', 'IN']
+    # Moving PointingMirror moves the x gantry
+    stage_group = [OffsetMirror.xgantry]
 
     def __init__(self, prefix, *, out_lines=None, in_lines=None, **kwargs):
         # Branching pattern

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -14,6 +14,7 @@ from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 from ophyd import PVPositioner
 
+from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .epics_motor import BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
@@ -151,7 +152,7 @@ class Gantry(OMMotor):
         super().check_value(pos)
 
 
-class OffsetMirror(BaseInterface, Device):
+class OffsetMirror(BaseInterface, GroupDevice):
     """
     X-ray Offset Mirror class.
 
@@ -318,7 +319,7 @@ class PointingMirror(InOutRecordPositioner, OffsetMirror):
         return super().check_value(pos)
 
 
-class XOffsetMirror(BaseInterface, Device):
+class XOffsetMirror(BaseInterface, GroupDevice):
     """
     X-ray Offset Mirror.
 
@@ -521,7 +522,7 @@ class XOffsetMirrorSwitch(XOffsetMirror):
                   doc='Yright slave axis [um]')
 
 
-class KBOMirror(BaseInterface, Device):
+class KBOMirror(BaseInterface, GroupDevice):
     """
     Kirkpatrick-Baez Mirror with Bender Axes.
 
@@ -660,7 +661,7 @@ bender_ds ({self.bender_ds.prefix})
 """
 
 
-class FFMirror(BaseInterface, Device):
+class FFMirror(BaseInterface, GroupDevice):
     """
     Fixed Focus Kirkpatrick-Baez Mirror.
 

--- a/pcdsdevices/mpod_apalis.py
+++ b/pcdsdevices/mpod_apalis.py
@@ -7,6 +7,8 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from pcdsdevices.interface import BaseInterface
 
+from .device import GroupDevice
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,7 +90,7 @@ class MPODApalisChannel(BaseInterface, Device):
                            % (max_current, max_current))
 
 
-class MPODApalisModule(BaseInterface, Device):
+class MPODApalisModule(BaseInterface, GroupDevice):
 
     """
     MPODApalis Module Object.

--- a/pcdsdevices/mrco_motion.py
+++ b/pcdsdevices/mrco_motion.py
@@ -5,13 +5,13 @@ This module contains classes related to the TMO-MRCO Motion System
 """
 
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface
 
 
-class MRCO(BaseInterface, Device):
+class MRCO(BaseInterface, GroupDevice):
     """
     MRCO Motion Class
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -16,6 +16,7 @@ from ophyd.signal import EpicsSignal
 
 from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
                                      PCDSAreaDetectorTyphosTrigger)
+from .device import GroupDevice
 from .epics_motor import IMS, BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
 from .interface import BaseInterface, LightpathInOutMixin
@@ -52,7 +53,7 @@ class PIMY(InOutRecordPositioner, BaseInterface):
         return super().stage()
 
 
-class PIM(BaseInterface, Device):
+class PIM(BaseInterface, GroupDevice):
     """
     Profile Intensity Monitor.
 
@@ -303,7 +304,7 @@ class PIMWithBoth(PIMWithFocus, PIMWithLED):
                          prefix_zoom=prefix_zoom, **kwargs)
 
 
-class LCLS2ImagerBase(BaseInterface, Device, LightpathInOutMixin):
+class LCLS2ImagerBase(BaseInterface, GroupDevice, LightpathInOutMixin):
     """
     Shared PVs and components from the LCLS2 imagers.
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -12,6 +12,7 @@ import logging
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
+from ophyd.ophydobj import OphydObject
 from ophyd.signal import EpicsSignal
 
 from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
@@ -46,10 +47,18 @@ class PIMY(InOutRecordPositioner, BaseInterface):
     _icon = 'fa.camera-retro'
 
     tab_whitelist = ['stage']
+    _pre_stage_state = None
 
-    def stage(self):
+    def stage(self) -> list[OphydObject]:
         """Save the original position to be restored on `unstage`."""
-        self._original_vals[self.state] = self.state.get()
+        self._pre_stage_state = self.state.get()
+        return super().stage()
+
+    def unstage(self) -> list[OphydObject]:
+        """Load the original position that was saved on `stage`."""
+        if self._pre_stage_state is not None:
+            self.state.put(self._pre_stage_state)
+        self._pre_stage_state = None
         return super().stage()
 
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -59,7 +59,7 @@ class PIMY(InOutRecordPositioner, BaseInterface):
         if self._pre_stage_state is not None:
             self.state.put(self._pre_stage_state)
         self._pre_stage_state = None
-        return super().stage()
+        return super().unstage()
 
 
 class PIM(BaseInterface, GroupDevice):

--- a/pcdsdevices/positioner.py
+++ b/pcdsdevices/positioner.py
@@ -161,8 +161,8 @@ class FuncPositioner(FltMvInterface, SoftPositioner):
         if force or time.monotonic() - self._last_update > self.update_rate:
             self._last_update = time.monotonic()
             pos = self._get_pos()
-            self._set_position(pos)
             self.notepad_signal.put(pos)
+            self._set_position(pos)
 
     def _check_finished(self):
         if self._done is None:

--- a/pcdsdevices/positioner.py
+++ b/pcdsdevices/positioner.py
@@ -142,13 +142,13 @@ class FuncPositioner(FltMvInterface, SoftPositioner):
     def _update_task(self, status):
         self._update_position()
         if self._check_finished():
+            self._started_moving = False
+            self._moving = False
             try:
                 status.set_finished()
             except InvalidState:
                 pass
-        if status.done:
-            self._started_moving = False
-            self._moving = False
+            self._update_position(force=True)
         else:
             self._new_update(status)
 
@@ -157,8 +157,8 @@ class FuncPositioner(FltMvInterface, SoftPositioner):
         self._update_position()
         return self._position
 
-    def _update_position(self):
-        if time.monotonic() - self._last_update > self.update_rate:
+    def _update_position(self, force=False):
+        if force or time.monotonic() - self._last_update > self.update_rate:
             self._last_update = time.monotonic()
             pos = self._get_pos()
             self._set_position(pos)

--- a/pcdsdevices/positioner.py
+++ b/pcdsdevices/positioner.py
@@ -144,11 +144,11 @@ class FuncPositioner(FltMvInterface, SoftPositioner):
         if self._check_finished():
             self._started_moving = False
             self._moving = False
+            self._update_position(force=True)
             try:
                 status.set_finished()
             except InvalidState:
                 pass
-            self._update_position(force=True)
         else:
             self._new_update(status)
 

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -197,6 +197,9 @@ class PulsePickerInOut(PulsePicker, GroupDevice):
                               2: 'CLOSED'}}
     _state_logic_mode = 'FIRST'
 
+    # When we move PulsePickerInOut, it moves inout
+    stage_group = [inout]
+
     def __init__(self, prefix, **kwargs):
         # inout follows naming convention
         parts = prefix.split(':')

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -9,6 +9,7 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.status import SubscriptionStatus
 from ophyd.status import wait as status_wait
 
+from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .inout import InOutPVStatePositioner, InOutRecordPositioner
 
@@ -166,7 +167,7 @@ class PulsePicker(InOutPVStatePositioner):
             self._wait(self.mode, 6, 'FOLLOWER')
 
 
-class PulsePickerInOut(PulsePicker):
+class PulsePickerInOut(PulsePicker, GroupDevice):
     """
     `PulsePicker` paired with a states record to control the Y position.
 

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -7,7 +7,6 @@ from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 from ophyd import FormattedComponent as FCpt
 
-from .device import GroupDevice
 from .doc_stubs import IonPump_base
 from .interface import BaseInterface
 
@@ -123,7 +122,7 @@ class IonPumpBase(BaseInterface, Device):
         return self._egu.get()
 
 
-class IonPumpWithController(IonPumpBase, GroupDevice):
+class IonPumpWithController(IonPumpBase):
     """
 %s
 

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -7,6 +7,7 @@ from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 from ophyd import FormattedComponent as FCpt
 
+from .device import GroupDevice
 from .doc_stubs import IonPump_base
 from .interface import BaseInterface
 
@@ -122,7 +123,7 @@ class IonPumpBase(BaseInterface, Device):
         return self._egu.get()
 
 
-class IonPumpWithController(IonPumpBase):
+class IonPumpWithController(IonPumpBase, GroupDevice):
     """
 %s
 

--- a/pcdsdevices/ref.py
+++ b/pcdsdevices/ref.py
@@ -1,13 +1,13 @@
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxis, EpicsMotorInterface
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
 
 
-class ReflaserL2SI(BaseInterface, Device, LightpathInOutMixin):
+class ReflaserL2SI(BaseInterface, GroupDevice, LightpathInOutMixin):
     tab_component_names = True
 
     lightpath_cpts = ['mirror']

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -1,6 +1,7 @@
 from ophyd import Component as Cpt
-from ophyd import Device, Signal
+from ophyd import Signal
 
+from .device import GroupDevice
 from .inout import InOutPositioner
 from .interface import BaseInterface, LightpathInOutMixin
 from .signal import PytmcSignal
@@ -43,7 +44,7 @@ class PneumaticActuator(InOutPositioner):
             self.out_cmd.put(1)
 
 
-class RTDSBase(BaseInterface, Device, LightpathInOutMixin):
+class RTDSBase(BaseInterface, GroupDevice, LightpathInOutMixin):
     """Rapid Turnaround Diagnostic Station."""
     lightpath_cpts = ['mpa1', 'mpa2', 'mpa3', 'mpa4']
     _lightpath_mixin = True

--- a/pcdsdevices/sample_delivery.py
+++ b/pcdsdevices/sample_delivery.py
@@ -5,6 +5,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.signal import EpicsSignal
 
+from .device import GroupDevice
 from .device import UnrelatedComponent as UCpt
 from .interface import BaseInterface
 from .signal import PytmcSignal
@@ -38,7 +39,7 @@ class ViciValve(BaseInterface, Device):
     curr_pos = Cpt(PytmcSignal, ':CurrentPos', io='i', kind='normal')
 
 
-class Selector(M3BasePLCDevice):
+class Selector(M3BasePLCDevice, GroupDevice):
     """
     A Selector for the sample delivery system.
 
@@ -232,7 +233,7 @@ class PropAir(BaseInterface, Device):
     high_limit = Cpt(PytmcSignal, ':HighLimit', io='io', kind='normal')
 
 
-class PCM(M3BasePLCDevice):
+class PCM(M3BasePLCDevice, GroupDevice):
     """
     A Pressure Control Module for the sample delivery system.
 
@@ -274,7 +275,7 @@ class IntegratedFlow(BaseInterface, Device):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class FlowIntegrator(BaseInterface, Device):
+class FlowIntegrator(BaseInterface, GroupDevice):
     """
     A Flow Integrator for the sample delivery system.
 
@@ -419,7 +420,7 @@ class ManifoldValve(BaseInterface, Device):
     interlocked = Cpt(PytmcSignal, ':Ilk', io='i', kind='normal')
 
 
-class GasManifold(M3BasePLCDevice):
+class GasManifold(M3BasePLCDevice, GroupDevice):
     """
     A Gas Manifold as used in the sample delivery system.
 

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -204,6 +204,65 @@ class AggregateSignal(Signal):
                                old_value=old_value)
 
 
+class PVStateSignal(AggregateSignal):
+    """
+    Signal that implements the `PVStatePositioner` state logic.
+
+    See `AggregateSignal` for more information.
+    """
+
+    def __init__(self, *, name, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._sub_map = {}
+        for signal_name in self.parent._state_logic.keys():
+            sig = self.parent
+            for part in signal_name.split('.'):
+                sig = getattr(sig, part)
+            self._sub_signals.append(sig)
+            self._sub_map[signal_name] = sig
+
+    def describe(self):
+        # Base description information
+        sub_sigs = [sig.name for sig in self._sub_signals]
+        desc = {'source': 'SUM:{}'.format(','.join(sub_sigs)),
+                'dtype': 'string',
+                'shape': [],
+                'enum_strs': tuple(state.name
+                                   for state in self.parent.states_enum)}
+        return {self.name: desc}
+
+    def _calc_readback(self):
+        state_value = None
+        for signal_name, info in self.parent._state_logic.items():
+            # Get last cached value
+            value = self._cache[self._sub_map[signal_name]]
+            try:
+                signal_state = info[value]
+            # Handle unaccounted readbacks
+            except KeyError:
+                state_value = self.parent._unknown
+                break
+            # Associate readback with device state
+            if signal_state != 'defer':
+                if state_value:
+                    # Handle inconsistent readbacks
+                    if signal_state != state_value:
+                        state_value = self.parent._unknown
+                        break
+                else:
+                    # Set state to first non-deferred value
+                    state_value = signal_state
+                    if self.parent._state_logic_mode == 'ALL':
+                        continue
+                    elif self.parent._state_logic_mode == 'FIRST':
+                        break
+        # If all states deferred, report as unknown
+        return state_value or self.parent._unknown
+
+    def put(self, value, **kwargs):
+        self.parent.move(value, **kwargs)
+
+
 class AvgSignal(Signal):
     """
     Signal that acts as a rolling average of another signal.

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -246,9 +246,15 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
         """
         Store the initial values of the aperture position before scanning.
         """
-        self._original_vals[self.xwidth.setpoint] = self.xwidth.readback.get()
-        self._original_vals[self.ywidth.setpoint] = self.ywidth.readback.get()
+        self._pre_stage_gap = self.position
         return super().stage()
+
+    def unstage(self):
+        """
+        Restore the initial values of the aperture position.
+        """
+        self.move(self._pre_stage_gap[0], self._pre_stage_gap[1], wait=True)
+        return super().unstage()
 
     def subscribe(self, cb, event_type=None, run=True):
         """

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -20,7 +20,7 @@ from ophyd import DynamicDeviceComponent as DDCpt
 from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 from ophyd.pv_positioner import PVPositioner
-from ophyd.signal import Signal
+from ophyd.signal import Signal, SignalRO
 from ophyd.status import Status
 from ophyd.status import wait as status_wait
 
@@ -58,10 +58,13 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
 
     # Placeholders for each component to override
     # These are expected to be positioners
-    xwidth = None
-    ywidth = None
-    xcenter = None
-    ycenter = None
+    xwidth = Cpt(SignalRO)
+    ywidth = Cpt(SignalRO)
+    xcenter = Cpt(SignalRO)
+    ycenter = Cpt(SignalRO)
+
+    # The gap opens/closes when we move the slits device
+    stage_group = [xwidth, ywidth]
 
     def __init__(self, *args, nominal_aperture=5.0, **kwargs):
         self._has_subscribed = False

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -16,7 +16,6 @@ import logging
 from collections import OrderedDict
 
 from ophyd import Component as Cpt
-from ophyd import Device
 from ophyd import DynamicDeviceComponent as DDCpt
 from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
@@ -26,6 +25,7 @@ from ophyd.status import Status
 from ophyd.status import wait as status_wait
 
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
                         LightpathMixin, MvInterface)
@@ -39,7 +39,7 @@ from .variety import set_metadata
 logger = logging.getLogger(__name__)
 
 
-class SlitsBase(MvInterface, Device, LightpathMixin):
+class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
     """
     Base class for slit motion interfacing.
     """
@@ -555,7 +555,7 @@ class PowerSlits(BeckhoffSlits):
     fsw = Cpt(NotImplementedSignal, ':FSW', kind='normal')
 
 
-class ExitSlits(BaseInterface, Device, LightpathInOutMixin):
+class ExitSlits(BaseInterface, GroupDevice, LightpathInOutMixin):
     tab_component_names = True
 
     lightpath_cpts = ['target']

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -2,15 +2,15 @@
 Module for the various spectrometers.
 """
 from ophyd.device import Component as Cpt
-from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal, PytmcSignal
 
 
-class Kmono(BaseInterface, Device, LightpathMixin):
+class Kmono(BaseInterface, GroupDevice, LightpathMixin):
     """
     K-edge Monochromator: Used for Undulator tuning and other experiments.
 
@@ -97,7 +97,7 @@ class Kmono(BaseInterface, Device, LightpathMixin):
             self._transmission = 1
 
 
-class VonHamosCrystal(BaseInterface, Device):
+class VonHamosCrystal(BaseInterface, GroupDevice):
     """Pitch, yaw, and translation motors for control of a single crystal."""
     tab_component_names = True
 
@@ -106,7 +106,7 @@ class VonHamosCrystal(BaseInterface, Device):
     trans = Cpt(BeckhoffAxisNoOffset, ':Translation', kind='normal')
 
 
-class VonHamosFE(BaseInterface, Device):
+class VonHamosFE(BaseInterface, GroupDevice):
     """
     von Hamos spectrometer with Focus and Energy motors.
 
@@ -211,7 +211,7 @@ class VonHamos4Crystal(VonHamosFE):
                          prefix_energy=prefix_energy, **kwargs)
 
 
-class Mono(BaseInterface, Device):
+class Mono(BaseInterface, GroupDevice):
     """
     L2S-I NEH 2.X Monochromator
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -16,7 +16,7 @@ from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .interface import MvInterface
-from .signal import AggregateSignal, PytmcSignal
+from .signal import PVStateSignal, PytmcSignal
 from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
@@ -315,65 +315,6 @@ class StatePositioner(MvInterface, Device, PositionerBase):
         be run without needing to run it to find out.
         """
         raise AttributeError('StatePositioner has no stop method.')
-
-
-class PVStateSignal(AggregateSignal):
-    """
-    Signal that implements the `PVStatePositioner` state logic.
-
-    See `AggregateSignal` for more information.
-    """
-
-    def __init__(self, *, name, **kwargs):
-        super().__init__(name=name, **kwargs)
-        self._sub_map = {}
-        for signal_name in self.parent._state_logic.keys():
-            sig = self.parent
-            for part in signal_name.split('.'):
-                sig = getattr(sig, part)
-            self._sub_signals.append(sig)
-            self._sub_map[signal_name] = sig
-
-    def describe(self):
-        # Base description information
-        sub_sigs = [sig.name for sig in self._sub_signals]
-        desc = {'source': 'SUM:{}'.format(','.join(sub_sigs)),
-                'dtype': 'string',
-                'shape': [],
-                'enum_strs': tuple(state.name
-                                   for state in self.parent.states_enum)}
-        return {self.name: desc}
-
-    def _calc_readback(self):
-        state_value = None
-        for signal_name, info in self.parent._state_logic.items():
-            # Get last cached value
-            value = self._cache[self._sub_map[signal_name]]
-            try:
-                signal_state = info[value]
-            # Handle unaccounted readbacks
-            except KeyError:
-                state_value = self.parent._unknown
-                break
-            # Associate readback with device state
-            if signal_state != 'defer':
-                if state_value:
-                    # Handle inconsistent readbacks
-                    if signal_state != state_value:
-                        state_value = self.parent._unknown
-                        break
-                else:
-                    # Set state to first non-deferred value
-                    state_value = signal_state
-                    if self.parent._state_logic_mode == 'ALL':
-                        continue
-                    elif self.parent._state_logic_mode == 'FIRST':
-                        break
-        # If all states deferred, report as unknown
-        return state_value or self.parent._unknown
-
-    def put(self, value, **kwargs):
-        self.parent.move(value, **kwargs)
 
 
 class PVStatePositioner(StatePositioner):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -447,6 +447,9 @@ class StateRecordPositionerBase(StatePositioner, GroupDevice):
 
     state = Cpt(EpicsSignal, '', write_pv=':GO', kind='hinted')
 
+    # Moving a state positioner puts to state
+    stage_group = [state]
+
     def __init__(self, prefix, *, name, **kwargs):
         super().__init__(prefix, name=name, **kwargs)
         self._has_subscribed_readback = False

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -12,6 +12,7 @@ from ophyd.signal import EpicsSignal
 from ophyd.status import SubscriptionStatus
 from ophyd.status import wait as status_wait
 
+from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .interface import MvInterface
@@ -437,7 +438,7 @@ class PVStatePositioner(StatePositioner):
                                    'override the move and set methods'))
 
 
-class StateRecordPositionerBase(StatePositioner):
+class StateRecordPositionerBase(StatePositioner, GroupDevice):
     """
     A `StatePositioner` for an EPICS states record.
 

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -198,13 +198,12 @@ def schedule_task(func, args=None, kwargs=None, delay=None):
             break
 
     def schedule():
-        if matched_thread is None:
+        if matched_thread is not None and context.event_thread is not None:
+            # Put into same queue
+            context.event_thread.queue.put((func, args, kwargs))
+        else:
             # Put into utility queue
             dispatcher.schedule_utility_task(func, *args, **kwargs)
-        else:
-            # Put into same queue
-            if context.event_thread is not None:
-                context.event_thread.queue.put((func, args, kwargs))
 
     if delay is None:
         # Do it right away

--- a/pcdsdevices/wfs.py
+++ b/pcdsdevices/wfs.py
@@ -1,13 +1,13 @@
 from ophyd import Component as Cpt
-from ophyd import Device
 
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATTempSensor
 
 
-class WaveFrontSensorTarget(BaseInterface, Device, LightpathInOutMixin):
+class WaveFrontSensorTarget(BaseInterface, GroupDevice, LightpathInOutMixin):
     tab_component_names = True
 
     lightpath_cpts = ['target']

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ ophyd>=1.5.1
 pcdscalc>=0.2.0
 pcdsutils>=0.4.0
 pint
-pmgr>=2.0.2
 prettytable
 pyepics>=3.4.2
 pytmc>=2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pint
 pmgr>=2.0.2
 prettytable
 pyepics>=3.4.2
+python>=3.9
 pytmc>=2.7.0
 pyyaml
 schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pint
 pmgr>=2.0.2
 prettytable
 pyepics>=3.4.2
-python>=3.9
 pytmc>=2.7.0
 pyyaml
 schema

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
         "typhos.ui": ["pcdsdevices = pcdsdevices.ui:path"],
     },
     install_requires=install_requires,
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -225,7 +225,7 @@ def test_group_device_class_errors():
         class MessyGroup(BasicGroup):
             stage_group = [BasicGroup.one, 'cats']
 
-    # stage_group targets should not be overriden in subclass
+    # stage_group targets should not be overriden in subclass except by Cpt
     with pytest.raises(TypeError):
         class OverrideGroup(BasicGroup):
             one = None

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing as mp
+import sys
 import threading
 import time
 
@@ -93,6 +94,10 @@ def test_mv_ginput(monkeypatch, fast_motor):
     inner_test()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Fails on Windows, no fcntl and different signal handling",
+    )
 def test_presets(presets, fast_motor):
     logger.debug('test_presets')
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,8 +1,5 @@
-import fcntl
 import logging
 import multiprocessing as mp
-import os
-import signal
 import threading
 import time
 
@@ -14,6 +11,11 @@ from pcdsdevices.interface import (BaseInterface, TabCompletionHelperClass,
                                    get_engineering_mode, set_engineering_mode,
                                    setup_preset_paths)
 from pcdsdevices.sim import FastMotor, SlowMotor
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +50,10 @@ def test_umv(slow_motor):
 
 def test_camonitor(fast_motor):
     logger.debug('test_camonitor')
-    pid = os.getpid()
 
     def interrupt():
-        time.sleep(0.1)
-        os.kill(pid, signal.SIGINT)
+        time.sleep(0.2)
+        fast_motor.end_monitor_thread()
 
     threading.Thread(target=interrupt, args=()).start()
     fast_motor.camonitor()

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import os.path
+import sys
 from unittest.mock import Mock
 
 import numpy as np
@@ -132,6 +133,10 @@ def test_lensstack_beamsize(monkeypatch, fake_lensstack):
     assert np.isclose(lensstack.beam_size.position, 500e-6, rtol=0.1, atol=0)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Fails on Windows, presets needed and not supported.",
+    )
 def test_lensstack_align(presets, monkeypatch, fake_lensstack):
     logger.debug('test_lensstack_align')
 

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -24,13 +24,25 @@ def basic():
 @pytest.fixture(scope='function')
 def advanced():
     pos = FastMotor()
+
+    fpstate = dict(status=None)
+
+    def move(*args, **kwargs):
+        fpstate['status'] = pos.move(*args, **kwargs)
+
+    def done(*args, **kwargs):
+        try:
+            return fpstate['status'].done
+        except KeyError:
+            return True
+
     return FuncPositioner(
         name='advanced',
-        move=pos.move,
+        move=move,
         get_pos=lambda: pos.position,
         set_pos=pos.set_position,
         stop=lambda: 0,
-        done=lambda: not pos.moving,
+        done=done,
         check_value=lambda pos: 0,
         limits=(-10, 10),
         update_rate=0.1,

--- a/tests/test_slits.py
+++ b/tests/test_slits.py
@@ -100,6 +100,7 @@ def test_slit_subscriptions(fake_slits):
     assert cb.called
 
 
+@pytest.mark.timeout(10)
 def test_slit_staging(fake_slits):
     logger.debug('test_slit_staging')
     slits = fake_slits
@@ -111,6 +112,18 @@ def test_slit_staging(fake_slits):
     # Check that unstage places everything back
     slits.xwidth.setpoint.sim_put(1.5)
     slits.ywidth.setpoint.sim_put(1.5)
+
+    def x_done(*args, **kwargs):
+        slits.xwidth.done.sim_put(0)
+        slits.xwidth.done.sim_put(1)
+
+    def y_done(*args, **kwargs):
+        slits.ywidth.done.sim_put(0)
+        slits.ywidth.done.sim_put(1)
+
+    slits.xwidth.setpoint.subscribe(x_done)
+    slits.ywidth.setpoint.subscribe(y_done)
+
     slits.unstage()
     assert slits.xwidth.setpoint.get() == 2.5
     assert slits.ywidth.setpoint.get() == 2.5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import logging
-import pty
 import sys
 import threading
 import time
@@ -7,6 +6,12 @@ import time
 import pytest
 
 import pcdsdevices.utils as util
+
+try:
+    import pty
+except ImportError:
+    pty = None
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+pty_missing = "Fails on Windows, pty not supported in Windows Python."
 
 
 @pytest.fixture(scope='function')
@@ -32,12 +33,20 @@ def input_later(sim_input, inp, delay=0.1):
     threading.Thread(target=inner, args=()).start()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=pty_missing,
+    )
 def test_is_input(sim_input):
     logger.debug('test_is_input')
     sim_input.write('a\n')
     assert util.is_input()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=pty_missing,
+    )
 @pytest.mark.timeout(5)
 def test_get_input_waits(sim_input):
     logger.debug('test_get_input_waits')
@@ -45,6 +54,10 @@ def test_get_input_waits(sim_input):
     assert util.get_input() == 'a'
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=pty_missing,
+    )
 @pytest.mark.timeout(0.5)
 def test_get_input_arrow(sim_input):
     logger.debug('test_get_input_arrow')
@@ -52,6 +65,10 @@ def test_get_input_arrow(sim_input):
     assert util.get_input() == util.arrow_up
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=pty_missing,
+    )
 @pytest.mark.timeout(0.5)
 def test_get_input_shift_arrow(sim_input):
     logger.debug('test_get_input_arrow')
@@ -59,6 +76,10 @@ def test_get_input_shift_arrow(sim_input):
     assert util.get_input() == util.shift_arrow_up
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=pty_missing,
+    )
 @pytest.mark.timeout(0.5)
 def test_cbreak(sim_input):
     logger.debug('test_cbreak')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

#### ENH
- Add GroupDevice: A device that is a group of components that will act independently.

This has the following implications:
- Components will have no references to this parent device. If
      accessed and used out of context, the components will be as if
      they were instantited completely separately.
- If a component is staged in a bluesky plan, it will not stage
      the ``GroupDevice``, and therefore will not stage the entire
      device tree.
- ``GroupDevice`` instances by default do nothing when staged.
      You can add specific subdevices to the stage list by setting the
      ``stage_group`` class attribute to a list of components.
- Following from the previous point, note that ``GroupDevice``
      instances cannot process top-level ``stage_sigs``. If you need
      top-level ``stage_sigs``, you should instead contain them in a
      subdevice that is not a ``GroupDevice``.
- ``GroupDevice`` instances that implement ``set`` are required
      to specify a ``stage_group`` to help remind you that these classes
      really do need to stage "something" before scanning. If your
      movable device really does not need this, you can set ``stage_group``
      to an empty list.
- When represented in typhos, we'll see the ``GroupDevice`` screen
      instead of the default device screens.
      (Note: at time of writing, this hypothetical ``GroupDevice``
      ui template does not yet exist).
- Certain devices will completely break if we remove their subdevice
      references: for example, consider the ``PsuedoPositioner`` class.
      For classes like these, we'll need to keep the parent references
      for the ``PseudoSingle`` instances. For the full list of classes that
      need to retain their ``parent`` attribute, see
      ``GroupDevice.needs_parent``.


#### Apply GroupDevice to:
- Acromag
- ArrivalTimeMonitor
- BaseGon
- BeckhoffJet
- BeckhoffJetManipulator
- BeckhoffJetSlits
- CCM
- CrystalTower1
- CrystalTower2
- CVMI
- DiagnosticTower
- ExitSlits
- FFMirror
- FlowIntegrator
- GasManifold
- ICT
- Injector
- IPIMB
- IPMDiode
- IPMMotion
- Kappa
- KBOMirror
- KMono
- KTOF
- LAMP
- LAMPMagneticBottle
- LaserInCoupling
- LCLS2ImagerBase
- LODCM
- LODCMEnergyC
- LODCMEnergySi
- Mono
- MPODApalisModule
- MRCO
- OffsetMirror
- PCM
- PIM
- PulsePickerInOut
- ReflaserL2SI
- RTDSBase
- SamPhi
- Selector
- SlitsBase
- StateRecordPositionerBase
- VonHamosCrystal
- VonHamosFE
- Wave8
- WaveFrontSensorTarget
- XOffsetMirror
- XYZStage

#### BUG
- Fix some race conditions in FuncPositioner
- Fix a race condition in schedule_task that could cause a task to never be run

#### MNT
- Clean up pmgr loading a bit (my previous edit to Mike's setup was a bit rough)
- Edit stage/unstage on PIMY to be compatible with GroupDevice
- Edit stage/unstage and the class definition on SlitsBase to be compatible with GroupDevice
- Move PVStateSignal from state.py to signal.py to avoid a circular import
- Make the tests importable and runnable on Windows

#### BLD
- Require Python 3.9 for type annotations
- Make pmgr optional, but if installed make sure it has a compatible version.

#### CI
- Update to 3.9-only version
- Fix the PIP test build

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #617 
A better approach to staging than in #857 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added `GroupDevice` tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
