### PR TITLE
Add in classes for qadc digitizers

### DIFF
--- a/docs/source/upcoming_release_notes/918-Add_classes_for_qadcs.rst
+++ b/docs/source/upcoming_release_notes/918-Add_classes_for_qadcs.rst
@@ -1,0 +1,33 @@
+918 Add classes for qadcs
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- QadcBase: Base class for qadc digitizers
+- Qadc: Class for FMC126 (old) digitizers
+- QadcSparsification: Class for holding FMC134 sparsification PVs.
+- Qadc134: Class for FMC134 (new) digitizers 
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson 

--- a/pcdsdevices/digitizers.py
+++ b/pcdsdevices/digitizers.py
@@ -605,3 +605,114 @@ class Wave8V2(Wave8V2Simple):
     xpm_mini = Cpt(Wave8V2XpmMini, ':XpmMini')
 
     xpm_msg = Cpt(Wave8V2XpmMsg, ':TrEvent')
+
+
+class QadcBase(BaseInterface, Device):
+    """
+    Base class common to all qadc digitizers.
+    """
+    ch0 = Cpt(EpicsSignalRO, ":CH0", kind="normal")
+    ch1 = Cpt(EpicsSignalRO, ":CH1", kind="normal")
+    ch2 = Cpt(EpicsSignalRO, ":CH2", kind="normal")
+    ch3 = Cpt(EpicsSignalRO, ":CH3", kind="normal")
+
+    config = Cpt(EpicsSignal, ":CONFIG", kind="config")
+    set_metadata(config, dict(variety='command-proc', value=1))
+
+
+class Qadc(QadcBase):
+    """
+    Class for older qadc, based on Abaco FMC126.
+    """
+    gain0_i = Cpt(EpicsSignal, ":GAIN0_I", kind="omitted")
+    gain0_ni = Cpt(EpicsSignal, ":GAIN0_NI", kind="omitted")
+    gain1_i = Cpt(EpicsSignal, ":GAIN1_I", kind="omitted")
+    gain1_ni = Cpt(EpicsSignal, ":GAIN1_NI", kind="omitted")
+    gain2_i = Cpt(EpicsSignal, ":GAIN2_I", kind="omitted")
+    gain2_ni = Cpt(EpicsSignal, ":GAIN2_NI", kind="omitted")
+    gain3_i = Cpt(EpicsSignal, ":GAIN3_I", kind="omitted")
+    gain3_ni = Cpt(EpicsSignal, ":GAIN3_NI", kind="omitted")
+
+    ichan = Cpt(EpicsSignal, ":ICHAN", kind="config")
+    interleave = Cpt(EpicsSignal, ":INTERLEAVE", kind="config")
+
+    length = Cpt(EpicsSignal, ":LENGTH", kind="config")
+
+    off0_i = Cpt(EpicsSignal, ":OFF0_I", kind="omitted")
+    off0_ni = Cpt(EpicsSignal, ":OFF0_NI", kind="omitted")
+    off1_i = Cpt(EpicsSignal, ":OFF1_I", kind="omitted")
+    off1_ni = Cpt(EpicsSignal, ":OFF1_NI", kind="omitted")
+    off2_i = Cpt(EpicsSignal, ":OFF2_I", kind="omitted")
+    off2_ni = Cpt(EpicsSignal, ":OFF2_NI", kind="omitted")
+    off3_i = Cpt(EpicsSignal, ":OFF3_I", kind="omitted")
+    off3_ni = Cpt(EpicsSignal, ":OFF3_NI", kind="omitted")
+
+    out = Cpt(EpicsSignalRO, ":OUT", kind="normal")
+
+    rawdata = Cpt(EpicsSignalRO, ":RAWDATA", kind="normal")
+
+    start = Cpt(EpicsSignal, ":START", kind="normal")
+
+    train = Cpt(EpicsSignal, ":TRAIN", kind="omitted")
+
+    trig_delay = Cpt(EpicsSignal, ":TRIG_DELAY", kind="config")
+    trig_event = Cpt(EpicsSignal, ":TRIG_EVENT", kind="config")
+
+
+class Qadc134Sparsification(BaseInterface, Device):
+    """
+    Class for Abaco FMC134, which supports sparsification.
+    """
+    hi_thresh = Cpt(EpicsSignal, ":HI_THRESH_RBV", write_pv=":HI_THRESH",
+                    kind="config")
+    lo_thresh = Cpt(EpicsSignal, ":LO_THRESH_RBV", write_pv=":LO_THRESH",
+                    kind="config")
+
+    sparse_en = Cpt(EpicsSignal, ":SPARSE_EN_RBV", write_pv=":SPARSE_EN",
+                    kind="config", doc="Enable sparse output arrays")
+
+    rows_after = Cpt(EpicsSignal, ":ROWS_AFTER_RBV", write_pv=":ROWS_AFTER",
+                     kind="config")
+    rows_before = Cpt(EpicsSignal, ":ROWS_BEFORE_RBV",
+                      write_pv=":ROWS_BEFORE", kind="config")
+
+    sparse0 = Cpt(EpicsSignalRO, ":SPARSE0", kind="config")
+    sparse1 = Cpt(EpicsSignalRO, ":SPARSE1", kind="config")
+
+
+class Qadc134(QadcBase):
+    """
+    Class for the Abaco FMC134 digitizer card.
+    """
+    sparsification = Cpt(Qadc134Sparsification, '', kind='omitted')
+
+    full_en = Cpt(EpicsSignal, ":FULL_EN_RBV", write_pv=":FULL_EN",
+                  kind="config", doc="Enable full size output arrays")
+
+    ichan = Cpt(EpicsSignal, ":ICHAN_RBV", write_pv=":ICHAN", kind="config",
+                doc="Interleave channel")
+    interleave = Cpt(EpicsSignal, ":INTERLEAVE_RBV", write_pv=":INTERLEAVE",
+                     kind="config", doc="Enable interleaving on ichan")
+
+    length = Cpt(EpicsSignal, ":LENGTH_RBV", write_pv=":LENGTH",
+                 kind="config")
+    prescale = Cpt(EpicsSignal, ":PRESCALE_RBV", write_pv=":PRESCALE",
+                   kind="config")
+
+    trig_delay = Cpt(EpicsSignal, ":TRIG_DELAY_RBV", write_pv=":TRIG_DELAY",
+                     kind="config", doc="Delay in 156.17 MHz ticks")
+    trig_event = Cpt(EpicsSignal, ":TRIG_EVENT_RBV", write_pv=":TRIG_EVENT",
+                     kind="config")
+
+    clear_config = Cpt(EpicsSignal, ":CLEAR_CONFIG", kind="config")
+    set_metadata(clear_config, dict(variety='command-proc', value=1))
+
+    out0 = Cpt(EpicsSignalRO, ":OUT0", kind="normal", doc="Signal in Volts")
+    out1 = Cpt(EpicsSignalRO, ":OUT1", kind="normal", doc="Signal in Volts")
+
+    rawdata0 = Cpt(EpicsSignalRO, ":RAWDATA0", kind="normal",
+                   doc="Signal in ADU")
+    rawdata1 = Cpt(EpicsSignalRO, ":RAWDATA1", kind="normal",
+                   doc="Signal in ADU")
+
+    start = Cpt(EpicsSignal, ":START", kind="normal")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds in classes for the Abaco FMC126 (old) and FMC134 (new) PCIe digitizers. 

## Motivation and Context
Generates typhos screens, enables scripting. 

Closes #918 

## How Has This Been Tested?
Tested by viewing a qadc in CXI, and viewing/configuring a qadc134 in RIX. 

## Where Has This Been Documented?
Docstrings. 


## Screenshots:
Old qadc:
![image](https://user-images.githubusercontent.com/29102919/151631121-72beb407-d6b2-418d-9714-a12ed7d0c954.png)

New qadc:
![image](https://user-images.githubusercontent.com/29102919/151631545-2954ae8c-db6e-4291-bec5-2bf062d37234.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
