### PR TITLE
Added LAMPFlowCell class to lamp_motion.py for the x454 configuration

### DIFF
--- a/docs/source/upcoming_release_notes/887-lampflowcell.rst
+++ b/docs/source/upcoming_release_notes/887-lampflowcell.rst
@@ -1,0 +1,30 @@
+887 lampflowcell
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- LAMPFlowCell class for new 4 axis flow cell manipulator replacing dVMI on LAMP.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- Mbosum

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -72,3 +72,37 @@ class LAMPMagneticBottle(BaseInterface, GroupDevice):
     magnet_x = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
     magnet_y = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
     magnet_z = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
+
+
+class LAMPFlowCell(BaseInterface, GroupDevice):
+    """
+    LAMP Motion Class
+
+    This class controls motors fixed to the LAMP Motion system for the IP1
+    endstation in TMO with the Flow Cell configuration for x454.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the LAMP motion system
+
+    name : str
+        Alias for the device
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+    tab_component_names = True
+
+    # Motor components
+    gas_jet_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    gas_jet_y = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+    gas_jet_z = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
+
+    flow_cell_x = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
+    flow_cell_y = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+    flow_cell_z = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
+    flow_cell_theta = Cpt(BeckhoffAxis, 'MMS:10', kind='normal')
+
+    sample_paddle_x = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
+    sample_paddle_y = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
+    sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- wgmege -->
Added LAMPFlowCell class at the end of lamp_motion.py to connect to motor PVs associated with the x454 configuration of LAMP motion components of the LAMP IP1 endstation. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The dVMI will be taken off of LAMP for x454 in exchange for a 4 axis flow cell manipulator. These axes need to be reflected in the motion control GUI.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the module with flake8 it came back clean.

(pcds-4.2.0) pslogin02:pcdsdevices bosum123$ flake8 ./lamp_motion.py
(pcds-4.2.0) pslogin02:pcdsdevices bosum123$

I also tested whether I can make a device with it to verify the PV and component names:

![image](https://user-images.githubusercontent.com/50626768/135694685-c523a78c-9b11-4e9d-9bdf-9a800edcf708.png)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
There is a docstring for the class. 

Confluence documentation is found here: 
https://confluence.slac.stanford.edu/display/L2SI/LAMP+Motion+System#LAMPMotionSystem-MechatronicParameters 
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
