### PR TITLE
FIX: do not init summary signal unless we have valid branches

### DIFF
--- a/docs/source/upcoming_release_notes/1069-fix_lp_sub_spam.rst
+++ b/docs/source/upcoming_release_notes/1069-fix_lp_sub_spam.rst
@@ -1,0 +1,33 @@
+1069 fix_lp_sub_spam
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- When initializing the lightpath summary signal from a happi load,
+  guard against bad input_branches or output_branches.
+  This stops us from spamming the terminal when loading from a db without
+  input_branches and output_branches.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1782,7 +1782,8 @@ class LightpathMixin(Device):
         self._md = new_md
         self.input_branches = self.md.input_branches
         self.output_branches = self.md.output_branches
-        self._init_summary_signal()
+        if self.input_branches and self.output_branches:
+            self._init_summary_signal()
 
 
 class LightpathInOutMixin(LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When initializing the lightpath branches from happi, guard against bad input_branches or output_branches.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If one of these lightpath-compatible devices is instantiated from an old happi db without input_branches and output_branches, it initializes the summary signal but everything fails in a spammy way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Worked in dev

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Need to add release notes
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
