### PR TITLE
Created a class and screen for JJ Slits

### DIFF
--- a/docs/source/upcoming_release_notes/1001-jj-slits.rst
+++ b/docs/source/upcoming_release_notes/1001-jj-slits.rst
@@ -11,11 +11,13 @@ Features
 
 Device Updates
 --------------
-- Updated the slits.py file to contain a new specific JJ Slit model AT_C8_HV. 
+- Added JJSlits_AT_C8_HV class within slits.py and a corresponding typhos screen for new Model: JJ X-Ray AT-C8-HV
+- Controls for x-axis GAP and Width.
+- Controls for y-axis GAP and Width.
 
 New Devices
 -----------
-- JJSlits_AT_C8_HV class within slits.py and a corresponding typhos screen for it.
+- Model: JJ X-Ray AT-C8-HV
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1001-jj-slits.rst
+++ b/docs/source/upcoming_release_notes/1001-jj-slits.rst
@@ -7,15 +7,15 @@ API Changes
 
 Features
 --------
-- New class and typhos screen for controlling JJSlits class.
+- N/A
 
 Device Updates
 --------------
-- Added JJSlits class within slits.py and a corresponding typhos screen.
+- N/A
 
 New Devices
 -----------
-- Model: JJ X-Ray AT-C8-HV
+- New `JJSlits` class and typhos screen for controlling JJSlits model AT-C8-HV with Beckhoff controls.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1001-jj-slits.rst
+++ b/docs/source/upcoming_release_notes/1001-jj-slits.rst
@@ -7,15 +7,15 @@ API Changes
 
 Features
 --------
-- New typhos screen for newly created JJSlits class
+- New typhos screen for newly created JJSlits class.
 
 Device Updates
 --------------
-- N/A
+- Updated the slits.py file to contain a new specific JJ Slit model AT_C8_HV. 
 
 New Devices
 -----------
-- JJSlits class within slits.py
+- JJSlits_AT_C8_HV class within slits.py and a corresponding typhos screen for it.
 
 Bugfixes
 --------
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- Ricardo Martinez (rsmm97)
+- rsmm97

--- a/docs/source/upcoming_release_notes/1001-jj-slits.rst
+++ b/docs/source/upcoming_release_notes/1001-jj-slits.rst
@@ -1,0 +1,30 @@
+1001 jj-slits
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- New typhos screen for newly created JJSlits class
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- JJSlits class within slits.py
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- Ricardo Martinez (rsmm97)

--- a/docs/source/upcoming_release_notes/1001-jj-slits.rst
+++ b/docs/source/upcoming_release_notes/1001-jj-slits.rst
@@ -7,13 +7,11 @@ API Changes
 
 Features
 --------
-- New typhos screen for newly created JJSlits class.
+- New class and typhos screen for controlling JJSlits class.
 
 Device Updates
 --------------
-- Added JJSlits_AT_C8_HV class within slits.py and a corresponding typhos screen for new Model: JJ X-Ray AT-C8-HV
-- Controls for x-axis GAP and Width.
-- Controls for y-axis GAP and Width.
+- Added JJSlits class within slits.py and a corresponding typhos screen.
 
 New Devices
 -----------

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -28,7 +28,7 @@ from ophyd.status import wait as status_wait
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
-from .epics_motor import BeckhoffAxisNoOffset
+from .epics_motor import BeckhoffAxisNoOffset, BeckhoffAxis
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
                         LightpathMixin, MvInterface)
 from .pmps import TwinCATStatePMPS

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -643,3 +643,18 @@ class SimLusiSlits(LusiSlits):
     ywidth = Cpt(FastMotor)
     xcenter = Cpt(FastMotor)
     ycenter = Cpt(FastMotor)
+
+class JJSlits(SlitsBase):
+    '''
+    Parameters
+    ---------
+    prefix : str
+    Base PV for the JJ X-RAY PLC System
+    name : str
+    '''
+
+    # Motor Components
+    xwidth = Cpt(BeckhoffAxis, ':XWIDTH', kind='normal')
+    ywidth = Cpt(BeckhoffAxis, ':YWIDTH', kind='normal')
+    xcenter = Cpt(BeckhoffAxis, ':XCENTER', kind='normal')
+    ycenter = Cpt(BeckhoffAxis, ':YCENTER', kind='normal')

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -644,13 +644,14 @@ class SimLusiSlits(LusiSlits):
     xcenter = Cpt(FastMotor)
     ycenter = Cpt(FastMotor)
 
-class JJSlits(SlitsBase):
+
+class JJSlits_AT_C8_HV(SlitsBase):
     '''
     Parameters
     ---------
     prefix : str
-    Base PV for the JJ X-RAY PLC System
-    name : str
+       Base PV for the JJ X-RAY PLC System
+    name : str, keyword-only
     '''
 
     # Motor Components

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -645,8 +645,22 @@ class SimLusiSlits(LusiSlits):
     ycenter = Cpt(FastMotor)
 
 
-class JJSlits_AT_C8_HV(SlitsBase):
+class JJSlits(SlitsBase):
     '''
+    Beckhoff Controlled AT-C8-HV JJ X-Ray Slits.
+    
+    The JJSlits class defines motor components for the specific JJ X-Ray slits
+    model AT-C8-HV. This model of JJSlits holds four in-vacuum motors that set
+    the position and opening of the aperture in two dimensions. For each
+    dimension, one motor defines the aperture opening, and another determines the
+    position of the aperture. This class allows an operator to control and scan
+    the position 'center' and opening 'width' of the aperture. The 'JJSlits'
+    class instantiates four sub-devices: 'JJSlits.xwidth', 'JJSlits.xcenter',
+    'JJSlits.ywidth', 'JJSlits.ycenter'.
+    
+    Beckhoff controlled JJSlits are implemented along the beamline in HXR
+    for beam attenuation.
+
     Parameters
     ---------
     prefix : str

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -651,11 +651,11 @@ class JJSlits(SlitsBase):
     The JJSlits class defines motor components for the specific JJ X-Ray slits
     model AT-C8-HV. This model of JJSlits holds four in-vacuum motors that set
     the position and opening of the aperture in two dimensions. For each
-    dimension, one motor defines the aperture opening, and another determines the
-    position of the aperture. This class allows an operator to control and scan
-    the position 'center' and opening 'width' of the aperture. The 'JJSlits'
-    class instantiates four sub-devices: 'JJSlits.xwidth', 'JJSlits.xcenter',
-    'JJSlits.ywidth', 'JJSlits.ycenter'.
+    dimension, one motor defines the aperture opening, and another determines
+    the position of the aperture. This class allows an operator to control
+    and scan the position 'center' and opening 'width' of the aperture. The
+    'JJSlits' class instantiates four sub-devices: 'JJSlits.xwidth',
+    'JJSlits.xcenter', 'JJSlits.ywidth', 'JJSlits.ycenter'.
     Beckhoff controlled JJSlits are implemented along the beamline in HXR
     for beam attenuation.
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -28,7 +28,7 @@ from ophyd.status import wait as status_wait
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
-from .epics_motor import BeckhoffAxisNoOffset, BeckhoffAxis
+from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
                         LightpathMixin, MvInterface)
 from .pmps import TwinCATStatePMPS
@@ -648,7 +648,6 @@ class SimLusiSlits(LusiSlits):
 class JJSlits(SlitsBase):
     '''
     Beckhoff Controlled AT-C8-HV JJ X-Ray Slits.
-    
     The JJSlits class defines motor components for the specific JJ X-Ray slits
     model AT-C8-HV. This model of JJSlits holds four in-vacuum motors that set
     the position and opening of the aperture in two dimensions. For each
@@ -657,7 +656,6 @@ class JJSlits(SlitsBase):
     the position 'center' and opening 'width' of the aperture. The 'JJSlits'
     class instantiates four sub-devices: 'JJSlits.xwidth', 'JJSlits.xcenter',
     'JJSlits.ywidth', 'JJSlits.ycenter'.
-    
     Beckhoff controlled JJSlits are implemented along the beamline in HXR
     for beam attenuation.
 

--- a/pcdsdevices/ui/JJSlits.detailed.ui
+++ b/pcdsdevices/ui/JJSlits.detailed.ui
@@ -1,0 +1,2084 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>955</width>
+    <height>766</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>398</width>
+       <height>400</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>750</width>
+       <height>600</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">PyDMLabel {
+color: black;
+background-color: none;
+border-radius: 0px;
+}</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_15">
+      <property name="geometry">
+       <rect>
+        <x>630</x>
+        <y>40</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:YWIDTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_17">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>190</y>
+        <width>161</width>
+        <height>101</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:XWIDTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>110</x>
+        <y>330</y>
+        <width>151</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>X-AXIS GAP WIDTH</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_8">
+      <property name="geometry">
+       <rect>
+        <x>600</x>
+        <y>340</y>
+        <width>151</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Y-AXIS GAP WIDTH</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_18">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>170</x>
+        <y>190</y>
+        <width>161</width>
+        <height>101</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:XWIDTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_16">
+      <property name="geometry">
+       <rect>
+        <x>630</x>
+        <y>170</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:YWIDTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_19">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>20</y>
+        <width>311</width>
+        <height>121</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:XCENTER.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>7.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_20">
+      <property name="geometry">
+       <rect>
+        <x>450</x>
+        <y>40</y>
+        <width>111</width>
+        <height>271</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:YCENTER.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>7.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>110</x>
+        <y>150</y>
+        <width>161</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>X-AXIS GAP CENTER</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_13">
+      <property name="geometry">
+       <rect>
+        <x>400</x>
+        <y>340</y>
+        <width>161</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Y-AXIS GAP CENTER</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_21">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>190</y>
+        <width>311</width>
+        <height>101</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string/>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-10.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator_22">
+      <property name="geometry">
+       <rect>
+        <x>630</x>
+        <y>40</y>
+        <width>121</width>
+        <height>271</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="baseSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string/>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::LeftEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>-10.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>10.000000000000000</double>
+      </property>
+     </widget>
+     <zorder>PyDMScaleIndicator_22</zorder>
+     <zorder>PyDMScaleIndicator_21</zorder>
+     <zorder>PyDMScaleIndicator_15</zorder>
+     <zorder>PyDMScaleIndicator_17</zorder>
+     <zorder>label_6</zorder>
+     <zorder>label_8</zorder>
+     <zorder>PyDMScaleIndicator_18</zorder>
+     <zorder>PyDMScaleIndicator_16</zorder>
+     <zorder>PyDMScaleIndicator_19</zorder>
+     <zorder>PyDMScaleIndicator_20</zorder>
+     <zorder>label_7</zorder>
+     <zorder>label_13</zorder>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="8" column="0">
+      <widget class="PyDMPushButton" name="PyDMPushButton_5">
+       <property name="palette">
+        <palette>
+         <active>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </active>
+         <inactive>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </inactive>
+         <disabled>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </disabled>
+        </palette>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>STOP</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="7">
+      <widget class="PyDMLabel" name="PyDMLabel_46">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH.RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="8">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="6">
+      <widget class="PyDMPushButton" name="PyDMPushButton_4">
+       <property name="palette">
+        <palette>
+         <active>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </active>
+         <inactive>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </inactive>
+         <disabled>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </disabled>
+        </palette>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>STOP</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH.STOP</string>
+       </property>
+       <property name="passwordProtected" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>X-AXIS</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWIDTH.HLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>High Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="9">
+      <widget class="PyDMPushButton" name="PyDMPushButton_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>HOME</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCENTER:PLC:bHomeCmd</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="PyDMPushButton" name="PyDMPushButton_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>HOME</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCENTER:PLC:bHomeCmd</string>
+       </property>
+       <property name="showConfirmDialog" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH.HLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>High Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="PyDMPushButton" name="PyDMPushButton_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>HOME</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWIDTH:PLC:bHomeCmd</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="8">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCENTER.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH.LLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Low Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="6">
+      <widget class="PyDMPushButton" name="PyDMPushButton_3">
+       <property name="palette">
+        <palette>
+         <active>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </active>
+         <inactive>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </inactive>
+         <disabled>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </disabled>
+        </palette>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>STOP</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCENTER.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCENTER.HLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>High Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="6">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>87</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Width (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_47">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCENTER.RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWIDTH.LLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Low Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="2" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCENTER.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWIDTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCENTER.LLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Low Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>87</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="9">
+      <widget class="PyDMPushButton" name="PyDMPushButton_8">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>HOME</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWIDTH:PLC:bHomeCmd</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCENTER.LLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Low Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="7">
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Y-AXIS</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="PyDMPushButton" name="PyDMPushButton">
+       <property name="palette">
+        <palette>
+         <active>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </active>
+         <inactive>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </inactive>
+         <disabled>
+          <colorrole role="Button">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Base">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+          <colorrole role="Window">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>0</green>
+             <blue>0</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </disabled>
+        </palette>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>STOP</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCENTER.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWIDTH.RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="7">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCENTER.RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCENTER.HLS</string>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="labelPosition" stdset="0">
+        <enum>QTabWidget::West</enum>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>High Lim</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="6">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>87</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>87</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Width (mm)</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="TyphosCompositeSignalPanel" name="signal_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Panel of Signals + Sub-Devices for Device
+    </string>
+     </property>
+     <property name="showOmitted" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosCompositeSignalPanel</class>
+   <extends>TyphosSignalPanel</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScaleIndicator</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.scale</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added a class for JJSlits_AT_C8_HV within slits.py.  Along with this was the creation of a typhos controls screen.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a necessary addition since the new JJ Slits model: AT-C8-HV move as a pair compared to the regular slits which can move individually. With the creation of this class and screen it can easily be used with various JJSlits_AT_C8_HV using happi and typhos.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested within the Test rack in building 901. Tested to make sure each axis of slits moves correctly and corresponds to controls screen.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
There is a comment within the new class describing the parameters and use.
<!--
## Screenshots (if appropriate):
-->
JJSlits have been moved and were not connected when screenshots were taken, hence the red boxes/errors.

<img width="482" alt="jjslits_ipython1" src="https://user-images.githubusercontent.com/88116804/165127518-c5893bcc-7ee0-4210-8928-bae5d2002e6e.PNG">

<img width="917" alt="jjslits_screen1" src="https://user-images.githubusercontent.com/88116804/165125626-4e081b33-320e-4f97-86e1-4e2637cf2e8f.PNG">

<img width="919" alt="jjslits_screen2" src="https://user-images.githubusercontent.com/88116804/165125644-073eb269-e628-4186-954f-72a6adacc2fd.PNG">


## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

