### PR TITLE
FIX: repr pretty and CCM status print exceptions

### DIFF
--- a/docs/source/upcoming_release_notes/908-fix_repr_pretty.rst
+++ b/docs/source/upcoming_release_notes/908-fix_repr_pretty.rst
@@ -1,0 +1,32 @@
+908 fix_repr_pretty
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- CCM status representation fixed in certain situations. (#908)
+- Exceptions will no longer be raised when generating device status
+  representations. (#909)
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -979,7 +979,7 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
         try:
             xavg = np.average([float(x_down), float(x_up)])
             xavg = f'{xavg:.3f}'
-        except TypeError:
+        except Exception:
             xavg = 'N/A'
 
         # Fill out the text

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -260,7 +260,6 @@ class BaseInterface:
             status_text = (f'{self}: Error showing status information. '
                            'Check IOC connection and device health.')
             logger.debug(status_text, exc_info=True)
-            raise
         pp.text(status_text)
 
     def status(self) -> str:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Status prints should not fail miserably. Make it so.

## Motivation and Context
Closes #908 
Closes #909

## How Has This Been Tested?
Local testing.

## Where Has This Been Documented?
Release notes.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
