### PR TITLE
Changing quadratic equation constants and limits

### DIFF
--- a/docs/source/upcoming_release_notes/1073-New_quadratic_equation_and_soft_limtis_for_VLS_focus_mirror.rst
+++ b/docs/source/upcoming_release_notes/1073-New_quadratic_equation_and_soft_limtis_for_VLS_focus_mirror.rst
@@ -1,0 +1,30 @@
+1073 New quadratic equation and soft limtis for VLS focus mirror
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- New quadratic equation and soft limits for VLS focus mirror
+
+Contributors
+------------
+- wwright-slac

--- a/pcdsdevices/crix_motion.py
+++ b/pcdsdevices/crix_motion.py
@@ -181,7 +181,7 @@ class VLSOptics(GroupDevice):
         cb=18.100,
         cc=27.677,
         pol=1,
-        limits=(5.159, 42.153),
+        limits=(5.278, 41.882),
         kind='hinted',
     )
     grating = Cpt(

--- a/pcdsdevices/crix_motion.py
+++ b/pcdsdevices/crix_motion.py
@@ -177,11 +177,11 @@ class VLSOptics(GroupDevice):
     mirror = Cpt(
         QuadraticBeckhoffMotor,
         "CRIX:VLS:MMS:MP",
-        ca=-0.2479,
-        cb=18.09,
-        cc=33.85,
+        ca=-0.7569,
+        cb=18.100,
+        cc=27.677,
         pol=1,
-        limits=(-31.99, 41.42),
+        limits=(5.159, 42.153),
         kind='hinted',
     )
     grating = Cpt(

--- a/pcdsdevices/crix_motion.py
+++ b/pcdsdevices/crix_motion.py
@@ -179,9 +179,9 @@ class VLSOptics(GroupDevice):
         "CRIX:VLS:MMS:MP",
         ca=-0.7569,
         cb=18.100,
-        cc=27.677,
+        cc=27.667,
         pol=1,
-        limits=(5.278, 41.882),
+        limits=(5.275, 41.882),
         kind='hinted',
     )
     grating = Cpt(

--- a/pcdsdevices/tests/test_crix_motion.py
+++ b/pcdsdevices/tests/test_crix_motion.py
@@ -7,8 +7,8 @@ from ..crix_motion import VLSOpticsSim
 
 # Calculation answers
 # Component = (mm, mrad)
-vls_mirror_lower = (-1.179, 5.159)
-vls_mirror_upper = (0.813, 42.153)
+vls_mirror_lower = (-1.179, 5.278)
+vls_mirror_upper = (0.813, 41.882)
 vls_grating_lower = (-1.74, 51.8462)
 vls_grating_upper = (1.2, 3.5410)
 

--- a/pcdsdevices/tests/test_crix_motion.py
+++ b/pcdsdevices/tests/test_crix_motion.py
@@ -7,8 +7,8 @@ from ..crix_motion import VLSOpticsSim
 
 # Calculation answers
 # Component = (mm, mrad)
-vls_mirror_lower = (-3.4743, -31.99)
-vls_mirror_upper = (0.4209, 41.42)
+vls_mirror_lower = (-1.179, 5.159)
+vls_mirror_upper = (0.813, 42.153)
 vls_grating_lower = (-1.74, 51.8462)
 vls_grating_upper = (1.2, 3.5410)
 

--- a/pcdsdevices/tests/test_crix_motion.py
+++ b/pcdsdevices/tests/test_crix_motion.py
@@ -8,7 +8,7 @@ from ..crix_motion import VLSOpticsSim
 # Calculation answers
 # Component = (mm, mrad)
 vls_mirror_lower = (-1.179, 5.275)
-vls_mirror_upper = (0.813, 41.892)
+vls_mirror_upper = (0.813, 41.882)
 vls_grating_lower = (-1.74, 51.8462)
 vls_grating_upper = (1.2, 3.5410)
 

--- a/pcdsdevices/tests/test_crix_motion.py
+++ b/pcdsdevices/tests/test_crix_motion.py
@@ -7,8 +7,8 @@ from ..crix_motion import VLSOpticsSim
 
 # Calculation answers
 # Component = (mm, mrad)
-vls_mirror_lower = (-1.179, 5.278)
-vls_mirror_upper = (0.813, 41.882)
+vls_mirror_lower = (-1.179, 5.275)
+vls_mirror_upper = (0.813, 41.892)
 vls_grating_lower = (-1.74, 51.8462)
 vls_grating_upper = (1.2, 3.5410)
 


### PR DESCRIPTION
VLS focusing mirror testing resulted in finding a new linear to angle conversion equation. This PR input these new coefficients into the crix_motion python module, in addition to changing the resulting soft angular soft limit values. This has been tested in production, this PR just ensures that the changes stick when the next tag is released.
