### PR TITLE
ENH: add evr motor

### DIFF
--- a/docs/source/upcoming_release_notes/1037-enh_evr_motor.rst
+++ b/docs/source/upcoming_release_notes/1037-enh_evr_motor.rst
@@ -28,4 +28,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- zllentz

--- a/docs/source/upcoming_release_notes/1037-enh_evr_motor.rst
+++ b/docs/source/upcoming_release_notes/1037-enh_evr_motor.rst
@@ -1,0 +1,31 @@
+1037 enh_evr_motor
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Added an ``ns_delay_scan motor`` to the evr ``Trigger`` class that is
+  convenient for scanning the delay in nanoseconds.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/evr.py
+++ b/pcdsdevices/evr.py
@@ -2,6 +2,22 @@ from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 
 from .interface import BaseInterface
+from .pv_positioner import PVPositionerIsClose
+
+EVR_TICK_NS = 8.3
+
+
+class EvrMotor(PVPositionerIsClose):
+    """
+    PV Positioner for adjusting an EVR channel.
+
+    Moves that are less than one tick
+    are considered immediately complete.
+    """
+    setpoint = Cpt(EpicsSignal, ":TDES", kind="normal")
+    readback = Cpt(EpicsSignalRO, ":BW_TDES", kind="hinted")
+    atol = EVR_TICK_NS
+    rtol = 0
 
 
 class Trigger(BaseInterface, Device):
@@ -9,7 +25,14 @@ class Trigger(BaseInterface, Device):
     eventcode = Cpt(EpicsSignal, ':EC_RBV', write_pv=':TEC', kind="config")
     eventrate = Cpt(EpicsSignalRO, ':RATE', kind="normal")
     label = Cpt(EpicsSignal, ':TCTL.DESC', kind="omitted")
-    ns_delay = Cpt(EpicsSignal, ':BW_TDES', write_pv=':TDES', kind="hinted")
+    ns_delay = Cpt(
+        EpicsSignal,
+        ':BW_TDES',
+        write_pv=':TDES',
+        tolerance=EVR_TICK_NS,
+        kind="hinted",
+    )
+    ns_delay_scan = Cpt(EvrMotor, '', kind="omitted")
     polarity = Cpt(EpicsSignal, ':TPOL', kind="config")
     width = Cpt(EpicsSignal, ':BW_TWIDCALC', write_pv=':TWID', kind="normal")
     enable_cmd = Cpt(EpicsSignal, ':TCTL', kind="omitted")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add EVR motor as described by James Cryan in https://jira.slac.stanford.edu/browse/LCLSECSD-1299
- Modify slightly for hints etc.
- Add a tolerance for the set/wait routines for the `ns_delay` signal

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Two reasons why the ns cannot be scanned:
1. Lingering issue with LCLS2 DAQ interface that rejects objects without .position
2. Waiting for a set fails/times out because the valid values for `ns_delay` must be tick-aligned. One tick is 8.3ns.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed that the class still loads.
Worked in TMO

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings
Writing pre-release docs

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
