### PR TITLE
ENH: CCM calc constant PVs and set_current_position(energy)

### DIFF
--- a/docs/source/upcoming_release_notes/871-ccm-pvs.rst
+++ b/docs/source/upcoming_release_notes/871-ccm-pvs.rst
@@ -1,0 +1,37 @@
+871 ccm-pvs
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Switch the CCM energy devices to use user PVs as the canonical source
+  of calculation constants. This allows the constants to be consistent
+  between sessions and keeps different sessions in sync with each other.
+- Add ``CCM.energy.set_current_position`` utility for adjusting the CCM
+  theta0 offset in order to synchronize the calculation with a known
+  photon energy values.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where epics motors could time out on the getting of
+  the ``egu`` property, which was causing issues with the displaying
+  of device status.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -159,16 +159,20 @@ class CCMConstantsMixin(Device):
         EpicsSignal,
         '{_constants_prefix}:GR',
         kind='config',
-        doc='The radius of the sapphire ball '
-            'connected to the Alio stage in mm.',
+        doc=(
+            'The radius of the sapphire ball '
+            'connected to the Alio stage in mm.'
+        ),
     )
     gd = FCpt(
         EpicsSignal,
         '{_constants_prefix}:GD',
         kind='config',
-        doc='Distance between the rotation axis and the '
+        doc=(
+            'Distance between the rotation axis and the '
             'center of the sapphire sphere located on the '
-            'Alio stage in mm',
+            'Alio stage in mm.'
+        ),
     )
 
     _enable_warn_constants: bool = True
@@ -486,10 +490,17 @@ class CCMEnergy(FltMvInterface, PseudoPositioner, CCMConstantsMixin):
         The PV prefix of the Alio motor, e.g. XPP:MON:MPZ:07A
     """
     # Pseudo motor and real motor
-    energy = Cpt(PseudoSingleInterface, egu='keV', kind='hinted',
-                 limits=(4, 25), verbose_name='CCM Photon Energy',
-                 doc='PseudoSingle that moves the calculated CCM '
-                     'selected energy in keV.')
+    energy = Cpt(
+        PseudoSingleInterface,
+        egu='keV',
+        kind='hinted',
+        limits=(4, 25),
+        verbose_name='CCM Photon Energy',
+        doc=(
+            'PseudoSingle that moves the calculated CCM '
+            'selected energy in keV.'
+        ),
+    )
     alio = Cpt(CCMAlio, '', kind='normal',
                doc='The motor that rotates the CCM crystal.')
 
@@ -498,9 +509,14 @@ class CCMEnergy(FltMvInterface, PseudoPositioner, CCMConstantsMixin):
                     doc='The crystal angle in degrees.')
     wavelength = Cpt(InternalSignal, kind='normal',
                      doc='The wavelength picked by the CCM in Angstroms.')
-    resolution = Cpt(InternalSignal, kind='normal',
-                     doc='A measure of how finely we can control the ccm '
-                         'output at this position in eV/um.')
+    resolution = Cpt(
+        InternalSignal,
+        kind='normal',
+        doc=(
+            'A measure of how finely we can control the ccm '
+            'output at this position in eV/um.'
+        ),
+    )
 
     tab_component_names = True
 
@@ -834,25 +850,45 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
     y_up_south_prefix : str, required keyword
         The prefix for the south upstream ccm y translation motor (y3).
     """
-    energy = Cpt(CCMEnergy, '', kind='hinted',
-                 doc='PseudoPositioner that moves the alio in '
-                     'terms of the calculated CCM energy.')
-    energy_with_vernier = Cpt(CCMEnergyWithVernier, '', kind='normal',
-                              doc='PsuedoPositioner that moves the alio in '
-                                  'terms of the calculated CCM energy while '
-                                  'also requesting a vernier move.')
+    energy = Cpt(
+        CCMEnergy, '', kind='hinted',
+        doc=(
+            'PseudoPositioner that moves the alio in '
+            'terms of the calculated CCM energy.'
+        ),
+    )
+    energy_with_vernier = Cpt(
+        CCMEnergyWithVernier, '', kind='normal',
+        doc=(
+            'PsuedoPositioner that moves the alio in '
+            'terms of the calculated CCM energy while '
+            'also requesting a vernier move.'
+        ),
+    )
 
     alio = UCpt(CCMAlio, kind='normal',
                 doc='The motor that rotates the CCM crystal.')
-    theta2fine = UCpt(CCMMotor, atol=0.01, kind='normal',
-                      doc='The motor that controls the fine adjustment '
-                          'of the of the second crystal theta angle.')
-    theta2coarse = UCpt(CCMPico, kind='normal',
-                        doc='The motor that controls the coarse adjustment '
-                            'of the of the second crystal theta angle.')
-    chi2 = UCpt(CCMPico, kind='normal',
-                doc='The motor that controls the adjustment of the'
-                    'second crystal chi angle.')
+    theta2fine = UCpt(
+        CCMMotor, atol=0.01, kind='normal',
+        doc=(
+            'The motor that controls the fine adjustment '
+            'of the of the second crystal theta angle.'
+        ),
+    )
+    theta2coarse = UCpt(
+        CCMPico, kind='normal',
+        doc=(
+            'The motor that controls the coarse adjustment '
+            'of the of the second crystal theta angle.'
+        ),
+    )
+    chi2 = UCpt(
+        CCMPico, kind='normal',
+        doc=(
+            'The motor that controls the adjustment of the'
+            'second crystal chi angle.'
+        ),
+    )
     x = UCpt(CCMX, add_prefix=[], kind='normal',
              doc='Combined motion of the CCM X motors.')
     y = UCpt(CCMY, add_prefix=[], kind='normal',

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -261,6 +261,9 @@ class CCMConstantsMixin(Device):
 
         This will be the value from the PV if things are working properly,
         otherwise it will fall back to the default value.
+
+        This is necessary because a value of 0 is nonphysical and in the case
+        of a disconnected value the show must go on.
         """
         if (
             self._dspacing
@@ -279,6 +282,9 @@ class CCMConstantsMixin(Device):
 
         This will be the value from the PV if things are working properly,
         otherwise it will fall back to the default value.
+
+        This is necessary because a value of 0 is nonphysical and in the case
+        of a disconnected value the show must go on.
         """
         if self._gr and self.gr.name in self._initialized_signal_names:
             return self._gr
@@ -295,6 +301,9 @@ class CCMConstantsMixin(Device):
 
         This will be the value from the PV if things are working properly,
         otherwise it will fall back to the default value.
+
+        This is necessary because a value of 0 is nonphysical and in the case
+        of a disconnected value the show must go on.
         """
         if self._gd and self.gd.name in self._initialized_signal_names:
             return self._gd
@@ -347,6 +356,12 @@ class CCMConstantsMixin(Device):
     def warn_invalid_constants(self, only_new: bool = False) -> None:
         """
         Warn if we have invalid values for our calculation constants.
+
+        The motivation here is twofold:
+        1. It should be easy for the user to know what is wrong and
+           why. The calculations should not be opaque.
+        2. The user should still be able to do "something" if there is
+           an issue here.
 
         For values to be valid, the PVs need to be connected and all
         but theta0 must be nonzero. Theta0 should also not be zero,

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -692,6 +692,7 @@ class CCMEnergyWithVernier(CCMEnergy):
 
     # These are duplicate warnings with main energy motor
     _enable_warn_constants: bool = False
+    hutch: str
 
     def __init__(
         self,
@@ -907,6 +908,9 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
                      'th2coarse', 'th2fine', 'alio2E', 'E2alio',
                      'home', 'kill', 'status',
                      'insert', 'remove', 'inserted', 'removed']
+
+    _in_pos: float
+    _out_pos: float
 
     def __init__(
         self,

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -376,15 +376,14 @@ class CCMConstantsMixin(Device):
         for num, (sig, val, default, old_warning) in enumerate(zip(
             sigs, vals, default_vals, self._prev_warnings,
         )):
-            new_warning = CCMConstantWarning.NO_WARNING
+            good_value = val or sig is self.theta0_deg
             if sig.connected:
-                if sig is self.theta0_deg:
-                    # theta0 has no bad values
-                    pass
-                elif not val:
+                if good_value:
+                    new_warning = CCMConstantWarning.NO_WARNING
+                else:
                     new_warning = CCMConstantWarning.INVALID_CONNECT
             elif sig.name in self._initialized_signal_names:
-                if val or sig is self.theta0_deg:
+                if good_value:
                     new_warning = CCMConstantWarning.VALID_DISCONNECT
                 else:
                     new_warning = CCMConstantWarning.INVALID_DISCONNECT

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -181,7 +181,6 @@ class CCMConstantsMixin(Device):
         else:
             self._constants_prefix = 'TST:CCM'
         self._theta0_deg: float = default_theta0_deg
-        self._theta0: float = default_theta0
         self._dspacing: float = default_dspacing
         self._gd: float = default_gd
         self._gr: float = default_gr

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -19,7 +19,7 @@ from .pseudopos import (PseudoPositioner, PseudoSingleInterface, SyncAxis,
                         SyncAxisOffsetMode)
 from .pv_positioner import PVPositionerIsClose
 from .signal import InternalSignal
-from .utils import get_status_float
+from .utils import doc_format_decorator, get_status_float
 
 logger = logging.getLogger(__name__)
 
@@ -191,8 +191,14 @@ class CCMConstantsMixin(Device):
         elif obj is self.gd:
             self._gd = value
 
+    @doc_format_decorator(
+        default_theta0_deg=default_theta0_deg,
+        default_dspacing=default_dspacing,
+        default_gr=default_gr,
+        default_gd=default_gd,
+    )
     def reset_calc_constant_defaults(self, confirm: bool = True):
-        f"""
+        """
         Put the default values into the ccm constants.
 
         This can be useful if values were reset due to autosave errors or if

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -176,6 +176,13 @@ class CCMConstantsMixin(Device):
     )
 
     _enable_warn_constants: bool = True
+    _theta0_deg: float
+    _dspacing: float
+    _gd: float
+    _gr: float
+    _initialized_signal_names: set
+    _prev_warnings: list[CCMConstantWarning]
+    _init_time: float
 
     def __init__(self, prefix: str, *args, **kwargs):
         if 'XPP' in prefix:
@@ -184,10 +191,10 @@ class CCMConstantsMixin(Device):
             self._constants_prefix = 'XCS:CCM'
         else:
             self._constants_prefix = 'TST:CCM'
-        self._theta0_deg: float = default_theta0_deg
-        self._dspacing: float = default_dspacing
-        self._gd: float = default_gd
-        self._gr: float = default_gr
+        self._theta0_deg = default_theta0_deg
+        self._dspacing = default_dspacing
+        self._gd = default_gd
+        self._gr = default_gr
         self._initialized_signal_names = set()
         self._prev_warnings = [CCMConstantWarning.NO_WARNING] * 4
         self._init_time = time.monotonic()

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -89,6 +89,13 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     EpicsMotor.low_limit_travel.kind = Kind.config
     EpicsMotor.direction_of_travel.kind = Kind.normal
 
+    _egu: str
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._egu = ''
+        self.motor_egu.subscribe(self._cache_egu)
+
     def format_status_info(self, status_info):
         """
         Override status info handler to render the motor.
@@ -310,12 +317,17 @@ Limit Switch: {switch_limits}
     @property
     def egu(self) -> str:
         """
-        Engineering units str if available, otherwise 'N/A'
+        Engineering units str if available, otherwise ''
+
+        Use the monitored/cached value rather than checking EPICS.
         """
-        if self.motor_egu.connected:
-            return self.motor_egu.get()
-        else:
-            return 'N/A'
+        return self._egu
+
+    def _cache_egu(self, value: str, **kwargs):
+        """
+        Cache the value of EGU for later use in the egu property.
+        """
+        self._egu = value
 
 
 class PCDSMotorBase(EpicsMotorInterface):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -307,6 +307,16 @@ Limit Switch: {switch_limits}
         finally:
             self.set_use_switch.put(0, wait=True)
 
+    @property
+    def egu(self) -> str:
+        """
+        Engineering units str if available, otherwise 'N/A'
+        """
+        if self.motor_egu.connected:
+            return self.motor_egu.get()
+        else:
+            return 'N/A'
+
 
 class PCDSMotorBase(EpicsMotorInterface):
     """

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -103,11 +103,11 @@ def test_ccm_calc(fake_ccm):
 
     theta_func = ccm.alio_to_theta(
         SAMPLE_ALIO,
-        calc._theta0,
-        calc._gr,
-        calc._gd,
+        calc.theta0_rad_val,
+        calc.gr_val,
+        calc.gd_val,
     )
-    wavelength_func = ccm.theta_to_wavelength(theta_func, calc._dspacing)
+    wavelength_func = ccm.theta_to_wavelength(theta_func, calc.dspacing_val)
     energy_func = ccm.wavelength_to_energy(wavelength_func)
     energy = calc.energy.position
     assert energy == energy_func

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -101,8 +101,13 @@ def test_ccm_calc(fake_ccm):
     logger.debug('real pos is %s', calc.real_position)
     logger.debug('sample alio is %s', SAMPLE_ALIO)
 
-    theta_func = ccm.alio_to_theta(SAMPLE_ALIO, calc.theta0, calc.gr, calc.gd)
-    wavelength_func = ccm.theta_to_wavelength(theta_func, calc.dspacing)
+    theta_func = ccm.alio_to_theta(
+        SAMPLE_ALIO,
+        calc._theta0,
+        calc._gr,
+        calc._gd,
+    )
+    wavelength_func = ccm.theta_to_wavelength(theta_func, calc._dspacing)
     energy_func = ccm.wavelength_to_energy(wavelength_func)
     energy = calc.energy.position
     assert energy == energy_func

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -184,6 +184,15 @@ def test_vernier(fake_ccm):
 
 
 @pytest.mark.timeout(5)
+def test_set_current_position(fake_ccm):
+    logger.debug('test_set_current_position')
+    mot = fake_ccm.energy.energy
+    for energy in range(6, 14):
+        mot.set_current_position(energy)
+        assert np.isclose(mot.position, energy)
+
+
+@pytest.mark.timeout(5)
 def test_disconnected_ccm():
     ccm.CCM(alio_prefix='ALIO', theta2fine_prefix='THETA',
             theta2coarse_prefix='THTA', chi2_prefix='CHI',

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -341,3 +341,18 @@ def combine_status_info(obj, status_info, attrs, separator='\n= {attr} ='):
         lines.append(child.format_status_info(status_info[attr]))
 
     return '\n'.join(lines)
+
+
+def doc_format_decorator(**doc_fmts):
+    """
+    Decorator for substituting values into a docstring.
+
+    This is useful for cases where we want to include module
+    constants in docstrings but we want the docstring to
+    update automatically when we decide to change the
+    constant.
+    """
+    def inner_decorator(func):
+        func.__doc__ = func.__doc__.format(**doc_fmts)
+        return func
+    return inner_decorator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
### CCM calc constant PVs
CCM class currently gets calculation constants from three places:
- defaults in ccm.py
- definitions in beamline.py
- definitions in happi

This replaces all of those options with:
- from PVs defined in the XPP and XCS hutches

This is accomplished using a mix-in class that is applied in several places, along with some light aliasing, so that all of these are valid ways to read/write to the constants:
- ccm.E.theta0.put(15)
- ccm.theta0.put(15)
- ccm.energy.theta0.put(15)
- ccm.E_Vernier.theta0.put(15)

And these will all be synchronized with each other, even between different hutch python sessions.

Note: since this removes configuration options, it will likely require changes to beamline.py and the happi database.

### CCM psuedomotor set_current_position(energy)
Adjusting the CCM offset manually is a pain. This function helps us do it efficiently.
If the scientist has knowledge that the current energy passing through the CCM is a specific value, they can now call `set_current_position` to enforce the value, which will automatically adjust the `theta0` constant appropriately to make it so.
With some light aliasing, this is accessible in multiple locations, such as:
- ccm.E.set_current_position(8)
- ccm.energy.set_current_position(8)
- ccm.energy.energy.set_current_position(8)

### Misc
Adjust the handling of the `egu` property to prevent property access from timing out while assembling device status.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The constants for these calculations are not synchronized between sessions, meaning we can get different results in different terminals and this can mess with both the data collection and the PVs that get written to with the calculated value. This also makes it so we can save values between sessions that are separated in time.

The offset for the CCM is not an intuitive constant to be setting, but the current photon energy is.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added one new test, verified that the real PVs connect, fixed some things I noticed interactively.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release docs.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
