### PR TITLE
FIX: mr1l0_homs, mr2l0_homs

### DIFF
--- a/docs/source/upcoming_release_notes/943-mr1l0_mr2l0_states.rst
+++ b/docs/source/upcoming_release_notes/943-mr1l0_mr2l0_states.rst
@@ -1,0 +1,32 @@
+943 mr1l0_mr2l0_states
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fixed mr1l0_homs and mr2l0_homs state counts in TwinCATMirrorStripe.
+  This should be set to 2 for mr1l0 (B4C, B4C/Ni) and mr2l0 (B4C, Ni).
+
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -15,6 +15,7 @@ from ophyd import FormattedComponent as FCpt
 from ophyd import PVPositioner
 
 from .device import GroupDevice
+from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init
 from .epics_motor import BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
@@ -777,6 +778,7 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
     in_states = []
     out_states = []
     _in_if_not_out = True
+    config = UpCpt(state_count=2)
 
     @property
     def transmission(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Sets state count for mr1l0_homs and mr2l0_homs mirror stripes.

## Motivation and Context
Closes #943 

## How Has This Been Tested?
`happi load`:
```
In [1]: mr1l0_homs.coating.states_list
Out[1]: ['Unknown', 'B4C', 'B4C/Ni']

In [2]: type(mr1l0_homs.coating).config.kwargs
Out[2]: {'state_count': 2}
```

## Where Has This Been Documented?
Release notes, issue, and PR text

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
