### PR TITLE
Add devices for Cycle RFoF systems

### DIFF
--- a/docs/source/upcoming_release_notes/930-Add_Cycle_RFoF_classes.rst
+++ b/docs/source/upcoming_release_notes/930-Add_Cycle_RFoF_classes.rst
@@ -1,0 +1,31 @@
+930 Add Cycle RFoF classes
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- CycleRfofRx: class for Cycle RFoF receiver.
+- CycleRfofTx: class for Cycle RFoF transmitter.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/lasers/rfof.py
+++ b/pcdsdevices/lasers/rfof.py
@@ -1,0 +1,29 @@
+"""
+Module for the RFoF systems used in the LCLS-II timing system.
+"""
+
+import logging
+
+from ophyd import Component as Cpt
+from ophyd import Device, EpicsSignal, EpicsSignalRO
+
+from pcdsdevices.interface import BaseInterface
+
+logger = logging.getLogger(__name__)
+
+
+class CycleRfofRx(BaseInterface, Device):
+    """
+    Class for reading back the Cycle RFoF receiver PVs.
+    """
+    rf_temperature = Cpt(EpicsSignalRO, ':RFTEMPERATURE', kind='normal')
+    rf_power = Cpt(EpicsSignalRO, ':RFPOWER', kind='normal')
+    optical_power = Cpt(EpicsSignalRO, ':OPTICALPOWER', kind='normal')
+
+
+class CycleRfofTx(CycleRfofRx):
+    """
+    Class for reading back the Cycle RFoF transmitter PVs.
+    """
+    # Transmitter adds a single control PV
+    enable_laser = Cpt(EpicsSignal, ':ENABLELASER', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add in classes for the Cycle RFoF transmitter and receiver. 

## Motivation and Context
These are useful in the new timing system. 

Closes #930 

## How Has This Been Tested?
Tested on RFoF systems in the timing lab. 

## Where Has This Been Documented?
Docstrings. 


## Screenshots (if appropriate):
Example TX screen. Ignore confusing units, that's an issue with Cycle's firmware. 

![image](https://user-images.githubusercontent.com/29102919/152209607-2200d33f-5a36-4bce-8605-cf298f798e88.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
