### PR TITLE
ENH: BeckhoffSlits UI

### DIFF
--- a/docs/source/upcoming_release_notes/873-slits-template.rst
+++ b/docs/source/upcoming_release_notes/873-slits-template.rst
@@ -1,0 +1,32 @@
+873 slits-template
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add typhos templates for BeckhoffSlits and PowerSlits using existing
+  elements from their normal pydm screens.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz
+- ghalym

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>395</width>
+    <height>468</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="form_layout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="TyphosSignalPanel" name="hint_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Panel of Signals for Device
+    </string>
+     </property>
+     <property name="showNormal" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="showConfig" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="showOmitted" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="QTabWidget" name="signal_tab">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabBarAutoHide">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="normal_tab">
+      <attribute name="title">
+       <string>Normal</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="misc_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="normal_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="normal_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>359</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="normal_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="normal_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="config_tab">
+      <attribute name="title">
+       <string>Configuration</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="config_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="config_scroll">
+         <property name="font">
+          <font>
+           <underline>false</underline>
+          </font>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="config_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>359</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="config_panel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="config_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>signal_tab</tabstop>
+  <tabstop>config_scroll</tabstop>
+  <tabstop>normal_scroll</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -847,42 +847,13 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>SOUTH</string>
-       </property>
-       <property name="indent">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="PyDMLabel" name="PyDMLabel_3">
-       <property name="maximumSize">
-        <size>
-         <width>80</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+     <item row="2" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
        <property name="toolTip">
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:TOP.HLS</string>
+        <string>ca://${prefix}:MMS:NORTH.LLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -896,48 +867,6 @@
        </property>
        <property name="circles" stdset="0">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:SOUTH.LLS</string>
-       </property>
-       <property name="onColor" stdset="0">
-        <color>
-         <red>0</red>
-         <green>255</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="PyDMLabel" name="PyDMLabel_4">
-       <property name="maximumSize">
-        <size>
-         <width>80</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:SOUTH.RBV</string>
        </property>
       </widget>
      </item>
@@ -964,78 +893,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:BOTTOM.LLS</string>
-       </property>
-       <property name="onColor" stdset="0">
-        <color>
-         <red>0</red>
-         <green>255</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>TOP</string>
-       </property>
-       <property name="indent">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="PyDMLabel" name="PyDMLabel">
-       <property name="maximumSize">
-        <size>
-         <width>80</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:TOP.RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>BOTTOM</string>
-       </property>
-       <property name="indent">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="6">
-      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Expert</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="2">
       <widget class="PyDMLabel" name="PyDMLabel_2">
        <property name="maximumSize">
@@ -1055,22 +912,125 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="5">
-      <widget class="PyDMPushButton" name="PyDMPushButton">
+     <item row="0" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
        <property name="toolTip">
         <string/>
        </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: red;</string>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.HLS</string>
        </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Stop</string>
+        <string>BOTTOM</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <property name="toolTip">
+        <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:TOP.STOP</string>
+        <string>ca://${prefix}:MMS:SOUTH.HLS</string>
        </property>
-       <property name="pressValue" stdset="0">
-        <string>1</string>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:BOTTOM&quot;,&quot;name&quot;:&quot;${name}_bottom&quot;}]</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>NORTH</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
@@ -1096,92 +1056,51 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+     <item row="2" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.LLS</string>
-       </property>
-       <property name="onColor" stdset="0">
-        <color>
-         <red>0</red>
-         <green>255</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
+       <property name="showUnits" stdset="0">
         <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.RBV</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
+     <item row="3" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
        <property name="text">
-        <string>NORTH</string>
+        <string>Stop</string>
        </property>
-       <property name="indent">
-        <number>5</number>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+     <item row="3" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
        <property name="toolTip">
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:BOTTOM.HLS</string>
-       </property>
-       <property name="onColor" stdset="0">
-        <color>
-         <red>0</red>
-         <green>255</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.HLS</string>
-       </property>
-       <property name="onColor" stdset="0">
-        <color>
-         <red>0</red>
-         <green>255</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:SOUTH.HLS</string>
+        <string>ca://${prefix}:MMS:SOUTH.LLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -1220,14 +1139,8 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="4">
-      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+     <item row="0" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel">
        <property name="maximumSize">
         <size>
          <width>80</width>
@@ -1237,8 +1150,11 @@
        <property name="toolTip">
         <string/>
        </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+        <string>ca://${prefix}:MMS:TOP.RBV</string>
        </property>
       </widget>
      </item>
@@ -1261,6 +1177,159 @@
        </property>
        <property name="channel" stdset="0">
         <string>ca://${prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>TOP</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:NORTH&quot;,&quot;name&quot;:&quot;${name}_north&quot;}]</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:TOP&quot;,&quot;name&quot;:&quot;${name}_top&quot;}]</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:SOUTH&quot;,&quot;name&quot;:&quot;${name}_south&quot;}]</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>SOUTH</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -1302,55 +1371,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="5">
-      <widget class="PyDMPushButton" name="PyDMPushButton_4">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: red;</string>
-       </property>
-       <property name="text">
-        <string>Stop</string>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.STOP</string>
-       </property>
-       <property name="pressValue" stdset="0">
-        <string>1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="6">
-      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Expert</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="6">
-      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton_3">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Expert</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="6">
-      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton_4">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Expert</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
@@ -1375,11 +1395,6 @@
    <header>typhos.display</header>
   </customwidget>
   <customwidget>
-   <class>TyphosRelatedSuiteButton</class>
-   <extends>QPushButton</extends>
-   <header>typhos.related_display</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
@@ -1398,6 +1413,11 @@
    <class>PyDMPushButton</class>
    <extends>QPushButton</extends>
    <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMShellCommand</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.shell_command</header>
   </customwidget>
   <customwidget>
    <class>PyDMScaleIndicator</class>

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>498</width>
-    <height>413</height>
+    <height>443</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -821,6 +821,16 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_13">
+     <property name="text">
+      <string>Individual Motor Control</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2">

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>480</width>
+    <width>488</width>
     <height>443</height>
    </rect>
   </property>
@@ -30,7 +30,7 @@
      </property>
     </widget>
    </item>
-   <item alignment="Qt::AlignHCenter">
+   <item>
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -40,18 +40,22 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>460</width>
+       <width>470</width>
        <height>150</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>460</width>
+       <width>470</width>
        <height>150</height>
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"/>
+      <string notr="true">PyDMLabel {
+color: black;
+background-color: none;
+border-radius: 0px;
+}</string>
      </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -394,12 +398,15 @@
        <rect>
         <x>4</x>
         <y>18</y>
-        <width>47</width>
-        <height>14</height>
+        <width>48</width>
+        <height>16</height>
        </rect>
       </property>
       <property name="text">
        <string>North</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
      <widget class="QLabel" name="label_6">
@@ -420,12 +427,15 @@
        <rect>
         <x>224</x>
         <y>18</y>
-        <width>47</width>
-        <height>14</height>
+        <width>38</width>
+        <height>16</height>
        </rect>
       </property>
       <property name="text">
        <string>Top</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
      <widget class="QLabel" name="label_8">

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -40,13 +40,13 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>450</width>
+       <width>460</width>
        <height>150</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>450</width>
+       <width>460</width>
        <height>150</height>
       </size>
      </property>
@@ -857,7 +857,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -880,7 +880,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -922,7 +922,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -955,7 +955,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -1104,7 +1104,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -1215,7 +1215,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -1290,7 +1290,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>
@@ -1323,7 +1323,7 @@
        </property>
        <property name="onColor" stdset="0">
         <color>
-         <red>0</red>
+         <red>255</red>
          <green>255</green>
          <blue>0</blue>
         </color>

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>498</width>
+    <width>468</width>
     <height>443</height>
    </rect>
   </property>
@@ -821,6 +821,16 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_13">

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>395</width>
-    <height>468</height>
+    <width>564</width>
+    <height>495</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,267 +30,815 @@
      </property>
     </widget>
    </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="TyphosSignalPanel" name="hint_panel">
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QFrame" name="frame">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="whatsThis">
-      <string>
-    Panel of Signals for Device
-    </string>
-     </property>
-     <property name="showNormal" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="showConfig" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="showOmitted" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="QTabWidget" name="signal_tab">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
-       <width>0</width>
-       <height>250</height>
+       <width>450</width>
+       <height>150</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>16777215</width>
-       <height>500</height>
+       <width>450</width>
+       <height>150</height>
       </size>
      </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
+     <property name="styleSheet">
+      <string notr="true"/>
      </property>
-     <property name="tabPosition">
-      <enum>QTabWidget::North</enum>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="tabShape">
-      <enum>QTabWidget::Rounded</enum>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
      </property>
-     <property name="currentIndex">
+     <property name="lineWidth">
       <number>0</number>
      </property>
-     <property name="elideMode">
-      <enum>Qt::ElideNone</enum>
+     <widget class="PyDMLabel" name="PyDMLabel_39">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>18</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_40">
+      <property name="geometry">
+       <rect>
+        <x>404</x>
+        <y>88</y>
+        <width>51</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_14">
+      <property name="geometry">
+       <rect>
+        <x>334</x>
+        <y>-2</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_15">
+      <property name="geometry">
+       <rect>
+        <x>264</x>
+        <y>-2</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:TOP.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_42">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>18</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>North</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>-2</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="lineWidth">
+       <number>1</number>
+      </property>
+      <property name="midLineWidth">
+       <number>0</number>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:NORTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_17">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>68</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_43">
+      <property name="geometry">
+       <rect>
+        <x>194</x>
+        <y>88</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>South</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
      </property>
-     <property name="usesScrollButtons">
-      <bool>false</bool>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="PyDMLabel" name="PyDMLabel_41">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="PyDMLabel" name="PyDMLabel_44">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_47">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="PyDMLabel" name="PyDMLabel_37">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="PyDMLabel" name="PyDMLabel_38">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_46">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>200</height>
+      </size>
      </property>
-     <property name="documentMode">
-      <bool>false</bool>
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <property name="tabBarAutoHide">
-      <bool>false</bool>
-     </property>
-     <widget class="QWidget" name="normal_tab">
-      <attribute name="title">
-       <string>Normal</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="misc_tab_layout">
-       <property name="leftMargin">
-        <number>2</number>
-       </property>
-       <property name="topMargin">
-        <number>2</number>
-       </property>
-       <property name="rightMargin">
-        <number>2</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>527</width>
+        <height>936</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QScrollArea" name="normal_scroll">
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_6">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>230</height>
+          </size>
          </property>
-         <widget class="QWidget" name="normal_widget">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>359</width>
-            <height>215</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="leftMargin">
-            <number>2</number>
-           </property>
-           <property name="topMargin">
-            <number>2</number>
-           </property>
-           <property name="rightMargin">
-            <number>2</number>
-           </property>
-           <property name="bottomMargin">
-            <number>2</number>
-           </property>
-           <item>
-            <widget class="TyphosSignalPanel" name="normal_panel">
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    Panel of Signals for Device
-    </string>
-             </property>
-             <property name="showHints" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showNormal" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="showConfig" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showOmitted" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="normal_spacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="error_message_attribute" stdset="0">
+          <string>plc.status</string>
+         </property>
         </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="config_tab">
-      <attribute name="title">
-       <string>Configuration</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="config_tab_layout">
-       <property name="leftMargin">
-        <number>2</number>
-       </property>
-       <property name="topMargin">
-        <number>2</number>
-       </property>
-       <property name="rightMargin">
-        <number>2</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
        <item>
-        <widget class="QScrollArea" name="config_scroll">
-         <property name="font">
-          <font>
-           <underline>false</underline>
-          </font>
+        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_8">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>230</height>
+          </size>
          </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         <property name="toolTip">
+          <string/>
          </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
+         <property name="error_message_attribute" stdset="0">
+          <string>plc.status</string>
          </property>
-         <widget class="QWidget" name="config_widget">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>359</width>
-            <height>215</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <property name="leftMargin">
-            <number>2</number>
-           </property>
-           <property name="topMargin">
-            <number>2</number>
-           </property>
-           <property name="rightMargin">
-            <number>2</number>
-           </property>
-           <property name="bottomMargin">
-            <number>2</number>
-           </property>
-           <item>
-            <widget class="TyphosSignalPanel" name="config_panel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    Panel of Signals for Device
-    </string>
-             </property>
-             <property name="showHints" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showNormal" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showOmitted" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="config_spacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
+        </widget>
+       </item>
+       <item>
+        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_7">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>230</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="error_message_attribute" stdset="0">
+          <string>plc.status</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_5">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>230</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="error_message_attribute" stdset="0">
+          <string>plc.status</string>
+         </property>
         </widget>
        </item>
       </layout>
@@ -314,21 +862,31 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosSignalPanel</class>
+   <class>TyphosPositionerWidget</class>
    <extends>QWidget</extends>
-   <header>typhos.panel</header>
+   <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
    <class>TyphosDisplayTitle</class>
    <extends>QFrame</extends>
    <header>typhos.display</header>
   </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScaleIndicator</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.scale</header>
+  </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>signal_tab</tabstop>
-  <tabstop>config_scroll</tabstop>
-  <tabstop>normal_scroll</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>564</width>
+    <width>708</width>
     <height>495</height>
    </rect>
   </property>
@@ -40,7 +40,7 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>450</width>
+       <width>480</width>
        <height>150</height>
       </size>
      </property>
@@ -68,7 +68,7 @@
         <x>224</x>
         <y>18</y>
         <width>41</width>
-        <height>16</height>
+        <height>21</height>
        </rect>
       </property>
       <property name="toolTip">
@@ -83,8 +83,8 @@
        <rect>
         <x>404</x>
         <y>88</y>
-        <width>51</width>
-        <height>16</height>
+        <width>61</width>
+        <height>21</height>
        </rect>
       </property>
       <property name="toolTip">
@@ -209,7 +209,7 @@
        <bool>true</bool>
       </property>
       <property name="showLimits" stdset="0">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <property name="showTicks" stdset="0">
        <bool>false</bool>
@@ -264,8 +264,8 @@
        <rect>
         <x>4</x>
         <y>18</y>
-        <width>41</width>
-        <height>16</height>
+        <width>51</width>
+        <height>21</height>
        </rect>
       </property>
       <property name="toolTip">
@@ -442,8 +442,8 @@
        <rect>
         <x>194</x>
         <y>88</y>
-        <width>41</width>
-        <height>16</height>
+        <width>51</width>
+        <height>21</height>
        </rect>
       </property>
       <property name="toolTip">
@@ -463,7 +463,7 @@
      <item row="1" column="1">
       <widget class="PyDMLabel" name="PyDMLabel_48">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -497,7 +497,7 @@
      <item row="0" column="2">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -518,6 +518,12 @@
      </item>
      <item row="1" column="0">
       <widget class="PyDMLabel" name="PyDMLabel_41">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -529,7 +535,7 @@
      <item row="1" column="2">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -550,6 +556,12 @@
      </item>
      <item row="0" column="0">
       <widget class="PyDMLabel" name="PyDMLabel_44">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -561,7 +573,7 @@
      <item row="0" column="1">
       <widget class="PyDMLabel" name="PyDMLabel_47">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -594,6 +606,12 @@
      </item>
      <item row="0" column="3">
       <widget class="PyDMLabel" name="PyDMLabel_37">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -605,7 +623,7 @@
      <item row="0" column="4">
       <widget class="PyDMLabel" name="PyDMLabel_45">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -639,7 +657,7 @@
      <item row="0" column="5">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -660,6 +678,12 @@
      </item>
      <item row="1" column="3">
       <widget class="PyDMLabel" name="PyDMLabel_38">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -671,7 +695,7 @@
      <item row="1" column="4">
       <widget class="PyDMLabel" name="PyDMLabel_46">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -705,7 +729,7 @@
      <item row="1" column="5">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -727,123 +751,455 @@
     </layout>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>200</height>
-      </size>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <property name="topMargin">
+      <number>0</number>
      </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>527</width>
-        <height>936</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_6">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>230</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="error_message_attribute" stdset="0">
-          <string>plc.status</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_8">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>230</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="error_message_attribute" stdset="0">
-          <string>plc.status</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_7">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>230</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="error_message_attribute" stdset="0">
-          <string>plc.status</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_5">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>230</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="error_message_attribute" stdset="0">
-          <string>plc.status</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>SOUTH</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:TOP.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:SOUTH.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:SOUTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:TOP.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:BOTTOM.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>TOP</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:TOP.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>BOTTOM</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:BOTTOM.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:TOP.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:TOP.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>NORTH</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:BOTTOM.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:SOUTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>0</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:BOTTOM.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:BOTTOM.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://{prefix}:MMS:NORTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="6">
+      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="6">
+      <widget class="TyphosRelatedSuiteButton" name="TyphosRelatedSuiteButton_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -862,14 +1218,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
-   <header>typhos.positioner</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosDisplayTitle</class>
    <extends>QFrame</extends>
    <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosRelatedSuiteButton</class>
+   <extends>QPushButton</extends>
+   <header>typhos.related_display</header>
   </customwidget>
   <customwidget>
    <class>PyDMLabel</class>
@@ -877,9 +1233,19 @@
    <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
    <class>PyDMLineEdit</class>
    <extends>QLineEdit</extends>
    <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
   </customwidget>
   <customwidget>
    <class>PyDMScaleIndicator</class>

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>468</width>
+    <width>480</width>
     <height>443</height>
    </rect>
   </property>
@@ -978,7 +978,7 @@
        </property>
        <property name="commands" stdset="0">
         <stringlist>
-         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:BOTTOM&quot;,&quot;name&quot;:&quot;${name}_bottom&quot;}]</string>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:BOTTOM','name':'${name}_bottom'}]&quot;</string>
         </stringlist>
        </property>
       </widget>
@@ -1200,7 +1200,7 @@
        </property>
        <property name="commands" stdset="0">
         <stringlist>
-         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:NORTH&quot;,&quot;name&quot;:&quot;${name}_north&quot;}]</string>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:NORTH','name':'${name}_north'}]&quot;</string>
         </stringlist>
        </property>
       </widget>
@@ -1236,9 +1236,12 @@
        <property name="text">
         <string>Expert</string>
        </property>
+       <property name="showIcon" stdset="0">
+        <bool>true</bool>
+       </property>
        <property name="commands" stdset="0">
         <stringlist>
-         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:TOP&quot;,&quot;name&quot;:&quot;${name}_top&quot;}]</string>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:TOP','name':'${name}_top'}]&quot;</string>
         </stringlist>
        </property>
       </widget>
@@ -1253,7 +1256,7 @@
        </property>
        <property name="commands" stdset="0">
         <stringlist>
-         <string>typhos pcdsdevices.epics_motor.BeckhoffAxis[{&quot;prefix&quot;:&quot;${prefix}:MMS:SOUTH&quot;,&quot;name&quot;:&quot;${name}_south&quot;}]</string>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:SOUTH','name':'${name}_south'}]&quot;</string>
         </stringlist>
        </property>
       </widget>

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>708</width>
-    <height>495</height>
+    <width>498</width>
+    <height>413</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -40,7 +40,7 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>480</width>
+       <width>450</width>
        <height>150</height>
       </size>
      </property>
@@ -62,38 +62,6 @@
      <property name="lineWidth">
       <number>0</number>
      </property>
-     <widget class="PyDMLabel" name="PyDMLabel_39">
-      <property name="geometry">
-       <rect>
-        <x>224</x>
-        <y>18</y>
-        <width>41</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Top</string>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_40">
-      <property name="geometry">
-       <rect>
-        <x>404</x>
-        <y>88</y>
-        <width>61</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Bottom</string>
-      </property>
-     </widget>
      <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_14">
       <property name="geometry">
        <rect>
@@ -259,22 +227,6 @@
        <double>0.000000000000000</double>
       </property>
      </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_42">
-      <property name="geometry">
-       <rect>
-        <x>4</x>
-        <y>18</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>North</string>
-      </property>
-     </widget>
      <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
       <property name="enabled">
        <bool>false</bool>
@@ -437,20 +389,56 @@
        <double>0.000000000000000</double>
       </property>
      </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_43">
+     <widget class="QLabel" name="label_5">
       <property name="geometry">
        <rect>
-        <x>194</x>
-        <y>88</y>
-        <width>51</width>
-        <height>21</height>
+        <x>4</x>
+        <y>18</y>
+        <width>47</width>
+        <height>14</height>
        </rect>
       </property>
-      <property name="toolTip">
-       <string/>
+      <property name="text">
+       <string>North</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
       </property>
       <property name="text">
        <string>South</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>18</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_8">
+      <property name="geometry">
+       <rect>
+        <x>410</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
       </property>
      </widget>
     </widget>
@@ -460,40 +448,6 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_48">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>75</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>3</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Decimal</enum>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
        <property name="sizePolicy">
@@ -501,6 +455,12 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>
@@ -516,22 +476,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="PyDMLabel" name="PyDMLabel_41">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Gap (mm)</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="2">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
        <property name="sizePolicy">
@@ -539,6 +483,12 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>
@@ -554,19 +504,28 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="PyDMLabel" name="PyDMLabel_44">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_10">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="toolTip">
-        <string/>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="text">
-        <string>Center (mm)</string>
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
@@ -582,6 +541,12 @@
         <size>
          <width>75</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="toolTip">
@@ -604,53 +569,28 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <widget class="PyDMLabel" name="PyDMLabel_37">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_9">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="toolTip">
-        <string/>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="text">
         <string>Center (mm)</string>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="4">
-      <widget class="PyDMLabel" name="PyDMLabel_45">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+       <property name="margin">
+        <number>0</number>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>75</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>3</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Decimal</enum>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
@@ -661,6 +601,12 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>
@@ -676,19 +622,31 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="3">
-      <widget class="PyDMLabel" name="PyDMLabel_38">
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
-       <property name="text">
-        <string>Gap (mm)</string>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
        </property>
       </widget>
      </item>
@@ -704,6 +662,12 @@
         <size>
          <width>75</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="toolTip">
@@ -726,15 +690,30 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="5">
-      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
         <string/>
        </property>
        <property name="precision" stdset="0">
@@ -744,7 +723,100 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:YWID_REQ</string>
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
@@ -760,10 +832,19 @@
        <property name="text">
         <string>SOUTH</string>
        </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
       </widget>
      </item>
      <item row="2" column="2">
       <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -771,7 +852,7 @@
         <bool>true</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.RBV</string>
+        <string>ca://${prefix}:MMS:NORTH.RBV</string>
        </property>
       </widget>
      </item>
@@ -781,7 +862,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:TOP.HLS</string>
+        <string>ca://${prefix}:MMS:TOP.HLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -804,7 +885,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:SOUTH.LLS</string>
+        <string>ca://${prefix}:MMS:SOUTH.LLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -823,6 +904,12 @@
      </item>
      <item row="3" column="2">
       <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -830,7 +917,7 @@
         <bool>true</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:SOUTH.RBV</string>
+        <string>ca://${prefix}:MMS:SOUTH.RBV</string>
        </property>
       </widget>
      </item>
@@ -840,7 +927,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:TOP.LLS</string>
+        <string>ca://${prefix}:MMS:TOP.LLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -863,7 +950,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:BOTTOM.LLS</string>
+        <string>ca://${prefix}:MMS:BOTTOM.LLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -885,10 +972,19 @@
        <property name="text">
         <string>TOP</string>
        </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
       </widget>
      </item>
      <item row="0" column="2">
       <widget class="PyDMLabel" name="PyDMLabel">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -896,7 +992,7 @@
         <bool>true</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:TOP.RBV</string>
+        <string>ca://${prefix}:MMS:TOP.RBV</string>
        </property>
       </widget>
      </item>
@@ -904,6 +1000,9 @@
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>BOTTOM</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
@@ -919,6 +1018,12 @@
      </item>
      <item row="1" column="2">
       <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -926,7 +1031,7 @@
         <bool>true</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:BOTTOM.RBV</string>
+        <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
        </property>
       </widget>
      </item>
@@ -942,7 +1047,7 @@
         <string>Stop</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:TOP.STOP</string>
+        <string>ca://${prefix}:MMS:TOP.STOP</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>
@@ -957,11 +1062,17 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:TOP.VAL</string>
+        <string>ca://${prefix}:MMS:TOP.VAL</string>
        </property>
       </widget>
      </item>
@@ -971,7 +1082,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.LLS</string>
+        <string>ca://${prefix}:MMS:NORTH.LLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -993,6 +1104,9 @@
        <property name="text">
         <string>NORTH</string>
        </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
       </widget>
      </item>
      <item row="1" column="3">
@@ -1001,7 +1115,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:BOTTOM.HLS</string>
+        <string>ca://${prefix}:MMS:BOTTOM.HLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -1024,7 +1138,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.HLS</string>
+        <string>ca://${prefix}:MMS:NORTH.HLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -1047,7 +1161,7 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:SOUTH.HLS</string>
+        <string>ca://${prefix}:MMS:SOUTH.HLS</string>
        </property>
        <property name="onColor" stdset="0">
         <color>
@@ -1072,11 +1186,17 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:BOTTOM.VAL</string>
+        <string>ca://${prefix}:MMS:BOTTOM.VAL</string>
        </property>
       </widget>
      </item>
@@ -1088,11 +1208,17 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.VAL</string>
+        <string>ca://${prefix}:MMS:NORTH.VAL</string>
        </property>
       </widget>
      </item>
@@ -1104,11 +1230,17 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.VAL</string>
+        <string>ca://${prefix}:MMS:NORTH.VAL</string>
        </property>
       </widget>
      </item>
@@ -1124,7 +1256,7 @@
         <string>Stop</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:BOTTOM.STOP</string>
+        <string>ca://${prefix}:MMS:BOTTOM.STOP</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>
@@ -1143,7 +1275,7 @@
         <string>Stop</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.STOP</string>
+        <string>ca://${prefix}:MMS:NORTH.STOP</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>
@@ -1162,7 +1294,7 @@
         <string>Stop</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://{prefix}:MMS:NORTH.STOP</string>
+        <string>ca://${prefix}:MMS:NORTH.STOP</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>

--- a/pcdsdevices/ui/BeckhoffSlits.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.embedded.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>464</width>
+    <width>468</width>
     <height>276</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item alignment="Qt::AlignHCenter">
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -73,13 +73,13 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>450</width>
+       <width>460</width>
        <height>150</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>450</width>
+       <width>460</width>
        <height>150</height>
       </size>
      </property>

--- a/pcdsdevices/ui/BeckhoffSlits.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>816</width>
-    <height>395</height>
+    <width>461</width>
+    <height>276</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -37,7 +37,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,0">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -65,10 +65,22 @@
    </item>
    <item>
     <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
-       <width>691</width>
-       <height>301</height>
+       <width>450</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>450</width>
+       <height>150</height>
       </size>
      </property>
      <property name="styleSheet">
@@ -83,99 +95,11 @@
      <property name="lineWidth">
       <number>0</number>
      </property>
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
-      <property name="geometry">
-       <rect>
-        <x>372</x>
-        <y>157</y>
-        <width>60</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:YCEN_REQ</string>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_37">
-      <property name="geometry">
-       <rect>
-        <x>224</x>
-        <y>160</y>
-        <width>71</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Center (mm)</string>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_38">
-      <property name="geometry">
-       <rect>
-        <x>224</x>
-        <y>188</y>
-        <width>67</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Gap (mm)</string>
-      </property>
-     </widget>
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
-      <property name="geometry">
-       <rect>
-        <x>372</x>
-        <y>187</y>
-        <width>60</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:YWID_REQ</string>
-      </property>
-     </widget>
      <widget class="PyDMLabel" name="PyDMLabel_39">
       <property name="geometry">
        <rect>
         <x>224</x>
-        <y>24</y>
+        <y>18</y>
         <width>41</width>
         <height>16</height>
        </rect>
@@ -191,7 +115,7 @@
       <property name="geometry">
        <rect>
         <x>404</x>
-        <y>94</y>
+        <y>88</y>
         <width>51</width>
         <height>16</height>
        </rect>
@@ -207,7 +131,7 @@
       <property name="geometry">
        <rect>
         <x>334</x>
-        <y>4</y>
+        <y>-2</y>
         <width>71</width>
         <height>144</height>
        </rect>
@@ -285,7 +209,7 @@
       <property name="geometry">
        <rect>
         <x>264</x>
-        <y>4</y>
+        <y>-2</y>
         <width>71</width>
         <height>144</height>
        </rect>
@@ -368,27 +292,11 @@
        <double>0.000000000000000</double>
       </property>
      </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_41">
-      <property name="geometry">
-       <rect>
-        <x>4</x>
-        <y>188</y>
-        <width>67</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Gap (mm)</string>
-      </property>
-     </widget>
      <widget class="PyDMLabel" name="PyDMLabel_42">
       <property name="geometry">
        <rect>
         <x>4</x>
-        <y>24</y>
+        <y>18</y>
         <width>41</width>
         <height>16</height>
        </rect>
@@ -407,7 +315,7 @@
       <property name="geometry">
        <rect>
         <x>54</x>
-        <y>4</y>
+        <y>-2</y>
         <width>141</width>
         <height>71</height>
        </rect>
@@ -494,7 +402,7 @@
       <property name="geometry">
        <rect>
         <x>54</x>
-        <y>74</y>
+        <y>68</y>
         <width>141</width>
         <height>71</height>
        </rect>
@@ -566,7 +474,7 @@
       <property name="geometry">
        <rect>
         <x>194</x>
-        <y>94</y>
+        <y>88</y>
         <width>41</width>
         <height>16</height>
        </rect>
@@ -578,242 +486,281 @@
        <string>South</string>
       </property>
      </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_44">
-      <property name="geometry">
-       <rect>
-        <x>4</x>
-        <y>160</y>
-        <width>71</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Center (mm)</string>
-      </property>
-     </widget>
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
-      <property name="geometry">
-       <rect>
-        <x>154</x>
-        <y>160</y>
-        <width>60</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:XCEN_REQ</string>
-      </property>
-     </widget>
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
-      <property name="geometry">
-       <rect>
-        <x>154</x>
-        <y>187</y>
-        <width>60</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:XWID_REQ</string>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_45">
-      <property name="geometry">
-       <rect>
-        <x>302</x>
-        <y>160</y>
-        <width>75</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_46">
-      <property name="geometry">
-       <rect>
-        <x>302</x>
-        <y>188</y>
-        <width>75</width>
-        <height>19</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_47">
-      <property name="geometry">
-       <rect>
-        <x>83</x>
-        <y>160</y>
-        <width>75</width>
-        <height>19</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_48">
-      <property name="geometry">
-       <rect>
-        <x>83</x>
-        <y>188</y>
-        <width>75</width>
-        <height>19</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="PyDMLabel" name="PyDMLabel_41">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="PyDMLabel" name="PyDMLabel_44">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_47">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="PyDMLabel" name="PyDMLabel_37">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="PyDMLabel" name="PyDMLabel_38">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_46">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/pcdsdevices/ui/BeckhoffSlits.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.embedded.ui
@@ -63,7 +63,7 @@
      </property>
     </widget>
    </item>
-   <item alignment="Qt::AlignHCenter">
+   <item>
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -73,18 +73,22 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>460</width>
+       <width>470</width>
        <height>150</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>460</width>
+       <width>470</width>
        <height>150</height>
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"/>
+      <string notr="true">PyDMLabel {
+color: black;
+background-color: none;
+border-radius: 0px;
+}</string>
      </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -427,12 +431,15 @@
        <rect>
         <x>4</x>
         <y>18</y>
-        <width>47</width>
-        <height>14</height>
+        <width>48</width>
+        <height>16</height>
        </rect>
       </property>
       <property name="text">
        <string>North</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
      <widget class="QLabel" name="label_6">
@@ -453,12 +460,15 @@
        <rect>
         <x>224</x>
         <y>18</y>
-        <width>47</width>
-        <height>14</height>
+        <width>38</width>
+        <height>16</height>
        </rect>
       </property>
       <property name="text">
        <string>Top</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
      <widget class="QLabel" name="label_8">

--- a/pcdsdevices/ui/BeckhoffSlits.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.embedded.ui
@@ -1,0 +1,854 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>816</width>
+    <height>395</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="sizeIncrement">
+   <size>
+    <width>1</width>
+    <height>1</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>400</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0">
+   <property name="spacing">
+    <number>3</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="minimumSize">
+      <size>
+       <width>691</width>
+       <height>301</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+      <property name="geometry">
+       <rect>
+        <x>372</x>
+        <y>157</y>
+        <width>60</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:YCEN_REQ</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_37">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>160</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Center (mm)</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_38">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>188</y>
+        <width>67</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Gap (mm)</string>
+      </property>
+     </widget>
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+      <property name="geometry">
+       <rect>
+        <x>372</x>
+        <y>187</y>
+        <width>60</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:YWID_REQ</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_39">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>24</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_40">
+      <property name="geometry">
+       <rect>
+        <x>404</x>
+        <y>94</y>
+        <width>51</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_14">
+      <property name="geometry">
+       <rect>
+        <x>334</x>
+        <y>4</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_15">
+      <property name="geometry">
+       <rect>
+        <x>264</x>
+        <y>4</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:TOP.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_41">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>188</y>
+        <width>67</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Gap (mm)</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_42">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>24</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>North</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>4</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="lineWidth">
+       <number>1</number>
+      </property>
+      <property name="midLineWidth">
+       <number>0</number>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:NORTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_17">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>74</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_43">
+      <property name="geometry">
+       <rect>
+        <x>194</x>
+        <y>94</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>South</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_44">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>160</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="text">
+       <string>Center (mm)</string>
+      </property>
+     </widget>
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+      <property name="geometry">
+       <rect>
+        <x>154</x>
+        <y>160</y>
+        <width>60</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:XCEN_REQ</string>
+      </property>
+     </widget>
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+      <property name="geometry">
+       <rect>
+        <x>154</x>
+        <y>187</y>
+        <width>60</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:XWID_REQ</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_45">
+      <property name="geometry">
+       <rect>
+        <x>302</x>
+        <y>160</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_46">
+      <property name="geometry">
+       <rect>
+        <x>302</x>
+        <y>188</y>
+        <width>75</width>
+        <height>19</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_47">
+      <property name="geometry">
+       <rect>
+        <x>83</x>
+        <y>160</y>
+        <width>75</width>
+        <height>19</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_48">
+      <property name="geometry">
+       <rect>
+        <x>83</x>
+        <y>188</y>
+        <width>75</width>
+        <height>19</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScaleIndicator</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.scale</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/BeckhoffSlits.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.embedded.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>461</width>
+    <width>464</width>
     <height>276</height>
    </rect>
   </property>
@@ -95,38 +95,6 @@
      <property name="lineWidth">
       <number>0</number>
      </property>
-     <widget class="PyDMLabel" name="PyDMLabel_39">
-      <property name="geometry">
-       <rect>
-        <x>224</x>
-        <y>18</y>
-        <width>41</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Top</string>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_40">
-      <property name="geometry">
-       <rect>
-        <x>404</x>
-        <y>88</y>
-        <width>51</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Bottom</string>
-      </property>
-     </widget>
      <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_14">
       <property name="geometry">
        <rect>
@@ -242,7 +210,7 @@
        <bool>true</bool>
       </property>
       <property name="showLimits" stdset="0">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <property name="showTicks" stdset="0">
        <bool>false</bool>
@@ -290,22 +258,6 @@
       </property>
       <property name="userUpperLimit" stdset="0">
        <double>0.000000000000000</double>
-      </property>
-     </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_42">
-      <property name="geometry">
-       <rect>
-        <x>4</x>
-        <y>18</y>
-        <width>41</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>North</string>
       </property>
      </widget>
      <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
@@ -470,20 +422,56 @@
        <double>0.000000000000000</double>
       </property>
      </widget>
-     <widget class="PyDMLabel" name="PyDMLabel_43">
+     <widget class="QLabel" name="label_5">
       <property name="geometry">
        <rect>
-        <x>194</x>
-        <y>88</y>
-        <width>41</width>
-        <height>16</height>
+        <x>4</x>
+        <y>18</y>
+        <width>47</width>
+        <height>14</height>
        </rect>
       </property>
-      <property name="toolTip">
-       <string/>
+      <property name="text">
+       <string>North</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
       </property>
       <property name="text">
        <string>South</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>18</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_8">
+      <property name="geometry">
+       <rect>
+        <x>410</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
       </property>
      </widget>
     </widget>
@@ -493,47 +481,19 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_48">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>75</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>3</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Decimal</enum>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>
@@ -549,23 +509,19 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="PyDMLabel" name="PyDMLabel_41">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Gap (mm)</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="2">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>
@@ -581,20 +537,35 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="PyDMLabel" name="PyDMLabel_44">
-       <property name="toolTip">
-        <string/>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="text">
-        <string>Center (mm)</string>
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
       <widget class="PyDMLabel" name="PyDMLabel_47">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -603,6 +574,12 @@
         <size>
          <width>75</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="toolTip">
@@ -625,57 +602,44 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <widget class="PyDMLabel" name="PyDMLabel_37">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Center (mm)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="4">
-      <widget class="PyDMLabel" name="PyDMLabel_45">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_9">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="minimumSize">
+       <property name="maximumSize">
         <size>
-         <width>75</width>
-         <height>0</height>
+         <width>80</width>
+         <height>16777215</height>
         </size>
        </property>
-       <property name="toolTip">
-        <string/>
+       <property name="text">
+        <string>Center (mm)</string>
        </property>
-       <property name="whatsThis">
-        <string/>
+       <property name="margin">
+        <number>0</number>
        </property>
-       <property name="precision" stdset="0">
-        <number>3</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Decimal</enum>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>
      <item row="0" column="5">
       <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="toolTip">
         <string/>
@@ -691,20 +655,38 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="3">
-      <widget class="PyDMLabel" name="PyDMLabel_38">
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
-       <property name="text">
-        <string>Gap (mm)</string>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
        </property>
       </widget>
      </item>
      <item row="1" column="4">
       <widget class="PyDMLabel" name="PyDMLabel_46">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -713,6 +695,12 @@
         <size>
          <width>75</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="toolTip">
@@ -735,15 +723,30 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="5">
-      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
         <string/>
        </property>
        <property name="precision" stdset="0">
@@ -753,7 +756,100 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:YWID_REQ</string>
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
        </property>
       </widget>
      </item>

--- a/pcdsdevices/ui/PowerSlits.detailed.ui
+++ b/pcdsdevices/ui/PowerSlits.detailed.ui
@@ -1,0 +1,1775 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>606</width>
+    <height>443</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="form_layout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>470</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>470</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">PyDMLabel {
+color: black;
+background-color: none;
+border-radius: 0px;
+}</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_14">
+      <property name="geometry">
+       <rect>
+        <x>334</x>
+        <y>-2</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_15">
+      <property name="geometry">
+       <rect>
+        <x>264</x>
+        <y>-2</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:TOP.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>-2</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="lineWidth">
+       <number>1</number>
+      </property>
+      <property name="midLineWidth">
+       <number>0</number>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:NORTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_17">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>68</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_5">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>18</y>
+        <width>48</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>North</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>South</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>18</y>
+        <width>38</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_8">
+      <property name="geometry">
+       <rect>
+        <x>410</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_20">
+      <property name="geometry">
+       <rect>
+        <x>-17</x>
+        <y>31</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:NORTH:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_21">
+      <property name="geometry">
+       <rect>
+        <x>-17</x>
+        <y>48</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:NORTH:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_22">
+      <property name="geometry">
+       <rect>
+        <x>196</x>
+        <y>118</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:SOUTH:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_23">
+      <property name="geometry">
+       <rect>
+        <x>196</x>
+        <y>101</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:SOUTH:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_24">
+      <property name="geometry">
+       <rect>
+        <x>192</x>
+        <y>48</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:TOP:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_25">
+      <property name="geometry">
+       <rect>
+        <x>192</x>
+        <y>31</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:TOP:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_26">
+      <property name="geometry">
+       <rect>
+        <x>406</x>
+        <y>118</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:BOTTOM:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_27">
+      <property name="geometry">
+       <rect>
+        <x>406</x>
+        <y>101</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:BOTTOM:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="0" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_47">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_46">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_13">
+     <property name="text">
+      <string>Individual Motor Control</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="2" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>BOTTOM</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:BOTTOM','name':'${name}_bottom'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>NORTH</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>TOP</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:NORTH','name':'${name}_north'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="showIcon" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:TOP','name':'${name}_top'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:SOUTH','name':'${name}_south'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>SOUTH</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMShellCommand</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.shell_command</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScaleIndicator</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.scale</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/PowerSlits.embedded.ui
+++ b/pcdsdevices/ui/PowerSlits.embedded.ui
@@ -1,0 +1,1239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>468</width>
+    <height>276</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="sizeIncrement">
+   <size>
+    <width>1</width>
+    <height>1</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>400</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,0">
+   <property name="spacing">
+    <number>3</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>470</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>470</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">PyDMLabel {
+color: black;
+background-color: none;
+border-radius: 0px;
+}</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_14">
+      <property name="geometry">
+       <rect>
+        <x>334</x>
+        <y>-2</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_15">
+      <property name="geometry">
+       <rect>
+        <x>264</x>
+        <y>-2</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:TOP.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>-2</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="lineWidth">
+       <number>1</number>
+      </property>
+      <property name="midLineWidth">
+       <number>0</number>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:NORTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_17">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>54</x>
+        <y>68</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-32.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_5">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>18</y>
+        <width>48</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>North</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>South</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>224</x>
+        <y>18</y>
+        <width>38</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_8">
+      <property name="geometry">
+       <rect>
+        <x>410</x>
+        <y>88</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_20">
+      <property name="geometry">
+       <rect>
+        <x>-17</x>
+        <y>31</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:NORTH:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_21">
+      <property name="geometry">
+       <rect>
+        <x>-17</x>
+        <y>48</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:NORTH:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_22">
+      <property name="geometry">
+       <rect>
+        <x>196</x>
+        <y>118</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:SOUTH:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_23">
+      <property name="geometry">
+       <rect>
+        <x>196</x>
+        <y>101</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:SOUTH:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_24">
+      <property name="geometry">
+       <rect>
+        <x>192</x>
+        <y>48</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:TOP:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_25">
+      <property name="geometry">
+       <rect>
+        <x>192</x>
+        <y>31</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:TOP:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_26">
+      <property name="geometry">
+       <rect>
+        <x>406</x>
+        <y>118</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:BOTTOM:RTD:02:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+     <widget class="PyDMLabel" name="PyDMLabel_27">
+      <property name="geometry">
+       <rect>
+        <x>406</x>
+        <y>101</y>
+        <width>75</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>75</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:BOTTOM:RTD:01:TEMP_RBV</string>
+      </property>
+      <property name="displayFormat" stdset="0">
+       <enum>PyDMLabel::Decimal</enum>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="0" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_47">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_46">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScaleIndicator</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.scale</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Make a typhos UI template for the BeckhoffSlits class using @ghalym 's pydm slit elements
- Make an example/guide as to how to make typhos templates
https://confluence.slac.stanford.edu/display/~zlentz/Converting+a+PyDM+UI+to+a+Typhos+Template%3A+Learning+by+Example
(I think some version of this will end up in the typhos docs and in the internal pcds docs)

Image:
![image](https://user-images.githubusercontent.com/10647860/134228953-196e0d2a-a282-4bdc-8f70-8dac311aa636.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Auto slits screen is kind of rough
- TMO wants the two screens to be the same
- I want the two screens to be the same
- Maggie already had some slit elements available from her previous screen work
- I wanted to make an example/tutorial for how to make typhos templates

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes
Recording the development process in my confluence page for use in docs later

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
