### PR TITLE
TST: relative imports and miscellaneous fixes

### DIFF
--- a/pcdsdevices/tests/conftest.py
+++ b/pcdsdevices/tests/conftest.py
@@ -16,13 +16,10 @@ from epics import PV
 from ophyd.signal import LimitError
 from ophyd.sim import FakeEpicsSignal, make_fake_device
 
-import pcdsdevices
-import pcdsdevices.analog_signals
-import pcdsdevices.lens
-import pcdsdevices.lxe
-from pcdsdevices.attenuator import MAX_FILTERS, Attenuator, _att_classes
-from pcdsdevices.device import UnrelatedComponent
-from pcdsdevices.interface import setup_preset_paths
+from .. import analog_signals, lens, lxe
+from ..attenuator import MAX_FILTERS, Attenuator, _att_classes
+from ..device import UnrelatedComponent
+from ..interface import setup_preset_paths
 
 MODULE_PATH = Path(__file__).parent
 
@@ -177,14 +174,14 @@ def find_all_callables() -> list:
 # instantiated that cannot be automatically determined from its signature,
 # add them here.
 class_to_essential_kwargs = {
-    pcdsdevices.analog_signals.Mesh: dict(sp_ch=0, rb_ch=0),
-    pcdsdevices.lens.LensStack: dict(
+    analog_signals.Mesh: dict(sp_ch=0, rb_ch=0),
+    lens.LensStack: dict(
         path=str(MODULE_PATH / 'test_lens_sets' / 'test'),
     ),
-    pcdsdevices.lens.SimLensStack: dict(
+    lens.SimLensStack: dict(
         path=str(MODULE_PATH / 'test_lens_sets' / 'test'),
     ),
-    pcdsdevices.lxe.LaserEnergyPositioner: dict(
+    lxe.LaserEnergyPositioner: dict(
         calibration_file=MODULE_PATH / 'xcslt8717_wpcalib_opa',
     ),
 }

--- a/pcdsdevices/tests/test_analog_signals.py
+++ b/pcdsdevices/tests/test_analog_signals.py
@@ -4,8 +4,8 @@ import pytest
 from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd.sim import make_fake_device
 
-import pcdsdevices.utils as key_press
-from pcdsdevices.analog_signals import Acromag, AcromagChannel, Mesh
+from .. import utils
+from ..analog_signals import Acromag, AcromagChannel, Mesh
 
 logger = logging.getLogger(__name__)
 
@@ -105,10 +105,10 @@ def test_tweak_mesh_voltage(fake_mesh, monkeypatch):
     def mock_tweak_down():
         return '\x1b[D'  # arrow left
 
-    monkeypatch.setattr(key_press, 'get_input', mock_tweak_up)
+    monkeypatch.setattr(utils, 'get_input', mock_tweak_up)
     fake_mesh.tweak_mesh_voltage(500.0, test_flag=True)
     assert fake_mesh.write_sig.get() == 1.5
-    monkeypatch.setattr(key_press, 'get_input', mock_tweak_down)
+    monkeypatch.setattr(utils, 'get_input', mock_tweak_down)
     fake_mesh.tweak_mesh_voltage(500.0, test_flag=True)
     assert fake_mesh.write_sig.get() == 1.0
 

--- a/pcdsdevices/tests/test_atm.py
+++ b/pcdsdevices/tests/test_atm.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from pcdsdevices.atm import ArrivalTimeMonitor
+from ..atm import ArrivalTimeMonitor
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_attenuator.py
+++ b/pcdsdevices/tests/test_attenuator.py
@@ -7,8 +7,8 @@ import pytest
 from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
 
-from pcdsdevices.attenuator import (AT1K4, AT2L0, MAX_FILTERS, AttBase,
-                                    Attenuator, _att_classes)
+from ..attenuator import (AT1K4, AT2L0, MAX_FILTERS, AttBase, Attenuator,
+                          _att_classes)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_beam_stats.py
+++ b/pcdsdevices/tests/test_beam_stats.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.beam_stats import LCLS, BeamStats
+from ..beam_stats import LCLS, BeamStats
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import numpy as np
 import pytest
@@ -260,7 +261,7 @@ def test_show_constant_warning(fake_ccm, caplog):
 def test_warn_invalid_constants(fake_ccm, caplog):
     logger.debug('test_warn_invalid_constants')
     # Trick the warning into thinking we've be initialized for a while
-    fake_ccm._init_time = 0
+    fake_ccm._init_time = time.monotonic() - 1000
     fake_ccm.theta0_deg.put(0)
     fake_ccm.dspacing.put(0)
     fake_ccm.gr.put(0)

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 from ophyd.sim import fake_device_cache, make_fake_device
 
-import pcdsdevices.ccm as ccm
-from pcdsdevices.sim import FastMotor
+from .. import ccm
+from ..sim import FastMotor
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_dc_devices.py
+++ b/pcdsdevices/tests/test_dc_devices.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.dc_devices import ICT
+from ..dc_devices import ICT
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_device.py
+++ b/pcdsdevices/tests/test_device.py
@@ -6,13 +6,13 @@ from ophyd.device import Kind
 from ophyd.positioner import SoftPositioner
 from ophyd.signal import Signal
 
-from pcdsdevices.device import GroupDevice
-from pcdsdevices.device import InterfaceComponent as ICpt
-from pcdsdevices.device import InterfaceDevice
-from pcdsdevices.device import ObjectComponent as OCpt
-from pcdsdevices.device import UnrelatedComponent as UCpt
-from pcdsdevices.device import UpdateComponent as UpCpt
-from pcdsdevices.device import to_interface
+from ..device import GroupDevice
+from ..device import InterfaceComponent as ICpt
+from ..device import InterfaceDevice
+from ..device import ObjectComponent as OCpt
+from ..device import UnrelatedComponent as UCpt
+from ..device import UpdateComponent as UpCpt
+from ..device import to_interface
 
 
 class Basic(Device):

--- a/pcdsdevices/tests/test_epics_motor.py
+++ b/pcdsdevices/tests/test_epics_motor.py
@@ -7,11 +7,10 @@ from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
 from ophyd.utils.epics_pvs import AlarmSeverity, AlarmStatus
 
-from pcdsdevices.epics_motor import (IMS, PMC100, BeckhoffAxis, EpicsMotor,
-                                     EpicsMotorInterface, Motor,
-                                     MotorDisabledError, Newport,
-                                     OffsetIMSWithPreset, OffsetMotor,
-                                     PCDSMotorBase)
+from ..epics_motor import (IMS, PMC100, BeckhoffAxis, EpicsMotor,
+                           EpicsMotorInterface, Motor, MotorDisabledError,
+                           Newport, OffsetIMSWithPreset, OffsetMotor,
+                           PCDSMotorBase)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_evr.py
+++ b/pcdsdevices/tests/test_evr.py
@@ -1,7 +1,7 @@
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.device_types import Trigger
+from ..device_types import Trigger
 
 
 @pytest.fixture(scope='function')

--- a/pcdsdevices/tests/test_gauge.py
+++ b/pcdsdevices/tests/test_gauge.py
@@ -4,8 +4,8 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.gauge import (GaugeSet, GaugeSetBase, GaugeSetMks,
-                               GaugeSetPirani, GaugeSetPiraniMks)
+from ..gauge import (GaugeSet, GaugeSetBase, GaugeSetMks, GaugeSetPirani,
+                     GaugeSetPiraniMks)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_gon.py
+++ b/pcdsdevices/tests/test_gon.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.gon import (
-    BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi, SimKappa, XYZStage)
+from ..gon import (BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi, SimKappa,
+                   XYZStage)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_inout.py
+++ b/pcdsdevices/tests/test_inout.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.inout import (InOutPositioner, InOutPVStatePositioner,
-                               InOutRecordPositioner, TwinCATInOutPositioner)
+from ..inout import (InOutPositioner, InOutPVStatePositioner,
+                     InOutRecordPositioner, TwinCATInOutPositioner)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -7,11 +7,10 @@ import time
 import ophyd
 import pytest
 
-from pcdsdevices.interface import (BaseInterface, TabCompletionHelperClass,
-                                   get_engineering_mode, set_engineering_mode,
-                                   setup_preset_paths)
-from pcdsdevices.sim import FastMotor, SlowMotor
-
+from ..interface import (BaseInterface, TabCompletionHelperClass,
+                         get_engineering_mode, set_engineering_mode,
+                         setup_preset_paths)
+from ..sim import FastMotor, SlowMotor
 from . import conftest
 
 try:

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -95,9 +95,9 @@ def test_mv_ginput(monkeypatch, fast_motor):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32",
+    sys.platform in ("win32", "darwin"),
     reason="Fails on Windows, no fcntl and different signal handling",
-    )
+)
 def test_presets(presets, fast_motor):
     logger.debug('test_presets')
 

--- a/pcdsdevices/tests/test_ipm.py
+++ b/pcdsdevices/tests/test_ipm.py
@@ -4,9 +4,8 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.inout import InOutRecordPositioner
-from pcdsdevices.ipm import (IPIMB, IPM, IPM_IPIMB, IPM_Wave8, IPMMotion,
-                             IPMTarget, Wave8)
+from ..inout import InOutRecordPositioner
+from ..ipm import IPIMB, IPM, IPM_IPIMB, IPM_Wave8, IPMMotion, IPMTarget, Wave8
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_jet.py
+++ b/pcdsdevices/tests/test_jet.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.jet import BeckhoffJet, Injector, InjectorWithFine
+from ..jet import BeckhoffJet, Injector, InjectorWithFine
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_lens.py
+++ b/pcdsdevices/tests/test_lens.py
@@ -8,8 +8,7 @@ import numpy as np
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.lens import (XFLS, LensStack, LensStackBase, Prefocus,
-                              SimLensStack)
+from ..lens import XFLS, LensStack, LensStackBase, Prefocus, SimLensStack
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_lic.py
+++ b/pcdsdevices/tests/test_lic.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from pcdsdevices.lic import LaserInCoupling
+from ..lic import LaserInCoupling
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_lodcm.py
+++ b/pcdsdevices/tests/test_lodcm.py
@@ -258,14 +258,14 @@ def test_tweak_x(fake_lodcm):
     # with x = 3 => z = 2.897066324421222
     lom.tweak_x(3, 'Si', wait=False)
     assert lom.x2.wm() == 3
-    assert lom.z2.wm() == 2.897066324421222
+    assert np.isclose(lom.z2.wm(), 2.897066324421222)
     # should move relative to current position
     # x2 = 3, z2 = 2.897066324421222
     lom.tweak_x(10, 'Si', wait=False)
     # x = 10 + current position
     # z = 9.656887748070739 + current position
     assert lom.x2.wm() == 13
-    assert lom.z2.wm() == 9.656887748070739 + 2.897066324421222
+    assert np.isclose(lom.z2.wm(), 9.656887748070739 + 2.897066324421222)
 
 
 def test_tweak_parallel(fake_lodcm):
@@ -277,22 +277,22 @@ def test_tweak_parallel(fake_lodcm):
     with patch('pcdsdevices.lodcm.LODCM.get_material',
                return_value='Si'):
         lom.tweak_parallel(3)
-        assert lom.x2.wm() == 1.1721933854678213
-        assert lom.z2.wm() == 2.761514560357321
+        assert np.isclose(lom.x2.wm(), 1.1721933854678213)
+        assert np.isclose(lom.z2.wm(), 2.761514560357321)
         lom.tweak_parallel(3)
         # with now x2 = 1.1721933854678213, z2 = 2.761514560357321
-        assert lom.x2.wm() == 1.1721933854678213 * 2
-        assert lom.z2.wm() == 2.761514560357321 * 2
+        assert np.isclose(lom.x2.wm(), 1.1721933854678213 * 2)
+        assert np.isclose(lom.z2.wm(), 2.761514560357321 * 2)
 
 
-def test_set_energy(fake_lodcm):
+def test_set_energy(fake_lodcm, monkeypatch):
     lom = fake_lodcm
     lom.set_energy(10, material='Si', reflection=(1, 1, 1))
 
-    assert lom.th1Si.wm() == 11.402710639982848
-    assert lom.th2Si.wm() == 11.402710639982848
-    assert lom.z1Si.wm() == -713.4828146545175
-    assert lom.z2Si.wm() == 713.4828146545175
+    assert np.isclose(lom.th1Si.wm(), 11.402710639982848)
+    assert np.isclose(lom.th2Si.wm(), 11.402710639982848)
+    assert np.isclose(lom.z1Si.wm(), -713.4828146545175)
+    assert np.isclose(lom.z2Si.wm(), 713.4828146545175)
 
 
 def test_tower1_crystal_type(fake_tower1):
@@ -406,21 +406,21 @@ def test_calc_geometry_c(fake_energy_c):
     with patch('pcdsdevices.lodcm.LODCMEnergyC.get_reflection',
                return_value=(1, 1, 1)):
         th, z = energy.calc_geometry(energy=10)
-        assert th == 17.51878596767417
-        assert z == 427.8469911590626
+        assert np.isclose(th, 17.51878596767417)
+        assert np.isclose(z, 427.8469911590626)
         th, z = energy.calc_geometry(energy=6)
-        assert th == 30.112367750143974
-        assert z == 171.63966796710216
+        assert np.isclose(th, 30.112367750143974)
+        assert np.isclose(z, 171.63966796710216)
 
     logger.info('Testing with C, (2, 2, 0)')
     with patch('pcdsdevices.lodcm.LODCMEnergyC.get_reflection',
                return_value=(2, 2, 0)):
         th, z = energy.calc_geometry(energy=10)
-        assert th == 29.443241721774093
-        assert z == 181.06811018121837
+        assert np.isclose(th, 29.443241721774093)
+        assert np.isclose(z, 181.06811018121837)
         th, z = energy.calc_geometry(energy=6)
-        assert th == 55.01163934185574
-        assert z == -109.32912449140694
+        assert np.isclose(th, 55.01163934185574)
+        assert np.isclose(z, -109.32912449140694)
 
 
 def test_calc_geometry_si(fake_energy_si):
@@ -429,21 +429,21 @@ def test_calc_geometry_si(fake_energy_si):
     with patch("pcdsdevices.lodcm.LODCMEnergySi.get_reflection",
                return_value=(1, 1, 1)):
         th, z = energy.calc_geometry(energy=10)
-        assert th == 11.402710639982848
-        assert z == 713.4828146545175
+        assert np.isclose(th, 11.402710639982848)
+        assert np.isclose(z, 713.4828146545175)
         th, z = energy.calc_geometry(energy=6)
-        assert th == 19.23880622548293
-        assert z == 377.45432488131866
+        assert np.isclose(th, 19.23880622548293)
+        assert np.isclose(z, 377.45432488131866)
 
     logger.info('Testing with Si, (2, 2, 0)')
     with patch("pcdsdevices.lodcm.LODCMEnergySi.get_reflection",
                return_value=(2, 2, 0)):
         th, z = energy.calc_geometry(energy=10)
-        assert th == 18.835297041786244
-        assert z == 388.56663653387835
+        assert np.isclose(th, 18.835297041786244)
+        assert np.isclose(z, 388.56663653387835)
         th, z = energy.calc_geometry(energy=6)
-        assert th == 32.55312408478254
-        assert z == 139.21560118646275
+        assert np.isclose(th, 32.55312408478254)
+        assert np.isclose(z, 139.21560118646275)
 
 
 def test_get_energy_c(fake_energy_c):
@@ -456,7 +456,7 @@ def test_get_energy_c(fake_energy_c):
         # current th1C.wm() should be 23
         assert energy.th1C.wm() == 23
         res = energy.get_energy()
-        assert res == 7.7039801344046515
+        assert np.isclose(res, 7.7039801344046515)
 
 
 def test_get_energy_si(fake_energy_si):
@@ -469,7 +469,7 @@ def test_get_energy_si(fake_energy_si):
         # current th1Si.wm() should be 23
         assert energy.th1Si.wm() == 23
         res = energy.get_energy()
-        assert res == 5.059840436879476
+        assert np.isclose(res, 5.059840436879476)
 
 
 def test_forward_si(fake_energy_si):
@@ -479,7 +479,7 @@ def test_forward_si(fake_energy_si):
     with patch("pcdsdevices.lodcm.LODCMEnergySi.get_reflection",
                return_value=(1, 1, 1)):
         res = energy.get_energy()
-        assert res == 5.059840436879476
+        assert np.isclose(res, 5.059840436879476)
         res = energy.forward(5.059840436879476)
         assert np.isclose(res.dr, 46)
         assert np.isclose(res.th1Si, 23)
@@ -495,7 +495,7 @@ def test_forward_c(fake_energy_c):
     with patch("pcdsdevices.lodcm.LODCMEnergyC.get_reflection",
                return_value=(1, 1, 1)):
         res = energy.get_energy()
-        assert res == 7.7039801344046515
+        assert np.isclose(res, 7.7039801344046515)
         res = energy.forward(7.7039801344046515)
         assert np.isclose(res.dr, 46)
         assert np.isclose(res.th1C, 23)

--- a/pcdsdevices/tests/test_lodcm.py
+++ b/pcdsdevices/tests/test_lodcm.py
@@ -5,10 +5,10 @@ import numpy as np
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.epics_motor import OffsetMotor
-from pcdsdevices.lodcm import (CHI1, CHI2, H1N, H2N, LODCM, Y1, Y2, Dectris,
-                               Diode, Foil, LODCMEnergyC, LODCMEnergySi,
-                               SimFirstTower, SimLODCM, SimSecondTower, YagLom)
+from ..epics_motor import OffsetMotor
+from ..lodcm import (CHI1, CHI2, H1N, H2N, LODCM, Y1, Y2, Dectris, Diode, Foil,
+                     LODCMEnergyC, LODCMEnergySi, SimFirstTower, SimLODCM,
+                     SimSecondTower, YagLom)
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +285,7 @@ def test_tweak_parallel(fake_lodcm):
         assert lom.z2.wm() == 2.761514560357321 * 2
 
 
-def test_set_energy(fake_lodcm, monkeypatch):
+def test_set_energy(fake_lodcm):
     lom = fake_lodcm
     lom.set_energy(10, material='Si', reflection=(1, 1, 1))
 

--- a/pcdsdevices/tests/test_lxe.py
+++ b/pcdsdevices/tests/test_lxe.py
@@ -8,10 +8,9 @@ from ophyd.sim import make_fake_device
 from ophyd.status import StatusTimeoutError
 from ophyd.status import wait as wait_status
 
-from pcdsdevices.lxe import (LaserEnergyPlotContext, LaserEnergyPositioner,
-                             LaserTiming, LaserTimingCompensation)
-from pcdsdevices.utils import convert_unit
-
+from ..lxe import (LaserEnergyPlotContext, LaserEnergyPositioner, LaserTiming,
+                   LaserTimingCompensation)
+from ..utils import convert_unit
 from .conftest import MODULE_PATH
 
 logger = logging.getLogger(__name__)

--- a/pcdsdevices/tests/test_mirror.py
+++ b/pcdsdevices/tests/test_mirror.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.mirror import KBOMirror, OffsetMirror, PointingMirror
+from ..mirror import KBOMirror, OffsetMirror, PointingMirror
 
 
 @pytest.fixture(scope='function')

--- a/pcdsdevices/tests/test_movablestand.py
+++ b/pcdsdevices/tests/test_movablestand.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.movablestand import MovableStand
+from ..movablestand import MovableStand
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_mpod.py
+++ b/pcdsdevices/tests/test_mpod.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.device_types import MPOD, MPODChannelHV, MPODChannelLV
-from pcdsdevices.mpod import MPODChannel, get_card_number
+from ..device_types import MPOD, MPODChannelHV, MPODChannelLV
+from ..mpod import MPODChannel, get_card_number
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_mpod_apalis.py
+++ b/pcdsdevices/tests/test_mpod_apalis.py
@@ -3,8 +3,8 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.device_types import MPODApalisModule4Channel
-from pcdsdevices.mpod_apalis import MPODApalisChannel, MPODApalisCrate
+from ..device_types import MPODApalisModule4Channel
+from ..mpod_apalis import MPODApalisChannel, MPODApalisCrate
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_mps.py
+++ b/pcdsdevices/tests/test_mps.py
@@ -6,9 +6,8 @@ import pytest
 from ophyd import Device
 from ophyd.sim import make_fake_device
 
-import pcdsdevices.mps as mps_module
-from pcdsdevices.mps import (MPS, MPSLimits, mps_factory, must_be_known,
-                             must_be_out)
+from .. import mps as mps_module
+from ..mps import MPS, MPSLimits, mps_factory, must_be_known, must_be_out
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_pim.py
+++ b/pcdsdevices/tests/test_pim.py
@@ -4,8 +4,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.pim import (PIM, PIMY, PPM, XPIM, PIMWithBoth, PIMWithFocus,
-                             PIMWithLED)
+from ..pim import PIM, PIMY, PPM, XPIM, PIMWithBoth, PIMWithFocus, PIMWithLED
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_positioner.py
+++ b/pcdsdevices/tests/test_positioner.py
@@ -4,8 +4,8 @@ import pytest
 from ophyd.signal import Signal
 from ophyd.utils import StatusTimeoutError
 
-from pcdsdevices.positioner import FuncPositioner
-from pcdsdevices.sim import FastMotor, SlowMotor
+from ..positioner import FuncPositioner
+from ..sim import FastMotor, SlowMotor
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_pseudopos.py
+++ b/pcdsdevices/tests/test_pseudopos.py
@@ -5,11 +5,10 @@ import pytest
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
 
-from pcdsdevices.pseudopos import (DelayBase, LookupTablePositioner,
-                                   OffsetMotorBase, PseudoSingleInterface,
-                                   SimDelayStage, SyncAxesBase, SyncAxis,
-                                   SyncAxisOffsetMode)
-from pcdsdevices.sim import FastMotor
+from ..pseudopos import (DelayBase, LookupTablePositioner, OffsetMotorBase,
+                         PseudoSingleInterface, SimDelayStage, SyncAxesBase,
+                         SyncAxis, SyncAxisOffsetMode)
+from ..sim import FastMotor
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_pulsepicker.py
+++ b/pcdsdevices/tests/test_pulsepicker.py
@@ -7,8 +7,8 @@ import pytest
 from ophyd.sim import make_fake_device
 from ophyd.status import wait as status_wait
 
-from pcdsdevices.inout import InOutRecordPositioner
-from pcdsdevices.pulsepicker import PulsePickerInOut
+from ..inout import InOutRecordPositioner
+from ..pulsepicker import PulsePickerInOut
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_pump.py
+++ b/pcdsdevices/tests/test_pump.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.pump import IonPump, IonPumpBase, IonPumpWithController
+from ..pump import IonPump, IonPumpBase, IonPumpWithController
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_ref.py
+++ b/pcdsdevices/tests/test_ref.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from pcdsdevices.ref import ReflaserL2SI
+from ..ref import ReflaserL2SI
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_sample_delivery.py
+++ b/pcdsdevices/tests/test_sample_delivery.py
@@ -3,8 +3,8 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.sample_delivery import (HPLC, PCM, CoolerShaker,
-                                         FlowIntegrator, GasManifold, Selector)
+from ..sample_delivery import (HPLC, PCM, CoolerShaker, FlowIntegrator,
+                               GasManifold, Selector)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_sequencer.py
+++ b/pcdsdevices/tests/test_sequencer.py
@@ -6,7 +6,7 @@ from bluesky.plan_stubs import sleep
 from bluesky.preprocessors import fly_during_wrapper, run_wrapper
 from ophyd.sim import NullStatus, make_fake_device
 
-from pcdsdevices.sequencer import EventSequencer
+from ..sequencer import EventSequencer
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_signal.py
+++ b/pcdsdevices/tests/test_signal.py
@@ -6,9 +6,9 @@ import pytest
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
 from ophyd.sim import FakeEpicsSignal
 
-import pcdsdevices
-from pcdsdevices.signal import (AvgSignal, PytmcSignal, SignalEditMD,
-                                UnitConversionDerivedSignal)
+from .. import signal as signal_module
+from ..signal import (AvgSignal, PytmcSignal, SignalEditMD,
+                      UnitConversionDerivedSignal)
 
 logger = logging.getLogger(__name__)
 
@@ -129,8 +129,8 @@ def test_unit_conversion_signal_metadata_sub(unit_conv_signal):
 
 
 def test_optional_epics_signal(monkeypatch):
-    monkeypatch.setattr(pcdsdevices.signal, 'EpicsSignal', FakeEpicsSignal)
-    opt = pcdsdevices.signal._OptionalEpicsSignal('test', name='opt')
+    monkeypatch.setattr(signal_module, 'EpicsSignal', FakeEpicsSignal)
+    opt = signal_module._OptionalEpicsSignal('test', name='opt')
 
     opt._epics_signal.put(123)
 
@@ -164,8 +164,8 @@ def test_optional_epics_signal(monkeypatch):
 
 
 def test_pvnotepad_signal(monkeypatch):
-    monkeypatch.setattr(pcdsdevices.signal, 'EpicsSignal', FakeEpicsSignal)
-    sig = pcdsdevices.signal.NotepadLinkedSignal(
+    monkeypatch.setattr(signal_module, 'EpicsSignal', FakeEpicsSignal)
+    sig = signal_module.NotepadLinkedSignal(
         read_pv='__abc123',
         attr_name='sig',  # pretend this was created with a component
         name='sig',

--- a/pcdsdevices/tests/test_slits.py
+++ b/pcdsdevices/tests/test_slits.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.slits import BeckhoffSlits, LusiSlits, SimLusiSlits
+from ..slits import BeckhoffSlits, LusiSlits, SimLusiSlits
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_spectrometer.py
+++ b/pcdsdevices/tests/test_spectrometer.py
@@ -3,8 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.spectrometer import (Kmono, VonHamos4Crystal, VonHamosFE,
-                                      VonHamosFER)
+from ..spectrometer import Kmono, VonHamos4Crystal, VonHamosFE, VonHamosFER
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_state.py
+++ b/pcdsdevices/tests/test_state.py
@@ -6,8 +6,8 @@ from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.state import (PVStatePositioner, StatePositioner,
-                               StateRecordPositioner, StateStatus)
+from ..state import (PVStatePositioner, StatePositioner, StateRecordPositioner,
+                     StateStatus)
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_targets.py
+++ b/pcdsdevices/tests/test_targets.py
@@ -3,10 +3,9 @@ import pytest
 import yaml
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.sim import FastMotor
-from pcdsdevices.targets import (XYGridStage, convert_to_physical,
-                                 get_unit_meshgrid, mesh_interpolation,
-                                 snake_grid_list)
+from ..sim import FastMotor
+from ..targets import (XYGridStage, convert_to_physical, get_unit_meshgrid,
+                       mesh_interpolation, snake_grid_list)
 
 
 @pytest.fixture(scope='function')

--- a/pcdsdevices/tests/test_timetool.py
+++ b/pcdsdevices/tests/test_timetool.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.timetool import Timetool, TimetoolWithNav
+from ..timetool import Timetool, TimetoolWithNav
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_ui.py
+++ b/pcdsdevices/tests/test_ui.py
@@ -1,6 +1,6 @@
 from typhos.utils import DISPLAY_PATHS
 
-from pcdsdevices.ui import path
+from ..ui import path
 
 
 def test_ui_entry_point():

--- a/pcdsdevices/tests/test_utils.py
+++ b/pcdsdevices/tests/test_utils.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-import pcdsdevices.utils as util
+from .. import utils
 
 try:
     import pty
@@ -40,7 +40,7 @@ def input_later(sim_input, inp, delay=0.1):
 def test_is_input(sim_input):
     logger.debug('test_is_input')
     sim_input.write('a\n')
-    assert util.is_input()
+    assert utils.is_input()
 
 
 @pytest.mark.skipif(
@@ -51,7 +51,7 @@ def test_is_input(sim_input):
 def test_get_input_waits(sim_input):
     logger.debug('test_get_input_waits')
     input_later(sim_input, 'a\n', delay=2)
-    assert util.get_input() == 'a'
+    assert utils.get_input() == 'a'
 
 
 @pytest.mark.skipif(
@@ -61,8 +61,8 @@ def test_get_input_waits(sim_input):
 @pytest.mark.timeout(0.5)
 def test_get_input_arrow(sim_input):
     logger.debug('test_get_input_arrow')
-    input_later(sim_input, util.arrow_up + '\n')
-    assert util.get_input() == util.arrow_up
+    input_later(sim_input, utils.arrow_up + '\n')
+    assert utils.get_input() == utils.arrow_up
 
 
 @pytest.mark.skipif(
@@ -72,8 +72,8 @@ def test_get_input_arrow(sim_input):
 @pytest.mark.timeout(0.5)
 def test_get_input_shift_arrow(sim_input):
     logger.debug('test_get_input_arrow')
-    input_later(sim_input, util.shift_arrow_up + '\n')
-    assert util.get_input() == util.shift_arrow_up
+    input_later(sim_input, utils.shift_arrow_up + '\n')
+    assert utils.get_input() == utils.shift_arrow_up
 
 
 @pytest.mark.skipif(
@@ -85,23 +85,24 @@ def test_cbreak(sim_input):
     logger.debug('test_cbreak')
     # send the ctrl+c character
     input_later(sim_input, '\x03\n')
-    assert util.get_input() == '\n'
+    assert utils.get_input() == '\n'
 
 
 def test_get_status_value():
     dummy_dictionary = {'dict1': {'dict2': {'value': 23}}}
-    res = util.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'value')
+    res = utils.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'value')
     assert res == 23
-    res = util.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'blah')
+    res = utils.get_status_value(dummy_dictionary, 'dict1', 'dict2', 'blah')
     assert res == 'N/A'
 
 
 def test_get_status_float():
     dummy_dictionary = {'dict1': {'dict2': {'value': 23.34343}}}
-    res = util.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'value')
+    res = utils.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'value')
     assert res == '23.3434'
-    res = util.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'blah')
+    res = utils.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'blah')
     assert res == 'N/A'
-    res = util.get_status_float(dummy_dictionary, 'dict1', 'dict2', 'value',
-                                precision=3)
+    res = utils.get_status_float(
+        dummy_dictionary, 'dict1', 'dict2', 'value', precision=3
+    )
     assert res == '23.343'

--- a/pcdsdevices/tests/test_valve.py
+++ b/pcdsdevices/tests/test_valve.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from pcdsdevices.valve import GateValve, InterlockError, PPSStopper, Stopper
+from ..valve import GateValve, InterlockError, PPSStopper, Stopper
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/tests/test_variety.py
+++ b/pcdsdevices/tests/test_variety.py
@@ -4,9 +4,9 @@ import ophyd
 import pytest
 import schema
 
-from pcdsdevices import tags
-from pcdsdevices.variety import (expand_dotted_dict, get_metadata,
-                                 set_metadata, validate_metadata)
+from .. import tags
+from ..variety import (expand_dotted_dict, get_metadata, set_metadata,
+                       validate_metadata)
 
 # A sentinel indicating the validated metadata should match the provided
 # metadata exactly

--- a/pcdsdevices/tests/test_wfs.py
+++ b/pcdsdevices/tests/test_wfs.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from pcdsdevices.wfs import WaveFrontSensorTarget
+from ..wfs import WaveFrontSensorTarget
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Relative imports in tests
* Miscellaneous floating point fixes
* CCM test failure when run individually or quickly (if it runs < 10 seconds after startup, it will fail)
* `np.isclose` for reference uses `rtol=1e-05, atol=1e-08` which I think is fine here

## Motivation and Context
This is mostly maintenance cleanup.
Closes #892 
Closes #864 

## How Has This Been Tested?
Test suite.

## Where Has This Been Documented?
Relevant issues

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
