### PR TITLE
Device classes for Apertures in AT1K0

### DIFF
--- a/docs/source/upcoming_release_notes/998-add_AT1K0_Apertures.rst
+++ b/docs/source/upcoming_release_notes/998-add_AT1K0_Apertures.rst
@@ -15,8 +15,8 @@ Device Updates
 
 New Devices
 -----------
-The X apertures for AT1K0 now have their own device with 1 state, "centered"
-The Y apertures for AT1K0 now have their own device with 4 states, ["5.5mm","8mm","10mm","13mm"]
+- The X apertures for AT1K0 now have their own device with 1 state, "centered"
+- The Y apertures for AT1K0 now have their own device with 4 states, ["5.5mm","8mm","10mm","13mm"]
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/998-add_AT1K0_Apertures.rst
+++ b/docs/source/upcoming_release_notes/998-add_AT1K0_Apertures.rst
@@ -1,0 +1,31 @@
+998 add AT1K0 Apertures
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+The X apertures for AT1K0 now have their own device with 1 state, "centered"
+The Y apertures for AT1K0 now have their own device with 4 states, ["5.5mm","8mm","10mm","13mm"]
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -31,7 +31,7 @@ MAX_FILTERS = 12
 class Gatt_Y_aperture(TwinCATStatePMPS):
     """
     Controls the Y axis component of the apertures inside AT1K0
-    Defines the state count as 4 (5.5mm, 8mm, 10mm, 13mm) to limit the number of
+    Defines the state count as 4, (5.5mm, 8mm, 10mm, 13mm) to limit the number of
     config PVs we connect to.
     """
 
@@ -44,7 +44,7 @@ class Gatt_Y_aperture(TwinCATStatePMPS):
 class Gatt_X_aperture(TwinCATStatePMPS):
     """
     Controls the X axis component of the apertures inside AT1K0
-    Defines the state count as 1 (centered) to limit the number of
+    Defines the state count as 1, (centered) to limit the number of
     config PVs we connect to.
     """
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -19,6 +19,7 @@ from .device import UnrelatedComponent as UCpt
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxisNoOffset
 from .inout import InOutPositioner, TwinCATInOutPositioner
+from .pmps import TwinCATStatePMPS
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
 from .signal import InternalSignal
 from .utils import get_status_float, get_status_value
@@ -27,6 +28,31 @@ from .variety import set_metadata
 logger = logging.getLogger(__name__)
 MAX_FILTERS = 12
 
+class Gatt_Y_aperture(TwinCATStatePMPS):
+    """
+    Controls the Y axis component of the apertures inside AT1K0
+    Defines the state count as 4 (5.5mm, 8mm, 10mm, 13mm) to limit the number of
+    config PVs we connect to.
+    """
+
+    states_list = []
+    in_states = []
+    out_states = []
+    _in_if_not_out = True
+    config = UpCpt(state_count=4)
+
+class Gatt_X_aperture(TwinCATStatePMPS):
+    """
+    Controls the X axis component of the apertures inside AT1K0
+    Defines the state count as 1 (centered) to limit the number of
+    config PVs we connect to.
+    """
+
+    states_list = []
+    in_states = []
+    out_states = []
+    _in_if_not_out = True
+    config = UpCpt(state_count=1)
 
 class Filter(InOutPositioner):
     """

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -19,8 +19,8 @@ from .device import UnrelatedComponent as UCpt
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxisNoOffset
 from .inout import InOutPositioner, TwinCATInOutPositioner
-from .pmps import TwinCATStatePMPS
 from .interface import BaseInterface, FltMvInterface, LightpathInOutMixin
+from .pmps import TwinCATStatePMPS
 from .signal import InternalSignal
 from .utils import get_status_float, get_status_value
 from .variety import set_metadata
@@ -28,31 +28,34 @@ from .variety import set_metadata
 logger = logging.getLogger(__name__)
 MAX_FILTERS = 12
 
-class Gatt_Y_aperture(TwinCATStatePMPS):
+
+class GattApertureY(TwinCATStatePMPS):
     """
-    Controls the Y axis component of the apertures inside AT1K0
-    Defines the state count as 4, (5.5mm, 8mm, 10mm, 13mm) to limit the number of
-    config PVs we connect to.
+    AT1K0 is a gas attenuator containing 4 discrete aperture arrays,
+    each with 4 discrete aperture sizes to attenuate the intensity of the beam.
+    This class Controls the Y axis component of the apertures inside AT1K0 and
+    Defines the state count as 4, (5.5mm, 8mm, 10mm, 13mm) to limit the
+    number of config PVs we connect to.
     """
 
-    states_list = []
     in_states = []
     out_states = []
-    _in_if_not_out = True
     config = UpCpt(state_count=4)
 
-class Gatt_X_aperture(TwinCATStatePMPS):
+
+class GattApertureX(TwinCATStatePMPS):
     """
+    AT1K0 is a gas attenuator containing 4 discrete aperture arrays,
+    each with 4 discrete aperture sizes to attenuate the intensity of the beam.
     Controls the X axis component of the apertures inside AT1K0
     Defines the state count as 1, (centered) to limit the number of
     config PVs we connect to.
     """
 
-    states_list = []
     in_states = []
     out_states = []
-    _in_if_not_out = True
     config = UpCpt(state_count=1)
+
 
 class Filter(InOutPositioner):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added two classes, GattApertureY, GatttApertureX to create new typhos screens that will replace the old screens.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A potentially preventable controls hotline call was taken because the old screens did not show all relevant info.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The typhos screens that these are used to build have been tested to move between the aperture and motor states that they interact with while the SXR didn't have beam on 4/14/2022
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
comments in class declarations
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [X] New/changed functions and methods are covered in the test suite where possible
- [X] Test suite passes locally
- [x] Test suite passes on travis
- [X] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [X] Pre-release docs include context, functional descriptions, and contributors as appropriate
