### PR TITLE
ENH: Namespace elog post

### DIFF
--- a/docs/source/upcoming_release_notes/967-namespace_elog_post.rst
+++ b/docs/source/upcoming_release_notes/967-namespace_elog_post.rst
@@ -1,0 +1,30 @@
+967 namespace elog post
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add function for posting ophyd object status (and lists of objects) to ELog as html.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/_html.py
+++ b/pcdsdevices/_html.py
@@ -1,0 +1,82 @@
+"""
+html templates for use in elog post formatting
+"""
+
+collapse_list_head = """<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+.collapsible {
+  background-color: #777;
+  color: white;
+  padding: 10px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+
+.collapsible:hover {
+  background-color: #555;
+}
+
+.collapsible:after {
+  content: '+';
+  color: white;
+  font-weight: bold;
+  float: right;
+  margin-left: 5px;
+}
+
+.active:after {
+  content: "-";
+}
+
+.content {
+  min-width: 100px;
+  overflow-x: auto;
+}
+
+.parent,
+.child {
+  display: none;
+  margin-left: 20px;
+}
+
+.parent.show,
+.child.show {
+  display: block;
+}
+</style>
+</head>
+<body>
+"""
+
+collapse_list_tail = """<script>
+// manage +/- toggle
+var coll = document.getElementsByClassName("collapsible");
+var i;
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var content = this.nextElementSibling;
+  });
+}
+
+// manage show/hide behavior
+var allCollapsibles = document.querySelectorAll('.collapsible');
+allCollapsibles.forEach( item => {
+  item.addEventListener("click", function() {
+     if(this.nextElementSibling.classList.contains('show')) {
+       this.nextElementSibling.classList.remove('show')
+     } else {
+       this.nextElementSibling.classList.add('show')
+     }
+  });
+});
+</script>
+
+</body>
+</html>"""

--- a/pcdsdevices/tests/conftest.py
+++ b/pcdsdevices/tests/conftest.py
@@ -237,3 +237,16 @@ def best_effort_instantiation(device_cls, *, skip_on_failure=True):
                 f'Unable to instantiate {device_cls}: {ex} (kwargs={kwargs})'
             )
         raise
+
+
+@pytest.fixture(scope='function')
+def elog():
+    class MockELog:
+        def __init__(self, *args, **kwargs):
+            self.posts = list()
+            self.enable_run_posts = True
+
+        def post(self, *args, **kwargs):
+            self.posts.append((args, kwargs))
+
+    return MockELog('TST')

--- a/pcdsdevices/tests/test_utils.py
+++ b/pcdsdevices/tests/test_utils.py
@@ -4,8 +4,12 @@ import threading
 import time
 
 import pytest
+from ophyd import Component as Cpt
+from ophyd import Device
 
 from .. import utils
+from ..device import GroupDevice
+from ..utils import post_ophyds_to_elog
 
 try:
     import pty
@@ -106,3 +110,46 @@ def test_get_status_float():
         dummy_dictionary, 'dict1', 'dict2', 'value', precision=3
     )
     assert res == '23.343'
+
+
+class StatusDevice(Device):
+    """ simulate a device with a status method """
+    def status(self):
+        return self.name
+
+
+class BasicGroup(StatusDevice, GroupDevice):
+    one = Cpt(StatusDevice, ':BASIC')
+    two = Cpt(StatusDevice, ':COMPLEX')
+
+
+class SomeDevice(StatusDevice):
+    some = Cpt(StatusDevice, ':SOME')
+    where = Cpt(StatusDevice, ':WHERE')
+
+
+def test_ophyd_to_elog(elog):
+    # make some devices
+
+    group = BasicGroup('GROUP', name='group')
+    some = SomeDevice('SOME', name='some')
+
+    post_ophyds_to_elog([group, some], hutch_elog=elog)
+    assert len(elog.posts) == 1
+    # count number of content entries
+    assert elog.posts[-1][0][0].count('<pre>') == 2
+
+    post_ophyds_to_elog([group.one, some.some], hutch_elog=elog)
+    assert len(elog.posts) == 1  # no children allowed by default
+
+    post_ophyds_to_elog([[group, some], group.one, some.some],
+                        allow_child=True, hutch_elog=elog)
+    assert len(elog.posts) == 2
+    assert elog.posts[-1][0][0].count('<pre>') == 4
+    # two list levels
+    assert elog.posts[-1][0][0].count("class='parent'") == 2
+
+    # half-hearted html validation
+    for post in elog.posts:
+        for tag in ['pre', 'div', 'button']:
+            assert post[0][0].count('<'+tag) == post[0][0].count('</'+tag)


### PR DESCRIPTION
## Description
Added a function (and helper function) for gathering up ophyd objects and posting them to the elog.  
Recursively walks through an iterable of devices and formats their `.status()` output into collapsible blocks.  

## Motivation and Context
[Jira ticket](https://jira.slac.stanford.edu/browse/LCLSPC-124).   
Was formerly in nabs [(PR)](https://github.com/pcdshub/nabs/pull/55), now moved over.

Hopefully this will provide another way for scientists to log their beamline state.  

With the new `biological_parents` attribute of `GroupDevices`, we can post entire namespaces without cluttering the post with child devices.  

## How Has This Been Tested?
Interactively, sample posts using devices in xcs hutch python, a few tests have been added to `test_utils.py`
pcds-5.3.0

## Where Has This Been Documented?
Docstrings, which have some example code

<img width="852" alt="image" src="https://user-images.githubusercontent.com/35379409/156434618-afec1d67-86bd-47d7-9032-d69dd6ed670e.png">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
