### PR TITLE
ENH: add util for rearranging the component order for typhos screens.

### DIFF
--- a/docs/source/upcoming_release_notes/994-reorder-cpts.rst
+++ b/docs/source/upcoming_release_notes/994-reorder-cpts.rst
@@ -1,0 +1,33 @@
+994 reorder-cpts
+################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add utilities for rearranging the order of components as seen by typhos.
+  This can be helpful for classes that inherit components from other classes
+  if they want to slot their new components in at specific places in the
+  automatic typhos tree.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -22,7 +22,7 @@ from .inout import InOutRecordPositioner
 from .interface import BaseInterface, FltMvInterface
 from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
-from .utils import get_status_value
+from .utils import get_status_value, reorder_components
 
 logger = logging.getLogger(__name__)
 
@@ -837,6 +837,9 @@ pitch: ({self.pitch.prefix})
 """
 
 
+@reorder_components(
+    end_with=['x_enc_rms', 'y_enc_rms', 'z_enc_rms', 'pitch_enc_rms']
+)
 class FFMirrorZ(FFMirror):
     """
     Fixed Focus Kirkpatrick-Baez Mirror with Z axis.
@@ -856,12 +859,6 @@ class FFMirrorZ(FFMirror):
 
     # RMS Cpts:
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
-
-
-end_with = ['x_enc_rms', 'y_enc_rms', 'z_enc_rms', 'pitch_enc_rms']
-
-for cpt_name in end_with:
-    FFMirrorZ._sig_attrs.move_to_end(cpt_name, last=True)
 
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):

--- a/pcdsdevices/tests/test_utils.py
+++ b/pcdsdevices/tests/test_utils.py
@@ -218,3 +218,47 @@ def test_set_standard_ordering(SampleClass):
     set_standard_ordering(SampleClass)
     target_order = ['sub', 'mot', 'hint', 'norm', 'cfg', 'omit']
     assert get_order(SampleClass) == target_order
+
+
+def test_reorder_decorators():
+    @reorder_components(start_with=['cat'])
+    class Pets(Device):
+        dog = Cpt(Signal)
+        cat = Cpt(Signal)
+
+    assert get_order(Pets) == ['cat', 'dog']
+
+    @move_subdevices_to_start(subdevice_cls=SampleSub)
+    class Fruits(Device):
+        apple = Cpt(Signal)
+        banana = Cpt(SampleSub, 'BANANA')
+
+    assert get_order(Fruits) == ['banana', 'apple']
+
+    @sort_components_by_name(reverse=True)
+    class Veggies(Device):
+        celery = Cpt(Signal)
+        lettuce = Cpt(Signal)
+
+    assert get_order(Veggies) == ['lettuce', 'celery']
+
+    @sort_components_by_kind
+    class Colors(Device):
+        blue = Cpt(Signal, kind='normal')
+        red = Cpt(Signal, kind='hinted')
+
+    assert get_order(Colors) == ['red', 'blue']
+
+    @set_standard_ordering
+    class ChessPieces(Device):
+        pawn = Cpt(Signal, kind='omitted')
+        king = Cpt(Signal, kind='hinted')
+        queen = Cpt(SampleSub, kind='hinted')
+        knight = Cpt(Signal, kind='config')
+        rook = Cpt(SampleSub, kind='normal')
+        bishop = Cpt(Signal, kind='config')
+
+    assert (
+        get_order(ChessPieces)
+        == ['queen', 'rook', 'king', 'bishop', 'knight', 'pawn']
+    )

--- a/pcdsdevices/tests/test_utils.py
+++ b/pcdsdevices/tests/test_utils.py
@@ -189,6 +189,13 @@ def test_reorder_components(SampleClass):
     assert get_order(SampleClass) == target_order
 
 
+def test_normalize_reorder_list_errors(SampleClass):
+    with pytest.raises(ValueError):
+        reorder_components(SampleClass, start_with=[Cpt(Signal)])
+    with pytest.raises(TypeError):
+        reorder_components(SampleClass, start_with=[1])
+
+
 def test_move_subdevices_to_start(SampleClass):
     move_subdevices_to_start(SampleClass)
     target_order = ['mot', 'sub', 'omit', 'cfg', 'norm', 'hint']

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -13,7 +13,7 @@ import time
 from collections.abc import Iterable
 from functools import reduce
 from types import MethodType
-from typing import Callable, Dict, Iterator, Optional, Union
+from typing import Callable, Dict, Iterator, List, Optional, Union
 
 import ophyd
 import pint
@@ -687,3 +687,31 @@ def post_ophyds_to_elog(objs, allow_child=False, hutch_elog=None):
 
     hutch_elog.post(final_post, tags=['ophyd_status'],
                     title='ophyd status report')
+
+
+def reorder_components(
+    cls: type,
+    start_with: Optional[List[str]] = None,
+    end_with: Optional[List[str]] = None,
+) -> None:
+    """
+    Rearrange the components in cls for typhos displays.
+
+    Internally, this works by switching around the keys in the _sig_attrs
+    OrderedDict.
+
+    Parameters
+    ----------
+    cls : type
+        The Device subclass that we'd like to rearrange the order of.
+    start_with : list of str, optional
+        The component names to bring to the top of the screen.
+    end_with : list of str, optional
+        The component names to bring to the bottom of the screen.
+    """
+    start_with = start_with or []
+    end_with = end_with or []
+    for cpt_name in reversed(start_with):
+        cls._sig_attrs.move_to_end(cpt_name, last=False)
+    for cpt_name in end_with:
+        cls._sig_attrs.move_to_end(cpt_name, last=True)

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -754,7 +754,7 @@ def _normalize_reorder_list(
                 output.append(reverse_map[obj])
             except KeyError as exc:
                 raise ValueError(
-                    f'Recieved component {obj}, which is not from the device '
+                    f'Received component {obj}, which is not from the device '
                     f'class {cls}. We have components with the following '
                     f'names: {", ".join(cls._sig_attrs)}'
                 ) from exc
@@ -762,7 +762,7 @@ def _normalize_reorder_list(
             output.append(obj)
         else:
             raise TypeError(
-                f'Recieved object {obj}, which is not a str or Component.'
+                f'Received object {obj}, which is not a str or Component.'
             )
     return output
 
@@ -884,7 +884,6 @@ def sort_components_by_kind(cls: type[Device]) -> type[Device]:
     omitted = []
     for name, cpt in cls._sig_attrs.items():
         if check_kind_flag(cpt.kind, Kind.hinted):
-            print(cpt.kind)
             hinted.append(name)
         elif check_kind_flag(cpt.kind, Kind.normal):
             normal.append(name)

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -720,15 +720,13 @@ def reorder_components(
         When used as a decorator with the reverse argument, this will
         return a function as required by the decorator interface.
     """
-    # Must happen outside of inner scope
-    start_with = _normalize_reorder_list(cls, start_with)
-    end_with = _normalize_reorder_list(cls, end_with)
-
     # Special decorator handling
     def inner(cls: type[Device]) -> type[Device]:
-        for cpt_name in reversed(start_with):
+        start_norm = _normalize_reorder_list(cls, start_with)
+        end_norm = _normalize_reorder_list(cls, end_with)
+        for cpt_name in reversed(start_norm):
             cls._sig_attrs.move_to_end(cpt_name, last=False)
-        for cpt_name in end_with:
+        for cpt_name in end_norm:
             cls._sig_attrs.move_to_end(cpt_name, last=True)
         return cls
 

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -693,7 +693,7 @@ def post_ophyds_to_elog(objs, allow_child=False, hutch_elog=None):
 
 
 def reorder_components(
-    cls: type,
+    cls: type[Device],
     start_with: Optional[List[Union[str, Cpt]]] = None,
     end_with: Optional[List[Union[str, Cpt]]] = None,
 ) -> None:
@@ -705,7 +705,7 @@ def reorder_components(
 
     Parameters
     ----------
-    cls : type
+    cls : Device subclass
         The Device subclass that we'd like to rearrange the order of.
     start_with : list of str, optional
         The component names to bring to the top of the screen.
@@ -721,7 +721,7 @@ def reorder_components(
 
 
 def _normalize_reorder_list(
-    cls: type,
+    cls: type[Device],
     cpts_or_names: Optional[List[Union[str, Cpt]]],
 ) -> List[str]:
     """
@@ -739,7 +739,10 @@ def _normalize_reorder_list(
     return output
 
 
-def move_subdevices_to_start(cls: type, subdevice_cls: type = Device):
+def move_subdevices_to_start(
+    cls: type[Device],
+    subdevice_cls: type[Device] = Device,
+):
     """
     Arrange the component order of a device class to put subdevices first.
 
@@ -750,7 +753,7 @@ def move_subdevices_to_start(cls: type, subdevice_cls: type = Device):
 
     Parameters
     ----------
-    cls : type
+    cls : Device subclass
         The Device subclass that we'd like to rearrange the order of.
     subdevice_cls: type, optional
         A specific class type to move to the front. If omitted, all device
@@ -763,7 +766,7 @@ def move_subdevices_to_start(cls: type, subdevice_cls: type = Device):
     reorder_components(cls, start_with=device_names)
 
 
-def sort_components_by_name(cls: type, reverse: bool = False):
+def sort_components_by_name(cls: type[Device], reverse: bool = False):
     """
     Arrange the component order of a device class in alphabetical order.
 
@@ -772,7 +775,7 @@ def sort_components_by_name(cls: type, reverse: bool = False):
 
     Parameters
     ----------
-    cls : type
+    cls : Device subclass
         The Device subclass that we'd like to rearrange the order of.
     reverse : bool, optional
         Set to True to sort in descending order instead.
@@ -781,7 +784,7 @@ def sort_components_by_name(cls: type, reverse: bool = False):
     reorder_components(cls, start_with=alphabetical)
 
 
-def sort_components_by_kind(cls: type):
+def sort_components_by_kind(cls: type[Device]):
     """
     Arrange the component order of a device class in kind order.
 
@@ -795,7 +798,7 @@ def sort_components_by_kind(cls: type):
 
     Parameters
     ----------
-    cls : type
+    cls : Device subclass
         The Device subclass that we'd like to rearrange the order of.
     """
     hinted = []
@@ -819,7 +822,7 @@ def sort_components_by_kind(cls: type):
     reorder_components(cls, end_with=omitted)
 
 
-def set_standard_ordering(cls: type):
+def set_standard_ordering(cls: type[Device]):
     """
     Set a sensible "standard" ordering for use in typhos.
 
@@ -832,7 +835,7 @@ def set_standard_ordering(cls: type):
 
     Parameters
     ----------
-    cls : type
+    cls : Device subclass
         The Device subclass that we'd like to rearrange the order of.
     """
     sort_components_by_name(cls)

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -733,9 +733,20 @@ def _normalize_reorder_list(
     output = []
     for obj in cpts_or_names:
         if isinstance(obj, Cpt):
-            output.append(reverse_map[obj])
-        else:
+            try:
+                output.append(reverse_map[obj])
+            except KeyError as exc:
+                raise ValueError(
+                    f'Recieved component {obj}, which is not from the device '
+                    f'class {cls}. We have components with the following '
+                    f'names: {", ".join(cls._sig_attrs)}'
+                ) from exc
+        elif isinstance(obj, str):
             output.append(obj)
+        else:
+            raise TypeError(
+                f'Recieved object {obj}, which is not a str or Component.'
+            )
     return output
 
 

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -807,6 +807,12 @@ def sort_components_by_kind(cls: type[Device]):
 
     The relative ordering of subdevices within a kind is preserved.
 
+    This function makes no attempt to disambiguate or sort
+    combination kinds. For example:
+
+    - "hinted | config" counts as "hinted"
+    - "normal | config" counts as "normal"
+
     Parameters
     ----------
     cls : Device subclass
@@ -817,20 +823,24 @@ def sort_components_by_kind(cls: type[Device]):
     config = []
     omitted = []
     for name, cpt in cls._sig_attrs.items():
-        if cpt.kind is Kind.hinted:
+        if check_kind_flag(cpt.kind, Kind.hinted):
+            print(cpt.kind)
             hinted.append(name)
-        elif cpt.kind is Kind.normal:
+        elif check_kind_flag(cpt.kind, Kind.normal):
             normal.append(name)
-        elif cpt.kind is Kind.config:
+        elif check_kind_flag(cpt.kind, Kind.config):
             config.append(name)
-        elif cpt.kind is Kind.omitted:
-            omitted.append(name)
         else:
-            raise TypeError(f'Invalid component kind {cpt.kind}')
+            omitted.append(name)
     reorder_components(cls, end_with=hinted)
     reorder_components(cls, end_with=normal)
     reorder_components(cls, end_with=config)
     reorder_components(cls, end_with=omitted)
+
+
+def check_kind_flag(kind: int, flag: Kind) -> bool:
+    """Return True if kind contains flag."""
+    return kind & flag == flag
 
 
 def set_standard_ordering(cls: type[Device]):

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -757,7 +757,7 @@ def move_subdevices_to_start(cls: type, subdevice_cls: type = Device):
         subclasses will be moved.
     """
     device_names = []
-    for name, cpt in cls._sig_attrs:
+    for name, cpt in cls._sig_attrs.items():
         if issubclass(cpt.cls, subdevice_cls):
             device_names.append(name)
     reorder_components(cls, start_with=device_names)
@@ -813,10 +813,10 @@ def sort_components_by_kind(cls: type):
             omitted.append(name)
         else:
             raise TypeError(f'Invalid component kind {cpt.kind}')
-    reorder_components(type, end_with=hinted)
-    reorder_components(type, end_with=normal)
-    reorder_components(type, end_with=config)
-    reorder_components(type, end_with=omitted)
+    reorder_components(cls, end_with=hinted)
+    reorder_components(cls, end_with=normal)
+    reorder_components(cls, end_with=config)
+    reorder_components(cls, end_with=omitted)
 
 
 def set_standard_ordering(cls: type):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Functional proof of concept for a "device rearranger" for typhos screens without any modifications to typhos. This relies on some ophyd internal implementation details, but in the future it could be swapped out for some explicit typhos order-signaling feature.

Usage
```
reorder_components(
    XPIM,
    start_with=['zoom_lock', 'focus_lock'],
    end_with=['target'],
)
```
or, equivalently
```
@reorder_components(start_with=['zoom_lock', 'focus_lock'], end_with=['target'])
class XPIM(Device):
    ....
```
Result: the `zoom_lock` and `focus_lock` are at the top of the `typhos` screen, the `target` has been shipped from the top to the bottom.
![image](https://user-images.githubusercontent.com/10647860/163070539-9bd3f6ae-7173-4cd4-a8ed-e0bdf56b0142.png)

This has been expanded to include the following helpers as well:
```
move_subdevices_to_start
sort_components_by_name
sort_components_by_kind
set_standard_ordering 
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#993 identified that there will be cases where we want to use inheritance but we also want to put the signals into specific orders. #801 uses a workaround to achieve the same thing, but this is more general and requires less code (and less thinking) per device.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added + interactive tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes and docstrings

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
