### PR TITLE
ENH: update to the new ephot pvs and add tests

### DIFF
--- a/docs/source/upcoming_release_notes/905-ephot-pvs.rst
+++ b/docs/source/upcoming_release_notes/905-ephot-pvs.rst
@@ -1,0 +1,32 @@
+905 ephot-pvs
+#############
+
+API Changes
+-----------
+- Switch the target PVs for BeamEnergyRequest from e.g. "XPP:USR:MCC:EPHOT" to
+  e.g. "XPP:USR:MCC:EPHOT:SET1", "RIX:USR:MCC:EPHOTK:SET1".
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add the ability for BeamEnergyRequest to write to PVs for either
+  the K or the L line and for either bunch 1 or bunch 2 in two bunch mode.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,7 +1,10 @@
 import logging
+import numbers
+import typing
 
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
+from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 
 from .interface import BaseInterface
@@ -63,17 +66,51 @@ class BeamEnergyRequest(PVPositionerDone):
     atol: int, optional
         Absolute tolerance that determines when the move is done and when to
         skip moves using the skip_small_moves parameter.
+
+    line: str, optional
+        Whether to use the K line or L line PV. If provided this should be a
+        string with a single character. The K line PVs have "EPHOTK"
+        in them, the L line PVs just have "EPHOT". This will default to the
+        line associated with the prefix hutch name, or to L line failing that.
+
+    bunch: int, optional
+        Whether to move the first bunch (1) or the second bunch (2). This is
+        only relevant for 2-color mode. Defaults to bunch 1.
     """
 
     # Default vernier tolerance
     atol = 5
 
-    setpoint = Cpt(EpicsSignal, ':USER:MCC:EPHOT', kind='hinted')
+    setpoint = FCpt(
+        EpicsSignal,
+        '{prefix}:USER:MCC:EPHOT{line_text}:SET{bunch}',
+        kind='hinted',
+    )
 
-    def __init__(self, prefix, *, name, skip_small_moves=True, atol=None,
-                 **kwargs):
+    line_text_dict = {
+        'K': 'K',
+        'L': '',
+    }
+    for k_hutch in ('k', 'TMO', 'RIX'):
+        line_text_dict[k_hutch] = line_text_dict['K']
+    for l_hutch in ('l', 'XPP', 'XCS', 'MFX', 'CXI', 'MEC'):
+        line_text_dict[l_hutch] = line_text_dict['L']
+
+    def __init__(
+        self,
+        prefix: str,
+        *,
+        name: str,
+        skip_small_moves: bool = True,
+        atol: typing.Optional[numbers.Real] = None,
+        line: typing.Optional[str] = None,
+        bunch: int = 1,
+        **kwargs
+    ):
         if atol is not None:
             self.atol = atol
+        self.line_text = self.line_text_dict.get(line or prefix, '')
+        self.bunch = bunch
         super().__init__(prefix, name=name, skip_small_moves=skip_small_moves,
                          **kwargs)
 

--- a/pcdsdevices/tests/test_beam_stats.py
+++ b/pcdsdevices/tests/test_beam_stats.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from ..beam_stats import LCLS, BeamStats
+from ..beam_stats import LCLS, BeamEnergyRequest, BeamStats
 
 logger = logging.getLogger(__name__)
 
@@ -86,3 +86,26 @@ def test_get_set_period(fake_lcls):
     assert lcls.bykik_get_period() == 200
     lcls.bykik_set_period(100)
     assert lcls.bykik_get_period() == 100
+
+
+def test_beam_energy_request_args():
+    # Defaults for xpp and tmo
+    xpp_request = BeamEnergyRequest('XPP', name='xpp_request')
+    assert xpp_request.setpoint.pvname == 'XPP:USER:MCC:EPHOT:SET1'
+    tmo_request = BeamEnergyRequest('TMO', name='tmo_request')
+    assert tmo_request.setpoint.pvname == 'TMO:USER:MCC:EPHOTK:SET1'
+    # Future TXI and multi-bunch specific options
+    tst_k1_request = BeamEnergyRequest(
+        'TST',
+        name='tst_k1_request',
+        line='k',
+        bunch=1,
+    )
+    assert tst_k1_request.setpoint.pvname == 'TST:USER:MCC:EPHOTK:SET1'
+    tst_l2_request = BeamEnergyRequest(
+        'TST',
+        name='tst_l2_request',
+        line='L',
+        bunch=2,
+    )
+    assert tst_l2_request.setpoint.pvname == 'TST:USER:MCC:EPHOT:SET2'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Update the `BeamEnergyRequest` class to point to the newly defined PVs
- Add support for K line additional letter and 1st vs 2nd bunch for `SET1` vs `SET2`
- Set the defaults for the new arguments such that the correct config is chosen for the existing hutches. That is, existing uses of `BeamEnergyRequest` will continue to work the same, just pointing to the new PV.
- Add tests to make sure I did it right

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We're standardizing our PVs that we use to communicate with the ACR about scanning changes for the Vernier and Undulators, so we'll stop using the previous PVs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added tests that the setpoint PVs are chosen correctly for XPP and TMO, and that a theoretical 2 bunch TXI would be able to select the PVs it needs.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I've added type annotations and docstrings, I'll also add a pre-release notes entry.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
