### PR TITLE
Added current monitoring PV to PTMPLC class

### DIFF
--- a/docs/source/upcoming_release_notes/968-PTMPLC.rst
+++ b/docs/source/upcoming_release_notes/968-PTMPLC.rst
@@ -1,0 +1,30 @@
+968 PTMPLC
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Added Current Monitoring PV.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- Mbosum

--- a/docs/source/upcoming_release_notes/968-PTMPLC.rst
+++ b/docs/source/upcoming_release_notes/968-PTMPLC.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- Added Current Monitoring PV.
+- Added Current Monitoring PV to ``pcdsdevices.pump.PTMPLC``.
 
 New Devices
 -----------

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -202,6 +202,7 @@ class PTMPLC(Device):
     pump_at_speed = Cpt(EpicsSignalRO, ':AT_SPD_RBV', kind='normal')
     pump_accelerating = Cpt(EpicsSignalRO, ':ACCEL_RBV', kind='normal')
     pump_speed = Cpt(EpicsSignalRO, ':SPEED_RBV', kind='normal')
+    pump_current = Cpt(EpicsSignalRO, ':CURR_MON_RBV', kind='normal')
     fault = Cpt(EpicsSignalRO, ':FAULT_RBV', kind='normal')
     warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal')
     alarm = Cpt(EpicsSignalRO, ':ALARM_RBV', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added variable for current monitoring below the pump_speed variable to the PTMPLC class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Scientists have requested to monitor pump current. The only issue I see here is this is read by serial, so if the serial interface is not working correctly, then both the current and speed will both display zero even when the pump is running fine.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


![Screenshot (634)](https://user-images.githubusercontent.com/50626768/157757935-dd65a14c-5a04-41c3-bf6c-e47a78dec6d3.png)

![Screenshot (635)](https://user-images.githubusercontent.com/50626768/157758108-01aec9ea-6cc4-4d5b-8fba-a44d7d93a935.png)




## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstring.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
