### PR TITLE
Do not merge: patch used in xcs for hxr spec

### DIFF
--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -3,9 +3,10 @@ Module for the various spectrometers.
 """
 from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
+from ophyd.signal import EpicsSignal
 
 from .device import GroupDevice
-from .epics_motor import BeckhoffAxisNoOffset, IMS, BeckhoffAxis
+from .epics_motor import IMS, BeckhoffAxis, BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal, PytmcSignal
 
@@ -320,6 +321,14 @@ class TMOSpectrometer(BaseInterface, GroupDevice):
     yag_theta = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')
 
 
+class IMSPatch(IMS):
+    user_setpoint = Cpt(EpicsSignal, ".VAL", limits=False, auto_monitor=True)
+
+    @property
+    def limits(self):
+        return (self.low_limit_travel.get(), self.high_limit_travel.get())
+
+
 class HXRSpectrometer(BaseInterface, GroupDevice):
     """
     HXR Single Shot Spectrometer motion components class.
@@ -335,17 +344,17 @@ class HXRSpectrometer(BaseInterface, GroupDevice):
 
     tab_component_names = True
 
-    xtaly = Cpt(IMS, ':441:MOTR', kind='normal',
+    xtaly = Cpt(IMSPatch, ':441:MOTR', kind='normal',
                 doc='crystal y')
-    th = Cpt(IMS, ':442:MOTR', kind='normal',
+    th = Cpt(IMSPatch, ':442:MOTR', kind='normal',
              doc='crystal angle')
-    tth = Cpt(IMS, ':443:MOTR', kind='normal',
+    tth = Cpt(IMSPatch, ':443:MOTR', kind='normal',
               doc='camera angle')
-    camd = Cpt(IMS, ':444:MOTR', kind='normal',
+    camd = Cpt(IMSPatch, ':444:MOTR', kind='normal',
                doc='camera distance')
-    camy = Cpt(IMS, ':447:MOTR', kind='normal',
+    camy = Cpt(IMSPatch, ':447:MOTR', kind='normal',
                doc='camera y')
-    iris = Cpt(IMS, ':445:MOTR', kind='normal',
+    iris = Cpt(IMSPatch, ':445:MOTR', kind='normal',
                doc='camera iris')
-    filter = Cpt(IMS, ':446:MOTR', kind='normal',
+    filter = Cpt(IMSPatch, ':446:MOTR', kind='normal',
                  doc='filter wheel, tbd if necessary')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
As a record and a point for discussion, the IMS motors on the HXR spectrometer have some wonky behavior where their control limits are never updated, and therefore the python session doesn't normally know where they are correctly. Unless we override them with the explicit values from the PV fields, they often do not know the correct soft limit locations.

In this case, I opted to set `limits=False` in the setpoint signal and I opted to override the `limits` property to use the field PV values directly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Do other IMS motors on the beamline also have this issue? We need to check and decide if this patch should be part of the IMS class, or if it just applies to this IOC.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This device works properly in XCS

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
