### PR TITLE
BUG: mark success if already at goal

### DIFF
--- a/docs/source/upcoming_release_notes/945-slow_motor_move_to_start.rst
+++ b/docs/source/upcoming_release_notes/945-slow_motor_move_to_start.rst
@@ -1,0 +1,31 @@
+945 slow_motor_move_to_start
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fixes issue in sim.slow_motor classes where threading behavior would fail if
+the destination was the same as the current position.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/sim.py
+++ b/pcdsdevices/sim.py
@@ -64,6 +64,12 @@ class SlowMotor(FastMotor):
 
         def update_thread(positioner, goal):
             positioner._moving = True
+            if positioner.position == goal:
+                # if already at the requested position, mark success
+                positioner._set_position(goal)  # needed for LiveTable format
+                positioner._done_moving(success=True)
+                return
+
             while positioner.position != goal and not self._stop:
                 if goal - positioner.position > 1:
                     positioner._set_position(positioner.position + 1)

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -44,6 +44,8 @@ def test_mv(fast_motor):
 def test_umv(slow_motor):
     logger.debug('test_umv')
     start_position = slow_motor.position
+    slow_motor.umvr(0)
+    assert slow_motor.position == start_position
     delta = 2
     slow_motor.umvr(delta)
     assert slow_motor.position == start_position + delta


### PR DESCRIPTION
## Description
Simulated Slow motors fail to move in a scan if the first position is the current position. 
Broadly, this issue appears any time sim.slow_motor was moved to its current position with the `wait` argument enabled

## Motivation and Context
This is a functionality that should be included.  
Addresses #945 

## How Has This Been Tested?
Tested interactively, test added to `test_interface.py`

## Where Has This Been Documented?
Code has been commented, related issue, this PR.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
