### PR TITLE
MNT/FIX: add detailed_tree from typhos and soft-link attenuator screens

### DIFF
--- a/docs/source/upcoming_release_notes/932-atten_screens.rst
+++ b/docs/source/upcoming_release_notes/932-atten_screens.rst
@@ -1,0 +1,31 @@
+932 atten_screens
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- ``detailed_tree.ui`` was vendored from typhos. The default attenuator screens
+- AT2L0, AT1K4, and AT2K2 will now default to ``detailed_tree.ui``.
+
+Contributors
+------------
+- klauer

--- a/docs/source/upcoming_release_notes/932-atten_screens.rst
+++ b/docs/source/upcoming_release_notes/932-atten_screens.rst
@@ -24,7 +24,7 @@ Bugfixes
 Maintenance
 -----------
 - ``detailed_tree.ui`` was vendored from typhos. The default attenuator screens
-- AT2L0, AT1K4, and AT2K2 will now default to ``detailed_tree.ui``.
+  AT2L0, AT1K4, and AT2K2 will now default to ``detailed_tree.ui``.
 
 Contributors
 ------------

--- a/pcdsdevices/ui/AT2L0.detailed.ui
+++ b/pcdsdevices/ui/AT2L0.detailed.ui
@@ -1,0 +1,1 @@
+detailed_tree.ui

--- a/pcdsdevices/ui/AT2L0.embedded.ui
+++ b/pcdsdevices/ui/AT2L0.embedded.ui
@@ -1,0 +1,1 @@
+detailed_tree.ui

--- a/pcdsdevices/ui/AttenuatorSXR_Ladder.detailed.ui
+++ b/pcdsdevices/ui/AttenuatorSXR_Ladder.detailed.ui
@@ -1,0 +1,1 @@
+detailed_tree.ui

--- a/pcdsdevices/ui/AttenuatorSXR_Ladder.embedded.ui
+++ b/pcdsdevices/ui/AttenuatorSXR_Ladder.embedded.ui
@@ -1,0 +1,1 @@
+detailed_tree.ui

--- a/pcdsdevices/ui/detailed_tree.ui
+++ b/pcdsdevices/ui/detailed_tree.ui
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>395</width>
+    <height>468</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphosCompositeSignalPanel" name="signal_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Panel of Signals + Sub-Devices for Device
+    </string>
+     </property>
+     <property name="showOmitted" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosCompositeSignalPanel</class>
+   <extends>TyphosSignalPanel</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Load correct screens without additional clicks for the solid attenuators

## Motivation and Context
Closes #932 as reported by users

## How Has This Been Tested?
Interactive testing with dev typhos

## Where Has This Been Documented?
PR text + issue

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
