### PR TITLE
ENH: State velo summary

### DIFF
--- a/docs/source/upcoming_release_notes/957-twincat-state-velo.rst
+++ b/docs/source/upcoming_release_notes/957-twincat-state-velo.rst
@@ -1,0 +1,33 @@
+957 twincat-state-velo
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- TwinCAT state devices now have a top-level "state_velo" summary signal.
+  This can be used to view the highest speed of all the configured state
+  speeds, and it can also be used to do a bulk edit. These are stored per
+  state destination in the IOC.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -22,6 +22,7 @@ from .epics_motor import IMS
 from .interface import MvInterface
 from .signal import (EpicsSignalEditMD, MultiDerivedSignal, PVStateSignal,
                      PytmcSignal)
+from .type_hints import SignalToValue
 from .utils import HelpfulIntEnum
 from .variety import set_metadata
 
@@ -716,11 +717,11 @@ class TwinCATStatePositioner(StatePositioner):
         doc='Configuration of state positions, deltas, etc.',
     )
 
-    def _get_state_velo(self, items):
+    def _get_state_velo(self, items: SignalToValue) -> float:
         """For state_velo, calculate the velocity to show."""
         return max(value for value in items.values())
 
-    def _set_state_velo(self, value):
+    def _set_state_velo(self, value: float) -> SignalToValue:
         """For state_velo, distribute the puts to all fields."""
         return {
             getattr(self.parent, name): value for name in

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -20,7 +20,8 @@ from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .interface import MvInterface
-from .signal import EpicsSignalEditMD, PVStateSignal, PytmcSignal
+from .signal import (EpicsSignalEditMD, MultiDerivedSignal, PVStateSignal,
+                     PytmcSignal)
 from .utils import HelpfulIntEnum
 from .variety import set_metadata
 
@@ -632,6 +633,29 @@ def state_config_dotted_names(state_count: int) -> list[Optional[str]]:
     ]
 
 
+def state_config_dotted_velos(state_count: int) -> list[Optional[str]]:
+    """
+    Returns the full dotted names of the state config velo components.
+
+    This does not include any entry for the unknown state and can be
+    passed direcly into the velocity summary MultiDerivedSignal attrs.
+
+    Parameters
+    ----------
+    state_count : int
+        The number of known states used by the device.
+
+    Returns
+    -------
+    dotted_names : list of str
+        The full dotted names in state enum order.
+    """
+    return [
+        f'config.{get_dynamic_state_attr(num)}.velo'
+        for num in range(1, state_count + 1)
+    ]
+
+
 class TwinCATStatePositioner(StatePositioner):
     """
     A `StatePositioner` from Beckhoff land.
@@ -692,6 +716,28 @@ class TwinCATStatePositioner(StatePositioner):
         doc='Configuration of state positions, deltas, etc.',
     )
 
+    def _get_state_velo(self, items):
+        return max(value for value in items.values())
+
+    def _set_state_velo(self, value):
+        return {
+            getattr(self.parent, name): value for name in
+            state_config_dotted_velos(self.parent.config.state_count)
+        }
+
+    state_velo = Cpt(
+        MultiDerivedSignal,
+        attrs=[
+            name for name in
+            state_config_dotted_velos(TWINCAT_MAX_STATES)
+        ],
+        calculate=_get_state_velo,
+        calculate_on_put=_set_state_velo,
+        kind='config',
+        # Real PV has no unit info yet, assume mm/s
+        metadata={'units': 'mm/s'},
+    )
+
     set_metadata(error_id, dict(variety='scalar', display_format='hex'))
     set_metadata(reset_cmd, dict(variety='command', value=1))
 
@@ -705,6 +751,11 @@ class TwinCATStatePositioner(StatePositioner):
             cls.state.kwargs['enum_attrs'] = (
                 state_config_dotted_names(state_count)
             )
+            cls.state_velo = copy.deepcopy(cls.state_velo)
+            cls.state_velo.kwargs['attrs'] = [
+                name for name in
+                state_config_dotted_velos(state_count)
+            ]
         # This includes the Device initialization, which assumes our
         # Component instances are finalized.
         # Therefore, do it last

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -723,10 +723,7 @@ class TwinCATStatePositioner(StatePositioner):
 
     def _set_state_velo(self, value: float) -> SignalToValue:
         """For state_velo, distribute the puts to all fields."""
-        return {
-            getattr(self.parent, name): value for name in
-            state_config_dotted_velos(self.parent.config.state_count)
-        }
+        return {sig: value for sig in self.signals}
 
     state_velo = Cpt(
         MultiDerivedSignal,

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -717,9 +717,11 @@ class TwinCATStatePositioner(StatePositioner):
     )
 
     def _get_state_velo(self, items):
+        """For state_velo, calculate the velocity to show."""
         return max(value for value in items.values())
 
     def _set_state_velo(self, value):
+        """For state_velo, distribute the puts to all fields."""
         return {
             getattr(self.parent, name): value for name in
             state_config_dotted_velos(self.parent.config.state_count)
@@ -736,6 +738,12 @@ class TwinCATStatePositioner(StatePositioner):
         kind='config',
         # Real PV has no unit info yet, assume mm/s
         metadata={'units': 'mm/s'},
+        doc=(
+            'State mover velocity. Displays the highest velocity of all the '
+            'state move destinations and allows bulk writes to all of these '
+            'velocity settings. Note that this velocity only applies to '
+            'moves done using the state selector box.'
+        ),
     )
 
     set_metadata(error_id, dict(variety='scalar', display_format='hex'))

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -639,7 +639,7 @@ def state_config_dotted_velos(state_count: int) -> list[Optional[str]]:
     Returns the full dotted names of the state config velo components.
 
     This does not include any entry for the unknown state and can be
-    passed direcly into the velocity summary MultiDerivedSignal attrs.
+    passed directly into the velocity summary MultiDerivedSignal attrs.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a velocity summary for the twincat state movers using the MultiDerivedSignal.
This signal has the following behavior:
- display the highest velocity defined among all the state destinations
- allows a one-step bulk write to all the state velocities for that motor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Bulk write is a common operation
- It's hard to manage the speeds in a screen as-designed, but with the summary it should be easy
- People keep getting the state velocities (hidden) mixed up with the motor point to point velocity (easy to find)

closes #957

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only. The multi-signal connects for the TMO PPMs and properly shows/updates the velocities.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
