### PR TITLE
ENH: Energy request waiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 build
 *.pyc
+*~
 
 #Coverage Reports
 htmlcov

--- a/docs/source/upcoming_release_notes/1013-energy-request-waiter.rst
+++ b/docs/source/upcoming_release_notes/1013-energy-request-waiter.rst
@@ -30,4 +30,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- zllentz

--- a/docs/source/upcoming_release_notes/1013-energy-request-waiter.rst
+++ b/docs/source/upcoming_release_notes/1013-energy-request-waiter.rst
@@ -1,0 +1,33 @@
+1013 energy-request-waiter
+##########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add an optional "acr_status_suffix" argument to ``BeamEnergyRequest`` that
+  instantiates an alternate version of the class that waits on an ACR PV to
+  know when the motion is done. This is a more suitable version of the class
+  for step scans and a less suitable version of the class for fly scans.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -4,6 +4,7 @@ from typing import Optional
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
+from ophyd.positioner import PositionerBase
 from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 from ophyd.sim import fake_device_cache, make_fake_device
@@ -34,7 +35,7 @@ class BeamStats(BaseInterface, Device):
         super().__init__(prefix=prefix, name=name, **kwargs)
 
 
-class BeamEnergyRequest(BaseInterface, Device):
+class BeamEnergyRequest(BaseInterface, Device, PositionerBase):
     """
     Positioner to request beam color changes from ACR in eV.
 

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -1,5 +1,4 @@
 import logging
-import numbers
 from typing import Optional
 
 from ophyd.device import Component as Cpt
@@ -7,6 +6,7 @@ from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
+from ophyd.sim import fake_device_cache, make_fake_device
 
 from .interface import BaseInterface
 from .pv_positioner import PVPositionerDone
@@ -59,13 +59,13 @@ class BeamEnergyRequest(BaseInterface, Device):
 
     Parameters
     ----------
-    prefix: str
+    prefix : str
         PV prefix for the request setpoint. This should always be a hutch name.
 
-    name: str, required keyword
+    name : str, required keyword
         Name to use for this device in log messages, data streams, etc.
 
-    skip_small_moves: bool, optional
+    skip_small_moves : bool, optional
         Has no effect if using the wait-on-PV version of the class, but will
         take effect for the no-wait version of the class.
         Defaults to True, which ignores move requests that are smaller than the
@@ -76,31 +76,27 @@ class BeamEnergyRequest(BaseInterface, Device):
         can skip the small moves here and move the monochromater and beam
         request devices in parallel.
 
-    atol: int, optional
+    atol : int, optional
         Has no effect if using the wait-on-PV version of the class, but will
         take effect for the no-wait version of the class.
         Absolute tolerance that determines when the move is done and when to
         skip moves using the skip_small_moves parameter.
 
-    line: str, optional
+    line : str, optional
         Whether to use the K line or L line PV. If provided this should be a
         string with a single character. The K line PVs have "EPHOTK"
         in them, the L line PVs just have "EPHOT". This will default to the
         line associated with the prefix hutch name, or to L line failing that.
 
-    bunch: int, optional
+    bunch : int, optional
         Whether to move the first bunch (1) or the second bunch (2). This is
         only relevant for 2-color mode. Defaults to bunch 1.
 
-    acr_status_suffix: str, optional
+    acr_status_suffix : str, optional
         If provided, we'll wait on the ACR PV specified by
         SIOC:SYS0:ML07:{suffix}. The selected PV should be 0 while the device
         is moving and 1 when it is done.
     """
-
-    # Default vernier tolerance
-    atol = 5
-
     setpoint = FCpt(
         EpicsSignal,
         '{prefix}:USER:MCC:EPHOT{line_text}:SET{bunch}',
@@ -135,6 +131,8 @@ class BeamEnergyRequest(BaseInterface, Device):
         acr_status_suffix: Optional[str] = None,
         **kwargs
     ):
+        if cls is not BeamEnergyRequest:
+            return super().__new__(cls)
         if acr_status_suffix is None:
             return super().__new__(BeamEnergyRequestNoWait)
         return super().__new__(BeamEnergyRequestACRWait)
@@ -144,14 +142,11 @@ class BeamEnergyRequest(BaseInterface, Device):
         prefix: str,
         *,
         name: str,
-        atol: Optional[numbers.Real] = None,
         line: Optional[str] = None,
         bunch: int = 1,
         acr_status_suffix: Optional[str] = None,
         **kwargs
     ):
-        if atol is not None:
-            self.atol = atol
         self.line_text = self.line_text_dict.get(line or prefix, '')
         self.bunch = bunch
         self.acr_status_suffix = acr_status_suffix
@@ -165,6 +160,8 @@ class BeamEnergyRequestNoWait(BeamEnergyRequest, PVPositionerDone):
     It will report done immediately and ignore moves that are smaller than
     atol.
     """
+    atol = 5
+
     # All done-related functionality is inherited from PVPositionerDone
     # Just implement skip_small_moves's default
     def __init__(self, *args, skip_small_moves: bool = True, **kwargs):
@@ -190,6 +187,47 @@ class BeamEnergyRequestACRWait(BeamEnergyRequest, PVPositioner):
         )
     )
     done_value = 1
+
+
+_FakeBeamEnergyRequestNoWait = make_fake_device(BeamEnergyRequestNoWait)
+_FakeBeamEnergyRequestACRWait = make_fake_device(BeamEnergyRequestACRWait)
+_FakeBeamEnergyRequest = make_fake_device(BeamEnergyRequest)
+
+
+class FakeBeamEnergyRequest(_FakeBeamEnergyRequest):
+    """
+    Required setup for fake classes to work properly with __new__ splitting
+    """
+    def __new__(
+        cls,
+        *args,
+        acr_status_suffix: Optional[str] = None,
+        **kwargs
+    ):
+        if cls is not FakeBeamEnergyRequest:
+            return super().__new__(cls)
+        if acr_status_suffix is None:
+            return super().__new__(FakeBeamEnergyRequestNoWait)
+        return super().__new__(FakeBeamEnergyRequestACRWait)
+
+
+class FakeBeamEnergyRequestNoWait(
+    _FakeBeamEnergyRequestNoWait,
+    FakeBeamEnergyRequest,
+):
+    ...
+
+
+class FakeBeamEnergyRequestACRWait(
+    _FakeBeamEnergyRequestACRWait,
+    FakeBeamEnergyRequest,
+):
+    ...
+
+
+fake_device_cache[BeamEnergyRequestNoWait] = FakeBeamEnergyRequestNoWait
+fake_device_cache[BeamEnergyRequestACRWait] = FakeBeamEnergyRequestACRWait
+fake_device_cache[BeamEnergyRequest] = FakeBeamEnergyRequest
 
 
 class LCLS(BaseInterface, Device):

--- a/pcdsdevices/pv_positioner.py
+++ b/pcdsdevices/pv_positioner.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from ophyd.device import Component as Cpt
 from ophyd.pv_positioner import PVPositioner
@@ -131,7 +133,17 @@ class PVPositionerDone(FltMvInterface, PVPositioner):
     done = Cpt(InternalSignal, value=0)
     done_value = 1
 
-    def __init__(self, prefix, *, name, skip_small_moves=False, **kwargs):
+    def __init__(
+        self,
+        prefix: str,
+        *,
+        name: str,
+        skip_small_moves: bool = False,
+        atol: Optional[float] = None,
+        **kwargs,
+    ):
+        if atol is not None:
+            self.atol = atol
         self.skip_small_moves = skip_small_moves
         super().__init__(prefix, name=name, **kwargs)
 

--- a/pcdsdevices/tests/test_beam_stats.py
+++ b/pcdsdevices/tests/test_beam_stats.py
@@ -91,6 +91,7 @@ def test_get_set_period(fake_lcls):
     assert lcls.bykik_get_period() == 100
 
 
+@pytest.mark.timeout(5)
 def test_beam_energy_request_args():
     # Defaults for xpp and tmo
     xpp_request = BeamEnergyRequest(
@@ -136,6 +137,7 @@ def test_beam_energy_request_args():
     assert 'TSTSUFFIX' in tst_l1_request.done.pvname
 
 
+@pytest.mark.timeout(5)
 def test_beam_energy_request_behavior():
     FakeCls = make_fake_device(BeamEnergyRequest)
 

--- a/pcdsdevices/tests/test_beam_stats.py
+++ b/pcdsdevices/tests/test_beam_stats.py
@@ -3,7 +3,10 @@ import logging
 import pytest
 from ophyd.sim import make_fake_device
 
-from ..beam_stats import LCLS, BeamEnergyRequest, BeamStats
+from ..beam_stats import (LCLS, BeamEnergyRequest, BeamEnergyRequestACRWait,
+                          BeamEnergyRequestNoWait, BeamStats,
+                          FakeBeamEnergyRequestACRWait,
+                          FakeBeamEnergyRequestNoWait)
 
 logger = logging.getLogger(__name__)
 
@@ -90,9 +93,13 @@ def test_get_set_period(fake_lcls):
 
 def test_beam_energy_request_args():
     # Defaults for xpp and tmo
-    xpp_request = BeamEnergyRequest('XPP', name='xpp_request')
+    xpp_request = BeamEnergyRequest(
+        'XPP',
+        name='xpp_request',
+        skip_small_moves=True,
+    )
     assert xpp_request.setpoint.pvname == 'XPP:USER:MCC:EPHOT:SET1'
-    tmo_request = BeamEnergyRequest('TMO', name='tmo_request')
+    tmo_request = BeamEnergyRequest('TMO', name='tmo_request', atol=4)
     assert tmo_request.setpoint.pvname == 'TMO:USER:MCC:EPHOTK:SET1'
     # Future TXI and multi-bunch specific options
     tst_k1_request = BeamEnergyRequest(
@@ -109,3 +116,58 @@ def test_beam_energy_request_args():
         bunch=2,
     )
     assert tst_l2_request.setpoint.pvname == 'TST:USER:MCC:EPHOT:SET2'
+    # let's test the class splitting here too
+    for obj in (
+        xpp_request,
+        tmo_request,
+        tst_k1_request,
+        tst_l2_request,
+    ):
+        assert isinstance(obj, BeamEnergyRequestNoWait)
+        assert isinstance(obj, BeamEnergyRequest)
+    # including a done PV
+    tst_l1_request = BeamEnergyRequest(
+        'TST',
+        name='tst_l2_request',
+        acr_status_suffix='TSTSUFFIX',
+    )
+    assert isinstance(tst_l1_request, BeamEnergyRequest)
+    assert isinstance(tst_l1_request, BeamEnergyRequestACRWait)
+    assert 'TSTSUFFIX' in tst_l1_request.done.pvname
+
+
+def test_beam_energy_request_behavior():
+    FakeCls = make_fake_device(BeamEnergyRequest)
+
+    # No wait variant: reports done immediately, skips moves smaller than atol
+    nowait = FakeCls('TST', name='nowait', skip_small_moves=True, atol=0.9)
+    assert isinstance(nowait, FakeBeamEnergyRequestNoWait)
+    nowait.setpoint.put(0)
+    assert nowait.position == 0
+    nowait.move(0.1).wait(timeout=0.1)
+    assert nowait.position == 0
+    nowait.move(1).wait(timeout=0.1)
+    assert nowait.position == 1
+
+    # Wait variant: acr needs to put 0 to when moving and 1 back when done
+    acrwait = FakeCls('TST', name='acrwait', acr_status_suffix='WAITER')
+    assert isinstance(acrwait, FakeBeamEnergyRequestACRWait)
+    acrwait.done.sim_put(1)
+    st = acrwait.move(1)
+    try:
+        st.wait(timeout=0.1)
+    except Exception:
+        ...
+    assert not st.done
+    acrwait.done.sim_put(0)
+    try:
+        st.wait(timeout=0.1)
+    except Exception:
+        ...
+    assert not st.done
+    acrwait.done.sim_put(1)
+    try:
+        st.wait(timeout=0.1)
+    except Exception:
+        ...
+    assert st.done

--- a/pcdsdevices/tests/test_beam_stats.py
+++ b/pcdsdevices/tests/test_beam_stats.py
@@ -146,16 +146,16 @@ def test_beam_energy_request_behavior():
     assert isinstance(nowait, FakeBeamEnergyRequestNoWait)
     nowait.setpoint.put(0)
     assert nowait.position == 0
-    nowait.move(0.1).wait(timeout=0.1)
+    nowait.move(0.1, timeout=0.1)
     assert nowait.position == 0
-    nowait.move(1).wait(timeout=0.1)
+    nowait.move(1, timeout=0.1)
     assert nowait.position == 1
 
     # Wait variant: acr needs to put 0 to when moving and 1 back when done
     acrwait = FakeCls('TST', name='acrwait', acr_status_suffix='WAITER')
     assert isinstance(acrwait, FakeBeamEnergyRequestACRWait)
     acrwait.done.sim_put(1)
-    st = acrwait.move(1)
+    st = acrwait.move(1, wait=False)
     try:
         st.wait(timeout=0.1)
     except Exception:
@@ -169,7 +169,7 @@ def test_beam_energy_request_behavior():
     assert not st.done
     acrwait.done.sim_put(1)
     try:
-        st.wait(timeout=0.1)
+        st.wait(timeout=1)
     except Exception:
         ...
     assert st.done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There's a mode that the energy request PVs can run in where done/not-done information is broadcast by ACR to one of a number of status PVs. This PR adds a mode to `BeamEnergyRequest` where motion will wait and report done based on that given PV instead of using the "done immediately" mechanisms.

This is accomplished by using (abusing?) the `__new__` mechanics to pick which subclass to substitute for `BeamEnergyRequest` based on the input arguments. These subclasses each implement `done` in a different way. The parent `BeamEnergyRequest` class continues to implement shared behavior e.g. pv names of the setpoint PV. This is similar to our handling of `PytmcSignal`. At the cost of some implementation complexity, compared to making a factory functions this allows all variants to be isinstance checked against the "factory".

This is fully backwards-compatible with the previous implementation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Request from James Cryan and it just seems like a better way to handle these overall
https://slac.slack.com/archives/C9RP2PQHM/p1652145320558209
https://jira.slac.stanford.edu/browse/LCLSPC-402

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively I verified that the PVs looked correct.
The fake devices seem to pass the tests I've set up for them.
This probably needs some test in TMO

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
