### PR TITLE
ENH: experiments with lazy loading for startup speed

### DIFF
--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -193,6 +193,8 @@ class BaseInterface:
         List of string regex to show in autocomplete for non-engineering mode.
     """
 
+    lazy_wait_for_connection = False
+
     tab_whitelist = (OphydObject_whitelist + BlueskyInterface_whitelist +
                      Device_whitelist + Signal_whitelist +
                      Positioner_whitelist)
@@ -215,6 +217,13 @@ class BaseInterface:
             )
 
         cls._class_tab = TabCompletionHelperClass(cls)
+        try:
+            cpts = [getattr(cls, name) for name in cls.component_names]
+        except AttributeError:
+            pass
+        else:
+            for cpt in cpts:
+                cpt.lazy = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- [x] Make components on `BaseInterface` subclasses lazy.
- [x] Set `BaseInterface`'s `lazy_wait_for_connection` to `False`, overriding the ophyd device default.
- [ ] Find other metrics to figure out where to apply lazy loading
- [ ] Rework some of the bigger classes to do fewer big subscriptions on load

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It takes ~40s for me to load all of our devices without this patch and ~20s with this patch for a 2x speedup.

`ophyd` has always had a lazy loading mechanism that we've been avoiding because it's less confusing to just have everything loaded at startup, especially because there are a bunch of init-time subscriptions and the whole `lazy_wait_for_connection` thing that don't play nice with each other.

I was doing profiling today and found that we create 32000 components to load our entire collection of beamline devices. This isn't sustainable for something like `lightpath`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP

Some testing will need to be done to see how this behaves live.
There are some annoyances wrt "late" errors that I'm worried about seeing.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
WIP

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
