### PR TITLE
FIX: add in valve_position to ValveBase

### DIFF
--- a/docs/source/upcoming_release_notes/1041-fix_valvebase.rst
+++ b/docs/source/upcoming_release_notes/1041-fix_valvebase.rst
@@ -1,0 +1,32 @@
+1041 fix_valvebase
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add the missing ``valve_position`` signal to ``ValveBase``,
+  making it available for all valve classes. This contains the valve's state,
+  e.g. "OPEN", "CLOSED", "MOVING", "INVALID"
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -95,6 +95,12 @@ class ValveBase(Device):
     PVs that are omitted in VCGLegacy are instead put in the VVC class.
     """
 
+    valve_position = Cpt(
+        EpicsSignalRO,
+        ':POS_STATE_RBV',
+        kind='hinted',
+        doc='Ex: OPEN, CLOSED, MOVING, INVALID, OPEN_F'
+    )
     open_command = Cpt(
         EpicsSignalWithRBV,
         ':OPN_SW',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add `valve_position` to `ValveBase`
* Unclear to me if "legacy" classes need reworking (do they have this PV? were they based on `ST_ValveBase`?). I think a further comparison of the PLC library and the pcdsdevices classes is in order.

## Motivation and Context
Closes #1041 

## How Has This Been Tested?
Test suite

## Where Has This Been Documented?
Issue + PR

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
