### PR TITLE
Add gfsplc

### DIFF
--- a/docs/source/upcoming_release_notes/869-added_GFS_fault_setpoint,_GCC,_PIP_autoOn_and_countdown_timer.rst
+++ b/docs/source/upcoming_release_notes/869-added_GFS_fault_setpoint,_GCC,_PIP_autoOn_and_countdown_timer.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
--GFS, GCC, PIP 
+- Added GFS fault setpoint, GCC, PIP auto-on and countdown timer
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/869-added_GFS_fault_setpoint,_GCC,_PIP_autoOn_and_countdown_timer.rst
+++ b/docs/source/upcoming_release_notes/869-added_GFS_fault_setpoint,_GCC,_PIP_autoOn_and_countdown_timer.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- jyin999

--- a/docs/source/upcoming_release_notes/869-added_GFS_fault_setpoint,_GCC,_PIP_autoOn_and_countdown_timer.rst
+++ b/docs/source/upcoming_release_notes/869-added_GFS_fault_setpoint,_GCC,_PIP_autoOn_and_countdown_timer.rst
@@ -1,0 +1,30 @@
+869 added GFS fault setpoint, GCC, PIP autoOn and countdown timer
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+-GFS, GCC, PIP 
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/gauge.py
+++ b/pcdsdevices/gauge.py
@@ -209,6 +209,18 @@ class GCCPLC(GaugePLC):
                               doc='Protection setpoint hysteresis')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='Interlock is ok')
+    auto_on = Cpt(EpicsSignalWithRBV, ':Auto_On', kind='config',
+                  doc=('Setting to automatically turn on the gauge when the'
+                       'reference gauge pressure is below protection '
+                       'setpoint'))
+    autoOn_countdown = Cpt(EpicsSignalRO, ':AutoOn_timer_RBV', kind='normal',
+                           doc='timer count down to turn on the gauge ')
+
+
+class GFSPLC(GCCPLC):
+    """Class for a fast shutter sensor gauge controlled by PLC."""
+    fault_setpoint_FS = Cpt(EpicsSignalRO, ':PSTATSPRBCK_FS', kind='config',
+                            doc='Vacuum fault setpoint for Fast shutter valve')
 
 
 class GHCPLC(GaugePLC):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -175,7 +175,7 @@ class PIPPLC(Device):
     plc_ai_offset = Cpt(EpicsSignalRO, ':AI_Offset_RBV', kind='config',
                         doc=('Analog input offset must match ion pump '
                              'analog ouput offset. Default: 13'))
-    auto_on = Cpt(EpicsSignalRO, ':Auto_On_RBV', kind='config',
+    auto_on = Cpt(EpicsSignalWithRBV, ':Auto_On', kind='config',
                   doc=('Setting to automatically turn on the ion pump when the'
                        'reference gauge pressure is below protection '
                        'setpoint'))
@@ -190,6 +190,8 @@ class PIPPLC(Device):
     interlock_device = Cpt(EpicsSignalRO, ':ILK_DEVICE_RBV', kind='config',
                            string=True,
                            doc='Vacuum device used for interlocking this pump')
+    autoOn_countdown = Cpt(EpicsSignalRO, ':AutoOn_timer_RBV', kind='normal',
+                           doc='Timer count down to turn on the ion pump ')
 
 
 class PTMPLC(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Add GFS fault setpoint, GCC and PIP auto_on and auto_on timer.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Dan Flath required to add GFS fault setpoint to readable through EPICS. Alex required to automatically turn on GCC and PIP after power outage. The modification allow user to turn on Auto recover function from EPICS GUI. 

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested following the confluence page. 
![image](https://user-images.githubusercontent.com/43865116/132727678-f8126980-306c-40f3-8245-a4b7fce1ab9d.png)



## Where Has This Been Documented?
Documented following the confluence page. 

<!--
![image](https://user-images.githubusercontent.com/55111839/132626506-8baf9e59-d065-422d-b275-b5d4846236c1.png)

-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
