### PR TITLE
WIP: limits handling robustness for poorly behaving IOC/gateway/unknown

### DIFF
--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -358,6 +358,19 @@ class UpdateComponent(Component):
         # Use our hostage component from __set_name__
         return self.copy_cpt.create_component(instance)
 
+    # Defer to copy_cpt for subscription handling
+    def subscriptions(self, event_type):
+        return self.copy_cpt.subscriptions(event_type)
+
+    def sub_default(self, func):
+        return self.copy_cpt.sub_default(func)
+
+    def sub_meta(self, func):
+        return self.copy_cpt.sub_meta(func)
+
+    def sub_value(self, func):
+        return self.copy_cpt.sub_value(func)
+
 
 class GroupDevice(Device):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- [x] Relocate some of the limit handling overrides from `Newport` to `EpicsMotorInterface` to make them more widely available
- [x] Allow `UpdateComponent` to use the subscription decorators
- [ ] Add some unit tests for limit handling that don't assume well-formed EPICS metadata on `user_setpoint`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We've observed that the majority of motor records in use at LCLS don't properly update the control limit metadata on their `user_setpoint` signals when `HLM` and `LLM` update. At some point I thought this was just the Newports but I'm annoyed and don't want to mess around with differentiating which are behaving normally and which are not. It's not immediately clear to me if these are driver issues or  gateway issues, but rather than muck about in that space I'm opting to use the `HLM` and `LLM` fields directly instead, which I know is more reliable at LCLS. The affected IOCs internally seem to ignore their stated ctrl limits in favor of the values stored in `HLM` and `LLM`.

The `EpicsMotor` class as implemented in `ophyd` should work perfectly fine if the motor record it's connected to updates its limit metadata appropriately.

The dangling repeat of the `_pos_updated` subscription can be removed when we use `UpCpt` since the subscription reference is copied from the original component.

Ref https://jira.slac.stanford.edu/browse/LCLSPC-457

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Interactively with `simioc`
- [ ] Unit tests
- [ ] Usage tests on live hardware

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
WIP

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
