### PR TITLE
ENH: Refactor LightpathMixin and all relevant devices

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - bluesky >=1.6.4
     - happi
     - jsonschema
-    - lightpath >0.6.9
+    - lightpath >=1.0.0
     - matplotlib-base
     - numpy
     - ophyd >=1.5.1

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - bluesky >=1.6.4
     - happi
     - jsonschema
+    - lightpath >0.6.9
     - matplotlib-base
     - numpy
     - ophyd >=1.5.1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -324,6 +324,7 @@ pcdsdevices.interface
     pcdsdevices.interface.BaseInterface
     pcdsdevices.interface.FltMvInterface
     pcdsdevices.interface.LightpathInOutMixin
+    pcdsdevices.interface.LightpathInOutCptMixin
     pcdsdevices.interface.LightpathMixin
     pcdsdevices.interface.MvInterface
     pcdsdevices.interface.TabCompletionHelperClass

--- a/docs/source/upcoming_release_notes/1028-enh_lp_mixin.rst
+++ b/docs/source/upcoming_release_notes/1028-enh_lp_mixin.rst
@@ -3,7 +3,7 @@
 
 API Changes
 -----------
-- Converts LightpathMixin to the new Lightpath API, consilodating
+- Converts LightpathMixin to the new Lightpath API, consolodating
   reporting into a single LightpathState Dataclass.  The lightpath
   subscription system has also been simplified by using an AggregateSignal
   to monitor all relevant components.

--- a/docs/source/upcoming_release_notes/1028-enh_lp_mixin.rst
+++ b/docs/source/upcoming_release_notes/1028-enh_lp_mixin.rst
@@ -1,0 +1,42 @@
+1028 enh_lp_mixin
+#################
+
+API Changes
+-----------
+- Converts LightpathMixin to the new Lightpath API, consilodating
+  reporting into a single LightpathState Dataclass.  The lightpath
+  subscription system has also been simplified by using an AggregateSignal
+  to monitor all relevant components.
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Updates LightpathMixin implementation to the new API for all
+  existing lightpath-active devices.  This includes but is not limited to:
+
+  - Mirrors
+  - LODCMs
+  - Attenuators
+
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adds happi containers that work with the new Lightpath interface.
+  Notably, these containers allow input_branches and output_branches
+  to be optional kwargs.  This lets these containers work with devices
+  that both do and do not implement the Lightpath interface.
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/atm.py
+++ b/pcdsdevices/atm.py
@@ -3,7 +3,7 @@ from ophyd import Component as Cpt
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset
-from .interface import BaseInterface, LightpathInOutMixin
+from .interface import BaseInterface, LightpathInOutCptMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATTempSensor
 
@@ -18,7 +18,7 @@ class ATMTarget(TwinCATStatePMPS):
     config = UpCpt(state_count=6)
 
 
-class ArrivalTimeMonitor(BaseInterface, GroupDevice, LightpathInOutMixin):
+class ArrivalTimeMonitor(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """
     Determines the arrival time of the x-ray relative to the optical laser.
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -398,7 +398,6 @@ class AttBaseWith3rdHarmonicLP(AttBaseWith3rdHarmonic, LightpathInOutCptMixin):
     """
     # dummy component list to satisfy Mixin checks
     lightpath_cpts = ['dummy']
-    pass
 
 
 class FeeAtt(AttBase, PVPositionerPC, LightpathInOutCptMixin):

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1357,8 +1357,15 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathMixin):
             obj = getattr(self, sig_name).state
             if not obj._state_initialized:
                 # This would prevent make check_inserted, etc. fail
-                self._retry_lightpath = True
-                return
+                utils.schedule_task(self._calc_cache_lightpath_state,
+                                    delay=2.0)
+
+                return LightpathState(
+                    inserted=True,
+                    removed=True,
+                    transmission=1,
+                    output_branch=self.output_branches[0]
+                )
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
             out_check.append(obj.check_removed(sig_value))

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1014,7 +1014,6 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
         The state is nested one device deeper than LightpathInOutCptMixin
         expects.
         """
-        self._check_valid_lightpath()
         if (not use_cache) or (self._cached_state is None):
             lightpath_kwargs = {}
             lp_sigs = self.lightpath_summary._signals.keys()
@@ -1085,16 +1084,17 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
             calc_status, 'energy_actual', 'value',
             scale=3 * 1e-3,
         )
+        blade_names = [cpt.split('.', 1)[0] for cpt in self.lightpath_cpts]
         cpt_states = [
             get_status_value(
                 status_info, cpt, 'state', 'state', 'value',
                 default_value=0
             )
-            for cpt in self.lightpath_cpts
+            for cpt in blade_names
         ]
 
         table = prettytable.PrettyTable()
-        table.field_names = ['State'] + list(self.lightpath_cpts)
+        table.field_names = ['State'] + list(blade_names)
         for state in LadderBladeState:
             row = [state.name] + ['X' if cpt_state == state.value else ''
                                   for cpt_state in cpt_states]
@@ -1341,7 +1341,6 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathMixin):
         The state is nested one device deeper than LightpathInOutCptMixin
         expects.
         """
-        self._check_valid_lightpath()
         if (not use_cache) or (self._cached_state is None):
             lightpath_kwargs = {}
             lp_sigs = self.lightpath_summary._signals.keys()
@@ -1415,7 +1414,7 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathMixin):
         )
         cpt_states = [
             get_status_value(
-                status_info, cpt, 'state', 'state', 'value',
+                status_info, cpt.split('.', 1)[0], 'state', 'state', 'value',
                 default_value=0
             )
             for cpt in self.lightpath_cpts

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1043,8 +1043,7 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
                 return LightpathState(
                     inserted=True,
                     removed=True,
-                    transmission=1,
-                    output_branch=self.output_branches[0]
+                    output={self.output_branches[0]: 1}
                 )
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
@@ -1059,8 +1058,7 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )
 
     def format_status_info(self, status_info):
@@ -1369,8 +1367,7 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathMixin):
                 return LightpathState(
                     inserted=True,
                     removed=True,
-                    transmission=1,
-                    output_branch=self.output_branches[0]
+                    output={self.output_branches[0]: 1}
                 )
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
@@ -1385,8 +1382,7 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )
 
     def format_status_info(self, status_info):

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -497,7 +497,7 @@ class SXRLadderAttenuatorStates(TwinCATInOutPositioner):
     config = UpCpt(state_count=9)
 
 
-class FEESolidAttenuatorBlade(BaseInterface, Device, LightpathInOutMixin):
+class FEESolidAttenuatorBlade(BaseInterface, LightpathInOutMixin):
     """
     Represents one basic solid attenuator blade.
 

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1038,8 +1038,15 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
             obj = getattr(self, sig_name).state
             if not obj._state_initialized:
                 # This would prevent make check_inserted, etc. fail
-                self._retry_lightpath = True
-                return
+                utils.schedule_task(self._calc_cache_lightpath_state,
+                                    delay=2.0)
+
+                return LightpathState(
+                    inserted=True,
+                    removed=True,
+                    transmission=1,
+                    output_branch=self.output_branches[0]
+                )
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
             out_check.append(obj.check_removed(sig_value))

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1030,8 +1030,7 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )
 
     def insert(self, wait: bool = False) -> MoveStatus:

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -938,7 +938,7 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
     y = UCpt(CCMY, add_prefix=[], kind='normal',
              doc='Combined motion of the CCM Y motors.')
 
-    lightpath_cpts = ['x']
+    lightpath_cpts = ['x.sync.readback']
     tab_whitelist = ['x1', 'x2', 'y1', 'y2', 'y3', 'E', 'E_Vernier',
                      'th2fine', 'alio2E', 'E2alio', 'alio', 'home',
                      'kill', 'insert', 'remove', 'inserted', 'removed']
@@ -1013,14 +1013,14 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
         text += f'x @ (mm): {xavg} [x1,x2={x_down},{x_up}]\n'
         return text
 
-    def calc_lightpath_state(self, x: float) -> LightpathState:
+    def calc_lightpath_state(self, x_sync: float) -> LightpathState:
         """
         Update the fields used by the lightpath to determine in/out.
 
         Compares the x position with the saved in and out values.
         """
-        self._inserted = np.isclose(x, self._in_pos)
-        self._removed = np.isclose(x, self._out_pos)
+        self._inserted = np.isclose(x_sync, self._in_pos)
+        self._removed = np.isclose(x_sync, self._out_pos)
         if self._removed:
             self._transmission = 1
         else:

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -8,7 +8,7 @@ from ophyd.ophydobj import Kind, OphydObject
 from ophyd.pseudopos import PseudoSingle
 from ophyd.signal import AttributeSignal, DerivedSignal
 
-from .signal import PVStateSignal
+from .signal import AggregateSignal, PVStateSignal
 
 
 class UnrelatedComponent(Component):
@@ -402,6 +402,7 @@ class GroupDevice(Device):
         PluginBase,
         PseudoSingle,
         PVStateSignal,
+        AggregateSignal
         ]
 
     def __init__(self, *args, **kwargs):

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -25,7 +25,7 @@ from .lasers.zoomtelescope import ZoomTelescope
 from .lens import XFLS, Prefocus
 from .lic import LaserInCoupling
 from .light_control import LightControl
-from .lodcm import LODCM
+from .lodcm import XCSLODCM, XPPLODCM
 from .mirror import OffsetMirror, PointingMirror
 from .movablestand import MovableStand
 from .mpod import MPOD, MPODChannelHV, MPODChannelLV

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from copy import copy, deepcopy
 
-import lightpath.happi.containers
+import lightpath.happi.containers as lp_containers
 from happi.item import EntryInfo, HappiItem, OphydItem
 
 
@@ -48,11 +48,20 @@ class LCLSItem(OphydItem):
                           'the ioc data.'), optional=True, enforce=str)
 
 
-class LCLSLightpathItem(lightpath.happi.containers.LightpathItem, LCLSItem):
+class LCLSLightpathItem(lp_containers.LightpathItem, LCLSItem):
     """
-    LCLS version of a LightpathItem
+    LCLS version of a LightpathItem.  Since some containers serve both
+    lightpath and non-lightpath devices, make branches and kwargs optional
+
+    The default for branches will be None, and omitted from the kwargs
+    dictionary if its option matches said default of None.
     """
-    pass
+    input_branches = copy(lp_containers.LightpathItem.input_branches)
+    input_branches.optional = True
+    input_branches.include_default_as_kwarg = False
+    output_branches = copy(lp_containers.LightpathItem.output_branches)
+    output_branches.optional = True
+    output_branches.include_default_as_kwarg = False
 
 
 class LegacyItem(HappiItem):
@@ -120,7 +129,7 @@ class LegacyItem(HappiItem):
         return self.detailed_screen
 
 
-class Vacuum(lightpath.happi.containers.LightpathItem, LegacyItem):
+class Vacuum(lp_containers.LightpathItem, LegacyItem):
     """
     Parent class for devices in the vacuum system.
     """
@@ -128,7 +137,7 @@ class Vacuum(lightpath.happi.containers.LightpathItem, LegacyItem):
     system.default = 'vacuum'
 
 
-class Diagnostic(lightpath.happi.containers.LightpathItem, LegacyItem):
+class Diagnostic(lp_containers.LightpathItem, LegacyItem):
     """
     Parent class for devices that are used as diagnostics.
     """
@@ -138,7 +147,7 @@ class Diagnostic(lightpath.happi.containers.LightpathItem, LegacyItem):
                      enforce=str)
 
 
-class BeamControl(lightpath.happi.containers.LightpathItem, LegacyItem):
+class BeamControl(lp_containers.LightpathItem, LegacyItem):
     """
     Parent class for devices that control any beam parameter.
     """
@@ -283,7 +292,7 @@ class Attenuator(BeamControl):
     kwargs.default['n_filters'] = "{{n_filters}}"
 
 
-class Stopper(lightpath.happi.containers.LightpathItem, LegacyItem):
+class Stopper(lp_containers.LightpathItem, LegacyItem):
     """
     Large devices that prevent beam when it could cause damage to hardware.
 
@@ -403,7 +412,7 @@ class MovableStand(LegacyItem):
     system.default = 'changeover'
 
 
-class Motor(lightpath.happi.containers.LightpathItem, LegacyItem):
+class Motor(lp_containers.LightpathItem, LegacyItem):
     """
     A Generic EpicsMotor
     """

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -5,6 +5,7 @@ import re
 import warnings
 from copy import copy, deepcopy
 
+import lightpath.happi.containers
 from happi.item import EntryInfo, HappiItem, OphydItem
 
 
@@ -47,27 +48,11 @@ class LCLSItem(OphydItem):
                           'the ioc data.'), optional=True, enforce=str)
 
 
-class LCLSLightpathItem(LCLSItem):
+class LCLSLightpathItem(lightpath.happi.containers.LightpathItem, LCLSItem):
     """
     LCLS version of a LightpathItem
-
-    Cannot simply mixin with lightpath version since importing
-    lightpath.happi.containers.LightpathItem results in entry points
-    picking up duplicate items.
     """
-    kwargs = deepcopy(OphydItem.kwargs)
-    kwargs.default = {'name': '{{name}}',
-                      'input_branches': '{{input_branches}}',
-                      'output_branches': '{{output_branches}}',
-                      }
-    active = EntryInfo("If the device is currently active",
-                       optional=False, enforce=bool, default=False)
-    input_branches = EntryInfo(('List of branches the device can receive '
-                                'beam from.'),
-                               optional=False, enforce=list)
-    output_branches = EntryInfo(('List of branches the device can deliver '
-                                'beam to.'),
-                                optional=False, enforce=list)
+    pass
 
 
 class LegacyItem(HappiItem):
@@ -135,7 +120,7 @@ class LegacyItem(HappiItem):
         return self.detailed_screen
 
 
-class Vacuum(LegacyItem):
+class Vacuum(lightpath.happi.containers.LightpathItem, LegacyItem):
     """
     Parent class for devices in the vacuum system.
     """
@@ -143,7 +128,7 @@ class Vacuum(LegacyItem):
     system.default = 'vacuum'
 
 
-class Diagnostic(LegacyItem):
+class Diagnostic(lightpath.happi.containers.LightpathItem, LegacyItem):
     """
     Parent class for devices that are used as diagnostics.
     """
@@ -153,7 +138,7 @@ class Diagnostic(LegacyItem):
                      enforce=str)
 
 
-class BeamControl(LegacyItem):
+class BeamControl(lightpath.happi.containers.LightpathItem, LegacyItem):
     """
     Parent class for devices that control any beam parameter.
     """
@@ -230,9 +215,9 @@ class PIM(Diagnostic):
     prefix = copy(Diagnostic.prefix)
     prefix.enforce = re.compile(r'.*PIM.*')
     prefix_det = EntryInfo("Prefix for associated camera", enforce=str)
-    device_class = copy(LegacyItem.device_class)
+    device_class = copy(Diagnostic.device_class)
     device_class.default = 'pcdsdevices.device_types.PIM'
-    kwargs = deepcopy(LegacyItem.kwargs)
+    kwargs = deepcopy(Diagnostic.kwargs)
     kwargs.default['prefix_det'] = "{{prefix_det}}"
 
 
@@ -266,7 +251,7 @@ class IPM(Diagnostic):
     """
     prefix = copy(Diagnostic.prefix)
     prefix.enforce = re.compile(r'.*IPM.*')
-    device_class = copy(LegacyItem.device_class)
+    device_class = copy(Diagnostic.device_class)
     device_class.default = 'pcdsdevices.device_types.IPM'
 
 
@@ -290,15 +275,15 @@ class Attenuator(BeamControl):
     """
     prefix = copy(BeamControl.prefix)
     prefix.enforce = re.compile(r'.*ATT.*')
-    device_class = copy(LegacyItem.device_class)
+    device_class = copy(BeamControl.device_class)
     device_class.default = 'pcdsdevices.device_types.Attenuator'
     n_filters = EntryInfo("Number of filters on the Attenuator",
                           enforce=int, optional=False)
-    kwargs = deepcopy(LegacyItem.kwargs)
+    kwargs = deepcopy(BeamControl.kwargs)
     kwargs.default['n_filters'] = "{{n_filters}}"
 
 
-class Stopper(LegacyItem):
+class Stopper(lightpath.happi.containers.LightpathItem, LegacyItem):
     """
     Large devices that prevent beam when it could cause damage to hardware.
 
@@ -386,11 +371,11 @@ class LODCM(BeamControl):
     mono_line : str
         Name of the mono line
     """
-    device_class = copy(LegacyItem.device_class)
+    device_class = copy(BeamControl.device_class)
     device_class.default = 'pcdsdevices.device_types.LODCM'
     mono_line = EntryInfo("Name of the MONO beamline",
                           enforce=str, optional=False)
-    kwargs = deepcopy(LegacyItem.kwargs)
+    kwargs = deepcopy(BeamControl.kwargs)
     kwargs.default.update({'mono_line': '{{mono_line}}',
                            'main_line': '{{beamline}}'})
 
@@ -418,7 +403,7 @@ class MovableStand(LegacyItem):
     system.default = 'changeover'
 
 
-class Motor(LegacyItem):
+class Motor(lightpath.happi.containers.LightpathItem, LegacyItem):
     """
     A Generic EpicsMotor
     """

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -336,6 +336,17 @@ class OffsetMirror(BeamControl):
     prefix_xy = EntryInfo("Prefix for X and Y motors", enforce=str)
     xgantry_prefix = EntryInfo("Prefix for the X Gantry", enforce=str)
 
+    # Lightpath relevant settings.  Ranges for various mirror settings
+    pitch_ranges = EntryInfo("valid pitch ranges for each destination",
+                             optional=True, enforce=list,
+                             include_default_as_kwarg=False)
+    x_ranges = EntryInfo("valid x positions, determining insertion",
+                         optional=True, enforce=list,
+                         include_default_as_kwarg=False)
+    y_ranges = EntryInfo("valid y positions, determining coating",
+                         optional=True, enforce=list,
+                         include_default_as_kwarg=False)
+
 
 class PulsePicker(BeamControl):
     """

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -47,6 +47,29 @@ class LCLSItem(OphydItem):
                           'the ioc data.'), optional=True, enforce=str)
 
 
+class LCLSLightpathItem(LCLSItem):
+    """
+    LCLS version of a LightpathItem
+
+    Cannot simply mixin with lightpath version since importing
+    lightpath.happi.containers.LightpathItem results in entry points
+    picking up duplicate items.
+    """
+    kwargs = deepcopy(OphydItem.kwargs)
+    kwargs.default = {'name': '{{name}}',
+                      'input_branches': '{{input_branches}}',
+                      'output_branches': '{{output_branches}}',
+                      }
+    active = EntryInfo("If the device is currently active",
+                       optional=False, enforce=bool, default=False)
+    input_branches = EntryInfo(('List of branches the device can receive '
+                                'beam from.'),
+                               optional=False, enforce=list)
+    output_branches = EntryInfo(('List of branches the device can deliver '
+                                'beam to.'),
+                                optional=False, enforce=list)
+
+
 class LegacyItem(HappiItem):
     """
     Formally, happi.device.Device

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -11,6 +11,8 @@ import math
 from ophyd.device import required_for_connection
 from ophyd.sim import NullStatus
 
+from pcdsdevices.interface import LightpathInOutMixin
+
 from .doc_stubs import basic_positioner_init, insert_remove
 from .state import (CombinedStateRecordPositioner, PVStatePositioner,
                     StatePositioner, StateRecordPositioner,
@@ -183,6 +185,12 @@ class CombinedInOutRecordPositioner(CombinedStateRecordPositioner,
     """
 
     __doc__ += basic_positioner_init
+
+
+class LightpathInOutRecordPositioner(InOutRecordPositioner,
+                                     LightpathInOutMixin):
+    """Lightpath-compatible InOutRecordPositioner"""
+    pass
 
 
 class Reflaser(InOutRecordPositioner):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1764,6 +1764,8 @@ class LightpathInOutMixin(LightpathMixin):
         for sig_name, sig_value in lightpath_kwargs.items():
             obj = getattr(self, sig_name)
             if isinstance(obj, LightpathInOutMixin):
+                # TO-DO: deprecate this condition, and rework classes
+                # it applies to.  (attenuators, RTDS)
                 # The inserted/removed are always just a getattr
                 # Therefore, they are safe to call in a callback
                 in_check.append(obj.inserted)

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1782,8 +1782,7 @@ class LightpathInOutMixin(LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )
 
 
@@ -1843,8 +1842,7 @@ class LightpathInOutCptMixin(LightpathMixin):
                 return LightpathState(
                     inserted=True,
                     removed=True,
-                    transmission=1,
-                    output_branch=self.output_branches[0]
+                    output={self.output_branches[0]: 1}
                 )
 
             # get state of the InOutPositioner and check status
@@ -1858,6 +1856,5 @@ class LightpathInOutCptMixin(LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1695,19 +1695,8 @@ class LightpathMixin(Device):
         self._cached_state = None
         self.input_branches = input_branches
         self.output_branches = output_branches
-        is_valid = (
-            (len(self.lightpath_cpts) > 0) and
-            (len(self.input_branches) > 0) and
-            (len(self.output_branches) > 0)
-        )
-        super().__init__(*args, **kwargs)
 
-        if not is_valid:
-            # not a valid lightpath device, but this does not prevent
-            # later subscriptions
-            raise NotImplementedError(
-                'did not specify input and/or output branches'
-            )
+        super().__init__(*args, **kwargs)
 
         self._init_summary_signal()
 
@@ -1729,27 +1718,6 @@ class LightpathMixin(Device):
                     'Did not implement LightpathMixin properly.  '
                     'Must supply a list of components (lightpath_cpts)'
                 )
-
-    def _check_valid_lightpath(self):
-        """
-        Checks if the full lightpath interface is implemented.
-        To be run before get_lightpath_state
-
-        Returns
-        -------
-        bool
-            if the lightpath interface is fully implemented
-        """
-        is_valid = (
-            (len(self.lightpath_cpts) > 0) and
-            (len(self.input_branches) > 0) and
-            (len(self.output_branches) > 0)
-        )
-        if not is_valid:
-            raise NotImplementedError(
-                'Lightpath Mixin not fully implemented.  Missing either '
-                'input_branches or output_branches. '
-            )
 
     def calc_lightpath_state(self, **kwargs) -> LightpathState:
         """
@@ -1845,7 +1813,6 @@ class LightpathInOutCptMixin(LightpathMixin):
         self.lightpath_summary.subscribe(self._calc_cache_lightpath_state)
 
     def get_lightpath_state(self, use_cache: bool = True) -> LightpathState:
-        self._check_valid_lightpath()
         if (not use_cache) or (self._cached_state is None):
             kwargs = {}
             for sig in self.lightpath_summary._signals:

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1698,7 +1698,8 @@ class LightpathMixin(Device):
 
         super().__init__(*args, **kwargs)
 
-        self._init_summary_signal()
+        if self.input_branches and self.output_branches:
+            self._init_summary_signal()
 
     def _init_summary_signal(self):
         for sig in self.lightpath_cpts:

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1571,7 +1571,92 @@ class LightpathState:
     output_branch: str
 
 
-class LightpathMixin(OphydObject):
+class LegacyLightpathMixin(OphydObject):
+    """
+    Mix-in class that makes it easier to establish a lightpath interface.
+
+    Use this on classes that are not state positioners but would still like to
+    be used as a top-level device in lightpath.
+    """
+    SUB_STATE = 'state'
+    _default_sub = SUB_STATE
+
+    # Component names whose values are relevant for inserted/removed
+    lightpath_cpts = []
+
+    # Flag to signify that subclass is another mixin, rather than a device
+    _lightpath_mixin = False
+
+    def __init__(self, *args, **kwargs):
+        self._lightpath_values = {}
+        self._lightpath_ready = False
+        self._retry_lightpath = False
+        super().__init__(*args, **kwargs)
+
+    def __init_subclass__(cls, **kwargs):
+        # Magic to subscribe to the list of components
+        super().__init_subclass__(**kwargs)
+        if cls._lightpath_mixin:
+            # Child of cls will inherit this as False
+            cls._lightpath_mixin = False
+        else:
+            if not cls.lightpath_cpts:
+                raise NotImplementedError('Did not implement LightpathMixin')
+            for cpt_name in cls.lightpath_cpts:
+                cpt = getattr(cls, cpt_name)
+                cpt.sub_default(cls._update_lightpath)
+
+    def _set_lightpath_states(self, lightpath_values):
+        # Override based on the use case
+        # update self._inserted, self._removed,
+        # and optionally self._transmission
+        # Should return a dict or None
+        raise NotImplementedError('Did not implement LightpathMixin')
+
+    def _update_lightpath(self, *args, obj, **kwargs):
+        try:
+            # Universally cache values
+            self._lightpath_values[obj] = kwargs
+            # Only do the first lightpath state once all cpts have chimed in
+            if len(self._lightpath_values) >= len(self.lightpath_cpts):
+                self._retry_lightpath = False
+                # Pass user function the full set of values
+                self._set_lightpath_states(self._lightpath_values)
+                self._lightpath_ready = not self._retry_lightpath
+                if self._lightpath_ready:
+                    # Tell lightpath to update
+                    self._run_subs(sub_type=self.SUB_STATE)
+                elif self._retry_lightpath and not self._destroyed:
+                    # Use this when the device wasn't ready to set states
+                    kw = dict(obj=obj)
+                    kw.update(kwargs)
+                    utils.schedule_task(self._update_lightpath,
+                                        args=args, kwargs=kw, delay=1.0)
+        except Exception:
+            # Without this, callbacks fail silently
+            logger.exception('Error in lightpath update callback for %s.',
+                             self.name)
+
+    @property
+    def inserted(self):
+        return self._lightpath_ready and bool(self._inserted)
+
+    @property
+    def removed(self):
+        return self._lightpath_ready and bool(self._removed)
+
+    @property
+    def transmission(self):
+        try:
+            return self._transmission
+        except AttributeError:
+            if self.inserted:
+                return 0
+            else:
+                return 1
+
+
+class LightpathMixin(Device, LegacyLightpathMixin):
     """
     Mix-in class that makes it easier to establish a lightpath interface.
 
@@ -1582,7 +1667,7 @@ class LightpathMixin(OphydObject):
     LightpathStatus object
     Create an object similar to the following:
 
-    class MyDevice(LightpathMixin, Device):
+    class MyDevice(LightpathMixin):
         lp_signals = ['sig1', 'sig2']
 
         def get_lightpath_status(self):
@@ -1681,5 +1766,5 @@ class LightpathInOutMixin(LightpathMixin):
             inserted=self._inserted,
             removed=self._removed,
             transmission=self._transmission,
-            output_branch=self._input_branch
+            output_branch=self._input_branches[0]
         )

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1685,8 +1685,8 @@ class LightpathMixin(Device):
     _lightpath_mixin = False
 
     # Mixin holds one summary signal that changes with lightpath_cpts
-    lightpath_summary = Cpt(SummarySignal, name='lightpath_summary',
-                            kind='omitted')
+    lightpath_summary: Signal = Cpt(SummarySignal, name='lightpath_summary',
+                                    kind='omitted')
 
     def __init__(self, *args,
                  input_branches=[], output_branches=[], **kwargs):
@@ -1701,7 +1701,7 @@ class LightpathMixin(Device):
         if self.input_branches and self.output_branches:
             self._init_summary_signal()
 
-    def _init_summary_signal(self):
+    def _init_summary_signal(self) -> None:
         for sig in self.lightpath_cpts:
             self.lightpath_summary.add_signal_by_attr_name(sig)
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1662,7 +1662,7 @@ class LightpathMixin(Device):
     .. code-block:: python
 
         class MyDevice(LightpathMixin):
-            lightpath_signals = ['sig1', 'sig2']
+            lightpath_cpts = ['sig1', 'sig2']
             sig1 = Cpt(Signal, ':SIG1')
             sig2 = Cpt(Signal, ':SIG2')
 
@@ -1678,7 +1678,7 @@ class LightpathMixin(Device):
                        output_branches=['L0'])
     """
     # Component names whose values are relevant for inserted/removed
-    lightpath_signals = []
+    lightpath_cpts = []
 
     # Flag to signify that subclass is another mixin, rather than a device
     _lightpath_mixin = False
@@ -1693,7 +1693,7 @@ class LightpathMixin(Device):
         self.input_branches = input_branches
         self.output_branches = output_branches
         super().__init__(*args, **kwargs)
-        for sig in self.lightpath_signals:
+        for sig in self.lightpath_cpts:
             self.lightpath_summary.add_signal_by_attr_name(sig)
 
         if not self.input_branches or not self.output_branches:
@@ -1708,7 +1708,7 @@ class LightpathMixin(Device):
             # Child of cls will inherit this as False
             cls._lightpath_mixin = False
         else:
-            if not cls.lightpath_signals:
+            if not cls.lightpath_cpts:
                 raise NotImplementedError(
                     'Did not implement LightpathMixin properly.  '
                     'Must supply a list of components (lightpath_cpts)'
@@ -1720,7 +1720,7 @@ class LightpathMixin(Device):
         for lightpath, given a set of signal values
 
         kwargs should be the same as the signal names provided in
-        ``lightpath_signals``
+        ``lightpath_cpts``
 
         Device logic goes here.
 
@@ -1755,6 +1755,8 @@ class LightpathInOutMixin(LightpathMixin):
     Also works recursively on other LightpathInOutMixin subclasses.
     """
     _lightpath_mixin = True
+    sig = Cpt(Signal, name='dummy_sig')
+    lightpath_cpts = ['sig']
 
     def _set_lightpath_states(self, lightpath_values):
         in_check = []

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1656,7 +1656,7 @@ class LegacyLightpathMixin(OphydObject):
                 return 1
 
 
-class LightpathMixin(Device, LegacyLightpathMixin):
+class LightpathMixin(Device):
     """
     Mix-in class that makes it easier to establish a lightpath interface.
 

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1684,7 +1684,8 @@ class LightpathMixin(Device):
     _lightpath_mixin = False
 
     # Mixin holds one summary signal that changes with lightpath_cpts
-    lightpath_summary = Cpt(SummarySignal, name='lightpath_summary')
+    lightpath_summary = Cpt(SummarySignal, name='lightpath_summary',
+                            kind='omitted')
 
     def __init__(self, *args,
                  input_branches=[], output_branches=[], **kwargs):

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -213,8 +213,7 @@ Target Position: {target_pos} [{t_units}]
         return LightpathState(
             inserted=inserted,
             removed=removed,
-            transmission=transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: transmission}
         )
 
     @property

--- a/pcdsdevices/ipm.py
+++ b/pcdsdevices/ipm.py
@@ -3,7 +3,9 @@ Module for the `IPM` intensity position monitor classes.
 """
 import logging
 import warnings
+from typing import Union
 
+from lightpath import LightpathState
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
@@ -14,7 +16,7 @@ from .doc_stubs import IPM_base, basic_positioner_init, insert_remove
 from .epics_motor import IMS
 from .evr import Trigger
 from .inout import InOutRecordPositioner
-from .interface import BaseInterface
+from .interface import BaseInterface, LightpathMixin
 from .utils import get_status_float, get_status_value, ipm_screen
 
 logger = logging.getLogger(__name__)
@@ -120,7 +122,7 @@ class IPMDiode(BaseInterface, GroupDevice):
     remove.__doc__ += insert_remove
 
 
-class IPMMotion(BaseInterface, GroupDevice):
+class IPMMotion(BaseInterface, GroupDevice, LightpathMixin):
     """
     Standard intensity position monitor.
 
@@ -135,6 +137,8 @@ class IPMMotion(BaseInterface, GroupDevice):
 
     tab_whitelist = ['target', 'diode', 'insert', 'remove', 'inserted',
                      'removed', 'ty', 'dx', 'dy']
+
+    lightpath_cpts = ['target.state', 'diode.state.state']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -190,6 +194,28 @@ Target Position: {target_pos} [{t_units}]
 {diode_type}Diode Position(x, y): \
 {x_motor_pos}, {y_motor_pos} [{d_units}]
 """
+
+    def calc_lightpath_state(
+        self,
+        target_state: Union[int, str],
+        diode_state_state: Union[int, str],
+    ) -> LightpathState:
+        target_cpt = self.target
+        diode_cpt = self.diode.state
+        inserted = (target_cpt.check_inserted(target_state) and
+                    diode_cpt.check_inserted(diode_state_state))
+        removed = (target_cpt.check_removed(target_state) and
+                   (diode_cpt.check_inserted(diode_state_state) or
+                   diode_cpt.check_removed(diode_state_state)))
+        transmission = (target_cpt.check_transmission(target_state) *
+                        diode_cpt.check_transmission(diode_state_state))
+
+        return LightpathState(
+            inserted=inserted,
+            removed=removed,
+            transmission=transmission,
+            output_branch=self.output_branches[0]
+        )
 
     @property
     def inserted(self):
@@ -568,4 +594,4 @@ def IPM(prefix, *, name, **kwargs):
         return IPM_Wave8(prefix, name=name,
                          prefix_wave8=kwargs.pop('prefix_wave8'), **kwargs)
     else:
-        return IPMMotion(prefix, name=name)
+        return IPMMotion(prefix, name=name, **kwargs)

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -22,7 +22,7 @@ from .sim import FastMotor
 logger = logging.getLogger(__name__)
 
 
-class XFLS(InOutRecordPositioner):
+class XFLS(InOutRecordPositioner, LightpathInOutMixin):
     """
     X-ray Focusing (Be) Lens Stack.
 

--- a/pcdsdevices/lens.py
+++ b/pcdsdevices/lens.py
@@ -14,7 +14,7 @@ from pcdscalc import be_lens_calcs as calcs
 from .doc_stubs import basic_positioner_init
 from .epics_motor import IMS
 from .inout import CombinedInOutRecordPositioner, InOutRecordPositioner
-from .interface import BaseInterface, tweak_base
+from .interface import BaseInterface, LightpathInOutMixin, tweak_base
 from .pseudopos import (PseudoPositioner, PseudoSingleInterface,
                         pseudo_position_argument, real_position_argument)
 from .sim import FastMotor
@@ -45,7 +45,7 @@ class XFLS(InOutRecordPositioner):
         super().__init__(prefix, name=name, **kwargs)
 
 
-class Prefocus(CombinedInOutRecordPositioner):
+class Prefocus(CombinedInOutRecordPositioner, LightpathInOutMixin):
     """
     PreFocussing Lens Stack (PFLS).
 

--- a/pcdsdevices/lic.py
+++ b/pcdsdevices/lic.py
@@ -3,7 +3,7 @@ from ophyd import Component as Cpt
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxisNoOffset
-from .interface import BaseInterface, LightpathInOutMixin
+from .interface import BaseInterface, LightpathInOutCptMixin
 from .pmps import TwinCATStatePMPS
 
 
@@ -25,7 +25,7 @@ class LICMirror(TwinCATStatePMPS):
     config = UpCpt(state_count=4)
 
 
-class LaserInCoupling(BaseInterface, GroupDevice, LightpathInOutMixin):
+class LaserInCoupling(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """
     Device to bring the optical laser to the sample via mirrors.
     """

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -1902,7 +1902,8 @@ class XPPLODCM(LODCM):
         removed = self.tower1.h1n_state.check_removed(h1n_state)
 
         if inserted and not removed:
-            output = {self.output_branches[1]: 1}
+            output = {self.output_branches[0]: 0.5,
+                      self.output_branches[1]: 0.5}
         elif not inserted and removed:
             output = {self.output_branches[0]: 1}
         else:

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -1311,11 +1311,6 @@ class LODCM(BaseInterface, GroupDevice, LightpathMixin):
         self,
         tower1_h1n_state_state: Union[int, str]
     ) -> LightpathState:
-        """
-        TODO: actually figure out the logic for this, this is likely
-        very very wrong.  Currently this would be best suited for
-        a LightpathInOutCptMixin, but I doubt this is all the logic
-        """
         return LightpathState(
             inserted=True,
             removed=True,
@@ -1840,6 +1835,25 @@ class XCSLODCM(LODCM):
         self,
         tower1_h1n_state_state: Union[int, str]
     ) -> LightpathState:
+        """
+        Calculates lightpath state for XCS LODCM.  This LODCM has 3
+        operating modes (as of 9/28/2022)
+
+        1. the 1st crystal of the lodcm is OUT then the beam goes to CXI.
+        2. The diamond crystal is IN then the pink beam goes to CXI while
+           a monochromatic beam can go to XCS at the same time.
+        3. The Silicon crystal is IN in which case monochromatic beam
+           only goes to XCS.
+
+        Parameters
+        ----------
+        tower1_h1n_state_state : Union[int, str]
+            The first crystal state.
+
+        Returns
+        -------
+        LightpathState
+        """
         h1n_state = tower1_h1n_state_state
         if not self.tower1.h1n_state._state_initialized:
             self.log.debug('tower1 state not initialized, scheduling '
@@ -1887,6 +1901,21 @@ class XPPLODCM(LODCM):
         self,
         tower1_h1n_state_state: Union[int, str]
     ) -> LightpathState:
+        """
+        Currently (as of 09/28/2022), the XPP LODCM does not consider
+        differing crystal states.  For now we only consider whether the
+        first crystal is in or out.
+
+        Parameters
+        ----------
+        tower1_h1n_state_state : Union[int, str]
+            The insertion state of the first tower crystal
+
+        Returns
+        -------
+        LightpathState
+        """
+
         h1n_state = tower1_h1n_state_state
         if not self.tower1.h1n_state._state_initialized:
             self.log.debug('tower1 state not initialized, scheduling '

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -510,7 +510,6 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
         """
         Helper function for finding the range a particular value falls into
 
-
         Parameters
         ----------
         ranges : List[List[numeric]]
@@ -521,7 +520,7 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
         Returns
         -------
         List[bool]
-            A list of booleans, reporting if the values is in each range
+            A list of booleans, reporting if the value is in each range
             in ``ranges``
         """
         if len(np.shape(ranges)) < 2:

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -221,8 +221,7 @@ class OffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
         return LightpathState(
             inserted=True,
             removed=False,
-            transmission=1,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: 1}
         )
 
     @property
@@ -477,8 +476,7 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
 
             if x_out:
                 return LightpathState(inserted=x_in, removed=x_out,
-                                      transmission=1,
-                                      output_branch=self.output_branches[0])
+                                      output={self.output_branches[0]: 1})
 
             # if in, check coating
             coating_index = self._get_coating_index(y_info)
@@ -491,8 +489,7 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
             return LightpathState(
                 inserted=x_in,
                 removed=x_out,
-                transmission=trans,
-                output_branch=out_branch
+                output={out_branch: trans}
             )
         except MirrorLogicError as ex:
             # a state for if calculation cannot proceed
@@ -500,8 +497,7 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
             return LightpathState(
                 inserted=False,
                 removed=False,
-                transmission=0,
-                output_branch=self.output_branches[0]
+                output={self.output_branches[0]: 0}
             )
 
     def _get_insertion_state(self, x: float) -> Tuple[bool, bool]:
@@ -790,16 +786,14 @@ class XOffsetMirrorBend(XOffsetMirror):
             return LightpathState(
                 inserted=x_in,
                 removed=x_out,
-                transmission=1,
-                output_branch=out_branch
+                output={out_branch: 1}
             )
         except MirrorLogicError as ex:
             self.log.debug(ex)
             return LightpathState(
                 inserted=False,
                 removed=False,
-                transmission=0,
-                output_branch=self.output_branches[0]
+                output={self.output_branches[0]: 0}
             )
 
 
@@ -851,8 +845,7 @@ class XOffsetMirrorSwitch(XOffsetMirror):
     ) -> LightpathState:
         # currently always in, no switching
         return LightpathState(
-            inserted=True, removed=False, transmission=1,
-            output_branch=self.output_branches[0]
+            inserted=True, removed=False, output={self.output_branches[0]: 1}
         )
 
 
@@ -903,8 +896,7 @@ class KBOMirror(BaseInterface, GroupDevice, LightpathMixin):
     ) -> LightpathState:
         # TODO: get real logic
         return LightpathState(
-            inserted=True, removed=False, transmission=1,
-            output_branch=self.output_branches[0]
+            inserted=True, removed=False, output={self.output_branches[0]: 1}
         )
 
     # Tab config: show components
@@ -1080,8 +1072,7 @@ class FFMirror(BaseInterface, GroupDevice, LightpathMixin):
     ) -> LightpathState:
         # TODO: get real logic
         return LightpathState(
-            inserted=True, removed=False, transmission=1,
-            output_branch=self.output_branches[0]
+            inserted=True, removed=False, output={self.output_branches[0]: 1}
         )
 
     # Tab config: show components

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -504,7 +504,7 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
             )
 
     def _find_matching_range_indices(
-        ranges: List[List[numeric, numeric]],
+        ranges: List[List[numeric]],
         value: numeric
     ) -> List[bool]:
         """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -708,7 +708,7 @@ class XOffsetMirrorBend(XOffsetMirror):
 
     1st and 2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
 
-    Currently services: mr1k1
+    Currently (09/28/2022) services: mr1k1
 
     Parameters
     ----------
@@ -807,7 +807,7 @@ class XOffsetMirrorSwitch(XOffsetMirror):
 
     1st and 2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
 
-    currently services: mr1k2
+    currently (09/28/2022) services: mr1k2
 
     Parameters
     ----------
@@ -1328,7 +1328,7 @@ class XOffsetMirrorXYState(XOffsetMirrorState):
     and insertion (x).  Thus, lightpath state calcs only require pitch
     ranges.
 
-    As of 22-09-12, this applies to mr1l3 and mr1l4.
+    Currently (09/28/2022) services: mr1l3, mr1l4.
 
     Parameters
     ----------

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -513,14 +513,14 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
 
         Parameters
         ----------
-        ranges : List[ List[numeric, numeric] ]
+        ranges : List[List[numeric]]
             A list of ranges.  Each range has a max and min value (exclusive)
         value : numeric
             Value to compare to each range
 
         Returns
         -------
-        List[int]
+        List[bool]
             A list of booleans, reporting if the values is in each range
             in ``ranges``
         """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -159,7 +159,7 @@ class Gantry(OMMotor):
         super().check_value(pos)
 
 
-class OffsetMirror(BaseInterface, GroupDevice):
+class OffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
     """
     X-ray Offset Mirror class.
 
@@ -205,6 +205,8 @@ class OffsetMirror(BaseInterface, GroupDevice):
     # Subscription types
     SUB_STATE = 'state'
 
+    lightpath_cpts = ['pitch.user_readback']
+
     # Tab config: show components
     tab_component_names = True
 
@@ -214,6 +216,14 @@ class OffsetMirror(BaseInterface, GroupDevice):
         self._prefix_xy = prefix_xy or prefix
         self._xgantry = xgantry_prefix or 'GANTRY:' + prefix + ':X'
         super().__init__(prefix, **kwargs)
+
+    def calc_lightpath_state(self, **kwargs) -> LightpathState:
+        return LightpathState(
+            inserted=True,
+            removed=False,
+            transmission=1,
+            output_branch=self.output_branches[0]
+        )
 
     @property
     def inserted(self):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -205,7 +205,7 @@ class OffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
     # Subscription types
     SUB_STATE = 'state'
 
-    lightpath_cpts = ['pitch.user_readback']
+    lightpath_cpts = ['pitch.readback']
 
     # Tab config: show components
     tab_component_names = True

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -21,7 +21,7 @@ from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .epics_motor import IMS, BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
-from .interface import BaseInterface, LightpathInOutMixin
+from .interface import BaseInterface, LightpathInOutCptMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATThermocouple
 from .signal import PytmcSignal
@@ -63,7 +63,7 @@ class PIMY(InOutRecordPositioner, BaseInterface):
         return super().unstage()
 
 
-class PIM(BaseInterface, GroupDevice):
+class PIM(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """
     Profile Intensity Monitor.
 
@@ -95,6 +95,8 @@ class PIM(BaseInterface, GroupDevice):
 
     tab_whitelist = ['y', 'remove', 'insert', 'removed', 'inserted']
     tab_component_names = True
+
+    lightpath_cpts = ['state']
 
     def infer_prefix(self, prefix):
         """Pulls out the first two segments of the prefix PV, if not already
@@ -182,13 +184,13 @@ Y Position: {y_pos} [{y_units}]
         if prefix_det:
             self._prefix_det = prefix_det
         else:
-            self._prefix_det = self.prefix_start+'CVV:01'
+            self._prefix_det = self.prefix_start+'CVV:01:'
 
         # Infer the zoom motor PV from the base prefix
         if prefix_zoom:
             self._prefix_zoom = prefix_zoom
         else:
-            self._prefix_zoom = self.prefix_start+'CLZ:01'
+            self._prefix_zoom = self.prefix_start+'CLZ:01:'
 
         super().__init__(prefix, name=name, **kwargs)
         self.y = self.state.motor
@@ -327,7 +329,7 @@ class LCLS2Target(TwinCATStatePMPS):
     config = UpCpt(state_count=4)
 
 
-class LCLS2ImagerBase(BaseInterface, GroupDevice, LightpathInOutMixin):
+class LCLS2ImagerBase(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """
     Shared PVs and components from the LCLS2 imagers.
 

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -9,6 +9,8 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd.status import SubscriptionStatus
 from ophyd.status import wait as status_wait
 
+from pcdsdevices.interface import LightpathInOutMixin
+
 from .device import GroupDevice
 from .doc_stubs import basic_positioner_init
 from .inout import InOutPVStatePositioner, InOutRecordPositioner
@@ -16,7 +18,7 @@ from .inout import InOutPVStatePositioner, InOutRecordPositioner
 logger = logging.getLogger(__name__)
 
 
-class PulsePicker(InOutPVStatePositioner):
+class PulsePicker(InOutPVStatePositioner, LightpathInOutMixin):
     """
     Device that picks which pulses to let through.
 

--- a/pcdsdevices/ref.py
+++ b/pcdsdevices/ref.py
@@ -3,7 +3,7 @@ from ophyd import Component as Cpt
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxis, EpicsMotorInterface
-from .interface import BaseInterface, LightpathInOutMixin
+from .interface import BaseInterface, LightpathInOutCptMixin
 from .pmps import TwinCATStatePMPS
 from .signal import PytmcSignal
 
@@ -18,7 +18,7 @@ class ReflaserL2SIMirror(TwinCATStatePMPS):
     config = UpCpt(state_count=2)
 
 
-class ReflaserL2SI(BaseInterface, GroupDevice, LightpathInOutMixin):
+class ReflaserL2SI(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """
     The L2SI design for the reference laser.
 

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -47,7 +47,6 @@ class PneumaticActuator(InOutPositioner):
 class RTDSBase(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """Rapid Turnaround Diagnostic Station."""
     lightpath_cpts = ['mpa1', 'mpa2', 'mpa3', 'mpa4']
-    _lightpath_mixin = True
 
     _icon = 'fa.stop-circle'
 

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -3,7 +3,7 @@ from ophyd import Signal
 
 from .device import GroupDevice
 from .inout import InOutPositioner
-from .interface import BaseInterface, LightpathInOutMixin
+from .interface import BaseInterface, LightpathInOutCptMixin
 from .signal import PytmcSignal
 
 
@@ -44,7 +44,7 @@ class PneumaticActuator(InOutPositioner):
             self.out_cmd.put(1)
 
 
-class RTDSBase(BaseInterface, GroupDevice, LightpathInOutMixin):
+class RTDSBase(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     """Rapid Turnaround Diagnostic Station."""
     lightpath_cpts = ['mpa1', 'mpa2', 'mpa3', 'mpa4']
     _lightpath_mixin = True

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -424,13 +424,18 @@ class AggregateSignal(Signal):
 
 class SummarySignal(AggregateSignal):
     """
-    Signal that holds a hash of the values of the constituent signals
+    Signal that holds a hash of the values of the constituent signals.
 
     Meant to allow tracking of constituent signals via callbacks.
-    The calculated readback value is useless.
+
+    The calculated readback value is useless, and should not be used
+    in any downstream calculations.  Use the signal/PV you actually
+    care about instead.
     """
     def _calc_readback(self):
         values = tuple(sig.get() for sig in self._signals)
+        # We return a hash here, rather than the tuple, to always provide
+        # an ophyd-compatible datatype.
         return hash(values)
 
 

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -422,6 +422,18 @@ class AggregateSignal(Signal):
         return super().destroy()
 
 
+class SummarySignal(AggregateSignal):
+    """
+    Signal that holds a hash of the values of the constituent signals
+
+    Meant to allow tracking of constituent signals via callbacks.
+    The calculated readback value is useless.
+    """
+    def _calc_readback(self):
+        values = (sig.get() for sig in self._signals.values())
+        return hash(values)
+
+
 class PVStateSignal(AggregateSignal):
     """
     Signal that implements the `PVStatePositioner` state logic.

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -430,7 +430,7 @@ class SummarySignal(AggregateSignal):
     The calculated readback value is useless.
     """
     def _calc_readback(self):
-        values = (sig.get() for sig in self._signals.values())
+        values = tuple(sig.get() for sig in self._signals)
         return hash(values)
 
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -79,6 +79,9 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
         self.vo = self.ycenter
         self._pre_stage_gap: tuple[float, float] = None
 
+        self._inserted = False
+        self._removed = False
+
     def format_status_info(self, status_info):
         """
         Override status info handler to render the slits.
@@ -312,6 +315,14 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
             removed=self._removed,
             output={self.output_branches[0]: self._transmission}
         )
+
+    @property
+    def inserted(self):
+        return self._inserted
+
+    @property
+    def removed(self):
+        return self._removed
 
 
 class BadSlitPositionerBase(FltMvInterface, PVPositioner):

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -30,7 +30,7 @@ from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset
-from .interface import (BaseInterface, FltMvInterface, LightpathInOutMixin,
+from .interface import (BaseInterface, FltMvInterface, LightpathInOutCptMixin,
                         LightpathMixin, MvInterface)
 from .pmps import TwinCATStatePMPS
 from .sensors import RTD, TwinCATTempSensor
@@ -51,7 +51,7 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
 
     # Mark as parent class for lightpath interface
     _lightpath_mixin = True
-    lightpath_cpts = ['xwidth', 'ywidth']
+    lightpath_cpts = ['xwidth.readback', 'ywidth.readback']
 
     # Tab settings
     tab_whitelist = ['open', 'close', 'block', 'hg', 'ho', 'vg', 'vo']
@@ -299,10 +299,10 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
 
     def calc_lightpath_state(
         self,
-        xwidth: float,
-        ywidth: float
+        xwidth_readback: float,
+        ywidth_readback: float
     ) -> LightpathState:
-        widths = [xwidth, ywidth]
+        widths = [xwidth_readback, ywidth_readback]
         self._inserted = (min(widths) < self.nominal_aperture.get())
         self._removed = not self._inserted
         self._transmission = 1.0 if self._inserted else 0.0
@@ -595,7 +595,7 @@ class ExitSlitTarget(TwinCATStatePMPS):
     config = UpCpt(state_count=3)
 
 
-class ExitSlits(BaseInterface, GroupDevice, LightpathInOutMixin):
+class ExitSlits(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     tab_component_names = True
 
     lightpath_cpts = ['target']

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -15,6 +15,7 @@ used.
 import logging
 from collections import OrderedDict
 
+from lightpath import LightpathState
 from ophyd import Component as Cpt
 from ophyd import DynamicDeviceComponent as DDCpt
 from ophyd import EpicsSignal, EpicsSignalRO
@@ -296,10 +297,22 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
         # Run subscriptions
         self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)
 
-    def _set_lightpath_states(self, lightpath_values):
-        widths = [kw['value'] for kw in lightpath_values.values()]
+    def calc_lightpath_state(
+        self,
+        xwidth: float,
+        ywidth: float
+    ) -> LightpathState:
+        widths = [xwidth, ywidth]
         self._inserted = (min(widths) < self.nominal_aperture.get())
         self._removed = not self._inserted
+        self._transmission = 1.0 if self._inserted else 0.0
+
+        return LightpathState(
+            inserted=self._inserted,
+            removed=self._removed,
+            transmission=self._transmission,
+            output_branch=self.output_branches[0]
+        )
 
 
 class BadSlitPositionerBase(FltMvInterface, PVPositioner):

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -310,8 +310,7 @@ class SlitsBase(MvInterface, GroupDevice, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )
 
 

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -217,7 +217,7 @@ class VonHamos4Crystal(VonHamosFE):
                          prefix_energy=prefix_energy, **kwargs)
 
 
-class Mono(BaseInterface, GroupDevice):
+class Mono(BaseInterface, GroupDevice, LightpathMixin):
     """
     L2S-I NEH 2.X Monochromator
 
@@ -295,8 +295,19 @@ class Mono(BaseInterface, GroupDevice):
     transmission = 1
     SUB_STATE = 'state'
 
+    # dummy component, state is always the same
+    lightpath_cpts = ['m_pi']
 
-class TMOSpectrometer(BaseInterface, GroupDevice):
+    def calc_lightpath_state(self, **kwargs) -> LightpathState:
+        return LightpathState(
+            inserted=True,
+            removed=False,
+            transmission=1,
+            output_branch=self.output_branches[0]
+        )
+
+
+class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     """
     TMO Fresnel Photon Spectrometer Motion components class.
 
@@ -331,8 +342,19 @@ class TMOSpectrometer(BaseInterface, GroupDevice):
     transmission = 1
     SUB_STATE = 'state'
 
+    # dummy signal, state is always the same
+    lightpath_cpts = ['yag_x']
 
-class HXRSpectrometer(BaseInterface, GroupDevice):
+    def calc_lightpath_state(self, **kwargs) -> LightpathState:
+        return LightpathState(
+            inserted=True,
+            removed=False,
+            transmission=1,
+            output_branch=self.output_branches[0]
+        )
+
+
+class HXRSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     """
     HXR Single Shot Spectrometer motion components class.
 
@@ -367,3 +389,14 @@ class HXRSpectrometer(BaseInterface, GroupDevice):
     removed = False
     transmission = 1
     SUB_STATE = 'state'
+
+    # dummy signal, state is always the same
+    lightpath_cpts = ['xtaly']
+
+    def calc_lightpath_state(self, **kwargs) -> LightpathState:
+        return LightpathState(
+            inserted=True,
+            removed=False,
+            transmission=1,
+            output_branch=self.output_branches[0]
+        )

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -343,9 +343,10 @@ class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     SUB_STATE = 'state'
 
     # dummy signal, state is always the same
-    lightpath_cpts = ['yag_x']
+    lightpath_cpts = ['yag_x.user_readback']
 
     def calc_lightpath_state(self, **kwargs) -> LightpathState:
+        # TODO: get real logic here, instead of legacy hard-coding
         return LightpathState(
             inserted=True,
             removed=False,
@@ -391,7 +392,7 @@ class HXRSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     SUB_STATE = 'state'
 
     # dummy signal, state is always the same
-    lightpath_cpts = ['xtaly']
+    lightpath_cpts = ['xtaly.user_readback']
 
     def calc_lightpath_state(self, **kwargs) -> LightpathState:
         return LightpathState(

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -296,7 +296,7 @@ class Mono(BaseInterface, GroupDevice, LightpathMixin):
     SUB_STATE = 'state'
 
     # dummy component, state is always the same
-    lightpath_cpts = ['m_pi']
+    lightpath_cpts = ['m_pi.user_readback']
 
     def calc_lightpath_state(self, **kwargs) -> LightpathState:
         return LightpathState(

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -98,8 +98,7 @@ class Kmono(BaseInterface, GroupDevice, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )
 
 
@@ -302,8 +301,7 @@ class Mono(BaseInterface, GroupDevice, LightpathMixin):
         return LightpathState(
             inserted=True,
             removed=False,
-            transmission=1,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: 1}
         )
 
 
@@ -350,8 +348,7 @@ class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
         return LightpathState(
             inserted=True,
             removed=False,
-            transmission=1,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: 1}
         )
 
 
@@ -398,6 +395,5 @@ class HXRSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
         return LightpathState(
             inserted=True,
             removed=False,
-            transmission=1,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: 1}
         )

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -1,5 +1,6 @@
 from enum import IntEnum
 
+from lightpath import LightpathState
 from ophyd import Component as Cpt
 from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
@@ -172,11 +173,20 @@ class PPSStopper2PV(BaseInterface, LightpathMixin):
         self.out_value = out_value
         super().__init__(prefix, **kwargs)
 
-    def _set_lightpath_states(self, lightpath_values):
-        self._inserted = (lightpath_values[self.in_signal]['value']
-                          == self.in_value)
-        self._removed = (lightpath_values[self.out_signal]['value']
-                         == self.out_value)
+    def calc_lightpath_state(
+        self, in_signal: int, out_signal: int
+    ) -> LightpathState:
+        self._inserted = (in_signal == self.in_value)
+        self._removed = (out_signal == self.out_value)
+
+        transmission = 0. if self._inserted else 1.0
+
+        return LightpathState(
+            inserted=self._inserted,
+            removed=self._removed,
+            transmission=transmission,
+            output_branch=self.output_branches[0]
+        )
 
 
 PPSStopperL2SI = PPSStopper2PV

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 from ophyd import Component as Cpt
-from ophyd import Device, EpicsSignal, EpicsSignalRO
+from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 
 from .inout import InOutPositioner, InOutPVStatePositioner
@@ -121,7 +121,7 @@ class PPSStopper(InOutPositioner):
         raise PermissionError("PPSStopper can not be commanded via EPICS")
 
 
-class PPSStopper2PV(LightpathMixin, BaseInterface, Device):
+class PPSStopper2PV(BaseInterface, LightpathMixin):
     """
     PPS Stopper with two PVs defining the state together.
 

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -184,8 +184,7 @@ class PPSStopper2PV(BaseInterface, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: transmission}
         )
 
 

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -6,7 +6,7 @@ from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
 
 from .inout import InOutPositioner, InOutPVStatePositioner
-from .interface import BaseInterface, LightpathMixin
+from .interface import BaseInterface, LightpathInOutMixin, LightpathMixin
 
 
 class Commands(IntEnum):
@@ -15,7 +15,7 @@ class Commands(IntEnum):
     open_valve = 1
 
 
-class Stopper(InOutPVStatePositioner):
+class Stopper(InOutPVStatePositioner, LightpathInOutMixin):
     """
     Controls Stopper.
 
@@ -77,7 +77,7 @@ class Stopper(InOutPVStatePositioner):
         return self.insert(**kwargs)
 
 
-class PPSStopper(InOutPositioner):
+class PPSStopper(InOutPositioner, LightpathInOutMixin):
     """
     PPS Stopper.
 

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -1,6 +1,9 @@
 """
 Module for the SXR Test Absorbers.
 """
+from typing import Tuple
+
+from lightpath import LightpathState
 from ophyd.device import Component as Cpt
 
 from .epics_motor import BeckhoffAxisNoOffset
@@ -23,10 +26,17 @@ class SxrTestAbsorber(BaseInterface, LightpathMixin):
 
     lightpath_cpts = ['absorber_vert']
 
-    def _set_lightpath_states(self, lightpath_values):
-        pos = lightpath_values[self.absorber_vert]['value']
+    def calc_lightpath_state(self, absorber_vert: Tuple) -> LightpathState:
+        pos = absorber_vert[0]  # user readback in tuple
         # 0 is out, negative is in
         # this device has never been inserted, so we don't know the in pos
         self._inserted = pos < -1
         self._removed = pos > -1
         self._transmission = int(self._removed)
+
+        return LightpathState(
+            inserted=self._inserted,
+            removed=self._removed,
+            transmission=self._transmission,
+            output_branch=self.output_branch[0]
+        )

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -38,5 +38,5 @@ class SxrTestAbsorber(BaseInterface, LightpathMixin):
             inserted=self._inserted,
             removed=self._removed,
             transmission=self._transmission,
-            output_branch=self.output_branch[0]
+            output_branch=self.output_branches[0]
         )

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -2,13 +2,12 @@
 Module for the SXR Test Absorbers.
 """
 from ophyd.device import Component as Cpt
-from ophyd.device import Device
 
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathMixin
 
 
-class SxrTestAbsorber(BaseInterface, LightpathMixin, Device):
+class SxrTestAbsorber(BaseInterface, LightpathMixin):
     """
     SXR Test Absorber: Used for testing the sxr beamline at high pulse rates.
 

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -35,6 +35,5 @@ class SxrTestAbsorber(BaseInterface, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=self._transmission,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: self._transmission}
         )

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -1,8 +1,6 @@
 """
 Module for the SXR Test Absorbers.
 """
-from typing import Tuple
-
 from lightpath import LightpathState
 from ophyd.device import Component as Cpt
 
@@ -24,10 +22,10 @@ class SxrTestAbsorber(BaseInterface, LightpathMixin):
 
     absorber_vert = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
 
-    lightpath_cpts = ['absorber_vert']
+    lightpath_cpts = ['absorber_vert.user_readback']
 
-    def calc_lightpath_state(self, absorber_vert: Tuple) -> LightpathState:
-        pos = absorber_vert[0]  # user readback in tuple
+    def calc_lightpath_state(self, absorber_vert: float) -> LightpathState:
+        pos = absorber_vert
         # 0 is out, negative is in
         # this device has never been inserted, so we don't know the in pos
         self._inserted = pos < -1

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -67,7 +67,8 @@ def make_fake_ccm():
                        x_down_prefix='X:DOWN', x_up_prefix='X:UP',
                        y_down_prefix='Y:DOWN', y_up_north_prefix='Y:UP:NORTH',
                        y_up_south_prefix='Y:UP:SOUTH', in_pos=8, out_pos=0,
-                       name='fake_ccm')
+                       name='fake_ccm',
+                       input_branches=['X0'], output_branches=['X0'])
 
     def init_pos(mot, pos=0):
         mot.user_readback.sim_put(0)

--- a/pcdsdevices/tests/test_mirror.py
+++ b/pcdsdevices/tests/test_mirror.py
@@ -134,10 +134,12 @@ def test_mirror_disconnected():
 @pytest.fixture(scope='function')
 def fake_kbo_mirror():
     FakeKBO = make_fake_device(KBOMirror)
-    return FakeKBO('TST:M1H', name="Test Mirror")
+    return FakeKBO('TST:M1H', name="Test Mirror",
+                   input_branches=['X0'], output_branches=['X0', 'X1'])
 
 
 def test_kbomirror_lighpath(fake_kbo_mirror):
     km = fake_kbo_mirror
-    assert km.inserted
-    assert not km.removed
+    lp_state = km.get_lightpath_state()
+    assert lp_state.inserted
+    assert not lp_state.removed

--- a/pcdsdevices/tests/test_slits.py
+++ b/pcdsdevices/tests/test_slits.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope='function')
 def fake_slits():
     FakeSlits = make_fake_device(LusiSlits)
-    slits = FakeSlits("TST:JAWS:", name='Test Slits')
+    slits = FakeSlits("TST:JAWS:", name='Test Slits',
+                      input_branches=['X0'], output_branches=['X0'])
     # Set centers
     slits.xcenter.readback.sim_put(0.0)
     slits.ycenter.readback.sim_put(0.0)
@@ -28,7 +29,8 @@ def fake_slits():
 @pytest.fixture(scope='function')
 def fake_beckhoff_slits():
     FakeBeckhoffSlits = make_fake_device(BeckhoffSlits)
-    slits = FakeBeckhoffSlits('TST:BKSLITS', name='test_slits')
+    slits = FakeBeckhoffSlits('TST:BKSLITS', name='test_slits',
+                              input_branches=['X0'], output_branches=['X0'])
     return slits
 
 
@@ -94,7 +96,7 @@ def test_slit_subscriptions(fake_slits):
     slits = fake_slits
     # Subscribe a pseudo callback
     cb = Mock()
-    slits.subscribe(cb, event_type=slits.SUB_STATE, run=False)
+    slits.xwidth.subscribe(cb, run=False)
     # Change the aperture size
     slits.xwidth.readback.sim_put(40.0)
     assert cb.called

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -4,6 +4,7 @@ Standard classes for LCLS Gate Valves.
 import logging
 from enum import IntEnum
 
+from lightpath import LightpathState
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 
@@ -202,11 +203,22 @@ class VRC(VVC, LightpathMixin):
         doc='Closed limit switch digital input'
     )
 
-    def _set_lightpath_states(self, lightpath_values):
+    def calc_lightpath_state(
+        self, open_limit: int, closed_limit: int
+    ) -> LightpathState:
         """Callback for updating inserted/removed for lightpath."""
 
-        self._inserted = lightpath_values[self.closed_limit]['value']
-        self._removed = lightpath_values[self.open_limit]['value']
+        self._inserted = bool(closed_limit)
+        self._removed = bool(open_limit)
+
+        trans = 0.0 if self._inserted else 1.0
+
+        return LightpathState(
+            inserted=self._inserted,
+            removed=self._removed,
+            transmission=trans,
+            output_branch=self.output_branches[0]
+        )
 
 
 class VRCClsLS(VVC):
@@ -491,9 +503,20 @@ class VFS(LightpathMixin):
         doc='Name of device that can veto this VFS'
     )
 
-    def _set_lightpath_states(self, lightpath_values):
-        self._inserted = lightpath_values[self.position_close]['value']
-        self._removed = lightpath_values[self.position_open]['value']
+    def calc_lightpath_state(self, position_open: int, position_close: int):
+        """Callback for updating inserted/removed for lightpath."""
+
+        self._inserted = bool(position_close)
+        self._removed = bool(position_open)
+
+        trans = 0.0 if self._inserted else 1.0
+
+        return LightpathState(
+            inserted=self._inserted,
+            removed=self._removed,
+            transmission=trans,
+            output_branch=self.output_branches[0]
+        )
 
 
 class VVCNO(Device):
@@ -585,11 +608,20 @@ class VRCNO(VVCNO, LightpathMixin):
         doc='Closed limit switch digital input'
     )
 
-    def _set_lightpath_states(self, lightpath_values):
+    def calc_lightpath_state(self, open_limit: int, closed_limit: int):
         """Callback for updating inserted/removed for lightpath."""
 
-        self._inserted = lightpath_values[self.closed_limit]['value']
-        self._removed = lightpath_values[self.open_limit]['value']
+        self._inserted = bool(closed_limit)
+        self._removed = bool(open_limit)
+
+        trans = 0.0 if self._inserted else 1.0
+
+        return LightpathState(
+            inserted=self._inserted,
+            removed=self._removed,
+            transmission=trans,
+            output_branch=self.output_branches[0]
+        )
 
 
 class VRCDA(VRC, VRCNO):

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -380,7 +380,7 @@ class VGC_2S(VRC):
     )
 
 
-class VFS(Device, LightpathMixin):
+class VFS(LightpathMixin):
     """
     VFS = Fast Shutter Valve
 

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -216,8 +216,7 @@ class VRC(VVC, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=trans,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: trans}
         )
 
 
@@ -514,8 +513,7 @@ class VFS(LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=trans,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: trans}
         )
 
 
@@ -619,8 +617,7 @@ class VRCNO(VVCNO, LightpathMixin):
         return LightpathState(
             inserted=self._inserted,
             removed=self._removed,
-            transmission=trans,
-            output_branch=self.output_branches[0]
+            output={self.output_branches[0]: trans}
         )
 
 

--- a/pcdsdevices/wfs.py
+++ b/pcdsdevices/wfs.py
@@ -3,7 +3,7 @@ from ophyd import Component as Cpt
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .epics_motor import BeckhoffAxisNoOffset
-from .interface import BaseInterface, LightpathInOutMixin
+from .interface import BaseInterface, LightpathInOutCptMixin
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATTempSensor
 
@@ -18,7 +18,8 @@ class WaveFrontSensorStates(TwinCATStatePMPS):
     config = UpCpt(state_count=6)
 
 
-class WaveFrontSensorTarget(BaseInterface, GroupDevice, LightpathInOutMixin):
+class WaveFrontSensorTarget(BaseInterface, GroupDevice,
+                            LightpathInOutCptMixin):
     """
     An array of targets used to determine the beam's wavefront.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bluesky>=1.6.4
 happi
 jsonschema
+lightpath>0.6.9
 numpy
 ophyd>=1.5.1
 pcdscalc>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bluesky>=1.6.4
 happi
 jsonschema
-lightpath>0.6.9
+lightpath>=1.0.0
 numpy
 ophyd>=1.5.1
 pcdscalc>=0.2.0


### PR DESCRIPTION
## Description
Reworks LightpathMixin to have a simpler interface and subscription system.
- Relevant signals are now grouped under a `SummarySignal` (a subclass of AggregateSignal)
- The only required method is now `get_lightpath_status`, which returns a dataclass contianing information needed by lightpath.
- Reworks some existing devices to implement this interface

Will have to be coordinated with a corresponding [lightpath PR](https://github.com/pcdshub/lightpath/pull/133)

This will require a significant overhaul of the existing devices that are to be used in lightpath.  Currently: 
- 177 devices are marked as active and participating in lightpath (active=True, lightpath=True)
  - Of these, only 108 implement the existing LightpathMixin
  - Several devices should be in the lightpath but are not (xpp_lodcm, xcs_lodcm in particular)
- This interface will likely require more specific device classes for branching devices, as their input and output branches will need specificity.

## Motivation and Context
Lightpath is getting an overhaul, and this new interface will be part of it

## How Has This Been Tested?
Eventually in the test suite

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
