### PR TITLE
TST: skip race condition test for now, must revisit later

### DIFF
--- a/docs/source/upcoming_release_notes/1055-tst_race_cond_bandaid.rst
+++ b/docs/source/upcoming_release_notes/1055-tst_race_cond_bandaid.rst
@@ -1,0 +1,31 @@
+1055 tst_race_cond_bandaid
+##########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Mark test_presets as xfail because it has a race condition that is
+  slowing down our development.
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -96,6 +96,7 @@ def test_mv_ginput(monkeypatch, fast_motor):
     inner_test()
 
 
+@pytest.mark.xfail(reason='annoying race condition, see #1050')
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),
     reason="Fails on Windows, no fcntl and different signal handling",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Mark test_presets as xfail for now

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We're not actively working on the presets system and the test has a race condition that is giving false failures on pull request builds. See #1050 for details.

I don't immediately have time to fix the test so I thought this was a prudent band-aid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Via test suite

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll add a release notes blurb but hopefully we'll remove it before the next tag

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
