### PR TITLE
FIX: follow-up to #964; subscribe-after-init

### DIFF
--- a/docs/source/upcoming_release_notes/963-init_ordering.rst
+++ b/docs/source/upcoming_release_notes/963-init_ordering.rst
@@ -20,7 +20,7 @@ New Devices
 Bugfixes
 --------
 - Fix race condition on initialization of new ``EpicsSignalEditMD`` and
-  ``EpicsSignalROEditMD``. (#963)
+  ``EpicsSignalROEditMD``. (#963, #978)
 
 Maintenance
 -----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
`EpicsSignalBaseEditMD` and related classes can have initialization problems as in #978 and #963.

## Motivation and Context
* Intending to close #978 
* Supersedes my failed fix in #964 
* I'm hoping to come up with a good fix the 2nd time around so a 3rd time around isn't necessary.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Test suite
* Loaded up LFE screen as in the issue and didn't notice a traceback
* Current `lfe` still shows log-related error messages

## Where Has This Been Documented?
* PR and issue text

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
