### PR TITLE
ENH: add post_elog_status to BaseInterface

### DIFF
--- a/docs/source/upcoming_release_notes/962-device_elog_post.rst
+++ b/docs/source/upcoming_release_notes/962-device_elog_post.rst
@@ -1,0 +1,30 @@
+962 device elog post
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds a post_elog_status method to the BaseInterface class, which posts to the registered primary elog if it exists.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -368,16 +368,19 @@ class BaseInterface:
         """
         Post device status to the primary elog, if possible.
         """
-        if has_elog:
-            try:
-                elog = get_primary_elog()
-                final_post = f'<pre>{self.status()}</pre>'
-                elog.post(final_post, tags=['ophyd_status'],
-                          title=f'{self.name} status report')
-            except ValueError:
-                logger.info('elog exists but has not been registered')
-        else:
+        if not has_elog:
             logger.info('No primary elog found, cannot post status.')
+            return
+
+        try:
+            elog = get_primary_elog()
+        except ValueError:
+            logger.info('elog exists but has not been registered')
+            return
+
+        final_post = f'<pre>{self.status()}</pre>'
+        elog.post(final_post, tags=['ophyd_status'],
+                  title=f'{self.name} status report')
 
 
 def get_name(obj, default):


### PR DESCRIPTION
## Description
With newfound experience posting to the ELog, we can give every device the ability to post its status to the elog.  

The `elog` package comes with a method for registering the elog so we leverage that and use `elog` as an optional dependency.  [(elog is registered on init)](https://github.com/pcdshub/elog/blob/dbe280a04d7f9d0209087b24ad938d25bcb98e5e/elog/elog.py#L146)

## Motivation and Context
[Jira ticket](https://jira.slac.stanford.edu/browse/LCLSPC-124)

We're hoping to provide scientists an easy and accessible way to log their beamline state. 

## How Has This Been Tested?
Interactively.  Tests for this seem redundant with existing status print tests and elog's own tests.  I've chosen to not write any new tests, but this time not out of sloth.

I also accidentally posted `at2l0` status to the xcsp23820 elog, so...

## Where Has This Been Documented?
Docstrings, though there's not much to describe

## Screenshots (if appropriate):
<img width="980" alt="image" src="https://user-images.githubusercontent.com/35379409/157113763-117236ad-51c8-4b52-80f9-c83c3ae52e7b.png">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
