### PR TITLE
MAINT: fix lightpath behavior for tmo spec, hxrsss

### DIFF
--- a/docs/source/upcoming_release_notes/997-spec-lightpath.rst
+++ b/docs/source/upcoming_release_notes/997-spec-lightpath.rst
@@ -1,0 +1,31 @@
+997 spec-lightpath
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where the TMO Spectrometer and the HXRSSS would spam errors
+  when loaded in lightpath.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -5,7 +5,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 
 from .device import GroupDevice
-from .epics_motor import BeckhoffAxisNoOffset, IMS, BeckhoffAxis
+from .epics_motor import IMS, BeckhoffAxis, BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal, PytmcSignal
 
@@ -319,6 +319,12 @@ class TMOSpectrometer(BaseInterface, GroupDevice):
     yag_z = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
     yag_theta = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')
 
+    # Lightpath constants
+    inserted = True
+    removed = False
+    transmission = 1
+    SUB_STATE = 'state'
+
 
 class HXRSpectrometer(BaseInterface, GroupDevice):
     """
@@ -349,3 +355,9 @@ class HXRSpectrometer(BaseInterface, GroupDevice):
                doc='camera iris')
     filter = Cpt(IMS, ':446:MOTR', kind='normal',
                  doc='filter wheel, tbd if necessary')
+
+    # Lightpath constants
+    inserted = True
+    removed = False
+    transmission = 1
+    SUB_STATE = 'state'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the stock lightpath constants from the 2.2 mono for "optics devices that are always in" to the tmo spec and the hxrsss. This is better than having broken support, though may not be completely accurate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
tmo lightpath has this error repeated infinitely now:
```
[2022-04-14 12:15:08] - ERROR -  Unable to determine device state for TMOSpectrometer(TMO:SPEC, name=sp1k4)
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.3.1/lib/python3.9/site-packages/lightpath/path.py", line 87, in find_device_state
    _in, _out = device.inserted, device.removed
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.3.1/lib/python3.9/site-packages/ophyd/device.py", line 1197, in __getattr__
    raise AttributeError(name)
AttributeError: inserted
```
The HXR spectrometer was in the same file and in my line of sight so I went ahead and did the same thing there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll make a docs thing after lunch

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
