### PR TITLE
BUG: fix Stopper container definition

### DIFF
--- a/docs/source/upcoming_release_notes/1009-stopper_container.rst
+++ b/docs/source/upcoming_release_notes/1009-stopper_container.rst
@@ -1,0 +1,30 @@
+1009 stopper_container
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix Stopper Happi container definition
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -221,7 +221,7 @@ class Stopper(Device):
         "STPR:XRT1:1:S5IN_MPS".
     """
     device_class = copy(Device.device_class)
-    device_class = 'pcdsdevices.device_types.Stopper'
+    device_class.default = 'pcdsdevices.device_types.Stopper'
 
 
 class OffsetMirror(BeamControl):


### PR DESCRIPTION
## Description
- Fixes Stopper Happi container definition

## Motivation and Context
closes https://github.com/pcdshub/happi/issues/245

## How Has This Been Tested?
`happi container-registry` works now

## Where Has This Been Documented?
Here
 
## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
