### PR TITLE
MNT: make LCLSItem fully lightpath compatible, for backcompat

### DIFF
--- a/docs/source/upcoming_release_notes/1065-mnt_backcompat_lightpathitem.rst
+++ b/docs/source/upcoming_release_notes/1065-mnt_backcompat_lightpathitem.rst
@@ -1,0 +1,31 @@
+1065 mnt_backcompat_lightpathitem
+#################################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- makes LCLSItem fully lightpath-compatible, to maintain backcompatibility
+  of happi db
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -28,6 +28,12 @@ class LCLSItem(OphydItem):
                       enforce=re.compile(r'[A-Z0-9]{3}$|[A-Z][0-9]S[0-9]{2}$'))
     lightpath = EntryInfo("If the device should be included in the "
                           "LCLS Lightpath", enforce=bool, default=False)
+    input_branches = EntryInfo(('List of branches the device can receive '
+                                'beam from.'),
+                               optional=True, enforce=list)
+    output_branches = EntryInfo(('List of branches the device can deliver '
+                                'beam to.'),
+                                optional=True, enforce=list)
     ioc_engineer = EntryInfo(('Engineer for the IOC. Used to build IOC '
                              'configs.'),
                              optional=True, enforce=str)


### PR DESCRIPTION
## Description
Makes LCLSItem fully lightpath-compatible.
- adds both input_branches and output_branches as optional fields in LCLSItem


## Motivation and Context
Turns out if we change anything with the happi database, the dev environment will explode. 
This is made possible by #1062, which made keyword arguments optional when creating a Lightpath device

## How Has This Been Tested?
With recent revisions to device_config https://github.com/pcdshub/device_config/pull/31/commits/7b6c15281ee482807d73db4c45fc7da18a4f85fa that return all containers to `LCLSItem`

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
