### PR TITLE
ENH: only hinted beckhoff ui errors

### DIFF
--- a/pcdsdevices/ui/BeckhoffAxis.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.detailed.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>392</width>
-    <height>564</height>
+    <height>591</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,7 +30,7 @@
    <item>
     <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -38,7 +38,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>230</height>
+       <height>16777215</height>
       </size>
      </property>
      <property name="toolTip">
@@ -46,6 +46,9 @@
      </property>
      <property name="error_message_attribute" stdset="0">
       <string>plc.status</string>
+     </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
      </property>
     </widget>
    </item>
@@ -224,8 +227,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>317</width>
-            <height>215</height>
+            <width>98</width>
+            <height>28</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -306,9 +309,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosSignalPanel</class>
-   <extends>QWidget</extends>
-   <header>typhos.panel</header>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
   <customwidget>
    <class>TyphosPositionerWidget</class>
@@ -316,9 +319,9 @@
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/BeckhoffAxis.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>337</width>
-    <height>258</height>
+    <width>369</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -89,6 +89,9 @@
      <property name="error_message_attribute" stdset="0">
       <string>plc.status</string>
      </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
+     </property>
     </widget>
    </item>
    <item>
@@ -121,14 +124,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
-   <header>typhos.positioner</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosDisplayTitle</class>
    <extends>QFrame</extends>
    <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use https://github.com/pcdshub/typhos/pull/522 to configure the Beckhoff positioner screens to be less trigger-happy about what counts as an "alarming" beckhoff motor.

~Cannot be merged before typhos is tagged with the above.~ Should not tag with this until typhos is tagged with the above. This can be merged so long as it's run in conjunction with a dev typhos build.

Also slightly adjusts the sizing for the detailed screen to make the error text less squished

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are lots of False positives in here related to https://jira.slac.stanford.edu/browse/LCLSPC-350 and this is a simple workaround.

After this PR, only the alarm state of the .RBV signal will be considered.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Need to
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
