### PR TITLE
ENH: filter motor status spam from other sessions

### DIFF
--- a/docs/source/upcoming_release_notes/868-filter-motor-spam.rst
+++ b/docs/source/upcoming_release_notes/868-filter-motor-spam.rst
@@ -1,0 +1,34 @@
+868 filter-motor-spam
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- ``EpicsMotorInterface`` subclasses will no longer spam logger errors and
+  warnings about alarm issues encountered by other users. These log messages
+  will only be shown if they were the result of moves in the current session.
+  Note that this log filtering assumes that all epics motors will have unique
+  ophyd names.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,4 +1,3 @@
-# Make sure this runs as early as possible
 # Hacky ophyd and pyepics hotfixes
 import epics.ca
 from ophyd.device import Device

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -1,8 +1,10 @@
+# Make sure this runs as early as possible
 # Hacky ophyd and pyepics hotfixes
 import epics.ca
 from ophyd.device import Device
 
 from ._version import get_versions
+from .registry import device_registry  # NOQA
 
 
 def __contains__(self, value):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -338,6 +338,12 @@ Limit Switch: {switch_limits}
         Returns True if the message should pass, or False if the message
         should be filtered.
         """
+        try:
+            name = record.ophyd_object_name
+        except AttributeError:
+            return True
+        if self.name != name:
+            return True
         return self._moved_in_session or ' alarm ' not in record.msg
 
     def _install_motion_error_filter(self):
@@ -345,7 +351,7 @@ Limit Switch: {switch_limits}
         Applies the _motion_error_filter to self.log.
         """
         filter_obj = SimpleNamespace(filter=self._motion_error_filter)
-        self.log.add_filter(filter_obj)
+        self.log.logger.add_filter(filter_obj)
 
     def _reset_moved_in_session(self, *args, **kwargs):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 from types import SimpleNamespace
+from typing import Optional
 
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
@@ -105,7 +106,7 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         self.motor_egu.subscribe(self._cache_egu)
         self._install_motion_error_filter()
 
-    def move(self, position, wait=True, **kwargs):
+    def move(self, position: float, wait: bool = True, **kwargs) -> MoveStatus:
         self._moved_in_session = True
         return super().move(position, wait=wait, **kwargs)
 
@@ -336,7 +337,7 @@ Limit Switch: {switch_limits}
         """
         return self._egu
 
-    def _cache_egu(self, value: str, **kwargs):
+    def _cache_egu(self, value: str, **kwargs) -> None:
         """
         Cache the value of EGU for later use in the egu property.
         """
@@ -376,7 +377,7 @@ Limit Switch: {switch_limits}
         """
         return self._moved_in_session or ' alarm ' not in record.msg
 
-    def _install_motion_error_filter(self):
+    def _install_motion_error_filter(self) -> None:
         """
         Applies the class _motion_error_filter to self.log if needed
         Adds our _instance_error_filter to the filter registry
@@ -387,7 +388,7 @@ Limit Switch: {switch_limits}
         self._reset_moved_in_session()
         self._motion_error_log_filters[self.name] = self._instance_error_filter
 
-    def _done_moving(self, value=None, **kwargs):
+    def _done_moving(self, value: Optional[int] = None, **kwargs) -> None:
         """
         Override _done_moving to always reset our _moved_in_session attribute.
 
@@ -399,7 +400,7 @@ Limit Switch: {switch_limits}
         if value:
             self._reset_moved_in_session()
 
-    def _reset_moved_in_session(self):
+    def _reset_moved_in_session(self) -> None:
         """
         Mark that a move have not yet been requested in this session.
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -102,7 +102,6 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
         self.subscribe(
             self._reset_moved_in_session,
             event_type=self.SUB_DONE,
-            run=True,
         )
         self._install_motion_error_filter()
 
@@ -367,7 +366,8 @@ Limit Switch: {switch_limits}
         """
         if not self._motion_error_log_filters:
             filter_obj = SimpleNamespace(filter=self._motion_error_filter)
-            self.log.logger.add_filter(filter_obj)
+            self.log.logger.addFilter(filter_obj)
+        self._reset_moved_in_session()
         self._motion_error_log_filters[self.name] = self._instance_error_filter
 
     def _reset_moved_in_session(self, *args, **kwargs):

--- a/pcdsdevices/registry.py
+++ b/pcdsdevices/registry.py
@@ -1,0 +1,3 @@
+from ophyd.ophydobj import register_instances_keyed_on_name
+
+device_registry = register_instances_keyed_on_name()

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -243,12 +243,13 @@ def test_show_constant_warning(fake_ccm, caplog):
         ccm.CCMConstantWarning.INVALID_CONNECT,
     ):
         caplog.clear()
-        fake_ccm._show_constant_warning(
-            warning,
-            fake_ccm.dspacing,
-            0.111111,
-            0.222222,
-        )
+        with caplog.at_level(logging.WARNING):
+            fake_ccm._show_constant_warning(
+                warning,
+                fake_ccm.dspacing,
+                0.111111,
+                0.222222,
+            )
         if warning == ccm.CCMConstantWarning.NO_WARNING:
             assert len(caplog.records) == 0
         else:
@@ -266,21 +267,22 @@ def test_warn_invalid_constants(fake_ccm, caplog):
     fake_ccm.gd.put(0)
     # We expect three warnings from the fake PVs that start at 0
     caplog.clear()
-    fake_ccm.warn_invalid_constants(only_new=False)
-    assert len(caplog.records) == 3
-    # We expect the warnings to not repeat
-    caplog.clear()
-    fake_ccm.warn_invalid_constants(only_new=True)
-    assert len(caplog.records) == 0
-    # Unless we ask them to
-    caplog.clear()
-    fake_ccm.warn_invalid_constants(only_new=False)
-    assert len(caplog.records) == 3
-    # Let's fix the issue and make sure no warnings are shown
-    fake_ccm.reset_calc_constant_defaults(confirm=False)
-    caplog.clear()
-    fake_ccm.warn_invalid_constants(only_new=False)
-    assert len(caplog.records) == 0
+    with caplog.at_level(logging.WARNING):
+        fake_ccm.warn_invalid_constants(only_new=False)
+        assert len(caplog.records) == 3
+        # We expect the warnings to not repeat
+        caplog.clear()
+        fake_ccm.warn_invalid_constants(only_new=True)
+        assert len(caplog.records) == 0
+        # Unless we ask them to
+        caplog.clear()
+        fake_ccm.warn_invalid_constants(only_new=False)
+        assert len(caplog.records) == 3
+        # Let's fix the issue and make sure no warnings are shown
+        fake_ccm.reset_calc_constant_defaults(confirm=False)
+        caplog.clear()
+        fake_ccm.warn_invalid_constants(only_new=False)
+        assert len(caplog.records) == 0
 
 
 @pytest.mark.timeout(5)

--- a/pcdsdevices/tests/test_epics_motor.py
+++ b/pcdsdevices/tests/test_epics_motor.py
@@ -407,13 +407,18 @@ def test_motion_error_filter(fake_epics_motor, caplog):
     sim_do_move(fake_epics_motor)
     caplog.clear()
     sim_done(fake_epics_motor)
-    unfiltered = len(caplog.records)
+    unfiltered = list(
+        tup for tup in caplog.record_tuples if tup[0] == 'ophyd.objects'
+    )
     # See a move and check how many logs at end
     sim_is_moving(fake_epics_motor)
     caplog.clear()
     sim_done(fake_epics_motor)
-    filtered = len(caplog.records)
-    assert unfiltered > filtered, "No logs filtered in the observed move."
+    filtered = list(
+        tup for tup in caplog.record_tuples if tup[0] == 'ophyd.objects'
+    )
+    msg = "No logs filtered in the observed move."
+    assert len(unfiltered) > len(filtered), msg
 
 
 @pytest.mark.parametrize("cls", [PCDSMotorBase, IMS, Newport, PMC100,

--- a/pcdsdevices/tests/test_epics_motor.py
+++ b/pcdsdevices/tests/test_epics_motor.py
@@ -45,12 +45,12 @@ def motor_setup(motor):
         motor.reinit_command.sim_put(0)
 
 
-def fake_motor(cls):
+def fake_motor(cls, name='test_motor'):
     """
     Given a real class, lets get a fake motor
     """
     FakeCls = fake_class_setup(cls)
-    motor = FakeCls('TST:MTR', name='test_motor')
+    motor = FakeCls('TST:MTR', name=name)
     motor_setup(motor)
     return motor
 
@@ -65,7 +65,7 @@ def fake_epics_motor(request):
     """
     Test EpicsMotorInterface and subclasses
     """
-    return fake_motor(request.param)
+    return fake_motor(request.param, name=f'mot_{request.node.name}')
 
 
 @pytest.fixture(scope='function',
@@ -74,23 +74,23 @@ def fake_pcds_motor(request):
     """
     Test PCDSMotorBase and subclasses
     """
-    return fake_motor(request.param)
+    return fake_motor(request.param, name=f'mot_{request.node.name}')
 
 
 @pytest.fixture(scope='function')
-def fake_ims():
+def fake_ims(request):
     """
     Test IMS-specific overrides
     """
-    return fake_motor(IMS)
+    return fake_motor(IMS, name=f'mot_{request.node.name}')
 
 
 @pytest.fixture(scope='function')
-def fake_beckhoff():
+def fake_beckhoff(request):
     """
     Test Beckhoff-specific overrides
     """
-    return fake_motor(BeckhoffAxis)
+    return fake_motor(BeckhoffAxis, name=f'mot_{request.node.name}')
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make the post-move error or warning about alarm levels only appear if we requested the move in the current session.
This is achieved by adding a context-sensitive log filter to the motor's `self.log`.

Note that this has a limitation where it will have unpredictable behavior if we have multiple objects with the same name. This is because the name is the piece of metadata that identifies the log messages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related `ophyd` code:
https://github.com/bluesky/ophyd/blob/dd4b3e389a0202ecacce39fc3965d703c616b0d4/ophyd/epics_motor.py#L283-L291
Note how these are run in a callback based on the done moving PV, which applies to all open sessions.

ref https://jira.slac.stanford.edu/browse/LCLSECSD-168

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some targetted tests that snoop on the logging outputs.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings and release notes.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
