### PR TITLE
FIX: call super() after setting up enum attrs

### DIFF
--- a/docs/source/upcoming_release_notes/963-init_ordering.rst
+++ b/docs/source/upcoming_release_notes/963-init_ordering.rst
@@ -1,0 +1,31 @@
+963 init_ordering
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix race condition on initialization of new ``EpicsSignalEditMD`` and
+  ``EpicsSignalROEditMD``. (#963)
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -805,9 +805,14 @@ class EpicsSignalBaseEditMD(EpicsSignalBase, SignalEditMD):
         *args,
         enum_attrs: Optional[list[Optional[str]]] = None,
         enum_strs: Optional[list[str]] = None,
+        parent: Optional[ophyd.ophydobj.OphydObject] = None,
+        name: Optional[str] = None,
         **kwargs
     ):
-        super().__init__(*args, **kwargs)
+        # Duplicate superclass handling of ``parent`` and ``name`` so we can
+        # initialize everything prior to calling super().__init__.
+        self._parent = parent
+        self._name = name or ""
 
         self._enum_attrs = list(enum_attrs or [])
         self._pending_signals = set()
@@ -847,6 +852,8 @@ class EpicsSignalBaseEditMD(EpicsSignalBase, SignalEditMD):
             # Override with strings
             self._enum_strings = list(enum_strs)
             self._metadata_override["enum_strs"] = self._enum_strings
+
+        super().__init__(*args, parent=parent, name=name, **kwargs)
 
     def destroy(self):
         super().destroy()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Callbacks *can* happen prior to the rest of `EpicsSignalROEditMD.__init__` being configured, so `.connected` raises AttributeError.

Re-orders initialization of affected classes.

## Motivation and Context
Closes #963 

## How Has This Been Tested?
Test suite and reloading xcspython

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
