### PR TITLE
ENH: add user enable PV

### DIFF
--- a/docs/source/upcoming_release_notes/901-bk-user-enable.rst
+++ b/docs/source/upcoming_release_notes/901-bk-user-enable.rst
@@ -1,0 +1,34 @@
+901 bk-user-enable
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add the user_enable signal (bUserEnable) to the BeckhoffAxisPLC class.
+  This is a signal that allows the user to unilaterally disable a
+  running motor's power. When enabled, it is up to the controller
+  whether or not to actually power the motor, but when disabled the
+  power will be shut off.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -937,6 +937,8 @@ class BeckhoffAxisPLC(Device):
                    doc='Start TwinCAT homing routine.')
     home_pos = Cpt(PytmcSignal, 'fHomePosition', io='io', kind='config',
                    doc='Numeric position of home.')
+    user_enable = Cpt(PytmcSignal, 'bUserEnable', io='io', kind='config',
+                      doc='Power enable/disable')
 
     set_metadata(err_code, dict(variety='scalar', display_format='hex'))
     set_metadata(cmd_err_reset, dict(variety='command', value=1))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PV was added back in March, let's include it in the screen.
This new signal will allow the user to cut power to their motors via EPICS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PV exists and would have been useful very recently with a runaway motor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only interactively:

![image](https://user-images.githubusercontent.com/10647860/141860539-0bcffd5d-8ec3-42b9-9c58-eedc7a4ad72e.png)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
