### PR TITLE
Add state classes for KBO mirrors with cooling and without cooling

### DIFF
--- a/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
+++ b/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
@@ -17,7 +17,7 @@ New Devices
 -----------
 - `KBOMirrorHEStates` - a class for KBO mirrors with coating states
  and cooling.
-- `KBOMirrorStates` - a class for KBO mirrors with coating states
+-  `KBOMirrorStates` - a class for KBO mirrors with coating states
  and no cooling
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
+++ b/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
@@ -16,9 +16,9 @@ Device Updates
 New Devices
 -----------
 - `KBOMirrorHEStates` - a class for KBO mirrors with coating states
- and cooling.
+  and cooling.
 - `KBOMirrorStates` - a class for KBO mirrors with coating states
- and no cooling
+  and no cooling
 Bugfixes
 --------
 - N/A

--- a/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
+++ b/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
@@ -15,10 +15,10 @@ Device Updates
 
 New Devices
 -----------
-`KBOMirrorHEStates` - a class for KBO mirrors with coating states
-and cooling.
-`KBOMirrorStates` - a class for KBO mirrors with coating states
-and no cooling
+- `KBOMirrorHEStates` - a class for KBO mirrors with coating states
+ and cooling.
+- `KBOMirrorStates` - a class for KBO mirrors with coating states
+ and no cooling
 Bugfixes
 --------
 - N/A
@@ -29,4 +29,4 @@ Maintenance
 
 Contributors
 ------------
-nrwslac
+- nrwslac

--- a/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
+++ b/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
@@ -17,7 +17,7 @@ New Devices
 -----------
 - `KBOMirrorHEStates` - a class for KBO mirrors with coating states
  and cooling.
--  `KBOMirrorStates` - a class for KBO mirrors with coating states
+- `KBOMirrorStates` - a class for KBO mirrors with coating states
  and no cooling
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
+++ b/docs/source/upcoming_release_notes/1016-kbo-coating-states.rst
@@ -1,0 +1,32 @@
+1016 kbo-coating-states
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+`KBOMirrorHEStates` - a class for KBO mirrors with coating states
+and cooling.
+`KBOMirrorStates` - a class for KBO mirrors with coating states
+and no cooling
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -884,6 +884,55 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
         return 1
 
 
+@reorder_components(
+    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds', 'x_enc_rms', 'y_enc_rms',
+        'pitch_enc_rms', 'bender_us_enc_rms', 'bender_ds_enc_rms', 'us_rtd', 'ds_rtd']
+)
+class KBOMirrorStates(KBOMirror):
+    """
+    Kirkpatrick-Baez Mirror with Bender Axes and Coating States.
+
+    1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
+                              doc='Control of the coating states via saved positions.')
+
+    # Tab config: show components
+    tab_component_names = True
+
+
+@reorder_components(
+    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds', 'x_enc_rms', 'y_enc_rms', 
+        'pitch_enc_rms', 'bender_us_enc_rms', 'bender_ds_enc_rms', 'us_rtd', 'ds_rtd', 'cool_flow1', 'cool_flow2', 'cool_press']
+)
+class KBOMirrorHEStates(KBOMirrorHE):
+    """
+    Kirkpatrick-Baez Mirror with Bender Axes and Cooling and Coating States.
+
+    1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
+                              doc='Control of the coating states via saved positions.')
+    # Tab config: show components
+    tab_component_names = True
+
+
 class CoatingState(Device):
     """
     Extra parent class to put "coating" as the first device in order.

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -885,9 +885,11 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
 
 
 @reorder_components(
-    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
+    end_with=[
+        'coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
         'x_enc_rms', 'y_enc_rms', 'pitch_enc_rms', 'bender_us_enc_rms',
-        'bender_ds_enc_rms', 'us_rtd', 'ds_rtd']
+        'bender_ds_enc_rms', 'us_rtd', 'ds_rtd'
+    ]
 )
 class KBOMirrorStates(KBOMirror):
     """
@@ -904,17 +906,19 @@ class KBOMirrorStates(KBOMirror):
         Alias for the device.
     """
     coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
-        doc='Control of the coating states via saved positions.')
+                  doc='Control of the coating states via saved positions.')
 
     # Tab config: show components
     tab_component_names = True
 
 
 @reorder_components(
-    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
+    end_with=[
+        'coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
         'x_enc_rms', 'y_enc_rms', 'pitch_enc_rms', 'bender_us_enc_rms',
         'bender_ds_enc_rms', 'us_rtd', 'ds_rtd', 'cool_flow1',
-        'cool_flow2', 'cool_press']
+        'cool_flow2', 'cool_press'
+    ]
 )
 class KBOMirrorHEStates(KBOMirrorHE):
     """
@@ -931,7 +935,7 @@ class KBOMirrorHEStates(KBOMirrorHE):
         Alias for the device.
     """
     coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
-        doc='Control of the coating states via saved positions.')
+                  doc='Control of the coating states via saved positions.')
     # Tab config: show components
     tab_component_names = True
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -885,8 +885,9 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
 
 
 @reorder_components(
-    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds', 'x_enc_rms', 'y_enc_rms',
-        'pitch_enc_rms', 'bender_us_enc_rms', 'bender_ds_enc_rms', 'us_rtd', 'ds_rtd']
+    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
+        'x_enc_rms', 'y_enc_rms', 'pitch_enc_rms', 'bender_us_enc_rms',
+        'bender_ds_enc_rms', 'us_rtd', 'ds_rtd']
 )
 class KBOMirrorStates(KBOMirror):
     """
@@ -903,15 +904,17 @@ class KBOMirrorStates(KBOMirror):
         Alias for the device.
     """
     coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
-                              doc='Control of the coating states via saved positions.')
+        doc='Control of the coating states via saved positions.')
 
     # Tab config: show components
     tab_component_names = True
 
 
 @reorder_components(
-    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds', 'x_enc_rms', 'y_enc_rms', 
-        'pitch_enc_rms', 'bender_us_enc_rms', 'bender_ds_enc_rms', 'us_rtd', 'ds_rtd', 'cool_flow1', 'cool_flow2', 'cool_press']
+    end_with=['coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
+        'x_enc_rms', 'y_enc_rms', 'pitch_enc_rms', 'bender_us_enc_rms',
+        'bender_ds_enc_rms', 'us_rtd', 'ds_rtd', 'cool_flow1',
+        'cool_flow2', 'cool_press']
 )
 class KBOMirrorHEStates(KBOMirrorHE):
     """
@@ -928,7 +931,7 @@ class KBOMirrorHEStates(KBOMirrorHE):
         Alias for the device.
     """
     coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
-                              doc='Control of the coating states via saved positions.')
+        doc='Control of the coating states via saved positions.')
     # Tab config: show components
     tab_component_names = True
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Coating States implemented for MR2K4 and MR3K4; need classes to support this. MR2K4 has cooling and MR3K4 does not. Therefore we need two new classes for KBO mirrors:
`KBOMirrorHEStates` and `KBOMirrorStates`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Coating States deployed to TMO MR2K4 and MR3K4
<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Launched each Typhos screen using:
`typhos 'pcdsdevices.mirror.KBOMirrorHEStates[{"prefix":"MR2K4:KBO"}]'`
`typhos 'pcdsdevices.mirror.KBOMirrorStates[{"prefix":"MR3K4:KBO"}]'`

Moved each mirror from one coating state to another and back. `B4C` <-> `Si` 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
