### PR TITLE
FIX: sl1k2 only has 2 targets

### DIFF
--- a/docs/source/upcoming_release_notes/937-sl1k2_targets.rst
+++ b/docs/source/upcoming_release_notes/937-sl1k2_targets.rst
@@ -1,0 +1,30 @@
+937 sl1k2_targets
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix SL1K2 target count (2 states + out instead of default).
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -1036,6 +1036,11 @@ class EpicsSignalBaseEditMD(EpicsSignalBase, SignalEditMD):
     def _run_metadata_callbacks(self):
         """Hook for metadata callbacks, mostly run by superclasses."""
         self._metadata_override["connected"] = self.connected
+        # TODO: to truncate the number of enum strings reported to the number
+        # that EPICS reports for the given PV, the following may be advisable.
+        # However, it seems to add additional confusing errors; so consider
+        # this a todo.
+        # self._metadata_override["enum_strs"] = self.enum_strs
         if self._metadata["connected"]:
             # The underlying PV has connected - check its enum_strs:
             self._check_signal_metadata()

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -27,6 +27,7 @@ from ophyd.status import wait as status_wait
 
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
+from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
                         LightpathMixin, MvInterface)
@@ -572,13 +573,22 @@ class PowerSlits(BeckhoffSlits):
     fsw = Cpt(NotImplementedSignal, ':FSW', kind='normal')
 
 
+class ExitSlitTarget(TwinCATStatePMPS):
+    """
+    Controls the exit slits target state.
+    Defines the state count as 3 (OUT and 2 targets) to limit the number of
+    config PVs we connect to.
+    """
+    config = UpCpt(state_count=3)
+
+
 class ExitSlits(BaseInterface, GroupDevice, LightpathInOutMixin):
     tab_component_names = True
 
     lightpath_cpts = ['target']
     _icon = 'fa.video-camera'
 
-    target = Cpt(TwinCATStatePMPS, ':YAG:STATE', kind='hinted',
+    target = Cpt(ExitSlitTarget, ':YAG:STATE', kind='hinted',
                  doc='Control of the YAG  stack via saved positions.')
     yag_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:YAG', kind='normal',
                     doc='Direct control of the Yag Stack motor.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fix number of targets on sl1k2

## Motivation and Context
Closes #937 

## How Has This Been Tested?
Loaded with happi

## Where Has This Been Documented?
PR/ issue

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
