### PR TITLE
Add device for optics notepad

### DIFF
--- a/docs/source/upcoming_release_notes/999-optics-notepad.rst
+++ b/docs/source/upcoming_release_notes/999-optics-notepad.rst
@@ -7,7 +7,7 @@ API Changes
 
 Features
 --------
-- class for storing pitch positions based on state
+- N/A 
 
 Device Updates
 --------------
@@ -15,7 +15,8 @@ Device Updates
 
 New Devices
 -----------
-- OpticsPitchNotepad
+- OpticsPitchNotepad - a class for storing pitch positions based on state in a notepad IOC
+  for mr1l0, mr2l0, mr1l4, mr1l3, and mr2l3.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/999-optics-notepad.rst
+++ b/docs/source/upcoming_release_notes/999-optics-notepad.rst
@@ -7,7 +7,7 @@ API Changes
 
 Features
 --------
-- N/A
+- class for storing pitch positions based on state
 
 Device Updates
 --------------

--- a/docs/source/upcoming_release_notes/999-optics-notepad.rst
+++ b/docs/source/upcoming_release_notes/999-optics-notepad.rst
@@ -1,0 +1,30 @@
+999 optics-notepad
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- OpticsPitchNotepad
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -915,3 +915,26 @@ class XOffsetMirrorState(XOffsetMirror, CoatingState):
     """
     # UI representation
     _icon = 'fa.minus-square'
+
+
+class OpticsPitchNotepad(BaseInterface, Device):
+    """
+        Class for storing pitch positions based on state 
+    """
+    MR1L0_Pitch_W = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
+    MR1L0_Pitch_SiC = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
+
+    MR2L0_Pitch_Coating1 = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
+    MR2L0_Pitch_Coating2 = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
+
+    MR1L4_Pitch_MEC_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating1')
+    MR1L4_Pitch_MEC_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating2')
+
+    MR1L4_Pitch_MFX_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating1')
+    MR1L4_Pitch_MFX_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating2')
+
+    MR1L3_Pitch_W = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating1')
+    MR1L3_Pitch_SiC = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating2')
+
+    MR2L3_Pitch_W = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
+    MR2L3_Pitch_SiC = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -919,27 +919,27 @@ class XOffsetMirrorState(XOffsetMirror, CoatingState):
 
 class OpticsPitchNotepad(BaseInterface, Device):
     """
-    Class for storing pitch positions based on state 
+    Class for storing pitch positions based on state
 
-    This provides an interface to the optics notepad IOC where 
+    This provides an interface to the optics notepad IOC where
     the X-Ray beam delivery team can store
     pitch set points based on coating state.
 
     """
-    MR1L0_Pitch_B4C = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
-    MR1L0_Pitch_Ni = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
+    mr1l0_pitch_b4c = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
+    mr1l0_pitch_ni = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
 
-    MR2L0_Pitch_B4C = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
-    MR2L0_Pitch_Ni = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
+    mr2l0_pitch_b4c = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
+    mr2l0_pitch_ni = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
 
-    MR1L4_Pitch_MEC_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating1')
-    MR1L4_Pitch_MEC_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating2')
+    mr1l4_pitch_mec_sic = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating1')
+    mr1l4_pitch_mec_w = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating2')
 
-    MR1L4_Pitch_MFX_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating1')
-    MR1L4_Pitch_MFX_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating2')
+    mr1l4_pitch_mfx_sic = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating1')
+    mr1l4_pitch_mfx_w = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating2')
 
-    MR1L3_Pitch_SiC = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating1')
-    MR1L3_Pitch_W = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating2')
+    mr1l3_pitch_sic = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating1')
+    mr1l3_pitch_w = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating2')
 
-    MR2L3_Pitch_SiC = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
-    MR2L3_Pitch_W = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')
+    mr2l3_pitch_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
+    mr2l3_pitch_w = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -919,7 +919,7 @@ class XOffsetMirrorState(XOffsetMirror, CoatingState):
 
 class OpticsPitchNotepad(BaseInterface, Device):
     """
-    Class for storing pitch positions based on state
+    class for storing pitch positions based on state
 
     This provides an interface to the optics notepad IOC where
     the X-Ray beam delivery team can store

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -919,13 +919,18 @@ class XOffsetMirrorState(XOffsetMirror, CoatingState):
 
 class OpticsPitchNotepad(BaseInterface, Device):
     """
-        Class for storing pitch positions based on state 
-    """
-    MR1L0_Pitch_SiC = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
-    MR1L0_Pitch_W = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
+    Class for storing pitch positions based on state 
 
-    MR2L0_Pitch_SiC = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
-    MR2L0_Pitch_W = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
+    This provides an interface to the optics notepad IOC where 
+    the X-Ray beam delivery team can store
+    pitch set points based on coating state.
+
+    """
+    MR1L0_Pitch_B4C = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
+    MR1L0_Pitch_Ni = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
+
+    MR2L0_Pitch_B4C = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
+    MR2L0_Pitch_Ni = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
 
     MR1L4_Pitch_MEC_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating1')
     MR1L4_Pitch_MEC_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating2')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -921,20 +921,20 @@ class OpticsPitchNotepad(BaseInterface, Device):
     """
         Class for storing pitch positions based on state 
     """
-    MR1L0_Pitch_W = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
-    MR1L0_Pitch_SiC = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
+    MR1L0_Pitch_SiC = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating1')
+    MR1L0_Pitch_W = Cpt(EpicsSignal, 'MR1L0:PITCH:Coating2')
 
-    MR2L0_Pitch_Coating1 = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
-    MR2L0_Pitch_Coating2 = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
+    MR2L0_Pitch_SiC = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating1')
+    MR2L0_Pitch_W = Cpt(EpicsSignal, 'MR2L0:PITCH:Coating2')
 
-    MR1L4_Pitch_MEC_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating1')
-    MR1L4_Pitch_MEC_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating2')
+    MR1L4_Pitch_MEC_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating1')
+    MR1L4_Pitch_MEC_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MEC:Coating2')
 
-    MR1L4_Pitch_MFX_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating1')
-    MR1L4_Pitch_MFX_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating2')
+    MR1L4_Pitch_MFX_SiC = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating1')
+    MR1L4_Pitch_MFX_W = Cpt(EpicsSignal, 'MR1L4:PITCH:MFX:Coating2')
 
-    MR1L3_Pitch_W = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating1')
-    MR1L3_Pitch_SiC = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating2')
+    MR1L3_Pitch_SiC = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating1')
+    MR1L3_Pitch_W = Cpt(EpicsSignal, 'MR1L3:PITCH:Coating2')
 
-    MR2L3_Pitch_W = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
-    MR2L3_Pitch_SiC = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')
+    MR2L3_Pitch_SiC = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
+    MR2L3_Pitch_W = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add device for optics notepad
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Create a device to easily generate a screen and interface with python.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
happi device optics_homs_notepad and typhos
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->


## Screenshots (if appropriate):
![optics-pitch-notepad](https://user-images.githubusercontent.com/79480290/164278847-ac4a8412-d942-46c0-a286-577e9a1d4130.png)



## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
