### PR TITLE
DOC: update LightpathMixin docstring example

### DIFF
--- a/docs/source/upcoming_release_notes/1075-doc_lp_example.rst
+++ b/docs/source/upcoming_release_notes/1075-doc_lp_example.rst
@@ -1,0 +1,30 @@
+1075 doc_lp_example
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- updates example in docstring of LightpathMixin
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1668,11 +1668,12 @@ class LightpathMixin(Device):
 
             def calc_lightpath_state(self, sig1=None, sig2=None):
                 # Logic, calculations using sig1, sig2
-                status = LightpathStatus(
-                    inserted=True, removed=False,
-                    transmission=0.0, output_branch='L3'
+                state = LightpathState(
+                    inserted=True,
+                    removed=False,
+                    output={self.output_branches[0]: 1.0}
                 )
-                return status
+                return state
 
         dev = MyDevice('PREFIX', name='dev', input_branches=['L0'],
                        output_branches=['L0'])

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1668,10 +1668,11 @@ class LightpathMixin(Device):
 
             def calc_lightpath_state(self, sig1=None, sig2=None):
                 # Logic, calculations using sig1, sig2
+                # self.output_branches assigned by LightpathMixin at __init__
                 state = LightpathState(
                     inserted=True,
                     removed=False,
-                    output={self.output_branches[0]: 1.0}
+                    output={self.output_branches[0]: 0.0}
                 )
                 return state
 


### PR DESCRIPTION
## Description
Updates the docstring of LightpathMixin to include a useful example

## Motivation and Context
I've already confused one person and would like to stop doing that

## How Has This Been Tested?
This is documentation

## Where Has This Been Documented?
This is documentation

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
