### PR TITLE
ENH: set component names to show up on all mirror device tab completion

### DIFF
--- a/docs/source/upcoming_release_notes/971-mirror-tabs.rst
+++ b/docs/source/upcoming_release_notes/971-mirror-tabs.rst
@@ -1,0 +1,30 @@
+971 mirror-tabs
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix issue where mirror devices had overfiltered tab completion results.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -199,7 +199,8 @@ class OffsetMirror(BaseInterface, GroupDevice):
     # Subscription types
     SUB_STATE = 'state'
 
-    tab_whitelist = ['pitch', 'xgantry', 'ygantry']
+    # Tab config: show components
+    tab_component_names = True
 
     def __init__(self, prefix, *, prefix_xy=None,
                  xgantry_prefix=None, **kwargs):
@@ -389,6 +390,9 @@ class XOffsetMirror(BaseInterface, GroupDevice):
     transmission = 1
     SUB_STATE = 'state'
 
+    # Tab config: show components
+    tab_component_names = True
+
     def format_status_info(self, status_info):
         """
         Override status info handler to render the Hard X-ray Offset Mirror.
@@ -490,6 +494,9 @@ class XOffsetMirrorBend(XOffsetMirror):
     us_rtd = Cpt(EpicsSignalRO, ':RTD:US:1_RBV', kind='normal')
     ds_rtd = Cpt(EpicsSignalRO, ':RTD:DS:1_RBV', kind='normal')
 
+    # Tab config: show components
+    tab_component_names = True
+
 
 # Maintain backward compatibility
 XOffsetMirror2 = XOffsetMirrorBend
@@ -523,6 +530,9 @@ class XOffsetMirrorSwitch(XOffsetMirror):
                  doc='Yleft master axis [um]')
     y_right = Cpt(BeckhoffAxisNoOffset, ':MMS:YRIGHT', kind='config',
                   doc='Yright slave axis [um]')
+
+    # Tab config: show components
+    tab_component_names = True
 
 
 class KBOMirror(BaseInterface, GroupDevice):
@@ -567,6 +577,9 @@ class KBOMirror(BaseInterface, GroupDevice):
     removed = False
     transmission = 1
     SUB_STATE = 'state'
+
+    # Tab config: show components
+    tab_component_names = True
 
     def format_status_info(self, status_info):
         """
@@ -696,6 +709,9 @@ class KBOMirrorHE(KBOMirror):
     cool_flow2 = Cpt(EpicsSignalRO, ':FLOW:2_RBV', kind='normal')
     cool_press = Cpt(EpicsSignalRO, ':PRESS:1_RBV', kind='normal')
 
+    # Tab config: show components
+    tab_component_names = True
+
 
 class FFMirror(BaseInterface, GroupDevice):
     """
@@ -729,6 +745,9 @@ class FFMirror(BaseInterface, GroupDevice):
     removed = False
     transmission = 1
     SUB_STATE = 'state'
+
+    # Tab config: show components
+    tab_component_names = True
 
     def format_status_info(self, status_info):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Put `tab_component_names = True` on every mirror device

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
None of the key parameters e.g. pitch were showing up in the filtered tab completion
See https://jira.slac.stanford.edu/browse/LCLSECSD-403

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
