### PR TITLE
MNT: pull branches from attached happi md, rather than as kwargs

### DIFF
--- a/pcdsdevices/ccm.py
+++ b/pcdsdevices/ccm.py
@@ -1022,8 +1022,8 @@ class CCM(BaseInterface, GroupDevice, LightpathMixin, CCMConstantsMixin):
 
         Compares the x position with the saved in and out values.
         """
-        self._inserted = np.isclose(x_up, self._in_pos)
-        self._removed = np.isclose(x_up, self._out_pos)
+        self._inserted = bool(np.isclose(x_up, self._in_pos))
+        self._removed = bool(np.isclose(x_up, self._out_pos))
         if self._removed:
             self._transmission = 1
         else:

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1693,20 +1693,22 @@ class LightpathMixin(Device):
         self._lightpath_ready = False
         self._retry_lightpath = False
         self._cached_state = None
-        self.input_branches = input_branches
-        self.output_branches = output_branches
+        self._md = None
 
         super().__init__(*args, **kwargs)
 
-        if self.input_branches and self.output_branches:
+        if input_branches and output_branches:
+            self._input_branches = input_branches
+            self._output_branches = output_branches
             self._init_summary_signal()
 
     def _init_summary_signal(self) -> None:
-        for sig in self.lightpath_cpts:
-            self.lightpath_summary.add_signal_by_attr_name(sig)
+        if self.lightpath_cpts:
+            for sig in self.lightpath_cpts:
+                self.lightpath_summary.add_signal_by_attr_name(sig)
 
-        self.lightpath_summary.subscribe(self._calc_cache_lightpath_state,
-                                         run=False)
+            self.lightpath_summary.subscribe(self._calc_cache_lightpath_state,
+                                             run=False)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -1763,6 +1765,41 @@ class LightpathMixin(Device):
         Intended for use as a callback subscribed to lightpath_summary
         """
         self.get_lightpath_state(use_cache=False)
+
+    @property
+    def input_branches(self):
+        """
+        return input_branches from happi metadata, unless provided at init
+        """
+        md = getattr(self, 'md', None)
+        if md:
+            return md.get('input_branches')
+        else:
+            return getattr(self, '_input_branches')
+
+    @property
+    def output_branches(self):
+        """
+        return output_branches from happi metadata, unless provided at init
+        """
+        md = getattr(self, 'md', None)
+        if md:
+            return md.get('output_branches')
+        else:
+            return getattr(self, '_output_branches')
+
+    @property
+    def md(self):
+        if self._md is None:
+            raise AttributeError('Device does not have an attached md, '
+                                 'and was likely not initialized from happi')
+        return self._md
+
+    @md.setter
+    def md(self, new_md):
+        """ initialize lightpath when md is set """
+        self._md = new_md
+        self._init_summary_signal()
 
 
 class LightpathInOutMixin(LightpathMixin):


### PR DESCRIPTION
## Description
In order to be backwards compatible with past happi db's, we should not require `input_branches` and `output_branches` as kwargs for a lightpath-compatible devices.  Instead of grabbing those parameters from happi and setting them as attributes on the ophyd object, instead we read them from the attached metadata namespace.  

If that namespace does not exist, we look for any branches provided at init, finally raising an exception if that fails.

The `lightpath_summary` signal is now initialized when either:
- `input_branches` and `output_branches` are provided at init
- the `md` attribute is set by happi, after initialization

## Motivation and Context
We realized that changing the kwargs for all lightpath devices would break the hutch python implementations, since they might be locked at earlier tags.  This is basically restoring the old initialization interface, or the option to use it at least.

## How Has This Been Tested?
`happi audit` checking device instantiation, get_lightpath_state, and the types of the dataclass fields
- this only fails on some devices due to unreachable PV's, which  might be fixed with 🌟 **the great device_config merge** 🌟 
lightpath opens for all paths, as well as in sim mode
test suite passes as well

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
