### PR TITLE
MNT: lodcm calc should not raise in background thread

### DIFF
--- a/docs/source/upcoming_release_notes/900-lodcm-nan.rst
+++ b/docs/source/upcoming_release_notes/900-lodcm-nan.rst
@@ -1,5 +1,5 @@
 900 lodcm-nan
-#################
+#############
 
 API Changes
 -----------
@@ -19,10 +19,11 @@ New Devices
 
 Bugfixes
 --------
-- In the LODCM calculation callback updates, return a NaN energy instead of
-  raising an exception in background thread when there is a problem
-  determining the crystal orientation. This prevents the calculated value
-  from going stale when it has become invalid, and it prevents logger spam.
+- In the LODCM "inverse" calculations, return a NaN energy instead of
+  raising an exception when there is a problem determining the crystal
+  orientation. This prevents the calculated value from going stale when
+  it has become invalid, and it prevents logger spam when this is
+  called in the pseudopositioner update position callback.
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/900-lodcm-nan.rst
+++ b/docs/source/upcoming_release_notes/900-lodcm-nan.rst
@@ -1,0 +1,33 @@
+900 lodcm-nan
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- In the LODCM calculation callback updates, return a NaN energy instead of
+  raising an exception in background thread when there is a problem
+  determining the crystal orientation. This prevents the calculated value
+  from going stale when it has become invalid, and it prevents logger spam.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -897,7 +897,10 @@ class LODCMEnergySi(FltMvInterface, PseudoPositioner, GroupDevice):
         pseudo_pos : PseudoPosition
             The pseudo position output.
         """
-        reflection = self.get_reflection()
+        try:
+            reflection = self.get_reflection()
+        except Exception:
+            return self.PseudoPosition(energy=np.NaN)
         real_pos = self.RealPosition(*real_pos)
         length = (2 * np.sin(np.deg2rad(real_pos.th1Si))
                     * diffraction.d_space('Si', reflection))
@@ -1114,7 +1117,10 @@ class LODCMEnergyC(FltMvInterface, PseudoPositioner, GroupDevice):
         pseudo_pos : PseudoPosition
             The pseudo position output.
         """
-        reflection = self.get_reflection()
+        try:
+            reflection = self.get_reflection()
+        except Exception:
+            return self.PseudoPosition(energy=np.NaN)
         real_pos = self.RealPosition(*real_pos)
         length = (2 * np.sin(np.deg2rad(real_pos.th1C))
                     * diffraction.d_space('C', reflection))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If our two crystal orientations do not match, make the calculation NaN instead of throwing an exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`inverse` is called in a callback, so if it throws an exception it ~barfs all over the screen~
It no longer spams the screen due to other changes since making this PR, but it still spams the logfile and it means we'll either have no value stored for the pseudoposition, or a stale value in the case of this error state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
