### PR TITLE
MAINT: delay the pint import, it is slow

### DIFF
--- a/docs/source/upcoming_release_notes/1030-delay-pint.rst
+++ b/docs/source/upcoming_release_notes/1030-delay-pint.rst
@@ -1,0 +1,31 @@
+1030 delay-pint
+###############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Delay the import of pint so that sessions with no unit conversions can
+  start up 2 seconds faster.
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -16,7 +16,6 @@ from types import MethodType
 from typing import Callable, Dict, Iterator, List, Optional, Union
 
 import ophyd
-import pint
 import prettytable
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
@@ -132,6 +131,7 @@ def convert_unit(value, unit, new_unit):
 
     global ureg
     if ureg is None:
+        import pint
         ureg = pint.UnitRegistry()
 
     expr = ureg.parse_expression(unit)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
import `pint` when it is used and no earlier.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
importing `pint` can be slow and should be skipped if it is not used.

`pint` is a module that is used in this repository to handle unit conversions.

During the first import of `pint`, it makes several additional imports whether the resources from those imports are used or not. I assume this is done to ensure that those optional dependencies are fully functional when used in conjunction with `pint`, and there is probably some base assumption that these imports are light operations.

The additional imports that pint makes in `pint.compat` on import of `pint` are:
- `pandas`
- `pyarrow` (via pandas)
- `numpy`
- `xarray`
- `dask`
- `scipy` (via dask)
- `distributed` (via dask)
- `fsspec` (via dask)

`pint` source code: https://github.com/hgrecco/pint/blob/30a6dad23f504316f6ede5d50dda97e141519995/pint/compat.py

In total, I observe a speedup from 2.60s to import the mirror classes (which don't use `pint`) to 0.69s, for a savings of about 1.9 seconds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
