### PR TITLE
LAMP_LV_17 motion class addition to lamp_motion.py

### DIFF
--- a/docs/source/upcoming_release_notes/933-lamp_lv_17.rst
+++ b/docs/source/upcoming_release_notes/933-lamp_lv_17.rst
@@ -1,0 +1,30 @@
+933 lamp_lv_17
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Adds a new class to interface with the LAMP motion configuration for LV17.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Mobosum
+
+Contributors
+------------
+- Mbosum

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -106,3 +106,34 @@ class LAMPFlowCell(BaseInterface, GroupDevice):
     flow_cell_y = Cpt(BeckhoffAxis, ':MMS:11', kind='normal')
     flow_cell_z = Cpt(BeckhoffAxis, ':MMS:12', kind='normal')
     flow_cell_theta = Cpt(BeckhoffAxis, ':MMS:13', kind='normal')
+
+class LAMP_LV_17(BaseInterface, GroupDevice):
+      """
+      LAMP Motion Class
+ 
+      This class controls motors fixed to the LAMP Motion system for the IP1
+      endstation in TMO with the Gas Jet, Sample Paddle, and Detector configuration for LV17.
+ 
+      Parameters
+      ----------
+      prefix : str
+          Base PV for the LAMP motion system
+
+     name : str
+         Alias for the device
+     """
+     # UI representation
+     _icon = 'fa.minus-square'
+     tab_component_names = True
+
+     # Motor Component 
+     gas_jet_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+     gas_jet_y = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+     gas_jet_z = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
+
+     sample_paddle_x = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
+     sample_paddle_y = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+     sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
+
+     detector_x = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
+     detector_y = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')

--- a/pcdsdevices/lamp_motion.py
+++ b/pcdsdevices/lamp_motion.py
@@ -107,33 +107,35 @@ class LAMPFlowCell(BaseInterface, GroupDevice):
     flow_cell_z = Cpt(BeckhoffAxis, ':MMS:12', kind='normal')
     flow_cell_theta = Cpt(BeckhoffAxis, ':MMS:13', kind='normal')
 
+
 class LAMP_LV_17(BaseInterface, GroupDevice):
-      """
-      LAMP Motion Class
- 
-      This class controls motors fixed to the LAMP Motion system for the IP1
-      endstation in TMO with the Gas Jet, Sample Paddle, and Detector configuration for LV17.
- 
-      Parameters
-      ----------
-      prefix : str
-          Base PV for the LAMP motion system
+    """
+    LAMP Motion Class
 
-     name : str
-         Alias for the device
-     """
-     # UI representation
-     _icon = 'fa.minus-square'
-     tab_component_names = True
+    This class controls motors fixed to the LAMP Motion system for the IP1
+    endstation in TMO with the Gas Jet, Sample Paddle, and Detector
+    configuration for LV17.
 
-     # Motor Component 
-     gas_jet_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
-     gas_jet_y = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
-     gas_jet_z = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the LAMP motion system
 
-     sample_paddle_x = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
-     sample_paddle_y = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
-     sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
+    name : str
+        Alias for the device
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+    tab_component_names = True
 
-     detector_x = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
-     detector_y = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
+    # Motor Component
+    gas_jet_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    gas_jet_y = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+    gas_jet_z = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
+
+    sample_paddle_x = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
+    sample_paddle_y = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+    sample_paddle_z = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
+
+    detector_x = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
+    detector_y = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added LAMPFlowCell class at the end of lamp_motion.py to connect to motor PVs associated with the x454 configuration of LAMP motion components of the LAMP IP1 endstation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In addition to the Gas Jet, and Sample Paddle manipulators, a 2 axis Detector manipulator has been added for the LV17 configuration of LAMP. These axes need to be reflected in the motion control GUI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the module with flake8 it came back clean:

![Screenshot (498)](https://user-images.githubusercontent.com/50626768/151887679-b4718430-8a05-46c6-84ed-776f99b7a98c.png)


I also tested whether I can make a device with it to verify the PV and component names:
![Screenshot (499)](https://user-images.githubusercontent.com/50626768/151888028-85c6cd49-e4d6-4edd-a206-f2a347d63d24.png)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
There is a docstring for the class.

Confluence documentation is found here:
https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=337052991
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
