### PR TITLE
Addition of LED PVs to CMVI Motion

### DIFF
--- a/pcdsdevices/cvmi_motion.py
+++ b/pcdsdevices/cvmi_motion.py
@@ -10,7 +10,6 @@ from .device import GroupDevice
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
 
-
 class CVMI(BaseInterface, GroupDevice):
     """
     CVMI Motion Class
@@ -41,6 +40,15 @@ class CVMI(BaseInterface, GroupDevice):
 
     sample_paddle = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
 
+    # LEDs
+    led1_name = Cpt(EpicsSignal, 'CVMI:LED:01:NAME', kind='normal')
+    led1_pct = Cpt(EpicsSignal, 'CVMI:LED:01:ILL:PCT', kind='normal')
+    led1_pwr = Cpt(EpicsSignalRO, 'CVMI:LED:01:PWR', kind='normal') 
+    
+    led2_name = Cpt(EpicsSignal, 'CVMI:LED:02:NAME', kind='normal')
+    led2_pct = Cpt(EpicsSignal, 'CVMI:LED:02:ILL:PCT', kind='normal')
+    led2_pwr = Cpt(EpicsSignalRO, 'CVMI:LED:02:PWR', kind='normal')
+    
 
 class KTOF(BaseInterface, GroupDevice):
     """

--- a/pcdsdevices/cvmi_motion.py
+++ b/pcdsdevices/cvmi_motion.py
@@ -5,10 +5,12 @@ This module contains classes related to the TMO-LAMP Motion System
 """
 
 from ophyd import Component as Cpt
+from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from .device import GroupDevice
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
+
 
 class CVMI(BaseInterface, GroupDevice):
     """
@@ -41,14 +43,14 @@ class CVMI(BaseInterface, GroupDevice):
     sample_paddle = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
 
     # LEDs
-    led1_name = Cpt(EpicsSignal, 'CVMI:LED:01:NAME', kind='normal')
-    led1_pct = Cpt(EpicsSignal, 'CVMI:LED:01:ILL:PCT', kind='normal')
-    led1_pwr = Cpt(EpicsSignalRO, 'CVMI:LED:01:PWR', kind='normal') 
-    
-    led2_name = Cpt(EpicsSignal, 'CVMI:LED:02:NAME', kind='normal')
-    led2_pct = Cpt(EpicsSignal, 'CVMI:LED:02:ILL:PCT', kind='normal')
-    led2_pwr = Cpt(EpicsSignalRO, 'CVMI:LED:02:PWR', kind='normal')
-    
+    led1_name = Cpt(EpicsSignal, ':LED:01:NAME', kind='normal')
+    led1_pct = Cpt(EpicsSignal, ':LED:01:ILL:PCT', kind='normal')
+    led1_pwr = Cpt(EpicsSignalRO, ':LED:01:PWR', kind='normal')
+
+    led2_name = Cpt(EpicsSignal, ':LED:02:NAME', kind='normal')
+    led2_pct = Cpt(EpicsSignal, ':LED:02:ILL:PCT', kind='normal')
+    led2_pwr = Cpt(EpicsSignalRO, ':LED:02:PWR', kind='normal')
+
 
 class KTOF(BaseInterface, GroupDevice):
     """

--- a/pcdsdevices/cvmi_motion.py
+++ b/pcdsdevices/cvmi_motion.py
@@ -19,6 +19,10 @@ class CVMI(BaseInterface, GroupDevice):
     This class controls motors fixed to the CVMI Motion system for the IP1
     endstation in TMO.
 
+    Added on, are basic control and readback PVs for LED rings attached to
+    the viewports on the vacuum chamber. These include illumination
+    percentage, power ON/OFF, and a naming string field.
+
     Parameters
     ----------
     prefix : str


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

I added class variables to CVMI for LED control PVs. These include  control and readback PVs for LED rings attached to the viewports on the vacuum chamber. These include illumination percentage, power ON/OFF, and a naming string field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It enables remote control of LED illumination on CVMI either through hutch python or the CVMI motion typhos screen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1.  ipython session, loading the class

![Screenshot (798)](https://user-images.githubusercontent.com/50626768/171295254-385d4230-8cfb-492a-8cdd-0b6969d671cd.png)


2. flake8

![Screenshot (799)](https://user-images.githubusercontent.com/50626768/171295528-5f263ad7-fb08-48b7-a324-0ff28a78028c.png)


3. test typhos screen 

![Screenshot (800)](https://user-images.githubusercontent.com/50626768/171295802-cab8581e-b073-4b98-a2cd-a6a7c98e8d0b.png)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

1. Class docstring
2. Confluence page (work in progress): https://confluence.slac.stanford.edu/display/L2SI/IP1+LED+controls

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
