### PR TITLE
MNT: MD error log, DOC: release notes

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,18 @@
 Release History
 ###############
 
+v5.0.2 (2021-12-02)
+===================
+
+Bugfixes
+--------
+- Fix issue where EpicsSignalEditMD could log enum error messages
+  for signals that did not edit their enum metadata.
+
+Contributors
+------------
+- zllentz
+
 
 v5.0.1 (2021-11-19)
 ===================
@@ -14,7 +26,6 @@ Bugfixes
 Contributors
 ------------
 - klauer
-
 
 
 v5.0.0 (2021-11-15)

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -988,10 +988,11 @@ class EpicsSignalBaseEditMD(EpicsSignalBase, SignalEditMD):
             "enum_strs", None
         ) or []
         if not self._original_enum_strings:
-            self.log.error(
-                "No enum strings on %r; was %r used inappropriately?",
-                self.pvname, type(self).__name__
-            )
+            if self._enum_string_override:
+                self.log.error(
+                    "No enum strings on %r; was %r used inappropriately?",
+                    self.pvname, type(self).__name__
+                )
             return
 
         if self._enum_count == 0:

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -984,15 +984,17 @@ class EpicsSignalBaseEditMD(EpicsSignalBase, SignalEditMD):
 
     def _check_signal_metadata(self):
         """Check the original enum strings to compare the attributes."""
+        if not self._enum_string_override:
+            return
+
         self._original_enum_strings = self._metadata.get(
             "enum_strs", None
         ) or []
         if not self._original_enum_strings:
-            if self._enum_string_override:
-                self.log.error(
-                    "No enum strings on %r; was %r used inappropriately?",
-                    self.pvname, type(self).__name__
-                )
+            self.log.error(
+                "No enum strings on %r; was %r used inappropriately?",
+                self.pvname, type(self).__name__
+            )
             return
 
         if self._enum_count == 0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Only show the md error log when we've edited the metadata.
- Achieve this by aborting the metadata checker when we did not edit the metadata.
- Add release notes for bugfix release to include in the 5.1.1 env

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- closes #914 
- env release is today

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Before:
```
In [1]: from pcdsdevices.epics_motor import Newport

In [2]: mot = Newport('XPP:LAS:MMN:02', name='mot')

No enum strings on 'XPP:LAS:MMN:02.RBV'; was 'EpicsSignalROEditMD' used inappropriately?
No enum strings on 'XPP:LAS:MMN:02.RBV'; was 'EpicsSignalROEditMD' used inappropriately?
No enum strings on 'XPP:LAS:MMN:02.VAL'; was 'EpicsSignalEditMD' used inappropriately?
```
After:
```
In [1]: from pcdsdevices.epics_motor import Newport

In [2]: mot = Newport('XPP:LAS:MMN:02', name='mot')

```
(no message after)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
