### PR TITLE
FIX: EpicsSignalEditMD and state positioner-related fixes

### DIFF
--- a/docs/source/upcoming_release_notes/935-fix_edit_md.rst
+++ b/docs/source/upcoming_release_notes/935-fix_edit_md.rst
@@ -1,0 +1,38 @@
+935 fix_edit_md
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- State names are no longer case-sensitive.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- EpicsSignalEditMD will be more lenient for cases where we have unset
+  metadata strings ("Invalid") from TwinCAT. This fixes recent issues
+  involving terminal spam and failure to update enum strings for
+  devices like the solid attenuators.
+- EpicsSignalEditMD will not send metadata updates until all composite
+  signals have connected and updated us with their values.
+
+Maintenance
+-----------
+- HelpfulIntEnum has been vendored from pcdsutils. This will be
+  switched to an import in a future release.
+
+Contributors
+------------
+- klauer
+- zllentz
+- tangkong

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -144,7 +144,9 @@ class InOutPositioner(StatePositioner):
             self._update_trans_enum(state, default)
 
     def _update_trans_enum(self, state, default):
-        index = self.states_list.index(self.get_state(state).name)
+        if state not in self.states_list:
+            state = self.get_state(state).name
+        index = self.states_list.index(state)
         self._trans_enum[index] = self._transmission.get(state, default)
 
     def _pos_in_list(self, state_list, check_state=None):

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -68,9 +68,15 @@ class InOutPositioner(StatePositioner):
     def _state_init(self):
         super()._state_init()
         if self._in_if_not_out:
-            self.in_states = [state for state in self.states_list
-                              if state not in self.out_states
-                              and state != self._unknown]
+            outish_states = [
+                self.get_state(state).name
+                for state in self.out_states + [self._unknown]
+            ]
+            self.in_states = [
+                state
+                for state in self.states_list
+                if state not in outish_states
+            ]
         self._trans_enum = {}
         self._extend_trans_enum(self.in_states, 0)
         self._extend_trans_enum(self.out_states, 1)

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -138,7 +138,7 @@ class InOutPositioner(StatePositioner):
             self._update_trans_enum(state, default)
 
     def _update_trans_enum(self, state, default):
-        index = self.states_list.index(state)
+        index = self.states_list.index(self.get_state(state).name)
         self._trans_enum[index] = self._transmission.get(state, default)
 
     def _pos_in_list(self, state_list, check_state=None):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -252,18 +252,26 @@ class StatePositioner(MvInterface, Device, PositionerBase):
         # Check for a malformed string digit
         if isinstance(value, str) and value.isdigit():
             value = int(value)
-        try:
-            return self.states_enum[value]
-        except KeyError:
+
+        if isinstance(value, int):
             try:
                 return self.states_enum(value)
             except ValueError:
-                err = ('{0} is not a valid state for {1}. Valid state names '
-                       'are: {2}, and their corresponding values are {3}.')
-                enum_names = [state.name for state in self.states_enum]
-                enum_values = [state.value for state in self.states_enum]
-                raise ValueError(err.format(value, self.name, enum_names,
-                                            enum_values))
+                ...
+        elif isinstance(value, self.states_enum):
+            return value
+        else:
+            for state_enum in self.states_enum:
+                if state_enum.name.lower() == value.lower():
+                    return state_enum
+
+        enum_names = [state.name for state in self.states_enum]
+        enum_values = [state.value for state in self.states_enum]
+        raise ValueError(
+            f"{value} is not a valid state for {self.name}."
+            f"Valid state names are: {enum_names}, "
+            f"and their corresponding values are {enum_values}."
+        )
 
     def _do_move(self, state):
         """

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -111,7 +111,6 @@ class StatePositioner(MvInterface, Device, PositionerBase):
     def _late_state_init(
         self,
         *args,
-        connected: bool = False,
         enum_strs: Optional[List[str]] = None,
         **kwargs
     ):

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -259,25 +259,16 @@ class StatePositioner(MvInterface, Device, PositionerBase):
         if isinstance(value, str) and value.isdigit():
             value = int(value)
 
-        if isinstance(value, int):
-            try:
-                return self.states_enum(value)
-            except ValueError:
-                ...
-        elif isinstance(value, self.states_enum):
-            return value
-        else:
-            for state_enum in self.states_enum:
-                if state_enum.name.lower() == value.lower():
-                    return state_enum
-
-        enum_names = [state.name for state in self.states_enum]
-        enum_values = [state.value for state in self.states_enum]
-        raise ValueError(
-            f"{value} is not a valid state for {self.name}. "
-            f"Valid state names are: {enum_names}, "
-            f"and their corresponding values are {enum_values}."
-        )
+        try:
+            return self.states_enum.from_any(value)
+        except ValueError:
+            enum_names = [state.name for state in self.states_enum]
+            enum_values = [state.value for state in self.states_enum]
+            raise ValueError(
+                f"{value} is not a valid state for {self.name}. "
+                f"Valid state names are: {enum_names}, "
+                f"and their corresponding values are {enum_values}."
+            ) from None
 
     def _do_move(self, state):
         """

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import copy
 import functools
 import logging
-from enum import Enum
 from typing import ClassVar, List, Optional
 
 from ophyd.device import Component as Cpt
@@ -22,6 +21,7 @@ from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .interface import MvInterface
 from .signal import EpicsSignalEditMD, PVStateSignal, PytmcSignal
+from .utils import HelpfulIntEnum
 from .variety import set_metadata
 
 logger = logging.getLogger(__name__)
@@ -318,7 +318,7 @@ class StatePositioner(MvInterface, Device, PositionerBase):
                 for alias in aliases:
                     state_def[alias] = i
         enum_name = self.__class__.__name__ + 'States'
-        enum = Enum(enum_name, state_def, start=0)
+        enum = HelpfulIntEnum(enum_name, state_def, start=0, module=__name__)
         if len(enum) != state_count:
             raise ValueError(('Bad states definition! Inconsistency in '
                               'states_list {} or _states_alias {}'

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import enum
 import operator
 import os
 import select
@@ -6,6 +9,7 @@ import sys
 import threading
 import time
 from functools import reduce
+from typing import Iterator, Union
 
 import ophyd
 import pint
@@ -356,3 +360,97 @@ def doc_format_decorator(**doc_fmts):
         func.__doc__ = func.__doc__.format(**doc_fmts)
         return func
     return inner_decorator
+
+
+EnumId = Union[enum.Enum, int, str]
+
+
+class HelpfulIntEnumMeta(enum.EnumMeta):
+    def __getattr__(self, key):
+        if hasattr(key, "lower"):
+            for item in self:
+                if item.name.lower() == key.lower():
+                    return item
+        return super().__getattr__(key)
+
+    def __getitem__(self, key):
+        if hasattr(key, "lower"):
+            for item in self:
+                if item.name.lower() == key.lower():
+                    return item
+        return super().__getitem__(key)
+
+
+class HelpfulIntEnum(enum.IntEnum, metaclass=HelpfulIntEnumMeta):
+    """
+    IntEnum subclass with some utility extensions and case insensitivity.
+    """
+
+    @classmethod
+    def from_any(cls, identifier: EnumId) -> HelpfulIntEnum:
+        """
+        Try all the ways to interpret identifier as the enum.
+        This is intended to consolidate the try/except tree typically used
+        to interpret external input as an enum.
+
+        Parameters
+        ----------
+        identifier : EnumId
+            Any str, int, or Enum value that corresponds with a valid value
+            on this HelpfulIntEnum instance.
+
+        Returns
+        -------
+        enum : HelpfulIntEnum
+            The corresponding enum object associated with the identifier.
+        """
+        try:
+            return cls[identifier]
+        except KeyError:
+            return cls(identifier)
+
+    @classmethod
+    def include(
+        cls,
+        identifiers: Iterator[EnumId],
+    ) -> set[HelpfulIntEnum]:
+        """
+        Returns all enum values matching the identifiers given.
+        This is a shortcut for calling cls.from_any many times and
+        assembling a set of the results.
+
+        Parameters
+        ----------
+        identifiers : Iterator[EnumId]
+            Any iterable that contains strings, ints, and Enum values that
+            correspond with valid values on this HelpfulIntEnum instance.
+
+        Returns
+        -------
+        enums : set[HelpfulIntEnum]
+            A set whose elements are the enum objects associated with the
+            input identifiers.
+        """
+        return {cls.from_any(ident) for ident in identifiers}
+
+    @classmethod
+    def exclude(
+        cls,
+        identifiers: Iterator[EnumId],
+    ) -> set[HelpfulIntEnum]:
+        """
+        Return all enum values other than the ones given.
+
+        Parameters
+        ----------
+        identifiers : Iterator[EnumId]
+            Any iterable that contains strings, ints, and Enum values that
+            correspond with valid values on this HelpfulIntEnum instance.
+
+        Returns
+        -------
+        enums : set[HelpfulIntEnum]
+            A set whose elements are the valid enum objects not associated
+            with the input identifiers.
+        """
+        return set(cls.__members__.values()) - cls.include(identifiers)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This fixes some issues related to a flurry of recent bug reports. The following changes have been made:
- The MD update signal will be more lenient for cases where specific unset values ("Invalid") persist from the TwinCAT PLC. Devices like TwinCAT state positioners will stop throwing large confusing errors related to invalid enum strings.
- The MD update signal will not send metadata updates until all composite signals are ready and have contributed their values.
- State names are no longer case-sensitive: states like "Out", "out", and "OUT" will be understood to be the same.
- HelpfulIntEnum has been temporarily vendored from pcdsutils/pcdsdaq. This will change to an import in a future release.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Several state devices have spammy errors when created that interfere with our ability to adjust their enum strings dynamically as viewed from Python.
- Several state devices have variations on the "OUT" string that all mean effectively the same thing, but were previously being interpreted as distinct entities. This lead to some devices being both "IN" and "OUT" because of a misunderstanding of the "Out" string as being "Not "OUT"", for example.
- [Related Jira Ticket](https://jira.slac.stanford.edu/browse/LCLSECSD-550)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The unit tests for pcdsdevices, which covers this section extensively, still pass.
Interactive testing was done to verify that affected real devices now have their behavior corrected, and that related devices have not had their behaviors broken.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here in this PR and in release notes. Some docstrings are included where appropriate and necessary.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
