### PR TITLE
Changing naming of override force close and fixing description

### DIFF
--- a/docs/source/upcoming_release_notes/1060-Fixing_some_confusing_naming_regard_override_force_close.rst
+++ b/docs/source/upcoming_release_notes/1060-Fixing_some_confusing_naming_regard_override_force_close.rst
@@ -1,0 +1,30 @@
+1060 Fixing some confusing naming regarding override force close
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- The commands for force closing and force opening status' were different. Override force open was override_force_open, but override force close was close_override. This just makes things clearer.
+
+Contributors
+------------
+- wwright-slac

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -537,11 +537,11 @@ class VVCNO(Device):
         kind='normal',
         doc='Epics command to close valve'
     )
-    close_override = Cpt(
+    override_force_close = Cpt(
         EpicsSignalWithRBV,
         ':FORCE_CLS',
         kind='omitted',
-        doc=('Epics Command for open the valve in override '
+        doc=('Epics Command for close the valve in override '
              'mode')
     )
     override_on = Cpt(
@@ -562,6 +562,13 @@ class VVCNO(Device):
         kind='normal',
         doc='PLC Output to close valve'
     )
+
+    @property
+    def close_override(self):
+        """
+        Fixes potential API breaks with old name
+        """
+        return self.override_force_close
 
 
 class VRCNO(VVCNO, LightpathMixin):


### PR DESCRIPTION
## Description
Issues described here: https://github.com/pcdshub/lcls-twincat-vacuum/issues/105
These changes are entirely cosmetic. Making sure the naming scheme for override force open and close are the same. 

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/100723754/196820939-87724ad2-496a-440b-889f-ee6e69656e11.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
