### PR TITLE
ENH: Fix / add screen methods

### DIFF
--- a/docs/source/upcoming_release_notes/1004-fix_screen_methods.rst
+++ b/docs/source/upcoming_release_notes/1004-fix_screen_methods.rst
@@ -28,4 +28,4 @@ Maintenance
 
 Contributors
 ------------
-- roberttk
+- tangkong

--- a/docs/source/upcoming_release_notes/1004-fix_screen_methods.rst
+++ b/docs/source/upcoming_release_notes/1004-fix_screen_methods.rst
@@ -1,0 +1,31 @@
+1004 fix_screen_methods
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- adds `.screen()` method to BaseInterface, which opens a typhos screen
+- adds AreaDetector specific `.screen()` method, which calls camViewer
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- fixes calls to ipm_screen
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- roberttk

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -65,7 +65,15 @@ class PCDSAreaDetectorBase(DetectorBase):
         return port_edges
 
     def screen(self, main=False):
-        """ Try and call camviewer here... """
+        """
+        Open camViewer screen for camera.
+
+        Parameters
+        ----------
+        main : bool, optional
+            Set to True to bring up 'main' edm config screen.
+            Defaults to False, which opens python viewer.
+        """
         if shutil.which('camViewer'):
             arglist = ['camViewer', '-H', str(get_hutch_name()).lower(),
                        '-c', self.name]

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -64,7 +64,7 @@ class PCDSAreaDetectorBase(DetectorBase):
                           for src, dest in port_edges]
         return port_edges
 
-    def screen(self, main=False):
+    def screen(self, main: bool=False) -> None:
         """
         Open camViewer screen for camera.
 
@@ -74,17 +74,17 @@ class PCDSAreaDetectorBase(DetectorBase):
             Set to True to bring up 'main' edm config screen.
             Defaults to False, which opens python viewer.
         """
-        if shutil.which('camViewer'):
-            arglist = ['camViewer', '-H', str(get_hutch_name()).lower(),
-                       '-c', self.name]
-            if main:
-                arglist.append('-m')
-
-            logger.info('starting camviewer')
-            subprocess.run(arglist, check=False)
-        else:
-            logger.info('no camViewer available')
+        if not shutil.which('camViewer'):
+            logger.error('no camViewer available')
             return
+
+        arglist = ['camViewer', '-H', str(get_hutch_name()).lower(),
+                    '-c', self.name]
+        if main:
+            arglist.append('-m')
+
+        logger.info('starting camviewer')
+        subprocess.run(arglist, check=False)
 
 
 class PCDSHDF5BlueskyTriggerable(SingleTrigger, PCDSAreaDetectorBase):
@@ -391,8 +391,9 @@ class PCDSAreaDetectorTyphos(Device):
                    '--oneline',
                    'GE:16,{0}:IMAGE1;{0},,{0}'.format(self.prefix[0:-1])]
 
-        subprocess.run(arglist, stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE, check=True)
+        self.log.info('Opening python viewer for camera...')
+        subprocess.run(arglist, stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL, check=True)
 
     # Make viewer available in Typhos screen
     cam_viewer = Cpt(AttributeSignal, attr='_open_screen', kind='normal')

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -5,6 +5,7 @@ All components at the detector level such as plugins or image processing
 functions needed by all instances of a detector are added here.
 """
 import logging
+import shutil
 import subprocess
 import time
 import warnings
@@ -62,6 +63,20 @@ class PCDSAreaDetectorBase(DetectorBase):
             port_edges = [(port_map[src].name, port_map[dest].name)
                           for src, dest in port_edges]
         return port_edges
+
+    def screen(self, main=False):
+        """ Try and call camviewer here... """
+        if shutil.which('camViewer'):
+            arglist = ['camViewer', '-H', str(get_hutch_name()).lower(),
+                       '-c', self.name]
+            if main:
+                arglist.append('-m')
+
+            logger.info('starting camviewer')
+            subprocess.run(arglist, check=False)
+        else:
+            logger.info('no camViewer available')
+            return
 
 
 class PCDSHDF5BlueskyTriggerable(SingleTrigger, PCDSAreaDetectorBase):
@@ -381,6 +396,10 @@ class PCDSAreaDetectorTyphos(Device):
 
     @_open_screen.setter
     def _open_screen(self, value):
+        self.open_viewer()
+
+    def screen(self):
+        """ Lean on open_viewer method """
         self.open_viewer()
 
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -534,8 +534,8 @@ class PCDSMotorBase(EpicsMotorInterface):
 
         logger.info(f'Opening {executable} for {self.name}...')
         subprocess.run([executable, arg],
-                       stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE)
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL)
 
     @raise_if_disconnected
     def set_current_position(self, pos):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -2,8 +2,8 @@
 Module for LCLS's special motor records.
 """
 import logging
-import os
 import shutil
+import subprocess
 from typing import ClassVar, Optional
 
 from ophyd.device import Component as Cpt
@@ -531,7 +531,11 @@ class PCDSMotorBase(EpicsMotorInterface):
                          executable)
             return
         arg = self.prefix
-        os.system(executable + ' ' + arg)
+
+        logger.info(f'Opening {executable} for {self.name}...')
+        subprocess.run([executable, arg],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE)
 
     @raise_if_disconnected
     def set_current_position(self, pos):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -402,8 +402,8 @@ class BaseInterface:
 
         # capture stdout and stderr
         subprocess.Popen(arglist,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+                         stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL)
 
 
 def get_name(obj, default):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -5,7 +5,9 @@ import functools
 import logging
 import numbers
 import re
+import shutil
 import signal
+import subprocess
 import time
 import typing
 from contextlib import contextmanager
@@ -381,6 +383,27 @@ class BaseInterface:
         final_post = f'<pre>{self.status()}</pre>'
         elog.post(final_post, tags=['ophyd_status'],
                   title=f'{self.name} status report')
+
+    def screen(self):
+        """
+        Open a screen for controlling the device.
+
+        Default behavior is the typhos screen, but this method can
+        be overridden for more specialized screens.
+        """
+
+        if shutil.which('typhos') is None:
+            logger.error('typhos is not installed, ',
+                         'screen cannot be opened')
+            return
+
+        arglist = ['typhos', f'{self.name}']
+        logger.info(f'Opening typhos screen for {self.name}...')
+
+        # capture stdout and stderr
+        subprocess.Popen(arglist,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
 
 
 def get_name(obj, default):

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -352,7 +352,7 @@ class IPIMB(BaseInterface, GroupDevice):
 
     def screen(self):
         """Function to call the (pyQT) screen for an IPIMB box."""
-        return ipm_screen('IPIMB', self._prefix, self._prefix_ioc)
+        return ipm_screen('IPIMB', self.prefix, self._prefix_ioc)
 
     @property
     def isum(self):
@@ -447,7 +447,7 @@ class Wave8(BaseInterface, GroupDevice):
 
     def screen(self):
         """Function to call the (pyQT) screen for a Wave8 box."""
-        return ipm_screen('Wave8', self._prefix, self._prefix_ioc)
+        return ipm_screen('Wave8', self.prefix, self._prefix_ioc)
 
     def apply_configuration(self):
         """Put to the 'DO_CONFIG' PV, causing config PVs to be applied."""

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -4,9 +4,9 @@ import enum
 import inspect
 import logging
 import operator
-import os
 import select
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -160,8 +160,11 @@ def ipm_screen(dettype, prefix, prefix_ioc):
     if shutil.which(executable) is None:
         raise EnvironmentError('%s is not on path, we cannot start the screen'
                                % executable)
-    os.system('%s --base %s --ioc %s --evr %s &' %
-              (executable, prefix, prefix_ioc, prefix+':TRIG'))
+
+    logger.info(f'Opening {dettype} screen for {prefix}...')
+    arglist = [executable, '--base', prefix, '--ioc', prefix_ioc,
+               '--evr', prefix+':TRIG']
+    _ = subprocess.Popen(arglist)
 
 
 def get_component(obj):


### PR DESCRIPTION
## Description
- Adds the `.screen` method to `BaseInterface`, which relies on typhos to auto-generate a screen
- Unifies existing `.screen` methods behind `subprocess`, for more flexibility and consistency
- Fixes bugs in existing IPM screen calls
- Adds camviewer-based `.screen` method to AreaDetector class, with option to open "main" edm screen or the python screen by default.


## Motivation and Context
[Jira](https://jira.slac.stanford.edu/browse/LCLSECSD-282)

There can be times where finding screens is difficult, so opening them from hutch-python can be helpful.  Leaning on existing engineering_tools functions seems to be an efficient path forward.  

IPM devices have proved difficult to universally write a screen method for.  The devices present in ipmConfigEpics do not always match devices in the hutch-python sessions, and  when they do the PV's do not match.  More details in the Jira ticket.  I have chosen to leave the IPM's out of this PR for the time being.

## How Has This Been Tested?
Interactively.  (not really sure how to test this)

## Where Has This Been Documented?
This PR, some docstrings

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
