### PR TITLE
BUG: forgot self in _find_matching_range_indices

### DIFF
--- a/docs/source/upcoming_release_notes/1072-bug_mirror_range_sig.rst
+++ b/docs/source/upcoming_release_notes/1072-bug_mirror_range_sig.rst
@@ -1,0 +1,30 @@
+1072 bug_mirror_range_sig
+#########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- fixes _find_matchiing_range_indices method signature to include self
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -504,6 +504,7 @@ class XOffsetMirror(BaseInterface, GroupDevice, LightpathMixin):
             )
 
     def _find_matching_range_indices(
+        self,
         ranges: List[List[numeric]],
         value: numeric
     ) -> List[bool]:


### PR DESCRIPTION
## Description
I forgot `self`, so callbacks blew up once real values were being passed through.  🤦‍♂️ 

## Motivation and Context
Fixes callback subscriptions blowing up when my helper methods didn't help.
It turns out that there are common scenarios where this function never gets called (when mirrors are removed), so early testing didn't reveal my stupidity.  

I thought I tested the various possibilities manually, but I guess I didn't.  I should add unit tests to this end but we'll punt that in favor of getting the fix in quickly

## How Has This Been Tested?
interactively 

## Where Has This Been Documented?
this PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
