### PR TITLE
PERF: remove unnecessary Status objects

### DIFF
--- a/docs/source/upcoming_release_notes/966-perf-last-status.rst
+++ b/docs/source/upcoming_release_notes/966-perf-last-status.rst
@@ -1,0 +1,33 @@
+966 perf-last-status
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Remove the instantiation of a status object at motor startup to help
+  improve the performance of loading large sessions. This object was not
+  strictly needed.
+
+Contributors
+------------
+- klauer
+- zllentz

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from threading import Event
 from types import MethodType, SimpleNamespace
+from typing import Optional
 from weakref import WeakSet
 
 import ophyd
@@ -21,7 +22,6 @@ from ophyd.device import Device
 from ophyd.ophydobj import Kind, OphydObject
 from ophyd.positioner import PositionerBase
 from ophyd.signal import AttributeSignal, Signal
-from ophyd.status import Status
 
 from . import utils
 from .signal import NotImplementedSignal
@@ -549,11 +549,12 @@ class MvInterface(BaseInterface):
     """
 
     tab_whitelist = ["mv", "wm", "wm_update"]
+    _last_status: Optional[ophyd.status.MoveStatus]
+    _mov_ev: Event
 
     def __init__(self, *args, **kwargs):
         self._mov_ev = Event()
-        self._last_status = Status()
-        self._last_status.set_finished()
+        self._last_status = None
         super().__init__(*args, **kwargs)
 
     def _log_move_limit_error(self, position, ex):
@@ -583,6 +584,8 @@ class MvInterface(BaseInterface):
         return st
 
     def wait(self, timeout=None):
+        if self._last_status is None:
+            return
         self._last_status.wait(timeout=timeout)
 
     def mv(self, position, timeout=None, wait=False, log=True):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Under the hood, these `Status` objects create daemon threads for running callbacks.

For one device, this isn't a big deal, but for a large device like xcs_lodcm, this can add up to hundreds of milliseconds.

Determined with the excellent tooling provided by the WIP https://github.com/pcdshub/pcdsutils/pull/47

## Motivation and Context
Let's speed up startup loading.

## How Has This Been Tested?
Locally.

## Where Has This Been Documented?
This PR text.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
