### PR TITLE
MAINT: remove PV that throws errors on psbuild

### DIFF
--- a/docs/source/upcoming_release_notes/1011-badpv.rst
+++ b/docs/source/upcoming_release_notes/1011-badpv.rst
@@ -1,0 +1,30 @@
+1011 badpv
+##########
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Remove unusable bunch_charge_2 signal from LCLS beam stats.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/docs/source/upcoming_release_notes/1011-badpv.rst
+++ b/docs/source/upcoming_release_notes/1011-badpv.rst
@@ -19,7 +19,9 @@ New Devices
 
 Bugfixes
 --------
-- Remove unusable bunch_charge_2 signal from LCLS beam stats.
+- Remove unusable bunch_charge_2 signal from LCLS beam stats. This PV seems
+  to contain a stale value that disagrees with bunch_charge and causes EPICS
+  errors on certain hosts.
 
 Maintenance
 -----------

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -140,8 +140,6 @@ class LCLS(BaseInterface, Device):
 
     bunch_charge = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO470', kind='normal',
                        doc='Bunch charge [nC]')
-    bunch_charge_2 = Cpt(EpicsSignalRO, 'FBCK:BCI0:1:CHRG',
-                         kind='normal', doc='Bunch Charge [nC]')
     beam_event_rate = Cpt(EpicsSignalRO, 'EVNT:SYS0:1:LCLSBEAMRATE',
                           kind='normal', doc='LCLSBEAM Event Rate [Hz]')
     ebeam_energy = Cpt(EpicsSignalRO, 'SIOC:SYS0:ML00:AO500', kind='normal',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove bunch_charge_2 from beam stats

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Super annoying every time on psbuild-rhel7
```
CA.Client.Exception...............................................
    Warning: "Identical process variable names on multiple servers"
    Context: "Channel: "FBCK:BCI0:1:CHRG", Connecting to: pscag01-build.slac.stanford.edu:45643, Ignored: pscag01-build.slac.stanford.edu:45580"
    Source File: ../cac.cpp line 1320
    Current Time: Wed May 18 2022 14:19:50.764512834
..................................................................
ERROR    run - Exception occurred during callback <function PyepicsShimPV.get_all_metadata_callback.<locals>.get_metadata_thread at 0x7fe46762a4c0> (pvname='FBCK:BCI0:1:CHRG')
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/ophyd/_dispatch.py", line 45, in run
    callback(*args, **kwargs)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/ophyd/_pyepics_shim.py", line 105, in get_metadata_thread
    md = self.get_all_metadata_blocking(timeout=timeout)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/ophyd/_pyepics_shim.py", line 97, in get_all_metadata_blocking
    self.get_timevars(timeout=timeout)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/pv.py", line 47, in wrapped
    return func(self, *args, **kwargs)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/pv.py", line 745, in get_timevars
    kwds = ca.get_timevars(self.chid, timeout=timeout, warn=warn)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/ca.py", line 577, in wrapper
    return fcn(*args, **kwds)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/ca.py", line 1784, in get_timevars
    metadata = get_with_metadata(chid, ftype=ftype, count=1, timeout=timeout,
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/ca.py", line 635, in wrapper
    return fcn(*args, **kwds)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/ca.py", line 1387, in get_with_metadata
    PySEVCHK('get', ret)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.0/lib/python3.9/site-packages/epics/ca.py", line 659, in PySEVCHK
    raise CASeverityException(func_name, message(status))
epics.ca.CASeverityException:  get returned 'Read access denied'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll do it in a bit

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
