### PR TITLE
TMO Spectrometer Class in Spectrometer.py

### DIFF
--- a/docs/source/upcoming_release_notes/876-tmo_spectrometer.rst
+++ b/docs/source/upcoming_release_notes/876-tmo_spectrometer.rst
@@ -1,0 +1,30 @@
+876 tmo_spectrometer
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+-  TMO Fresnel Photon Spectrometer Motion components class.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- Mbosum

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -289,6 +289,7 @@ class Mono(BaseInterface, GroupDevice):
     transmission = 1
     SUB_STATE = 'state'
 
+
 class TMO_Spectrometer(BaseInterface, GroupDevice):
     """
     TMO Fresnel Photon Spectrometer Motion components class.
@@ -303,11 +304,11 @@ class TMO_Spectrometer(BaseInterface, GroupDevice):
     name : str
         Alias for the device
     """
-    #UI Representation
+    # UI Representation
     _icon = 'fa.minus-square'
     tab_component_names = True
 
-     # Motor components: can read/write positions
+    # Motor components: can read/write positions
     lens_x = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
     foil_x = Cpt(BeckhoffAxisNoOffset, ':MMS:02', kind='normal')
     zone_plate_x = Cpt(BeckhoffAxisNoOffset, ':MMS:03', kind='normal')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -291,7 +291,7 @@ class Mono(BaseInterface, GroupDevice):
 
 class TMO_Spectrometer(BaseInterface, GroupDevice):
     """
-    TMO Spectrometer Motion components class.
+    TMO Fresnel Photon Spectrometer Motion components class.
 
     Photon Spectrometer with LCLS-II Beckhoff motion architecture.
 
@@ -304,8 +304,8 @@ class TMO_Spectrometer(BaseInterface, GroupDevice):
         Alias for the device
     """
     #UI Representation
-     _icon = 'fa.minus-square'
-     tab_component_names = True
+    _icon = 'fa.minus-square'
+    tab_component_names = True
 
      # Motor components: can read/write positions
     lens_x = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -290,7 +290,7 @@ class Mono(BaseInterface, GroupDevice):
     SUB_STATE = 'state'
 
 
-class TMO_Spectrometer(BaseInterface, GroupDevice):
+class TMOSpectrometer(BaseInterface, GroupDevice):
     """
     TMO Fresnel Photon Spectrometer Motion components class.
 

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -288,3 +288,32 @@ class Mono(BaseInterface, GroupDevice):
     removed = False
     transmission = 1
     SUB_STATE = 'state'
+
+class TMO_Spectrometer(BaseInterface, GroupDevice):
+    """
+    TMO Spectrometer Motion components class.
+
+    Photon Spectrometer with LCLS-II Beckhoff motion architecture.
+
+    Parameters:
+    -----------
+    prefix : str
+        Base PV for the motion system
+
+    name : str
+        Alias for the device
+    """
+    #UI Representation
+     _icon = 'fa.minus-square'
+     tab_component_names = True
+
+     # Motor components: can read/write positions
+    lens_x = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
+    foil_x = Cpt(BeckhoffAxisNoOffset, ':MMS:02', kind='normal')
+    zone_plate_x = Cpt(BeckhoffAxisNoOffset, ':MMS:03', kind='normal')
+    zone_plate_y = Cpt(BeckhoffAxisNoOffset, ':MMS:04', kind='normal')
+    zone_plate_z = Cpt(BeckhoffAxisNoOffset, ':MMS:05', kind='normal')
+    yag_x = Cpt(BeckhoffAxisNoOffset, ':MMS:06', kind='normal')
+    yag_y = Cpt(BeckhoffAxisNoOffset, ':MMS:07', kind='normal')
+    yag_z = Cpt(BeckhoffAxisNoOffset, ':MMS:08', kind='normal')
+    yag_theta = Cpt(BeckhoffAxisNoOffset, ':MMS:09', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added a class at the end of spectrometer.py to connect to motor PVs associated with the TMO Photon Spectrometer.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A tmo_spectrometer class is necessary for creating an entry in the happi database and for connecting to a typhos GUI to control motion along the axes.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested the module with flake8 and pytest and both came back clean.

(pcds-4.2.0) psdev04:pcdsdevices bosum123$ flake8 spectrometer.py
(pcds-4.2.0) psdev04:pcdsdevices bosum123$


(pcds-4.2.0) psdev04:pcdsdevices bosum123$ pytest spectrometer.py
============================================================== test session starts ===============================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
PyQt5 5.12.3 -- Qt runtime 5.12.9 -- Qt compiled 5.12.9
rootdir: /reg/g/pcds/epics-dev/bosum123/hutch_python/pcdsdevices
plugins: benchmark-3.4.1, timeout-1.4.2, qt-3.3.0
collected 0 items

================================================================ warnings summary ================================================================
../../../../../../../../cds/group/pcds/pyps/conda/py39/envs/pcds-4.2.0/lib/python3.9/site-packages/past/builtins/misc.py:45
  /cds/group/pcds/pyps/conda/py39/envs/pcds-4.2.0/lib/python3.9/site-packages/past/builtins/misc.py:45: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import reload

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================================== 1 warning in 3.48s ===============================================================
(pcds-4.2.0) psdev04:pcdsdevices bosum123$




I also tested whether I  can make a device with it to verify the PV and component names:

![Screenshot (275)](https://user-images.githubusercontent.com/50626768/134786091-b53d457c-d85a-433e-8ed5-0a49d5378a8b.png)



![Screenshot (277)](https://user-images.githubusercontent.com/50626768/134786078-4034d1a8-9e39-4855-a1af-df0bdd34b72d.png)




<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://confluence.slac.stanford.edu/pages/viewpage.action?spaceKey=L2SI&title=Spectrometer+Motion+System+and+Spectrometer+Design

There is a docstring in the class.
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
