### PR TITLE
BLD: seems like new pyqt breaks the CI, pin for now

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - scipy
   run_constrained:
     - pmgr >=2.0.2
+    - pyqt <5.15
 
 test:
   imports:

--- a/docs/source/upcoming_release_notes/1010-pin-qt.rst
+++ b/docs/source/upcoming_release_notes/1010-pin-qt.rst
@@ -1,0 +1,31 @@
+1010 pin-qt
+###########
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Add a run constraint for pyqt to avoid latest while we work out testing
+  failures
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add run constraint on pyqt to avoid the latest version
Does not need to propagate to the conda-forge recipe, probably

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests crash in the same way as they did for pydm at pyqt 5.15

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Hopefully the tests don't crash after this

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-rel notes only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
