### PR TITLE
ENH: add reference PV to the beam request object

### DIFF
--- a/docs/source/upcoming_release_notes/982-beamreqref.rst
+++ b/docs/source/upcoming_release_notes/982-beamreqref.rst
@@ -1,0 +1,31 @@
+982 beamreqref
+##############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Added "ref" signal to "BeamEnergyRequest" to track the energy
+  reference PV.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -85,11 +85,19 @@ class BeamEnergyRequest(PVPositionerDone):
         EpicsSignal,
         '{prefix}:USER:MCC:EPHOT{line_text}:SET{bunch}',
         kind='hinted',
+        doc=(
+            'The setpoint PV that acr listens on to update the '
+            'vernier or undulator PVs as appropriate.'
+        ),
     )
     ref = FCpt(
         EpicsSignal,
         '{prefix}:USER:MCC:EPHOT{line_text}:REF{bunch}',
         kind='normal',
+        doc=(
+            'A reference PV for the photon energy at the nominal '
+            'position of the vernier or undulator.'
+        ),
     )
 
     line_text_dict = {

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -86,6 +86,11 @@ class BeamEnergyRequest(PVPositionerDone):
         '{prefix}:USER:MCC:EPHOT{line_text}:SET{bunch}',
         kind='hinted',
     )
+    ref = FCpt(
+        EpicsSignal,
+        '{prefix}:USER:MCC:EPHOT{line_text}:REF{bunch}',
+        kind='normal',
+    )
 
     line_text_dict = {
         'K': 'K',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Each of these beam request PVs has an accompanying REF PV that is used as a reference by ACR to determine how to change the energy. This PR adds the PV.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
James Cryan asked for this and it was really easy to do

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
PV connects

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet, need to add notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
