### PR TITLE
TST: add option to skip device classes in find_all_device_classes

### DIFF
--- a/docs/source/upcoming_release_notes/1077-tst_skip_dev_cls.rst
+++ b/docs/source/upcoming_release_notes/1077-tst_skip_dev_cls.rst
@@ -1,0 +1,30 @@
+1077 tst_skip_dev_cls
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- adds argument to ``conftest.find_all_device_classes`` that allows specified device classes to be skipped.
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/tests/conftest.py
+++ b/pcdsdevices/tests/conftest.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import ophyd
 import pytest
@@ -113,7 +113,7 @@ def find_pcdsdevices_submodules() -> Dict[str, ModuleType]:
     return modules
 
 
-def find_all_classes(classes, skip: Optional[List[str]] = None) -> list:
+def find_all_classes(classes, skip: Optional[List[str]] = None) -> List[Any]:
     """Find all device classes in pcdsdevices and return them as a list."""
     skip = skip or []
 
@@ -138,7 +138,9 @@ def find_all_classes(classes, skip: Optional[List[str]] = None) -> list:
     return list(sorted(set(devices), key=sort_key))
 
 
-def find_all_device_classes(skip: Optional[List[str]] = None) -> list:
+def find_all_device_classes(
+    skip: Optional[List[str]] = None
+) -> List[ophyd.Device]:
     """
     Find all device classes in pcdsdevices and return them as a list.
     Skip any devices with their name in ``skip``
@@ -147,7 +149,7 @@ def find_all_device_classes(skip: Optional[List[str]] = None) -> list:
     return find_all_classes(ophyd.Device, skip=skip)
 
 
-def find_all_callables() -> list:
+def find_all_callables() -> List[Callable]:
     """Find all callables in pcdsdevices and return them as a list."""
     def should_include(obj):
         try:

--- a/pcdsdevices/tests/conftest.py
+++ b/pcdsdevices/tests/conftest.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import ophyd
 import pytest
@@ -113,8 +113,10 @@ def find_pcdsdevices_submodules() -> Dict[str, ModuleType]:
     return modules
 
 
-def find_all_classes(classes, skip: List[str] = []) -> list:
+def find_all_classes(classes, skip: Optional[List[str]] = None) -> list:
     """Find all device classes in pcdsdevices and return them as a list."""
+    skip = skip or []
+
     def should_include(obj):
         return (
             inspect.isclass(obj) and
@@ -136,11 +138,12 @@ def find_all_classes(classes, skip: List[str] = []) -> list:
     return list(sorted(set(devices), key=sort_key))
 
 
-def find_all_device_classes(skip: List[str] = []) -> list:
+def find_all_device_classes(skip: Optional[List[str]] = None) -> list:
     """
     Find all device classes in pcdsdevices and return them as a list.
     Skip any devices with their name in ``skip``
     """
+    skip = skip or []
     return find_all_classes(ophyd.Device, skip=skip)
 
 

--- a/pcdsdevices/tests/conftest.py
+++ b/pcdsdevices/tests/conftest.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Dict
+from typing import Dict, List
 
 import ophyd
 import pytest
@@ -113,14 +113,15 @@ def find_pcdsdevices_submodules() -> Dict[str, ModuleType]:
     return modules
 
 
-def find_all_classes(classes) -> list:
+def find_all_classes(classes, skip: List[str] = []) -> list:
     """Find all device classes in pcdsdevices and return them as a list."""
     def should_include(obj):
         return (
             inspect.isclass(obj) and
             issubclass(obj, classes) and
             not obj.__module__.startswith("ophyd") and
-            not obj.__module__.startswith("pcdsdevices.tests")
+            not obj.__module__.startswith("pcdsdevices.tests") and
+            obj.__name__ not in skip
         )
 
     def sort_key(cls):
@@ -135,9 +136,12 @@ def find_all_classes(classes) -> list:
     return list(sorted(set(devices), key=sort_key))
 
 
-def find_all_device_classes() -> list:
-    """Find all device classes in pcdsdevices and return them as a list."""
-    return find_all_classes(ophyd.Device)
+def find_all_device_classes(skip: List[str] = []) -> list:
+    """
+    Find all device classes in pcdsdevices and return them as a list.
+    Skip any devices with their name in ``skip``
+    """
+    return find_all_classes(ophyd.Device, skip=skip)
 
 
 def find_all_callables() -> list:


### PR DESCRIPTION
## Description
Adds an optional argument to `find_all_classes` (and by extension `find_all_device_classes`) that skips certain class names.  

## Motivation and Context
Filtering based on subclass has worked in the past, but now searching for all subclasses of ophyd.Device can return the lightpathmixins, which need a little more work to subclass properly.  This only appeared as a problem in https://github.com/pcdshub/atef/pull/132

## How Has This Been Tested?
Test suite runs, atef test suite can be modified to pass now too

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
