### PR TITLE
ENH: Add KBOMirrorHE and add y axis to KBOMirror status

### DIFF
--- a/docs/source/upcoming_release_notes/949-kbo-fixes.rst
+++ b/docs/source/upcoming_release_notes/949-kbo-fixes.rst
@@ -11,14 +11,11 @@ Features
 
 Device Updates
 --------------
-Flow/Pressure sensor hardware added to MR2K4 KBO. 
-Update software for readbacks.                                        
+- Added Y axis to KBOMirror status printout
 
-Added KBOMirrorHE class
-Added Y axis to KBOMirror status
 New Devices
 -----------
-- N/A
+- Added KBOMirrorHE class to be used with KBOMirrors with cooling, like MR2K4.
 
 Bugfixes
 --------
@@ -30,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-Nick Waters
+- nrwslac

--- a/docs/source/upcoming_release_notes/949-kbo-fixes.rst
+++ b/docs/source/upcoming_release_notes/949-kbo-fixes.rst
@@ -1,0 +1,33 @@
+949 kbo-fixes
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+Flow/Pressure sensor hardware added to MR2K4 KBO. 
+Update software for readbacks.                                        
+
+Added KBOMirrorHE class
+Added Y axis to KBOMirror status
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+Nick Waters

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -696,6 +696,7 @@ class KBOMirrorHE(KBOMirror):
     cool_flow2 = Cpt(EpicsSignalRO, ':FLOW:2_RBV', kind='normal')
     cool_press = Cpt(EpicsSignalRO, ':PRESS:1_RBV', kind='normal')
 
+
 class FFMirror(BaseInterface, GroupDevice):
     """
     Fixed Focus Kirkpatrick-Baez Mirror.

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -562,11 +562,6 @@ class KBOMirror(BaseInterface, GroupDevice):
     us_rtd = Cpt(EpicsSignalRO, ':RTD:BEND:US:1_RBV', kind='normal')
     ds_rtd = Cpt(EpicsSignalRO, ':RTD:BEND:DS:1_RBV', kind='normal')
 
-    # Cooling water flow and pressure sensors
-    cool_flow1  = Cpt(EpicsSignalRO, ':FLOW:1_RBV', kind='normal')
-    cool_flow2  = Cpt(EpicsSignalRO, ':FLOW:2_RBV', kind='normal')
-    cool_press = Cpt(EpicsSignalRO, ':PRESS:1_RBV', kind='normal')
-
     # Lightpath config: implement inserted, removed, transmission, subscribe
     inserted = True
     removed = False
@@ -681,6 +676,24 @@ bender_ds ({self.bender_ds.prefix})
     bender_ds_enc_rms: {b_ds_enc_rms}
 """
 
+class KBOMirrorHE(KBOMirror):
+    """
+    Kirkpatrick-Baez Mirror with Bender Axes and Cooling.
+
+    1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    # Cooling water flow and pressure sensors
+    cool_flow1 = Cpt(EpicsSignalRO, ':FLOW:1_RBV', kind='normal')
+    cool_flow2 = Cpt(EpicsSignalRO, ':FLOW:2_RBV', kind='normal')
+    cool_press = Cpt(EpicsSignalRO, ':PRESS:1_RBV', kind='normal')
 
 class FFMirror(BaseInterface, GroupDevice):
     """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -676,6 +676,7 @@ bender_ds ({self.bender_ds.prefix})
     bender_ds_enc_rms: {b_ds_enc_rms}
 """
 
+
 class KBOMirrorHE(KBOMirror):
     """
     Kirkpatrick-Baez Mirror with Bender Axes and Cooling.

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -562,6 +562,11 @@ class KBOMirror(BaseInterface, GroupDevice):
     us_rtd = Cpt(EpicsSignalRO, ':RTD:BEND:US:1_RBV', kind='normal')
     ds_rtd = Cpt(EpicsSignalRO, ':RTD:BEND:DS:1_RBV', kind='normal')
 
+    # Cooling water flow and pressure sensors
+    cool_flow1  = Cpt(EpicsSignalRO, ':FLOW:1_RBV', kind='normal')
+    cool_flow2  = Cpt(EpicsSignalRO, ':FLOW:2_RBV', kind='normal')
+    cool_press = Cpt(EpicsSignalRO, ':PRESS:1_RBV', kind='normal')
+
     # Lightpath config: implement inserted, removed, transmission, subscribe
     inserted = True
     removed = False

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -611,6 +611,13 @@ class KBOMirror(BaseInterface, GroupDevice):
                                    'units')
         x_description = get_status_value(status_info, 'x', 'description',
                                          'value')
+        y_position = get_status_value(status_info, 'y', 'position')
+        y_user_setpoint = get_status_value(status_info, 'y',
+                                           'user_setpoint', 'value')
+        y_units = get_status_value(status_info, 'y', 'user_setpoint',
+                                   'units')
+        y_description = get_status_value(status_info, 'y', 'description',
+                                         'value')
         p_position = get_status_value(status_info, 'pitch', 'position')
         p_user_setpoint = get_status_value(status_info, 'pitch',
                                            'user_setpoint', 'value')
@@ -645,6 +652,12 @@ x_up: ({self.x.prefix})
     position: {x_position}
     user_setpoint: {x_user_setpoint} [{x_units}]
     description: {x_description}
+------
+y_up: ({self.y.prefix})
+------
+    position: {y_position}
+    user_setpoint: {y_user_setpoint} [{y_units}]
+    description: {y_description}
 ------
 pitch: ({self.pitch.prefix})
 ------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Added cooling flow/pressure sensor readouts in a KBO mirror child class: KBOMirrorHE
* Added Y axis to device status output
<!--- Describe your changes in detail -->

## Motivation and Context
New hardware installed.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran in local pydev environment and view in a typhos screen with mirror mr2k4.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->


## Screenshots:
![kboHE](https://user-images.githubusercontent.com/79480290/153662505-2ae93acc-eadd-4be8-b2fd-24280754a35e.png)

<img width="771" alt="kbo status" src="https://user-images.githubusercontent.com/79480290/153482485-5256eac7-18fa-4c7a-8538-5b016fb315d8.png">


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
