### PR TITLE
ENH: Add biological parents to GroupDevice

### DIFF
--- a/docs/source/upcoming_release_notes/958-biological_parents_for_GroupDevice.rst
+++ b/docs/source/upcoming_release_notes/958-biological_parents_for_GroupDevice.rst
@@ -1,0 +1,30 @@
+958 biological parents for GroupDevice
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Adds a biological parent attribute to GroupDevice, for tracking parents without alerting stage() methods
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -367,6 +367,8 @@ class GroupDevice(Device):
     - Components will have no references to this parent device. If
       accessed and used out of context, the components will be as if
       they were instantited completely separately.
+    - The parent device will be stashed in the ``biological_parent``
+      attribute, in case it's needed (by something other than the RE)
     - If a component is staged in a bluesky plan, it will not stage
       the ``GroupDevice``, and therefore will not stage the entire
       device tree.
@@ -410,6 +412,7 @@ class GroupDevice(Device):
             # The following types break without parents
             if not isinstance(cpt, tuple(self.needs_parent)):
                 cpt._parent = None
+                cpt.biological_parent = self
         if self.stage_group is None:
             self.stage_group = []
         else:

--- a/pcdsdevices/tests/test_device.py
+++ b/pcdsdevices/tests/test_device.py
@@ -194,6 +194,7 @@ def test_group_device_basic():
     group = BasicGroup('GROUP', name='group')
     assert group.one.parent is None
     assert group.two.parent is None
+    assert group.two.biological_parent is group
     assert group.bad.dev.parent is group.bad
     assert group.one not in group.stage()
     assert group.two not in group.unstage()


### PR DESCRIPTION
## Description
Adds ``biological_parent`` attribute to GroupDevice objects.  

## Motivation and Context
We orphan the devices to hide them from ``stage`` methods, but then they get lost forever

## How Has This Been Tested?
Ran test suite, opened a few GroupDevices (xrt_m2h, xcs_sb2_ipm)

## Where Has This Been Documented?
A line in the docstring

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
