### PR TITLE
add PID kill at the end of CCM motion

### DIFF
--- a/docs/source/upcoming_release_notes/1034-Kill_ccm_PID_on_move.rst
+++ b/docs/source/upcoming_release_notes/1034-Kill_ccm_PID_on_move.rst
@@ -1,0 +1,31 @@
+1034 Kill ccm PID on move
+#################
+
+API Changes
+-----------
+Overwrite default move method for the CCMEnergy class to kill the PID loop at the end of each move (default)
+This should prevent the piezo motor from heating up and breaking vacuum or frying itself.
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+espov

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -680,6 +680,27 @@ class CCMEnergy(FltMvInterface, PseudoPositioner, CCMConstantsMixin):
         new_theta0_deg = new_theta0_rad * 180 / np.pi
         self.theta0_deg.put(new_theta0_deg)
 
+    def move(self, *args, kill=True, wait=True, **kwargs):
+        """ 
+        Overwrite the move method to add a PID kill at the
+        end of each move.
+
+        Context: the PID loop keeps looking for the final position forever.
+        The motor thus runs at too high duty cycles, heats up and causes
+        vacuum spikes in the chamber. This has led to MPS trips.
+        In addition, there is serious potential to fry the motor itself,
+        as it is run too intensively.
+        """
+        if kill:
+            # Must always wait if we are killing the PID
+            wait=True
+        st = super().move(*args, wait=wait, **kwargs)
+        time.sleep(0.01) # safety wait. Necessary?
+        if kill:
+            print('Kill alio PID')
+            self.alio.kill()
+        return st
+
 
 class CCMEnergyWithVernier(CCMEnergy):
     """
@@ -751,6 +772,7 @@ class CCMEnergyWithVernier(CCMEnergy):
         alio = real_pos.alio
         energy = self.alio_to_energy(alio)
         return self.PseudoPosition(energy=energy)
+
 
 
 class CCMX(SyncAxis):

--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -681,7 +681,7 @@ class CCMEnergy(FltMvInterface, PseudoPositioner, CCMConstantsMixin):
         self.theta0_deg.put(new_theta0_deg)
 
     def move(self, *args, kill=True, wait=True, **kwargs):
-        """ 
+        """
         Overwrite the move method to add a PID kill at the
         end of each move.
 
@@ -693,9 +693,9 @@ class CCMEnergy(FltMvInterface, PseudoPositioner, CCMConstantsMixin):
         """
         if kill:
             # Must always wait if we are killing the PID
-            wait=True
+            wait = True
         st = super().move(*args, wait=wait, **kwargs)
-        time.sleep(0.01) # safety wait. Necessary?
+        time.sleep(0.01)  # safety wait. Necessary?
         if kill:
             print('Kill alio PID')
             self.alio.kill()
@@ -772,7 +772,6 @@ class CCMEnergyWithVernier(CCMEnergy):
         alio = real_pos.alio
         energy = self.alio_to_energy(alio)
         return self.PseudoPosition(energy=energy)
-
 
 
 class CCMX(SyncAxis):

--- a/pcdsdevices/tests/test_ccm.py
+++ b/pcdsdevices/tests/test_ccm.py
@@ -52,8 +52,10 @@ def fake_ccm():
 
 
 class FakeAlio(FastMotor):
-    kill = None
     home = None
+
+    def kill(self):
+        print('Killing alio PID')
 
 
 def make_fake_ccm():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Kill CCM's PID loop at the end of a move command

## Motivation and Context
The PID loop keeps looking for the final position forever. The motor thus runs at too high duty cycles, heats up and causes vacuum spikes in the chamber. This has led to MPS trips. In addition, there is serious potential to fry the motor itself, as it is run too intensively.


## How Has This Been Tested?
Currently running at XPP for CCM experiments. Still waiting on confirmation that this all works fine before finalizing this pull request

## Where Has This Been Documented?
Docstring of the new move function.


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
