### PR TITLE
ENH: add pre-move check for beckhoff axis nonzero velo

### DIFF
--- a/docs/source/upcoming_release_notes/1076-enh_zero_vel_check.rst
+++ b/docs/source/upcoming_release_notes/1076-enh_zero_vel_check.rst
@@ -1,0 +1,31 @@
+1076 enh_zero_vel_check
+#######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Throw a clear error when the user tries to move a ``BeckhoffAxis`` that has
+  the default velocity (zero), rather than failing silently.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1038,6 +1038,26 @@ class BeckhoffAxis(EpicsMotorInterface):
 
         return status
 
+    def check_value(self, pos: float) -> None:
+        """
+        Check that the motor can reach the position.
+
+        Inherits limits and related checks from parent classes.
+        Adds one additional check: the velocity must be nonzero
+        for a move to succeed. Otherwise, the move fails silently.
+
+        Beckhoff EPICS motors at LCLS that have never been initialized
+        before default to a zero velocity for safety. This check
+        lets the user know why the motor does not move.
+        """
+        super().check_value(pos)
+        velo = self.velocity.get()
+        if velo <= 0:
+            raise RuntimeError(
+                f'Motor velocity is {velo}, which is not valid. '
+                'Please configure a nonzero, positive velocity.'
+            )
+
 
 class BeckhoffAxisPLC_Pre140(BeckhoffAxisPLC):
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1054,7 +1054,7 @@ class BeckhoffAxis(EpicsMotorInterface):
         velo = self.velocity.get()
         if velo <= 0:
             raise RuntimeError(
-                f'Motor velocity is {velo}, which is not valid. '
+                f'{self.name} velocity is {velo}, which is not valid. '
                 'Please configure a nonzero, positive velocity.'
             )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When the user requests a `BeckhoffAxis` move, check that the velocity is nonzero before attempting the move.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you execute a move with velocity=0, nothing happens and it can be confusing.
This makes it so at least an exception is raised.

This exception shows up in the typhos screen too.

The BeckhoffAxis EPICS motor records default to velocity=0 for safety.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests and tested interactively with test PLC

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll make a pre-release doc
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
