### PR TITLE
ENH: Added OldVonHamos4Crystal and OldVonHamosCrystal classes to pcds…

### DIFF
--- a/docs/source/upcoming_release_notes/1056-Add_Gen1VonHamos4Crystal.rst
+++ b/docs/source/upcoming_release_notes/1056-Add_Gen1VonHamos4Crystal.rst
@@ -1,4 +1,4 @@
-1056 Add OldVonHamos4Crystal
+1056 Add Gen1VonHamos4Crystal
 #################
 
 API Changes
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- Added OldVonHamos4Crystal and OldVonHamosCrystal to the spectrometer device to support the pre-ADS 4 crystal VonHamos
+- Added Gen1VonHamos4Crystal and Gen1VonHamosCrystal to the spectrometer device to support the pre-ADS 4 crystal VonHamos
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1056-Add_OldVonHamos4Crystal.rst
+++ b/docs/source/upcoming_release_notes/1056-Add_OldVonHamos4Crystal.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- jortiz
+- jortiz-slac

--- a/docs/source/upcoming_release_notes/1056-Add_OldVonHamos4Crystal.rst
+++ b/docs/source/upcoming_release_notes/1056-Add_OldVonHamos4Crystal.rst
@@ -1,0 +1,30 @@
+1056 Add OldVonHamos4Crystal
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Added OldVonHamos4Crystal and OldVonHamosCrystal to the spectrometer device to support the pre-ADS 4 crystal VonHamos
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- jortiz

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -42,7 +42,7 @@ from .sample_delivery import (HPLC, PCM, CoolerShaker, FlowIntegrator,
 from .sensors import RTD, TwinCATThermocouple
 from .sequencer import EventSequencer
 from .slits import Slits
-from .spectrometer import Kmono, VonHamos4Crystal
+from .spectrometer import Kmono, VonHamos4Crystal, OldVonHamos4Crystal
 from .timetool import Timetool, TimetoolWithNav
 from .valve import GateValve, Stopper
 from .wfs import WaveFrontSensorTarget

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -42,7 +42,7 @@ from .sample_delivery import (HPLC, PCM, CoolerShaker, FlowIntegrator,
 from .sensors import RTD, TwinCATThermocouple
 from .sequencer import EventSequencer
 from .slits import Slits
-from .spectrometer import Kmono, OldVonHamos4Crystal, VonHamos4Crystal
+from .spectrometer import Gen1VonHamos4Crystal, Kmono, VonHamos4Crystal
 from .timetool import Timetool, TimetoolWithNav
 from .valve import GateValve, Stopper
 from .wfs import WaveFrontSensorTarget

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -42,7 +42,7 @@ from .sample_delivery import (HPLC, PCM, CoolerShaker, FlowIntegrator,
 from .sensors import RTD, TwinCATThermocouple
 from .sequencer import EventSequencer
 from .slits import Slits
-from .spectrometer import Kmono, VonHamos4Crystal, OldVonHamos4Crystal
+from .spectrometer import Kmono, OldVonHamos4Crystal, VonHamos4Crystal
 from .timetool import Timetool, TimetoolWithNav
 from .valve import GateValve, Stopper
 from .wfs import WaveFrontSensorTarget

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -364,7 +364,7 @@ class HXRSpectrometer(BaseInterface, GroupDevice):
     SUB_STATE = 'state'
 
 
-class OldVonHamosCrystal(BaseInterface, GroupDevice):
+class Gen1VonHamosCrystal(BaseInterface, GroupDevice):
     """Pitch, yaw, and translation motors for control of a single crystal."""
 
     tab_component_names = True
@@ -380,7 +380,7 @@ class OldVonHamosCrystal(BaseInterface, GroupDevice):
         super().__init__(prefix, **kwargs)
 
 
-class OldVonHamos4Crystal(BaseInterface, GroupDevice):
+class Gen1VonHamos4Crystal(BaseInterface, GroupDevice):
     """
     Four crystal Von Hamos setup controlled with a Beckhoff PLC.
 
@@ -400,7 +400,7 @@ class OldVonHamos4Crystal(BaseInterface, GroupDevice):
 
     common_yaw = Cpt(EpicsMotorInterface, ':01', kind='normal', name='Common Rotation')
 
-    cr1 = Cpt(OldVonHamosCrystal, '', transAxis=':02', yawAxis=':06', pitchAxis=':10' , kind='normal', name='Crystal 1')
-    cr2 = Cpt(OldVonHamosCrystal, '', transAxis=':03', yawAxis=':07', pitchAxis=':11' , kind='normal', name='Crystal 2')
-    cr3 = Cpt(OldVonHamosCrystal, '', transAxis=':04', yawAxis=':08', pitchAxis=':12' , kind='normal', name='Crystal 3')
-    cr4 = Cpt(OldVonHamosCrystal, '', transAxis=':05', yawAxis=':09', pitchAxis=':13' , kind='normal', name='Crystal 4')
+    cr1 = Cpt(Gen1VonHamosCrystal, '', transAxis=':02', yawAxis=':06', pitchAxis=':10' , kind='normal', name='Crystal 1')
+    cr2 = Cpt(Gen1VonHamosCrystal, '', transAxis=':03', yawAxis=':07', pitchAxis=':11' , kind='normal', name='Crystal 2')
+    cr3 = Cpt(Gen1VonHamosCrystal, '', transAxis=':04', yawAxis=':08', pitchAxis=':12' , kind='normal', name='Crystal 3')
+    cr4 = Cpt(Gen1VonHamosCrystal, '', transAxis=':05', yawAxis=':09', pitchAxis=':13' , kind='normal', name='Crystal 4')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -369,14 +369,14 @@ class Gen1VonHamosCrystal(BaseInterface, GroupDevice):
 
     tab_component_names = True
 
-    pitch = FCpt(EpicsMotorInterface, '{prefix}{_pitchAxis}', kind='normal')
-    yaw = FCpt(EpicsMotorInterface, '{prefix}{_yawAxis}'  , kind='normal')
-    trans = FCpt(EpicsMotorInterface, '{prefix}{_transAxis}', kind='normal')
+    pitch = FCpt(EpicsMotorInterface, '{prefix}{_pitch_axis}', kind='normal')
+    yaw = FCpt(EpicsMotorInterface, '{prefix}{_yaw_axis}'  , kind='normal')
+    trans = FCpt(EpicsMotorInterface, '{prefix}{_trans_axis}', kind='normal')
 
-    def __init__(self, prefix, pitchAxis, yawAxis, transAxis, **kwargs):
-        self._pitchAxis = pitchAxis
-        self._yawAxis = yawAxis
-        self._transAxis = transAxis
+    def __init__(self, prefix, pitch_axis, yaw_axis, trans_axis, **kwargs):
+        self._pitch_axis = pitch_axis
+        self._yaw_axis = yaw_axis
+        self._trans_axis = trans_axis
         super().__init__(prefix, **kwargs)
 
 
@@ -400,7 +400,7 @@ class Gen1VonHamos4Crystal(BaseInterface, GroupDevice):
 
     common_yaw = Cpt(EpicsMotorInterface, ':01', kind='normal', name='Common Rotation')
 
-    cr1 = Cpt(Gen1VonHamosCrystal, '', transAxis=':02', yawAxis=':06', pitchAxis=':10' , kind='normal', name='Crystal 1')
-    cr2 = Cpt(Gen1VonHamosCrystal, '', transAxis=':03', yawAxis=':07', pitchAxis=':11' , kind='normal', name='Crystal 2')
-    cr3 = Cpt(Gen1VonHamosCrystal, '', transAxis=':04', yawAxis=':08', pitchAxis=':12' , kind='normal', name='Crystal 3')
-    cr4 = Cpt(Gen1VonHamosCrystal, '', transAxis=':05', yawAxis=':09', pitchAxis=':13' , kind='normal', name='Crystal 4')
+    cr1 = Cpt(Gen1VonHamosCrystal, '', trans_axis=':02', yaw_axis=':06', pitch_axis=':10' , kind='normal', name='Crystal 1')
+    cr2 = Cpt(Gen1VonHamosCrystal, '', trans_axis=':03', yaw_axis=':07', pitch_axis=':11' , kind='normal', name='Crystal 2')
+    cr3 = Cpt(Gen1VonHamosCrystal, '', trans_axis=':04', yaw_axis=':08', pitch_axis=':12' , kind='normal', name='Crystal 3')
+    cr4 = Cpt(Gen1VonHamosCrystal, '', trans_axis=':05', yaw_axis=':09', pitch_axis=':13' , kind='normal', name='Crystal 4')


### PR DESCRIPTION
…devices/spectrometer.py

<!--- Provide a general summary of your changes in the Title above -->
## Description
Added OldVonHamos4Crystal and OldVonHamosCrystal classes to pcdsdevices/spectrometer.py

## Motivation and Context
This will allow scientists/users to manipulate the old four crystal Von Hamos interactively in a hutch python session.

## How Has This Been Tested?
Classes were tested using simulated motors then tested on actual Von Hamos hardware using a ipython session.
All axes were tested.

## Where Has This Been Documented?
Doctrings used in classes.
modification and tests are documented in JIRA https://jira.slac.stanford.edu/browse/LCLSECSD-1513

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [NA] Test suite passes locally
- [NA ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
