### PR TITLE
MNT: Various changes from XPP

### DIFF
--- a/docs/source/upcoming_release_notes/879-Various_changes_from_XPP.rst
+++ b/docs/source/upcoming_release_notes/879-Various_changes_from_XPP.rst
@@ -1,0 +1,33 @@
+879 Various changes from XPP
+#################
+
+API Changes
+-----------
+- `isum` components have been renamed to `sum` in IPM detector classes.
+- The motor components for PIM classes have been shortened by removing `_motor` from their names (e.g. `zoom_motor` is now `zoom`).
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- The default theta0 values for CCM objects has been changed from 14.9792 to 15.1027.
+- An acceleration component was added to the IMS class.
+- IPM objects now have short aliases for their motors (`ty`, `dx`, `dy`).
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Tab whitelists have been cut down to make things simpler for non-expert users.
+
+Contributors
+------------
+- ZryletTC

--- a/docs/source/upcoming_release_notes/879-Various_changes_from_XPP.rst
+++ b/docs/source/upcoming_release_notes/879-Various_changes_from_XPP.rst
@@ -18,7 +18,8 @@ Device Updates
 
 New Devices
 -----------
-- N/A
+- BeckhoffAxis_Pre140 has been added to support versions of lcls-twincat-motion
+  prior to v1.4.0. This has been aliased to OldBeckhoffAxis for backcompat.
 
 Bugfixes
 --------

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -30,7 +30,7 @@ si_111_dspacing = 3.1356011499587773
 si_511_dspacing = 1.0452003833195924
 
 # Defaults
-default_theta0_deg = 14.9792
+default_theta0_deg = 15.1027
 default_theta0 = default_theta0_deg * np.pi/180
 default_dspacing = si_111_dspacing
 default_gr = 3.175

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -918,11 +918,9 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
              doc='Combined motion of the CCM Y motors.')
 
     lightpath_cpts = ['x']
-    tab_component_names = True
-    tab_whitelist = ['x1', 'x2', 'y1', 'y2', 'y3', 'E', 'E_vernier',
-                     'th2coarse', 'th2fine', 'alio2E', 'E2alio',
-                     'home', 'kill', 'status',
-                     'insert', 'remove', 'inserted', 'removed']
+    tab_whitelist = ['x1', 'x2', 'y1', 'y2', 'y3', 'E', 'E_Vernier',
+                     'th2fine', 'alio2E', 'E2alio', 'alio', 'home',
+                     'kill', 'insert', 'remove', 'inserted', 'removed']
 
     _in_pos: float
     _out_pos: float

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1009,7 +1009,7 @@ class BeckhoffAxis(EpicsMotorInterface):
         return status
 
 
-class BeckhoffAxis_Pre140PLC(BeckhoffAxisPLC):
+class BeckhoffAxisPLC_Pre140(BeckhoffAxisPLC):
     """
     Disable some newly introduced signals.
     """
@@ -1026,7 +1026,7 @@ class BeckhoffAxis_Pre140(BeckhoffAxis):
     prior to v1.4.0, which is when the homing routines were
     introduced.
     """
-    plc = Cpt(BeckhoffAxis_Pre140PLC, ':PLC:', kind='normal',
+    plc = Cpt(BeckhoffAxisPLC_Pre140, ':PLC:', kind='normal',
               doc='PLC error handling.')
 
     def home(self, *args, **kwargs):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -577,7 +577,6 @@ class IMS(PCDSMotorBase):
     velocity = Cpt(EpicsSignal, '.VELO', limits=True, kind='config')
     velocity_base = Cpt(EpicsSignal, '.VBAS', kind='omitted')
     velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
-    acceleration = Cpt(EpicsSignal, '.ACCL', kind='config')
 
     tab_whitelist = ['reinitialize', 'acceleration', 'clear_.*']
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -579,6 +579,7 @@ class IMS(PCDSMotorBase):
     velocity = Cpt(EpicsSignal, '.VELO', limits=True, kind='config')
     velocity_base = Cpt(EpicsSignal, '.VBAS', kind='omitted')
     velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
+    acceleration = Cpt(EpicsSignal, '.ACCL', kind='config')
 
     tab_whitelist = ['auto_setup', 'reinitialize', 'clear_.*']
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -69,8 +69,8 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     # Current Dial position
     dial_position = Cpt(EpicsSignalRO, '.DRBV', kind='normal')
 
-    tab_whitelist = ["set_current_position", "home", "velocity", "enable",
-                     "disable", "check_limit_switches", "get_low_limit",
+    tab_whitelist = ["set_current_position", "home", "velocity",
+                     "check_limit_switches", "get_low_limit",
                      "set_low_limit", "get_high_limit", "set_high_limit"]
 
     set_metadata(EpicsMotor.home_forward, dict(variety='command-proc',
@@ -447,8 +447,6 @@ class PCDSMotorBase(EpicsMotorInterface):
     # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, '.SPG', kind='omitted')
 
-    tab_whitelist = ["spg_stop", "spg_pause", "spg_go"]
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.stage_sigs[self.motor_spg] = 2
@@ -581,7 +579,7 @@ class IMS(PCDSMotorBase):
     velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
     acceleration = Cpt(EpicsSignal, '.ACCL', kind='config')
 
-    tab_whitelist = ['auto_setup', 'reinitialize', 'clear_.*']
+    tab_whitelist = ['reinitialize', 'acceleration', 'clear_.*']
 
     # The singleton parameter manager object.
     _pm = None

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1014,6 +1014,7 @@ class BeckhoffAxis_Pre140PLC(BeckhoffAxisPLC):
     Disable some newly introduced signals.
     """
     cmd_home = None
+    home_pos = None
     user_enable = None
 
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1012,6 +1012,15 @@ class BeckhoffAxis(EpicsMotorInterface):
         return status
 
 
+class OldBeckhoffAxisPLC(BeckhoffAxisPLC):
+    cmd_home = None
+
+
+class OldBeckhoffAxis(BeckhoffAxis):
+    plc = Cpt(OldBeckhoffAxisPLC, ':PLC:', kind='normal',
+              doc='PLC error handling.')
+
+
 class BeckhoffAxisNoOffset(BeckhoffAxis):
     """
     A BeckhoffAxis with various fields read-only.

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1009,13 +1009,33 @@ class BeckhoffAxis(EpicsMotorInterface):
         return status
 
 
-class OldBeckhoffAxisPLC(BeckhoffAxisPLC):
+class BeckhoffAxis_Pre140PLC(BeckhoffAxisPLC):
+    """
+    Disable some newly introduced signals.
+    """
     cmd_home = None
+    user_enable = None
 
 
-class OldBeckhoffAxis(BeckhoffAxis):
-    plc = Cpt(OldBeckhoffAxisPLC, ':PLC:', kind='normal',
+class BeckhoffAxis_Pre140(BeckhoffAxis):
+    """
+    Beckhoff Axis compatible with PLCs running older software.
+
+    This version targets the versions of lcls-twincat-motion
+    prior to v1.4.0, which is when the homing routines were
+    introduced.
+    """
+    plc = Cpt(BeckhoffAxis_Pre140PLC, ':PLC:', kind='normal',
               doc='PLC error handling.')
+
+    def home(self, *args, **kwargs):
+        """
+        Override ``home`` with a clear error message.
+        """
+        raise NotImplementedError("This axis does not support homing.")
+
+
+OldBeckhoffAxis = BeckhoffAxis_Pre140
 
 
 class BeckhoffAxisNoOffset(BeckhoffAxis):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -34,15 +34,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 engineering_mode = True
 
-OphydObject_whitelist = ["name", "connected", "check_value", "log"]
-BlueskyInterface_whitelist = ["trigger", "read", "describe", "stage",
-                              "unstage"]
-Device_whitelist = ["read_attrs", "configuration_attrs", "summary",
-                    "wait_for_connection", "stop", "get", "configure"]
-Signal_whitelist = ["value", "put"]
+OphydObject_whitelist = []
+BlueskyInterface_whitelist = []
+Device_whitelist = ["stop"]
+Signal_whitelist = ["value", "put", "get"]
 Positioner_whitelist = ["settle_time", "timeout", "egu", "limits", "move",
-                        "position", "moving", "set_position",
-                        "set_current_position"]
+                        "position", "moving", "set_current_position"]
 
 
 class _TabCompletionHelper:
@@ -552,7 +549,7 @@ class MvInterface(BaseInterface):
     applications.
     """
 
-    tab_whitelist = ["mv", "wm", "camonitor", "wm_update"]
+    tab_whitelist = ["mv", "wm", "wm_update"]
 
     def __init__(self, *args, **kwargs):
         self._mov_ev = Event()

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -313,7 +313,7 @@ class IPIMB(BaseInterface, GroupDevice):
 
     Attributes
     ----------
-    isum
+    sum
         Total sum of all 4 channels (i0 if standard IPM device).
 
     xpos, ypos
@@ -329,9 +329,9 @@ class IPIMB(BaseInterface, GroupDevice):
         Trigger component.
     """
 
-    tab_whitelist = ['isum', 'xpos', 'ypos']
+    tab_whitelist = ['sum', 'xpos', 'ypos']
 
-    isum = Cpt(EpicsSignalRO, ':SUM', kind='hinted')
+    sum = Cpt(EpicsSignalRO, ':SUM', kind='hinted')
     xpos = Cpt(EpicsSignalRO, ':XPOS', kind='normal')
     ypos = Cpt(EpicsSignalRO, ':YPOS', kind='normal')
     evr_channel = Cpt(Trigger, ':TRIG:TRIG0', kind='normal')
@@ -402,9 +402,9 @@ class Wave8(BaseInterface, GroupDevice):
         Alias for the wave8.
     """
 
-    tab_whitelist = ['isum', 'xpos', 'ypos']
+    tab_whitelist = ['sum', 'xpos', 'ypos']
 
-    isum = Cpt(EpicsSignalRO, ':SUM', kind='normal')
+    sum = Cpt(EpicsSignalRO, ':SUM', kind='normal')
     xpos = Cpt(EpicsSignalRO, ':XPOS', kind='normal')
     ypos = Cpt(EpicsSignalRO, ':YPOS', kind='normal')
     evr_channel = Cpt(Trigger, ':TRIG:TRIG0', kind='normal')
@@ -449,9 +449,9 @@ class IPM_Det(BaseInterface, Device):
     """Base class for IPM_IPIMB and IPM_Wave8. Not meant to be instantiated."""
     tab_component_names = True
 
-    def isum(self):
-        """Returns the detector's isum value."""
-        return self.det.isum.get()
+    def sum(self):
+        """Returns the detector's sum value."""
+        return self.det.sum.get()
 
     def xpos(self):
         """Returns the detector's xpos value."""

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -2,6 +2,7 @@
 Module for the `IPM` intensity position monitor classes.
 """
 import logging
+import warnings
 
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
@@ -352,6 +353,17 @@ class IPIMB(BaseInterface, GroupDevice):
     def screen(self):
         """Function to call the (pyQT) screen for an IPIMB box."""
         return ipm_screen('IPIMB', self._prefix, self._prefix_ioc)
+
+    @property
+    def isum(self):
+        """
+        Backcompatibility alias for the sum signal.
+        """
+        warnings.warn(
+            'isum is deprecated, please use sum instead',
+            DeprecationWarning,
+        )
+        return self.sum
 
 
 class Wave8Channel(BaseInterface, Device):

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -133,7 +133,13 @@ class IPMMotion(BaseInterface, GroupDevice):
     _icon = 'ei.screenshot'
 
     tab_whitelist = ['target', 'diode', 'insert', 'remove', 'inserted',
-                     'removed']
+                     'removed', 'ty', 'dx', 'dy']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ty = self.target.motor
+        self.dx = self.diode.x_motor
+        self.dy = self.diode.y_motor
 
     def format_status_info(self, status_info):
         """

--- a/pcdsdevices/jet.py
+++ b/pcdsdevices/jet.py
@@ -5,7 +5,7 @@ from ophyd import Component as Cpt
 
 from .device import GroupDevice
 from .device import UnrelatedComponent as UCpt
-from .epics_motor import IMS, BeckhoffAxis
+from .epics_motor import IMS, OldBeckhoffAxis
 from .interface import BaseInterface
 
 
@@ -74,19 +74,19 @@ class BeckhoffJetManipulator(BaseInterface, GroupDevice):
 
     tab_component_names = True
 
-    x = Cpt(BeckhoffAxis, ':X', kind='normal')
-    y = Cpt(BeckhoffAxis, ':Y', kind='normal')
-    z = Cpt(BeckhoffAxis, ':Z', kind='normal')
+    x = Cpt(OldBeckhoffAxis, ':X', kind='normal')
+    y = Cpt(OldBeckhoffAxis, ':Y', kind='normal')
+    z = Cpt(OldBeckhoffAxis, ':Z', kind='normal')
 
 
 class BeckhoffJetSlits(BaseInterface, GroupDevice):
     """Pair of Beckhoff-controlled slits where each blade has X & Y motors."""
     tab_component_names = True
 
-    top_x = Cpt(BeckhoffAxis, ':TOP_X', kind='normal')
-    top_y = Cpt(BeckhoffAxis, ':TOP_Y', kind='normal')
-    bot_x = Cpt(BeckhoffAxis, ':BOT_X', kind='normal')
-    bot_y = Cpt(BeckhoffAxis, ':BOT_Y', kind='normal')
+    top_x = Cpt(OldBeckhoffAxis, ':TOP_X', kind='normal')
+    top_y = Cpt(OldBeckhoffAxis, ':TOP_Y', kind='normal')
+    bot_x = Cpt(OldBeckhoffAxis, ':BOT_X', kind='normal')
+    bot_y = Cpt(OldBeckhoffAxis, ':BOT_Y', kind='normal')
 
 
 class BeckhoffJet(BaseInterface, GroupDevice):
@@ -110,4 +110,4 @@ class BeckhoffJet(BaseInterface, GroupDevice):
 
     jet = Cpt(BeckhoffJetManipulator, ':JET', kind='normal')
     ss = Cpt(BeckhoffJetSlits, ':SS', kind='normal')
-    vh_epix_x = Cpt(BeckhoffAxis, ':DET:X', kind='normal')
+    vh_epix_x = Cpt(OldBeckhoffAxis, ':DET:X', kind='normal')

--- a/pcdsdevices/jet.py
+++ b/pcdsdevices/jet.py
@@ -5,7 +5,7 @@ from ophyd import Component as Cpt
 
 from .device import GroupDevice
 from .device import UnrelatedComponent as UCpt
-from .epics_motor import IMS, OldBeckhoffAxis
+from .epics_motor import IMS, BeckhoffAxis_Pre140
 from .interface import BaseInterface
 
 
@@ -74,19 +74,19 @@ class BeckhoffJetManipulator(BaseInterface, GroupDevice):
 
     tab_component_names = True
 
-    x = Cpt(OldBeckhoffAxis, ':X', kind='normal')
-    y = Cpt(OldBeckhoffAxis, ':Y', kind='normal')
-    z = Cpt(OldBeckhoffAxis, ':Z', kind='normal')
+    x = Cpt(BeckhoffAxis_Pre140, ':X', kind='normal')
+    y = Cpt(BeckhoffAxis_Pre140, ':Y', kind='normal')
+    z = Cpt(BeckhoffAxis_Pre140, ':Z', kind='normal')
 
 
 class BeckhoffJetSlits(BaseInterface, GroupDevice):
     """Pair of Beckhoff-controlled slits where each blade has X & Y motors."""
     tab_component_names = True
 
-    top_x = Cpt(OldBeckhoffAxis, ':TOP_X', kind='normal')
-    top_y = Cpt(OldBeckhoffAxis, ':TOP_Y', kind='normal')
-    bot_x = Cpt(OldBeckhoffAxis, ':BOT_X', kind='normal')
-    bot_y = Cpt(OldBeckhoffAxis, ':BOT_Y', kind='normal')
+    top_x = Cpt(BeckhoffAxis_Pre140, ':TOP_X', kind='normal')
+    top_y = Cpt(BeckhoffAxis_Pre140, ':TOP_Y', kind='normal')
+    bot_x = Cpt(BeckhoffAxis_Pre140, ':BOT_X', kind='normal')
+    bot_y = Cpt(BeckhoffAxis_Pre140, ':BOT_Y', kind='normal')
 
 
 class BeckhoffJet(BaseInterface, GroupDevice):
@@ -110,4 +110,4 @@ class BeckhoffJet(BaseInterface, GroupDevice):
 
     jet = Cpt(BeckhoffJetManipulator, ':JET', kind='normal')
     ss = Cpt(BeckhoffJetSlits, ':SS', kind='normal')
-    vh_epix_x = Cpt(OldBeckhoffAxis, ':DET:X', kind='normal')
+    vh_epix_x = Cpt(BeckhoffAxis_Pre140, ':DET:X', kind='normal')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -88,11 +88,11 @@ class PIM(BaseInterface, GroupDevice):
     _prefix_start = ''
 
     state = Cpt(PIMY, '', kind='normal')
-    zoom_motor = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
+    zoom = FCpt(IMS, '{self._prefix_zoom}', kind='normal')
     detector = FCpt(PCDSAreaDetectorEmbedded, '{self._prefix_det}',
                     kind='normal')
 
-    tab_whitelist = ['y_motor', 'remove', 'insert', 'removed', 'inserted']
+    tab_whitelist = ['y', 'remove', 'insert', 'removed', 'inserted']
     tab_component_names = True
 
     def infer_prefix(self, prefix):
@@ -119,17 +119,17 @@ class PIM(BaseInterface, GroupDevice):
         status: str
             Formatted string with all relevant status information.
         """
-        focus = get_status_value(status_info, 'focus_motor', 'position')
-        f_units = get_status_value(status_info, 'focus_motor', 'user_setpoint',
+        focus = get_status_value(status_info, 'focus', 'position')
+        f_units = get_status_value(status_info, 'focus', 'user_setpoint',
                                    'units')
         state_pos = get_status_value(status_info, 'state', 'position')
         y_pos = get_status_float(status_info, 'state', 'motor', 'position',
                                  precision=4)
         y_units = get_status_value(status_info, 'state', 'motor',
                                    'user_setpoint', 'units')
-        zoom = get_status_float(status_info, 'zoom_motor', 'position',
+        zoom = get_status_float(status_info, 'zoom', 'position',
                                 precision=4)
-        z_units = get_status_value(status_info, 'zoom_motor', 'user_setpoint',
+        z_units = get_status_value(status_info, 'zoom', 'user_setpoint',
                                    'units')
 
         name = ' '.join(self.prefix.split(':'))
@@ -190,7 +190,7 @@ Y Position: {y_pos} [{y_units}]
             self._prefix_zoom = self.prefix_start+'CLZ:01'
 
         super().__init__(prefix, name=name, **kwargs)
-        self.y_motor = self.state.motor
+        self.y = self.state.motor
 
 
 class PIMWithFocus(PIM):
@@ -220,7 +220,7 @@ class PIMWithFocus(PIM):
         be inferred from `prefix`.
     """
 
-    focus_motor = FCpt(IMS, '{self._prefix_focus}', kind='normal')
+    focus = FCpt(IMS, '{self._prefix_focus}', kind='normal')
 
     def __init__(self, prefix, *, name, prefix_focus=None, **kwargs):
         self.infer_prefix(prefix)

--- a/pcdsdevices/tests/test_ipm.py
+++ b/pcdsdevices/tests/test_ipm.py
@@ -147,7 +147,7 @@ def test_ipm_subscriptions(fake_ipm):
 def test_ipm_box_readback(fake_ipm_with_box):
     logger.debug('test_ipm_ipimb_readback')
     ipm = fake_ipm_with_box
-    ipm.isum()
+    ipm.sum()
     ipm.xpos()
     ipm.ypos()
     ipm.channel().amplitude.get()

--- a/pcdsdevices/tests/test_pim.py
+++ b/pcdsdevices/tests/test_pim.py
@@ -16,9 +16,9 @@ def fake_pim():
     pim = FakePIM('Test:Yag', name='test')
     pim.state.state.sim_put(0)
     pim.state.state.sim_set_enum_strs(['Unknown'] + PIMY.states_list)
-    pim.y_motor.error_severity.sim_put(0)
-    pim.y_motor.bit_status.sim_put(0)
-    pim.y_motor.motor_spg.sim_put(2)
+    pim.y.error_severity.sim_put(0)
+    pim.y.bit_status.sim_put(0)
+    pim.y.motor_spg.sim_put(2)
     return pim
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This is a collection of changes that were being used in the XPP's dev version of pcdsdevices.
This includes:
- updating the default theta0 for CCM objects
- using a hacky version of BeckhoffAxis in the Liquid Jet classes to work with the old version currently used by IOC
- adding the acceleration field to the IMS class
- changing component names, aliases, and tab whitelists

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some parts were done to make things work (better).
Some parts were done because scientists requested them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be a comment in the code or updating a docstring -->
Docstrings have (mostly) been updated accordingly, and everything will be covered in the pre-release notes.


## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
