### PR TITLE
Allow user offsets for TMOSpectrometer attributes

### DIFF
--- a/docs/source/upcoming_release_notes/975-tmo_spec_offsets.rst
+++ b/docs/source/upcoming_release_notes/975-tmo_spec_offsets.rst
@@ -1,0 +1,30 @@
+975 tmo_spec_offsets
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Allow for user offsets to TMO Spectrometer motors.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- Mbosum

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -5,7 +5,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 
 from .device import GroupDevice
-from .epics_motor import BeckhoffAxisNoOffset, IMS
+from .epics_motor import BeckhoffAxisNoOffset, IMS, BeckhoffAxis
 from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal, PytmcSignal
 
@@ -309,15 +309,15 @@ class TMOSpectrometer(BaseInterface, GroupDevice):
     tab_component_names = True
 
     # Motor components: can read/write positions
-    lens_x = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
-    foil_x = Cpt(BeckhoffAxisNoOffset, ':MMS:02', kind='normal')
-    zone_plate_x = Cpt(BeckhoffAxisNoOffset, ':MMS:03', kind='normal')
-    zone_plate_y = Cpt(BeckhoffAxisNoOffset, ':MMS:04', kind='normal')
-    zone_plate_z = Cpt(BeckhoffAxisNoOffset, ':MMS:05', kind='normal')
-    yag_x = Cpt(BeckhoffAxisNoOffset, ':MMS:06', kind='normal')
-    yag_y = Cpt(BeckhoffAxisNoOffset, ':MMS:07', kind='normal')
-    yag_z = Cpt(BeckhoffAxisNoOffset, ':MMS:08', kind='normal')
-    yag_theta = Cpt(BeckhoffAxisNoOffset, ':MMS:09', kind='normal')
+    lens_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
+    foil_x = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+    zone_plate_x = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
+    zone_plate_y = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
+    zone_plate_z = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+    yag_x = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
+    yag_y = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
+    yag_z = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
+    yag_theta = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')
 
 
 class HXRSpectrometer(BaseInterface, GroupDevice):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Allow user offsets for TMO spectrometer motors by reading motor Cpts via BeckhoffAxis class instead.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Open loop motors are susceptible to losing position. Once Scientists have tuned everything nicely its a huge hassle to try to realign stuff from scratch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
![Screenshot (652)](https://user-images.githubusercontent.com/50626768/159054088-6758edc0-366c-494d-b446-0b077b4bcdb2.png)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
Docstring
## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
