### PR TITLE
Mirror screens

### DIFF
--- a/docs/source/upcoming_release_notes/993-new_devices_for_mirrors.rst
+++ b/docs/source/upcoming_release_notes/993-new_devices_for_mirrors.rst
@@ -1,0 +1,31 @@
+993 new devices for mirrors
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- XOffsetMirrorRTDs
+- FFMirrorZ
+
+Bugfixes
+--------
+- Fix typhos placement for FFMirrorZ by rearranging `_sig_attrs`
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -22,27 +22,8 @@ from .interface import BaseInterface, FltMvInterface
 from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
 from .utils import get_status_value
-from .inout import TwinCATInOutPositioner
 
 logger = logging.getLogger(__name__)
-
-
-class TwinCATMirrorStripeNoPMPS(TwinCATInOutPositioner):
-    states_list = []
-    in_states = []
-    out_states = []
-    _in_if_not_out = True
-    config = UpCpt(state_count=2)
-
-
-class CoatingStateNoPMPS(Device):
-    """
-    Extra parent class to put "coating" as the first device in order.
-
-    This makes it appear at the top of the screen in typhos.
-    """
-    coating = Cpt(TwinCATMirrorStripeNoPMPS, ':COATING:STATE', kind='hinted',
-                  doc='Control of the coating states via saved positions.')
 
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):
@@ -110,8 +91,7 @@ class OMMotor(FltMvInterface, PVPositioner):
         Parameters
         ----------
         position : float
-            Position to check for validity.
-
+            Position to check for validity.  
         Raises
         ------
         ValueError
@@ -764,20 +744,6 @@ bender_ds ({self.bender_ds.prefix})
     description: {b_ds_description}
     bender_ds_enc_rms: {b_ds_enc_rms}
 """
-
-class KBOMirrorState(KBOMirror, CoatingStateNoPMPS):
-    """
-    Kirkpatrick-Baez Mirror with Bender Axes and Coating States. Manual PMPS. 
-
-    1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
-
-    Parameters
-    ----------
-    prefix : str
-        Base PV for the mirror.
-
-    name : str
-    """
 
 
 class KBOMirrorHE(KBOMirror):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -27,39 +27,6 @@ from .utils import get_status_value
 logger = logging.getLogger(__name__)
 
 
-class TwinCATMirrorStripe(TwinCATStatePMPS):
-    """
-    Subclass of TwinCATStatePMPS for the mirror coatings.
-
-    Unless most TwinCATStatePMPS, we have:
-    - Only in_states
-    - No in_states block the beam
-
-    We also clear the states_list and set _in_if_not_out to True
-    to automatically pick up the coatings from each mirror enum.
-    """
-    states_list = []
-    in_states = []
-    out_states = []
-    _in_if_not_out = True
-    config = UpCpt(state_count=2)
-
-    @property
-    def transmission(self):
-        """The mirror coating never blocks the beam."""
-        return 1
-
-
-class CoatingState(Device):
-    """
-    Extra parent class to put "coating" as the first device in order.
-
-    This makes it appear at the top of the screen in typhos.
-    """
-    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
-                  doc='Control of the coating states via saved positions.')
-
-
 class OMMotor(FltMvInterface, PVPositioner):
     """Base class for each motor in the LCLS offset mirror system."""
     __doc__ += basic_positioner_init
@@ -93,6 +60,7 @@ class OMMotor(FltMvInterface, PVPositioner):
         ----------
         position : float
             Position to check for validity.  
+
         Raises
         ------
         ValueError
@@ -888,6 +856,39 @@ class FFMirrorZ(FFMirror):
 
     # RMS Cpts:
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
+
+
+class TwinCATMirrorStripe(TwinCATStatePMPS):
+    """
+    Subclass of TwinCATStatePMPS for the mirror coatings.
+
+    Unless most TwinCATStatePMPS, we have:
+    - Only in_states
+    - No in_states block the beam
+
+    We also clear the states_list and set _in_if_not_out to True
+    to automatically pick up the coatings from each mirror enum.
+    """
+    states_list = []
+    in_states = []
+    out_states = []
+    _in_if_not_out = True
+    config = UpCpt(state_count=2)
+
+    @property
+    def transmission(self):
+        """The mirror coating never blocks the beam."""
+        return 1
+
+
+class CoatingState(Device):
+    """
+    Extra parent class to put "coating" as the first device in order.
+
+    This makes it appear at the top of the screen in typhos.
+    """
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
 
 class XOffsetMirrorState(XOffsetMirror, CoatingState):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -12,7 +12,7 @@ import numpy as np
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
-from ophyd import PVPositioner 
+from ophyd import PVPositioner
 
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
@@ -59,7 +59,7 @@ class OMMotor(FltMvInterface, PVPositioner):
         Parameters
         ----------
         position : float
-            Position to check for validity.  
+            Position to check for validity.
 
         Raises
         ------

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -765,7 +765,7 @@ bender_ds ({self.bender_ds.prefix})
     bender_ds_enc_rms: {b_ds_enc_rms}
 """
 
-class KBOMirrorState(KBOMirror, CoatingState):
+class KBOMirrorState(KBOMirror, CoatingStateNoPMPS):
     """
     Kirkpatrick-Baez Mirror with Bender Axes and Coating States
 
@@ -926,7 +926,7 @@ class FFMirrorZ(FFMirror):
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
 
-class XOffsetMirrorState(XOffsetMirror, CoatingStateNoPMPS):
+class XOffsetMirrorState(XOffsetMirror, CoatingState):
     """
     X-ray Offset Mirror with Yleft/Yright
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -857,7 +857,8 @@ class FFMirrorZ(FFMirror):
     # RMS Cpts:
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
-end_with = ['x_enc_rms', 'y_enc_rms', 'pitch_enc_rms']
+
+end_with = ['x_enc_rms', 'y_enc_rms', 'z_enc_rms','pitch_enc_rms']
 
 for cpt_name in end_with:
     FFMirrorZ._sig_attrs.move_to_end(cpt_name, last=True)

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -857,6 +857,11 @@ class FFMirrorZ(FFMirror):
     # RMS Cpts:
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
+end_with = ['x_enc_rms', 'y_enc_rms', 'pitch_enc_rms']
+
+for cpt_name in end_with:
+    FFMirrorZ._sig_attrs.move_to_end(cpt_name, last=True)
+
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):
     """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -12,8 +12,7 @@ import numpy as np
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
-from ophyd import PVPositioner
-
+from ophyd import PVPositioner 
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init
@@ -23,8 +22,27 @@ from .interface import BaseInterface, FltMvInterface
 from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
 from .utils import get_status_value
+from .inout import TwinCATInOutPositioner
 
 logger = logging.getLogger(__name__)
+
+
+class TwinCATMirrorStripeNoPMPS(TwinCATInOutPositioner):
+    states_list = []
+    in_states = []
+    out_states = []
+    _in_if_not_out = True
+    config = UpCpt(state_count=2)
+
+
+class CoatingStateNoPMPS(Device):
+    """
+    Extra parent class to put "coating" as the first device in order.
+
+    This makes it appear at the top of the screen in typhos.
+    """
+    coating = Cpt(TwinCATMirrorStripeNoPMPS, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):
@@ -908,7 +926,7 @@ class FFMirrorZ(FFMirror):
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
 
-class XOffsetMirrorState(XOffsetMirror, CoatingState):
+class XOffsetMirrorState(XOffsetMirror, CoatingStateNoPMPS):
     """
     X-ray Offset Mirror with Yleft/Yright
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -13,6 +13,7 @@ from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 from ophyd import PVPositioner 
+
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init
@@ -507,12 +508,9 @@ class XOffsetMirrorRTDs(XOffsetMirror):
         Alias for the device.
     """
     # RTD Cpts:
-    rtd_1 = Cpt(PytmcSignal, ':RTD:1', io='i',
-                          kind='normal')
-    rtd_2 = Cpt(PytmcSignal, ':RTD:2', io='i',
-                          kind='normal')
-    rtd_3 = Cpt(PytmcSignal, ':RTD:3', io='i',
-                          kind='normal')
+    rtd_1 = Cpt(PytmcSignal, ':RTD:1', io='i', kind='normal')
+    rtd_2 = Cpt(PytmcSignal, ':RTD:2', io='i', kind='normal')
+    rtd_3 = Cpt(PytmcSignal, ':RTD:3', io='i', kind='normal')
 
 
 class XOffsetMirrorBend(XOffsetMirror):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -767,7 +767,7 @@ bender_ds ({self.bender_ds.prefix})
 
 class KBOMirrorState(KBOMirror, CoatingStateNoPMPS):
     """
-    Kirkpatrick-Baez Mirror with Bender Axes and Coating States
+    Kirkpatrick-Baez Mirror with Bender Axes and Coating States. Manual PMPS. 
 
     1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -464,7 +464,7 @@ class XOffsetMirrorRTDs(XOffsetMirror):
     X-ray Offset Mirror.
 
     1st and 2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
-    
+
     With 3 RTD sensors installed.
 
     Parameters

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -858,7 +858,7 @@ class FFMirrorZ(FFMirror):
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
 
-end_with = ['x_enc_rms', 'y_enc_rms', 'z_enc_rms','pitch_enc_rms']
+end_with = ['x_enc_rms', 'y_enc_rms', 'z_enc_rms', 'pitch_enc_rms']
 
 for cpt_name in end_with:
     FFMirrorZ._sig_attrs.move_to_end(cpt_name, last=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Added class `XOffsetMirrorRTDs`.
- Added class `FFMirrorZ`
<!--- Describe your changes in detail -->
- Offset mirrors in the XRT recieved RTDS; make hardware additions reflect in device.
- Dream MR4/5K4 are `FFMirror` with Z axis; add device support for the Z axis.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
New Hardware installations.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Typhos screen for `XOffsetMirrorRTDs` launched using local `pydev_env`:
- `typhos 'pcdsdevices.mirror.XOffsetMirrorRTDs[{"prefix":"MR1L3:HOMS"}]'`
- happi entries made for `mr4k4_kbo` and `mr5k4_kbo`
- `FFOffsetZ` screens tested with `typhos mr*k4_kbo`
- need gateway access for `MR4K4:KBO && MR5K4:KBO` done
- inheriting `FFMirror` in `FFMirrorZ` puts the Z axis in a bit of an awkward position. Worth making its own class? Fixed by re-ordering `_sig_attrs`

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
Will be documented in release changes.
<!--  This can simply be  a comment in the code or updating a docstring -->



## Screenshots :
![image](https://user-images.githubusercontent.com/79480290/163064305-53bd42fe-1b69-4ab3-bf0b-9724e0526860.png)
<img width="609" alt="Screen Shot 2022-04-14 at 10 13 30 AM" src="https://user-images.githubusercontent.com/79480290/163439983-bcb4a902-37b2-4214-b089-14d1b75be092.png">## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
