### PR TITLE
MNT: fully remove lp_container.LightpathItem

### DIFF
--- a/docs/source/upcoming_release_notes/1070-mnt_rm_lightpathitem.rst
+++ b/docs/source/upcoming_release_notes/1070-mnt_rm_lightpathitem.rst
@@ -1,0 +1,30 @@
+1070 mnt_rm_lightpathitem
+#########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fully removes LightpathItem from containers that subclassed it
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -135,7 +135,7 @@ class LegacyItem(HappiItem):
         return self.detailed_screen
 
 
-class Vacuum(lp_containers.LightpathItem, LegacyItem):
+class Vacuum(LCLSItem, LegacyItem):
     """
     Parent class for devices in the vacuum system.
     """
@@ -143,7 +143,7 @@ class Vacuum(lp_containers.LightpathItem, LegacyItem):
     system.default = 'vacuum'
 
 
-class Diagnostic(lp_containers.LightpathItem, LegacyItem):
+class Diagnostic(LCLSItem, LegacyItem):
     """
     Parent class for devices that are used as diagnostics.
     """
@@ -153,7 +153,7 @@ class Diagnostic(lp_containers.LightpathItem, LegacyItem):
                      enforce=str)
 
 
-class BeamControl(lp_containers.LightpathItem, LegacyItem):
+class BeamControl(LCLSItem, LegacyItem):
     """
     Parent class for devices that control any beam parameter.
     """
@@ -298,7 +298,7 @@ class Attenuator(BeamControl):
     kwargs.default['n_filters'] = "{{n_filters}}"
 
 
-class Stopper(lp_containers.LightpathItem, LegacyItem):
+class Stopper(LCLSItem, LegacyItem):
     """
     Large devices that prevent beam when it could cause damage to hardware.
 
@@ -429,7 +429,7 @@ class MovableStand(LegacyItem):
     system.default = 'changeover'
 
 
-class Motor(lp_containers.LightpathItem, LegacyItem):
+class Motor(LCLSItem, LegacyItem):
     """
     A Generic EpicsMotor
     """


### PR DESCRIPTION
## Description
We made LCLSItem lightpath-compatible but forgot to switch all the other devices from lp_containers.LightpathItem

## Motivation and Context
To fully apply the previous bugfix #1065 

## How Has This Been Tested?
In updating the device_config, lucid screens work, happi audits work

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
