### PR TITLE
ENH: USB encoder

### DIFF
--- a/docs/source/upcoming_release_notes/1038-usb_encoder.rst
+++ b/docs/source/upcoming_release_notes/1038-usb_encoder.rst
@@ -1,0 +1,30 @@
+1038 usb_encoder
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- New set_zero method to DelayBase
+
+New Devices
+-----------
+- usb_encoder
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- espov

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -798,13 +798,6 @@ class DelayBase(FltMvInterface, PseudoPositioner):
         new_offset = position - self.position[0]
         self.user_offset.put(new_offset)
 
-    def set_zero(self):
-        """
-        Set current position to 0
-        """
-        self.set_current_position(0)
-        return
-
     def format_status_info(self, status_info):
         """
         Use the renderer from the subdevice

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -785,7 +785,7 @@ class DelayBase(FltMvInterface, PseudoPositioner):
         return self.PseudoPosition(delay=delay_value + self.user_offset.get())
 
     def set_current_position(self, position):
-        '''
+        """
         Calculate and configure the user_offset value, indicating the provided
         ``position`` as the new current position.
 
@@ -793,10 +793,17 @@ class DelayBase(FltMvInterface, PseudoPositioner):
         ----------
         position
             The new current position.
-        '''
+        """
         self.user_offset.put(0.0)
         new_offset = position - self.position[0]
         self.user_offset.put(new_offset)
+
+    def set_zero(self):
+        """
+        Set current position to 0
+        """
+        self.set_current_position(0)
+        return
 
     def format_status_info(self, status_info):
         """

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -8,7 +8,7 @@ from ophyd import Device, EpicsSignal
 from .interface import BaseInterface
 
 
-class USBEncoder(BaseInterface, Device):
+class UsDigitalUsbEncoder(BaseInterface, Device):
     """
     Class for the USB encoder by US Digital.
     https://www.usdigital.com/products/accessories/interfaces/usb/usb4

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -25,9 +25,11 @@ class USBEncoder(BaseInterface, Device):
     scale = Cpt(EpicsSignal, ':SCALE', kind='config')
     offset = Cpt(EpicsSignal, ':OFFSET', kind='config')
 
-    tab_whitelist = ['pos', 'set_zero', 'scale', 'offset']
+    tab_whitelist = ['pos', 'set_zero', 'set_zero_with_stage',
+                     'scale', 'offset']
 
-    def __init__(self, stage=None):
+    def __init__(self, prefix, *, name, stage=None, **kwargs):
+        super().__init__(prefix, name=name, **kwargs)
         self.stage = stage
 
     def set_zero(self):
@@ -45,8 +47,9 @@ class USBEncoder(BaseInterface, Device):
             hasattr(self.stage, 'set_current_position')
         ):
             self.stage.set_current_position(0)
+            print(f'Reset encoder {self.name} and axis {self.stage.name} to 0')
         else:
             print('No stage associated with that encoder,')
             print('or stage is not settable.\n')
-            print('Resetting endoder only.')
+            print('Resetting encoder only.')
         return

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -51,9 +51,14 @@ class USBEncoder(BaseInterface, Device):
             hasattr(self.linked_axis, 'set_current_position')
         ):
             self.linked_axis.set_current_position(0)
-            print(f'Reset encoder {self.name} and axis {self.stage.name} to 0')
+            print(
+                f'Reset encoder {self.name} and axis'
+                f' {self.linked_axis.name} to 0.'
+            )
         else:
-            print('No stage associated with that encoder,')
-            print('or stage is not settable.\n')
+            print(
+                'No stage associated with that encoder,'
+                'or stage is not settable.\n'
+            )
             print('Resetting encoder only.')
         return

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -1,0 +1,32 @@
+"""
+Class to handle USB encoders
+"""
+
+from ophyd import Component as Cpt
+from ophyd import Device, EpicsSignal
+
+from .interface import BaseInterface
+
+
+class USBEncoder(BaseInterface, Device):
+    """
+    Delay generator single channel class
+
+    Parameters
+    ----------
+    prefix: str
+        Base PV of the USB encoder
+
+    name: str
+        USB encoder name
+    """
+    zero = Cpt(EpicsSignal, ':ZEROCNT', kind='omitted')
+    pos = Cpt(EpicsSignal, ':POSITION', kind='hinted')
+    scale = Cpt(EpicsSignal, ':SCALE', kind='config')
+    offset = Cpt(EpicsSignal, ':OFFSET', kind='config')
+
+    tab_whitelist = ['pos', 'set_zero', 'scale', 'offset']
+
+    def set_zero(self):
+        """ Resets the encoder counts to 0 """
+        self.zero.put(1)

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -10,7 +10,7 @@ from .interface import BaseInterface
 
 class USBEncoder(BaseInterface, Device):
     """
-    Class for the encoder by US Digital.
+    Class for the USB encoder by US Digital.
     https://www.usdigital.com/products/accessories/interfaces/usb/usb4
 
     Parameters

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -10,7 +10,8 @@ from .interface import BaseInterface
 
 class USBEncoder(BaseInterface, Device):
     """
-    USB encoder class
+    Class for the encoder by US Digital.
+    https://www.usdigital.com/products/accessories/interfaces/usb/usb4
 
     Parameters
     ----------
@@ -28,9 +29,9 @@ class USBEncoder(BaseInterface, Device):
     tab_whitelist = ['pos', 'set_zero', 'set_zero_with_stage',
                      'scale', 'offset']
 
-    def __init__(self, prefix, *, name, stage=None, **kwargs):
+    def __init__(self, prefix, *, name, linked_axis=None, **kwargs):
         super().__init__(prefix, name=name, **kwargs)
-        self.stage = stage
+        self.linked_axis = linked_axis
 
     def set_zero(self):
         """ Resets the encoder counts to 0 """
@@ -44,9 +45,9 @@ class USBEncoder(BaseInterface, Device):
         self.zero.put(1)
         if (
             self.stage is not None or
-            hasattr(self.stage, 'set_current_position')
+            hasattr(self.linked_axis, 'set_current_position')
         ):
-            self.stage.set_current_position(0)
+            self.linked_axis.set_current_position(0)
             print(f'Reset encoder {self.name} and axis {self.stage.name} to 0')
         else:
             print('No stage associated with that encoder,')

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -47,7 +47,7 @@ class USBEncoder(BaseInterface, Device):
         """
         self.zero.put(1)
         if (
-            self.stage is not None or
+            self.linked_axis is not None or
             hasattr(self.linked_axis, 'set_current_position')
         ):
             self.linked_axis.set_current_position(0)

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -10,7 +10,7 @@ from .interface import BaseInterface
 
 class USBEncoder(BaseInterface, Device):
     """
-    Delay generator single channel class
+    USB encoder class
 
     Parameters
     ----------
@@ -27,6 +27,26 @@ class USBEncoder(BaseInterface, Device):
 
     tab_whitelist = ['pos', 'set_zero', 'scale', 'offset']
 
+    def __init__(self, stage=None):
+        self.stage = stage
+
     def set_zero(self):
         """ Resets the encoder counts to 0 """
         self.zero.put(1)
+
+    def set_zero_with_stage(self):
+        """
+        Resets the encoder counts to 0 and sets the stage offset
+        so that its position is also 0.
+        """
+        self.zero.put(1)
+        if (
+            self.stage is not None or
+            hasattr(self.stage, 'set_current_position')
+        ):
+            self.stage.set_current_position(0)
+        else:
+            print('No stage associated with that encoder,')
+            print('or stage is not settable.\n')
+            print('Resetting endoder only.')
+        return

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -42,7 +42,7 @@ class UsDigitalUsbEncoder(BaseInterface, Device):
 
     def set_zero_with_axis(self):
         """
-        Resets the encoder counts to 0 and sets the stage offset
+        Resets the encoder counts to 0 and sets the linked_axis offset
         so that its position is also 0.
         """
         self.zero.put(1)
@@ -57,8 +57,8 @@ class UsDigitalUsbEncoder(BaseInterface, Device):
             )
         else:
             print(
-                'No stage associated with that encoder,'
-                'or stage is not settable.\n'
+                'No axis associated with that encoder,'
+                'or axis is not settable.\n'
             )
             print('Resetting encoder only.')
         return

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -20,13 +20,16 @@ class USBEncoder(BaseInterface, Device):
 
     name: str
         USB encoder name
+
+    linked_axis: device
+        Instance of the axis on which the encoder is mounted
     """
     zero = Cpt(EpicsSignal, ':ZEROCNT', kind='omitted')
     pos = Cpt(EpicsSignal, ':POSITION', kind='hinted')
     scale = Cpt(EpicsSignal, ':SCALE', kind='config')
     offset = Cpt(EpicsSignal, ':OFFSET', kind='config')
 
-    tab_whitelist = ['pos', 'set_zero', 'set_zero_with_stage',
+    tab_whitelist = ['pos', 'set_zero', 'set_zero_with_axis',
                      'scale', 'offset']
 
     def __init__(self, prefix, *, name, linked_axis=None, **kwargs):
@@ -37,7 +40,7 @@ class USBEncoder(BaseInterface, Device):
         """ Resets the encoder counts to 0 """
         self.zero.put(1)
 
-    def set_zero_with_stage(self):
+    def set_zero_with_axis(self):
         """
         Resets the encoder counts to 0 and sets the stage offset
         so that its position is also 0.

--- a/pcdsdevices/usb_encoder.py
+++ b/pcdsdevices/usb_encoder.py
@@ -46,10 +46,7 @@ class UsDigitalUsbEncoder(BaseInterface, Device):
         so that its position is also 0.
         """
         self.zero.put(1)
-        if (
-            self.linked_axis is not None or
-            hasattr(self.linked_axis, 'set_current_position')
-        ):
+        if hasattr(self.linked_axis, 'set_current_position'):
             self.linked_axis.set_current_position(0)
             print(
                 f'Reset encoder {self.name} and axis'
@@ -60,5 +57,5 @@ class UsDigitalUsbEncoder(BaseInterface, Device):
                 'No axis associated with that encoder,'
                 'or axis is not settable.\n'
             )
-            print('Resetting encoder only.')
+            print('Reset encoder only.')
         return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add USB encoder class to pcdsdevices. 

## Motivation and Context
This will allow to remove it from the beamline.py files and ensure better uniformity in handling USB encoder devices. A set_zero method has also been added to the DelayBase class. This will allow reset of the delay to the time zero to use the same command as the encoder.
The USB encoder class can take a linked stage and both can be set to 0 using the `set_zero_with_stage` method.

## How Has This Been Tested?
Tested in xpp3. Behaves as expected.

## Where Has This Been Documented?
Docstring

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
