### PR TITLE
ENH: NC error status in BeckhoffAxis

### DIFF
--- a/docs/source/upcoming_release_notes/1063-enh_nc_error_status.rst
+++ b/docs/source/upcoming_release_notes/1063-enh_nc_error_status.rst
@@ -1,0 +1,32 @@
+1063 enh_nc_error_status
+########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Allow ``BeckhoffAxis`` devices to report the NC error from the
+  beckhoff PLC as part of the move status.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where ``BeckhoffAxis`` devices would show error status
+  after nearly any move, even those that ended normally.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1009,8 +1009,10 @@ class BeckhoffAxis(EpicsMotorInterface):
 
         See ophydobj.subscribe for full details.
 
-        This is a full re-implementation of subscribe for custom error
-        handling. Unlike during EpicsMotor's move, the move status will
+        This is a thin wrapper over subscribe for custom error handling
+        to intercept the normal end of move handler.
+
+        Unlike during EpicsMotor's move, the move status will
         be set to the Beckhoff error message if there is one.
         The move will be marked as successful otherwise.
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1056,10 +1056,7 @@ class BeckhoffAxis(EpicsMotorInterface):
             error_code = self.plc.err_code.get()
             if error_code > 0:
                 error_message = f"{hex(error_code)}: {error_message}"
-                exc = RuntimeError(error_message)
-            else:
-                exc = RuntimeError(error_message)
-            status.set_exception(exc)
+            status.set_exception(RuntimeError(error_message))
         else:
             status.set_finished()
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1056,7 +1056,7 @@ class BeckhoffAxis(EpicsMotorInterface):
             error_code = self.plc.err_code.get()
             if error_code > 0:
                 error_message = f"{hex(error_code)}: {error_message}"
-                exc = NCError(error_message)
+                exc = RuntimeError(error_message)
             else:
                 exc = RuntimeError(error_message)
             status.set_exception(exc)
@@ -1105,13 +1105,6 @@ class BeckhoffAxis(EpicsMotorInterface):
             raise
 
         return status
-
-
-class NCError(RuntimeError):
-    """
-    An error source from the beckhoff NC error table.
-    """
-    ...
 
 
 class BeckhoffAxisPLC_Pre140(BeckhoffAxisPLC):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1022,10 +1022,14 @@ class BeckhoffAxis(EpicsMotorInterface):
         the error logic in _move_changed.
         """
         # Mutate subscribe appropriately if this is the exact sub req done
+        # Or if it's a similar one using non-deprecated set_finished
         # See PositionerBase.move
         if all((
             event_type == self._SUB_REQ_DONE,
-            callback.__qualname__ == 'StatusBase._finished',
+            callback.__qualname__ in (
+                'StatusBase._finished',
+                'StatusBase.set_finished',
+            ),
             not run,
         )):
             # Find the actual status object

--- a/pcdsdevices/tests/test_epics_motor.py
+++ b/pcdsdevices/tests/test_epics_motor.py
@@ -5,6 +5,7 @@ import pytest
 from bluesky import RunEngine
 from bluesky.plan_stubs import close_run, open_run, stage, unstage
 from ophyd.sim import make_fake_device
+from ophyd.status import MoveStatus
 from ophyd.status import wait as status_wait
 from ophyd.utils.epics_pvs import AlarmSeverity, AlarmStatus
 from ophyd.utils.errors import LimitError
@@ -315,6 +316,64 @@ def test_beckhoff_error_clear(fake_beckhoff):
     assert m.plc.cmd_err_reset.get() == 1
     m.stage()
     m.unstage()
+
+
+def test_beckhoff_error_status(fake_beckhoff: BeckhoffAxis):
+    # Helper
+    def sim_move(dest: float, error: str = '', code: int = 0) -> MoveStatus:
+        status = fake_beckhoff.move(dest, wait=False)
+        assert fake_beckhoff.user_setpoint.get() == dest
+        fake_beckhoff.motor_done_move.sim_put(0)
+        fake_beckhoff.user_readback.sim_put(dest)
+        fake_beckhoff.plc.status.sim_put(error)
+        fake_beckhoff.plc.err_code.sim_put(code)
+        fake_beckhoff.motor_done_move.sim_put(1)
+        return status
+
+    # Known starting configuration
+    fake_beckhoff.user_readback.sim_put(0)
+    fake_beckhoff.user_setpoint.sim_put(0)
+    fake_beckhoff.plc.status.sim_put("")
+    fake_beckhoff.plc.err_code.sim_put(0)
+    fake_beckhoff.motor_done_move.sim_put(1)
+    fake_beckhoff.direction_of_travel.sim_put(0)
+    fake_beckhoff.low_limit_switch.sim_put(0)
+    fake_beckhoff.high_limit_switch.sim_put(0)
+    fake_beckhoff.user_readback.alarm_severity = AlarmSeverity.NO_ALARM
+    fake_beckhoff.user_readback.alarm_status = AlarmStatus.NO_ALARM
+
+    # No error normal case
+    status = sim_move(dest=1)
+    status.wait(timeout=1)
+
+    # No error from cases that would be error in EpicsMotor
+    # Limit switch case
+    fake_beckhoff.low_limit_switch.sim_put(1)
+    status = sim_move(dest=-2)
+    status.wait(timeout=1)
+    fake_beckhoff.low_limit_switch.sim_put(0)
+    # Alarm severity case
+    fake_beckhoff.user_readback.alarm_severity = AlarmSeverity.MAJOR
+    status = sim_move(dest=3)
+    status.wait(timeout=1)
+    fake_beckhoff.user_readback.alarm_severity = AlarmSeverity.NO_ALARM
+
+    # Yes error, message preserved
+    msg = 'test_error'
+    status = sim_move(dest=4, error=msg)
+    with pytest.raises(RuntimeError):
+        status.wait(timeout=1)
+    status_msg = status.exception().args[0]
+    assert status_msg == msg
+
+    # Yes error, message and error code preserved
+    code = 17056  # Real error code 0x42a0
+    status = sim_move(dest=5, error=msg, code=code)
+    with pytest.raises(RuntimeError):
+        status.wait(timeout=1)
+    status_msg = status.exception().args[0]
+    assert status_msg in status_msg
+    assert hex(code) in status_msg
 
 
 def test_motor_factory():

--- a/pcdsdevices/tests/test_epics_motor.py
+++ b/pcdsdevices/tests/test_epics_motor.py
@@ -326,6 +326,7 @@ def test_beckhoff_error_status(fake_beckhoff: BeckhoffAxis):
         fake_beckhoff.motor_done_move.sim_put(0)
         fake_beckhoff.user_readback.sim_put(dest)
         fake_beckhoff.plc.status.sim_put(error)
+        fake_beckhoff.plc.err_bool.sim_put(bool(error))
         fake_beckhoff.plc.err_code.sim_put(code)
         fake_beckhoff.motor_done_move.sim_put(1)
         return status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Makes the NC error message and error code get into the status output for BeckhoffAxis moves
- Skips normal EpicsMotor move status handling for BeckhoffAxis, which nearly always has a false positive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
EpicsMotor's MoveStatus gives a lot of false positives and doesn't take advantage of the extra information that we have access to in BeckhoffAxis.

Contributes to https://jira.slac.stanford.edu/browse/LCLSPC-397

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test case
The old tests currently fail, probably related to the way I messed around with the move method
The test I added passes locally
This needs to be tested on a real motor

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
