### PR TITLE
Adding separate module for LED (and other light devices) control

### DIFF
--- a/docs/source/upcoming_release_notes/1039-Create_separate_module_for_light_control.rst
+++ b/docs/source/upcoming_release_notes/1039-Create_separate_module_for_light_control.rst
@@ -29,4 +29,3 @@ Maintenance
 Contributors
 ------------
 - wwright-slac
-- klauer

--- a/docs/source/upcoming_release_notes/1039-Create_separate_module_for_light_control.rst
+++ b/docs/source/upcoming_release_notes/1039-Create_separate_module_for_light_control.rst
@@ -1,0 +1,32 @@
+1039 Create separate module for light control
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- New module for controlling intensity of LEDs or Fiber-Lites, light_control.py
+- Removing CvmiLed from cvmi_motion.py
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- wwright-slac
+- klauer

--- a/pcdsdevices/cvmi_motion.py
+++ b/pcdsdevices/cvmi_motion.py
@@ -6,23 +6,10 @@ This module contains classes related to the TMO-LAMP Motion System
 
 from ophyd import Component as Cpt
 
-from .device import Device, GroupDevice
+from .device import GroupDevice
 from .epics_motor import BeckhoffAxis
 from .interface import BaseInterface
-from .signal import PytmcSignal
-
-
-class CvmiLED(Device):
-    """
-    Basic control and readback PVs for LED rings attached to the viewports
-    on the vacuum chamber. These include illumination percentage,
-    power ON/OFF, and a naming string field.
-    """
-
-    # LED variables
-    desc = Cpt(PytmcSignal, ':NAME', io='io', kind='normal', string=True)
-    pct = Cpt(PytmcSignal, ':ILL:PCT', kind='normal', io='io')
-    pwr = Cpt(PytmcSignal, ':PWR', kind='normal', io='i')
+from .light_control import LightControl
 
 
 class CVMI(BaseInterface, GroupDevice):
@@ -41,7 +28,7 @@ class CVMI(BaseInterface, GroupDevice):
     pct : str
         Illumination percentage of a particular endstation LED.
     pwr : str
-        ON/OFF powered boolean of a particular endstation LED>
+        ON/OFF powered boolean of a particular endstation LED.
     name : str
         Alias for the device
     """
@@ -61,8 +48,8 @@ class CVMI(BaseInterface, GroupDevice):
     sample_paddle = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
 
     # LEDs
-    led1 = Cpt(CvmiLED, ':LED:01')
-    led2 = Cpt(CvmiLED, ':LED:02')
+    led1 = Cpt(LightControl, ':LED:01')
+    led2 = Cpt(LightControl, ':LED:02')
 
 
 class KTOF(BaseInterface, GroupDevice):

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -24,6 +24,7 @@ from .lasers.thorlabsWFS import ThorlabsWfs40
 from .lasers.zoomtelescope import ZoomTelescope
 from .lens import XFLS, Prefocus
 from .lic import LaserInCoupling
+from .light_control import LightControl
 from .lodcm import LODCM
 from .mirror import OffsetMirror, PointingMirror
 from .movablestand import MovableStand

--- a/pcdsdevices/light_control.py
+++ b/pcdsdevices/light_control.py
@@ -1,0 +1,44 @@
+"""
+Module for controlling LEDs or fiber-lites.
+To be paired with FB_LED function block.
+"""
+
+
+import logging
+
+from ophyd import Component as Cpt
+
+from .device import Device
+from .signal import PytmcSignal
+
+logger = logging.getLogger(__name__)
+
+
+class LightControl(Device):
+    """
+    Basic control and readback PVs for LEDs/Fiber-Lites.
+    These include illumination percentage, power ON/OFF,
+    and a naming string field.
+    """
+
+    # LED variables
+    desc = Cpt(
+        PytmcSignal, ':NAME',
+        io='io',
+        kind='normal',
+        string=True
+    )
+
+    pct = Cpt(
+        PytmcSignal, ':ILL:PCT',
+        kind='normal',
+        io='io',
+        doc='Illuminator percentage'
+    )
+
+    pwr = Cpt(
+        PytmcSignal, ':PWR',
+        kind='normal',
+        io='i',
+        doc='Illuminator power boolean (ON/OFF)'
+    )


### PR DESCRIPTION
## Description
Added a separate module, light_control.py, for devices for controlling light brightness. Removed internal module CvmiLed from cvmi_motion.py

## Motivation and Context
https://github.com/pcdshub/pcdsdevices/issues/1039

## How Has This Been Tested?
<img width="529" alt="image" src="https://user-images.githubusercontent.com/100723754/179088804-27c4ecb1-5008-471e-beb6-87cb1633c364.png">

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/100723754/179088887-7f4dd305-2f82-4270-8815-204f9cefeb98.png">

A lot of the testing was previously done by @Mbosum here: https://github.com/pcdshub/pcdsdevices/pull/1017

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
