### PR TITLE
ENH: make PVStateSignal report enum_strs and write_access metadata

### DIFF
--- a/docs/source/upcoming_release_notes/1046-pvstate_metadata.rst
+++ b/docs/source/upcoming_release_notes/1046-pvstate_metadata.rst
@@ -1,0 +1,32 @@
+1046 pvstate metadata
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Make devices that use ``PVStateSignal`` like ``GateValve``
+  and ``PulsePicker`` report their enum states and write permissions
+  in subscriptions for applications like typhos and lightpath.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/pulsepicker.py
+++ b/pcdsdevices/pulsepicker.py
@@ -43,6 +43,7 @@ class PulsePicker(InOutPVStatePositioner):
     _state_logic = {'blade': {0: 'OPEN',
                               1: 'CLOSED',
                               2: 'CLOSED'}}
+    _state_logic_set_ref = 'cmd_open'
     # QIcon for UX
     _icon = 'fa.compass'
 

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -445,7 +445,7 @@ class PVStateSignal(AggregateSignal):
         """
         return tuple(state.name for state in self.parent.states_enum)
 
-    def describe(self) -> Dict[str: Dict[str: Any]]:
+    def describe(self) -> Dict[str, Dict[str, Any]]:
         """
         Make sure a reasonable description exists for bluesky scans.
         """

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import copy
 import functools
 import logging
-from typing import ClassVar, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from ophyd.device import Component as Cpt
 from ophyd.device import Device, required_for_connection
@@ -372,9 +372,9 @@ class PVStatePositioner(StatePositioner):
 
     state = Cpt(PVStateSignal, kind='hinted')
 
-    _state_logic = {}
-    _state_logic_mode = 'ALL'
-    _state_logic_set_ref = None
+    _state_logic: ClassVar[Dict[str, Dict[Any, str]]] = {}
+    _state_logic_mode: ClassVar[str] = 'ALL'
+    _state_logic_set_ref: ClassVar[Optional[str]] = None
 
     def __init__(self, prefix, *, name, **kwargs):
         if self.__class__ is PVStatePositioner:

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -362,6 +362,10 @@ class PVStatePositioner(StatePositioner):
         state. You can set this to 'FIRST' instead to use the first state
         found while traversing the `_state_logic` tree. This means an earlier
         state definition can mask a later state definition.
+
+    _state_logic_set_ref : str or None
+        An optional reference to the component that will be used to set some
+        metadata on the state signal if provided.
     """
 
     __doc__ = __doc__ % basic_positioner_init
@@ -370,6 +374,7 @@ class PVStatePositioner(StatePositioner):
 
     _state_logic = {}
     _state_logic_mode = 'ALL'
+    _state_logic_set_ref = None
 
     def __init__(self, prefix, *, name, **kwargs):
         if self.__class__ is PVStatePositioner:

--- a/pcdsdevices/stopper.py
+++ b/pcdsdevices/stopper.py
@@ -53,6 +53,8 @@ class Stopper(InOutPVStatePositioner):
                                    1: 'OUT'},
                     'closed_limit': {0: 'defer',
                                      1: 'IN'}}
+    _state_logic_set_ref = 'command'
+
     # QIcon for UX
     _icon = 'fa.times-circle'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`PVStateSignal` has been given `enum_strs` and `write_access` metadata that behaves similarly to how the `EpicsSignal` metadata does.

On the first value calculation, which occurs only after the device is fully ready to go, we check the parent states device for its static state enum to use to collect the enum strings and for a setpoint reference that we can subscribe to for write access metadata updates, forwarding these in the `PVStateSignal` as appropriate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We noticed in the lightpath that any devices with `PVStateSignal` behaved inappropriately at the pcdsdevices level, creating what naively looks like ui bugs in `lightpath`, while actually being sourced to here.

This signal type is used in the legacy stoppers, gate valves, pulse pickers, and movable stands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively by loading happi devices and via checking the lightpath.
Unit test added.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I need to make the pre-release docs.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
