### PR TITLE
BUG: Fix preset state readbacks

### DIFF
--- a/docs/source/upcoming_release_notes/955-preset-rbv.rst
+++ b/docs/source/upcoming_release_notes/955-preset-rbv.rst
@@ -1,0 +1,30 @@
+955 preset-rbv
+##############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- States readbacks from preset positions are now correct.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1234,7 +1234,7 @@ class Presets:
             if method_name.startswith('wm_'):
                 state_name = method_name.replace('wm_', '', 1)
                 wm_state = getattr(device, method_name)
-                diff = wm_state()
+                diff = abs(wm_state())
                 if diff < closest:
                     state = state_name
                     closest = diff

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -113,6 +113,7 @@ def test_presets(presets, fast_motor):
     assert fast_motor.wm_zero() == -3
     assert fast_motor.wm_sample() == 0
     assert fast_motor.wm_four() == 1
+    assert fast_motor.presets.state() == 'sample'
 
     # Clear paths, refresh, should still exist
     old_paths = fast_motor.presets._paths
@@ -121,11 +122,13 @@ def test_presets(presets, fast_motor):
     setup_preset_paths(**old_paths)
     assert fast_motor.wm_zero() == -3
     assert fast_motor.wm_sample() == 0
+    assert fast_motor.presets.state() == 'sample'
 
     fast_motor.mv_zero(wait=True)
     fast_motor.mvr(1, wait=True)
     assert fast_motor.wm_zero() == -1
     assert fast_motor.wm() == 1
+    assert fast_motor.presets.state() == 'zero'
 
     # Sleep for one so we don't override old history
     time.sleep(1)

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -125,10 +125,11 @@ def test_presets(presets, fast_motor):
     assert fast_motor.presets.state() == 'sample'
 
     fast_motor.mv_zero(wait=True)
+    assert fast_motor.presets.state() == 'zero'
     fast_motor.mvr(1, wait=True)
     assert fast_motor.wm_zero() == -1
     assert fast_motor.wm() == 1
-    assert fast_motor.presets.state() == 'zero'
+    assert fast_motor.presets.state() == 'Unknown'
 
     # Sleep for one so we don't override old history
     time.sleep(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix the issue where preset state readbacks were wrong.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These state readbacks show up in the terminal pretty printer and are confusing if incorrect.
closes #955 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test to demonstrate the failure, fixed the code appropriately, test now passes.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only in release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
