### PR TITLE
ENH/FIX: setup pmgr later

### DIFF
--- a/docs/source/upcoming_release_notes/1025-setup_pmgr_later.rst
+++ b/docs/source/upcoming_release_notes/1025-setup_pmgr_later.rst
@@ -1,0 +1,34 @@
+1025 setup_pmgr_later
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add IMS.setup_pmgr as a public API for applications that want to initialize
+  pmgr support before the first device uses it. This was previously private
+  API at IMS._setup_pmgr.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Create the pmgr resources when they are first used rather than on IMS
+  init, saving 3 seconds of startup time for users that don't need
+  pmgr resources.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -596,10 +596,6 @@ class IMS(PCDSMotorBase):
     # If we fail to create _pm, set bool to only try once
     _pm_init_error = False
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._setup_pmgr_if_needed()
-
     def stage(self):
         """
         Stage the IMS motor.
@@ -724,7 +720,7 @@ class IMS(PCDSMotorBase):
 
         Returns nothing.
         """
-        self.check_pmgr()
+        self._setup_and_check_pmgr()
         self._pm.apply_config(self.prefix, cfgname)
 
     def get_configuration(self):
@@ -734,7 +730,7 @@ class IMS(PCDSMotorBase):
         Returns the current configuration name as a string or throws an
         exception.
         """
-        self.check_pmgr()
+        self._setup_and_check_pmgr()
         return self._pm.get_config(self.prefix)
 
     @staticmethod
@@ -770,7 +766,7 @@ class IMS(PCDSMotorBase):
                 print("    %s" % m)
 
     @staticmethod
-    def _setup_pmgr():
+    def setup_pmgr():
         try:
             from pmgr import pmgrAPI
         except ImportError:
@@ -795,10 +791,12 @@ class IMS(PCDSMotorBase):
     @staticmethod
     def _setup_pmgr_if_needed():
         if IMS._pm is None and not IMS._pm_init_error:
-            IMS._setup_pmgr()
+            IMS.setup_pmgr()
 
     @staticmethod
     def check_pmgr():
+        if IMS._pm is None:
+            raise RuntimeError('pmgr has not been set up yet, call setup_pmgr')
         if IMS._pm_init_error:
             raise RuntimeError('pmgr not available, initialized with an error')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Rather than setting up pmgr on the first IMS init, do it on the first pmgr usage.
Make `IMS.setup_pmgr` public API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It takes 3 seconds to setup the pmgr because the import is slow.
Applications that don't use pmgr shouldn't pay this cost.
Applications that do use pmgr may want to set it up manually before using it, so we provide a public API for doing this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I need to check this a bit on nfs, there's no easy to way to make regression tests here

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release notes only
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
