### PR TITLE
ENH: add flt mv interface to beam energy request

### DIFF
--- a/docs/source/upcoming_release_notes/1032-enh_mv_on_requestor.rst
+++ b/docs/source/upcoming_release_notes/1032-enh_mv_on_requestor.rst
@@ -1,0 +1,31 @@
+1032 enh_mv_on_requestor
+########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Upgrade BeamEnergyRequest from BaseInterface to FltMvInterface
+  to pick up all the move aliases.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/beam_stats.py
+++ b/pcdsdevices/beam_stats.py
@@ -9,7 +9,7 @@ from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import AttributeSignal, EpicsSignal, EpicsSignalRO
 from ophyd.sim import fake_device_cache, make_fake_device
 
-from .interface import BaseInterface
+from .interface import BaseInterface, FltMvInterface
 from .pv_positioner import PVPositionerDone
 from .signal import AvgSignal
 
@@ -35,7 +35,7 @@ class BeamStats(BaseInterface, Device):
         super().__init__(prefix=prefix, name=name, **kwargs)
 
 
-class BeamEnergyRequest(BaseInterface, Device, PositionerBase):
+class BeamEnergyRequest(FltMvInterface, Device, PositionerBase):
     """
     Positioner to request beam color changes from ACR in eV.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Quick fix: upgrade the beam energy requestor from BaseInterface to FltMvInterface for all the movement aliases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
James Cryan noticed this was missing on slack.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively + the tests for this device still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release notes will have an entry for it

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
