### PR TITLE
Enable slider on LightControl.ui

### DIFF
--- a/docs/source/upcoming_release_notes/1057-Enabling_slider_on_LightControl.ui.rst
+++ b/docs/source/upcoming_release_notes/1057-Enabling_slider_on_LightControl.ui.rst
@@ -1,0 +1,30 @@
+1057 Enabling slider on LightControl.ui
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Enabling slider on LightControl.ui
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- wwright-slac

--- a/pcdsdevices/ui/LightControl.ui
+++ b/pcdsdevices/ui/LightControl.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>348</width>
-    <height>195</height>
+    <width>525</width>
+    <height>237</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -51,17 +51,32 @@
      <property name="showUnits" stdset="0">
       <bool>true</bool>
      </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
      <property name="channel" stdset="0">
-      <string>sig://${name}.pct</string>
+      <string>sig://${name}_pct</string>
+     </property>
+     <property name="ignoreMouseWheel" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="tickPosition" stdset="0">
+      <enum>QSlider::NoTicks</enum>
      </property>
      <property name="userDefinedLimits" stdset="0">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="userMinimum" stdset="0">
       <double>0.000000000000000</double>
      </property>
      <property name="userMaximum" stdset="0">
       <double>100.000000000000000</double>
+     </property>
+     <property name="step_size" stdset="0">
+      <number>0</number>
      </property>
     </widget>
    </item>
@@ -100,6 +115,25 @@
        <property name="wordWrap">
         <bool>false</bool>
        </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextEditorInteraction</set>
+       </property>
+       <property name="channel" stdset="0">
+        <string>sig://${name}.pct</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="PyDMLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
        <property name="channel" stdset="0">
         <string>sig://${name}.pct</string>
        </property>
@@ -127,19 +161,24 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
    <class>PyDMSlider</class>
    <extends>QFrame</extends>
    <header>pydm.widgets.slider</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
## Description
The slider element on the LightControl.ui was not working, this required just a quick change to the pydm options. Also, added the option to manually type in a number for the illuminator percentage, rather than just needing to use the slider.

## How Has This Been Tested?
This was tested by setting PYTHONPATH to my pcdsdevices working directory, and adjusting the slider. This was confirmed with visually inspecting the light on the device.

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
