### PR TITLE
FIX: some of the south slits had north PV references

### DIFF
--- a/docs/source/upcoming_release_notes/1052-fix_slits_typos.rst
+++ b/docs/source/upcoming_release_notes/1052-fix_slits_typos.rst
@@ -1,0 +1,30 @@
+1052 fix_slits_typos
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix PV typos in the BeckhoffSlits and PowerSlits typhos ui templates.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/ui/BeckhoffSlits.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffSlits.detailed.ui
@@ -1097,7 +1097,7 @@ border-radius: 0px;
         <string>Stop</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.STOP</string>
+        <string>ca://${prefix}:MMS:SOUTH.STOP</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>
@@ -1186,7 +1186,7 @@ border-radius: 0px;
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+        <string>ca://${prefix}:MMS:SOUTH.VAL</string>
        </property>
       </widget>
      </item>

--- a/pcdsdevices/ui/PowerSlits.detailed.ui
+++ b/pcdsdevices/ui/PowerSlits.detailed.ui
@@ -1429,7 +1429,7 @@ border-radius: 0px;
         <string>Stop</string>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.STOP</string>
+        <string>ca://${prefix}:MMS:SOUTH.STOP</string>
        </property>
        <property name="pressValue" stdset="0">
         <string>1</string>
@@ -1518,7 +1518,7 @@ border-radius: 0px;
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+        <string>ca://${prefix}:MMS:SOUTH.VAL</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In the beckhoff and power slits uis (sort of copy pasted from each other) there was a typo on the south blade rows.
This PR fixes the typo.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed this when helping TMO near the end of the run.
I suspect this row of the screen doesn't get much use...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I need to make a pre-release note

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
