### PR TITLE
MNT: fix up all stop methods

### DIFF
--- a/docs/source/upcoming_release_notes/344-stop_methods.rst
+++ b/docs/source/upcoming_release_notes/344-stop_methods.rst
@@ -1,0 +1,31 @@
+344 stop_methods
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- All stop methods now use the ophyd-defined signature, including a
+  keyword-only ``success`` boolean.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -24,7 +24,7 @@ class TurboPump(BaseInterface, Device):
         """Start the Turbo Pump"""
         self.start.put(1)
 
-    def stop(self):
+    def stop(self, *, success: bool = False):
         """Start the Turbo Pump"""
         self.start.put(0)
 
@@ -39,7 +39,7 @@ class EbaraPump(BaseInterface, Device):
         """Start the Turbo Pump"""
         self.start.put(1)
 
-    def stop(self):
+    def stop(self, *, success: bool = False):
         """Start the Turbo Pump"""
         self.start.put(0)
 

--- a/pcdsdevices/sequencer.py
+++ b/pcdsdevices/sequencer.py
@@ -328,7 +328,7 @@ class EventSequencer(BaseInterface, Device, MonitorFlyerMixin, FlyerInterface):
         st = SubscriptionStatus(self.play_status, done, run=True)
         return st
 
-    def stop(self):
+    def stop(self, *, success: bool = False):
         """Stop the EventSequencer."""
         logger.debug("Stopping the EventSequencer")
         self.play_control.put(0)

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -81,7 +81,7 @@ class SlowMotor(FastMotor):
                              args=(self, position))
         t.start()
 
-    def stop(self):
+    def stop(self, *, success: bool = False):
         self._stop = True
 
 

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -437,7 +437,7 @@ class StateRecordPositioner(StateRecordPositionerBase):
             self._has_subscribed_readback = True
         return cid
 
-    def stop(self, *, success=False):
+    def stop(self, *, success: bool = False):
         return self.motor.stop(success=success)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
ophyd expects a kwarg-only boolean `success` in `stop` methods.

ref. https://github.com/bluesky/ophyd/blob/810eae0894e3f349ea043f7e22ff49450c88af5a/ophyd/device.py#L1325

## Motivation and Context
Closes #344 

## How Has This Been Tested?
Test suite

## Where Has This Been Documented?
Pre-release notes

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
