### PR TITLE
MNT: rework for the 4-blade attenuator screens

### DIFF
--- a/docs/source/upcoming_release_notes/1080-sattscreens.rst
+++ b/docs/source/upcoming_release_notes/1080-sattscreens.rst
@@ -1,0 +1,34 @@
+1080 sattscreens
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Four blade SXR solid attenuator (AT1K4 and AT2K2) screens have been updated
+  to include all of the filters installed on each blade. It will also show the
+  per-blade filters that the calculator will insert when "Apply Configuration"
+  is clicked. The custom energy line edit will now remain visible regardless of
+  the "Actual/Custom" Photon Energy selection.
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/ui/AttenuatorCalculatorSXR_Blade_config.embedded.ui
+++ b/pcdsdevices/ui/AttenuatorCalculatorSXR_Blade_config.embedded.ui
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>816</width>
+    <height>113</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>${BLADE}</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>${FILTER}</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMLabel" name="Material">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>(material)</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${prefix}:AXIS:${BLADE}:FILTER:${FILTER}:Material</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::String</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMLabel" name="Thickness">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>(thickness um)</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${prefix}:AXIS:${BLADE}:FILTER:${FILTER}:Thickness</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::Decimal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMByteIndicator" name="Inserted">
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${prefix}:AXIS:${BLADE}:FILTER:${FILTER}:Active</string>
+     </property>
+     <property name="orientation" stdset="0">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="bigEndian" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="numBits" stdset="0">
+      <number>1</number>
+     </property>
+     <property name="shift" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="labels" stdset="0">
+      <stringlist>
+       <string>Bit 0</string>
+      </stringlist>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMLabel" name="Stuck">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>(stuck)</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${prefix}:AXIS:${BLADE}:FILTER:${FILTER}:IsStuck</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::String</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade.detailed.ui
+++ b/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade.detailed.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>569</width>
-    <height>812</height>
+    <width>659</width>
+    <height>1926</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -118,6 +118,40 @@
     </widget>
    </item>
    <item>
+    <widget class="PyDMEmbeddedDisplay" name="AllFilterInfo">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_FourBlade_all_filters.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -134,14 +168,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMEmbeddedDisplay</class>
    <extends>QFrame</extends>
    <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade_all_filters.ui
+++ b/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade_all_filters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>847</width>
-    <height>664</height>
+    <width>910</width>
+    <height>1058</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,10 +17,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="bladenum">
        <property name="font">
         <font>
          <underline>true</underline>
@@ -35,14 +41,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="filternum">
        <property name="font">
         <font>
          <underline>true</underline>
         </font>
        </property>
        <property name="text">
-        <string>Inserted Material</string>
+        <string>Filter #</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -50,7 +56,22 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="material">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>Material</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="thickness">
        <property name="font">
         <font>
          <underline>true</underline>
@@ -65,7 +86,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_8">
+      <widget class="QLabel" name="active">
        <property name="font">
         <font>
          <underline>true</underline>
@@ -83,7 +104,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="stuck">
        <property name="font">
         <font>
          <underline>true</underline>
@@ -100,40 +121,10 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>Transmission</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_6">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>3rd Harmonic</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
-    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay">
+    <widget class="PyDMEmbeddedDisplay" name="blade1">
      <property name="toolTip">
       <string/>
      </property>
@@ -141,15 +132,21 @@
       <number>0</number>
      </property>
      <property name="macros" stdset="0">
-      <string>{&quot;FILTER&quot;:&quot;01&quot;}</string>
+      <string>{&quot;BLADE&quot;: &quot;01&quot;}</string>
      </property>
      <property name="filename" stdset="0">
-      <string>AttenuatorCalculatorSXR_Blade.embedded.ui</string>
+      <string>AttenuatorCalculatorSXR_FourBlade_blade_all_filters.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_2">
+    <widget class="PyDMEmbeddedDisplay" name="blade2">
      <property name="toolTip">
       <string/>
      </property>
@@ -157,15 +154,21 @@
       <number>0</number>
      </property>
      <property name="macros" stdset="0">
-      <string>{&quot;FILTER&quot;:&quot;02&quot;}</string>
+      <string>{&quot;BLADE&quot;: &quot;02&quot;}</string>
      </property>
      <property name="filename" stdset="0">
-      <string>AttenuatorCalculatorSXR_Blade.embedded.ui</string>
+      <string>AttenuatorCalculatorSXR_FourBlade_blade_all_filters.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_3">
+    <widget class="PyDMEmbeddedDisplay" name="blade3">
      <property name="toolTip">
       <string/>
      </property>
@@ -173,15 +176,21 @@
       <number>0</number>
      </property>
      <property name="macros" stdset="0">
-      <string>{&quot;FILTER&quot;:&quot;03&quot;}</string>
+      <string>{&quot;BLADE&quot;: &quot;03&quot;}</string>
      </property>
      <property name="filename" stdset="0">
-      <string>AttenuatorCalculatorSXR_Blade.embedded.ui</string>
+      <string>AttenuatorCalculatorSXR_FourBlade_blade_all_filters.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
+    <widget class="PyDMEmbeddedDisplay" name="blade4">
      <property name="toolTip">
       <string/>
      </property>
@@ -189,10 +198,16 @@
       <number>0</number>
      </property>
      <property name="macros" stdset="0">
-      <string>{&quot;FILTER&quot;:&quot;04&quot;}</string>
+      <string>{&quot;BLADE&quot;: &quot;04&quot;}</string>
      </property>
      <property name="filename" stdset="0">
-      <string>AttenuatorCalculatorSXR_Blade.embedded.ui</string>
+      <string>AttenuatorCalculatorSXR_FourBlade_blade_all_filters.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade_blade_all_filters.ui
+++ b/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade_blade_all_filters.ui
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>704</width>
+    <height>316</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;01&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_12">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;02&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_11">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;03&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_10">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;04&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;05&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_8">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;06&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_7">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;07&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="macros" stdset="0">
+      <string>{&quot;FILTER&quot;: &quot;08&quot;, &quot;BLADE&quot;: &quot;${BLADE}&quot;}</string>
+     </property>
+     <property name="filename" stdset="0">
+      <string>AttenuatorCalculatorSXR_Blade_config.embedded.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade_calc.ui
+++ b/pcdsdevices/ui/AttenuatorCalculatorSXR_FourBlade_calc.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>661</width>
-    <height>686</height>
+    <width>660</width>
+    <height>503</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,1,1">
+  <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,1,0">
    <property name="spacing">
     <number>10</number>
    </property>
@@ -35,7 +35,7 @@
    <item>
     <widget class="QFrame" name="frame_2">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -43,7 +43,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>150</height>
+       <height>125</height>
       </size>
      </property>
      <property name="frameShape">
@@ -74,7 +74,7 @@
          <string>Photon Energy</string>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
+         <item alignment="Qt::AlignTop">
           <widget class="PyDMLabel" name="ActualEnergy">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -99,7 +99,7 @@
            </property>
           </widget>
          </item>
-         <item>
+         <item alignment="Qt::AlignTop">
           <widget class="PyDMEnumButton" name="EnergyEnum">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -118,7 +118,7 @@
            </property>
           </widget>
          </item>
-         <item>
+         <item alignment="Qt::AlignTop">
           <widget class="PyDMLineEdit" name="CustomPhotonEnergy">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -130,13 +130,25 @@
             <string/>
            </property>
            <property name="rules" stdset="0">
-            <string>[{&quot;name&quot;: &quot;IfCustom&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;expression&quot;: &quot;ch[0] == 1&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:SYS:EnergySource&quot;, &quot;trigger&quot;: true}]}]</string>
+            <string>[]</string>
            </property>
            <property name="precision" stdset="0">
             <number>0</number>
            </property>
            <property name="showUnits" stdset="0">
             <bool>true</bool>
+           </property>
+           <property name="precisionFromPV" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="alarmSensitiveContent" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="PyDMToolTip" stdset="0">
+            <string/>
            </property>
            <property name="channel" stdset="0">
             <string>ca://${prefix}:SYS:CustomPhotonEnergy</string>
@@ -152,8 +164,27 @@
          <string>Transmission</string>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
+         <item alignment="Qt::AlignVCenter">
+          <widget class="QLabel" name="DesiredTransmissionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Desired transmission:</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignVCenter">
           <widget class="PyDMLineEdit" name="DesiredTransmission">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -186,8 +217,8 @@
          <bool>false</bool>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_5">
-         <item>
-          <widget class="PyDMEnumButton" name="PyDMEnumButton_2">
+         <item alignment="Qt::AlignVCenter">
+          <widget class="PyDMEnumButton" name="CalculationModeEnumButton">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -233,7 +264,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item alignment="Qt::AlignTop">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Calculation Results</string>
@@ -261,14 +292,14 @@
           <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item>
-          <widget class="QLabel" name="label">
+          <widget class="QLabel" name="label_a">
            <property name="text">
             <string>At</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="PyDMLabel" name="ActualEnergy_2">
+          <widget class="PyDMLabel" name="CalculationEnergyLabel">
            <property name="font">
             <font>
              <weight>75</weight>
@@ -296,7 +327,7 @@
           </widget>
          </item>
          <item alignment="Qt::AlignLeft">
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="label_best_config">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -309,7 +340,7 @@
           </widget>
          </item>
          <item alignment="Qt::AlignLeft">
-          <widget class="PyDMLabel" name="ActualEnergy_3">
+          <widget class="PyDMLabel" name="CalculationTransmission">
            <property name="font">
             <font>
              <weight>75</weight>
@@ -337,14 +368,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="label_with_mode">
            <property name="text">
             <string>with mode</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="PyDMLabel" name="ActualEnergy_4">
+          <widget class="PyDMLabel" name="CalculationMode">
            <property name="font">
             <font>
              <weight>75</weight>
@@ -372,7 +403,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_4">
+          <widget class="QLabel" name="label_is">
            <property name="text">
             <string>is:</string>
            </property>
@@ -393,6 +424,146 @@
          </item>
         </layout>
        </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="PyDMLabel" name="PyDMLabel_7">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="rules" stdset="0">
+           <string>[{&quot;name&quot;: &quot;FilterText&quot;, &quot;property&quot;: &quot;Text&quot;, &quot;initial_value&quot;: &quot;True&quot;, &quot;expression&quot;: &quot;ch[0][0] == 1 and \&quot;Removed\&quot; or f\&quot;Insert {ch[0][0] - 1}\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:SYS:BestConfiguration_RBV&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: false}]}]</string>
+          </property>
+          <property name="precision" stdset="0">
+           <number>0</number>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveContent" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="PyDMToolTip" stdset="0">
+           <string/>
+          </property>
+          <property name="channel" stdset="0">
+           <string>ca://${prefix}:SYS:BestConfiguration_RBV.[0]</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLabel" name="PyDMLabel_8">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="rules" stdset="0">
+           <string>[{&quot;name&quot;: &quot;FilterText&quot;, &quot;property&quot;: &quot;Text&quot;, &quot;initial_value&quot;: &quot;True&quot;, &quot;expression&quot;: &quot;ch[0][1] == 1 and \&quot;Removed\&quot; or f\&quot;Insert {ch[0][1] - 1}\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:SYS:BestConfiguration_RBV&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: false}]}]</string>
+          </property>
+          <property name="precision" stdset="0">
+           <number>0</number>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveContent" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="PyDMToolTip" stdset="0">
+           <string/>
+          </property>
+          <property name="channel" stdset="0">
+           <string>ca://${prefix}:SYS:BestConfiguration_RBV.[1]</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLabel" name="PyDMLabel_9">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="rules" stdset="0">
+           <string>[{&quot;name&quot;: &quot;FilterText&quot;, &quot;property&quot;: &quot;Text&quot;, &quot;initial_value&quot;: &quot;True&quot;, &quot;expression&quot;: &quot;ch[0][2] == 1 and \&quot;Removed\&quot; or f\&quot;Insert {ch[0][2] - 1}\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:SYS:BestConfiguration_RBV&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: false}]}]</string>
+          </property>
+          <property name="precision" stdset="0">
+           <number>0</number>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveContent" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="PyDMToolTip" stdset="0">
+           <string/>
+          </property>
+          <property name="channel" stdset="0">
+           <string>ca://${prefix}:SYS:BestConfiguration_RBV.[2]</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLabel" name="PyDMLabel_10">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="rules" stdset="0">
+           <string>[{&quot;name&quot;: &quot;FilterText&quot;, &quot;property&quot;: &quot;Text&quot;, &quot;initial_value&quot;: &quot;True&quot;, &quot;expression&quot;: &quot;ch[0][3] == 1 and \&quot;Removed\&quot; or f\&quot;Insert {ch[0][3] - 1}\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:SYS:BestConfiguration_RBV&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: false}]}]</string>
+          </property>
+          <property name="precision" stdset="0">
+           <number>0</number>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveContent" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="PyDMToolTip" stdset="0">
+           <string/>
+          </property>
+          <property name="channel" stdset="0">
+           <string>ca://${prefix}:SYS:BestConfiguration_RBV.[3]</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="PyDMByteIndicator" name="ActiveConfig_2">
@@ -417,14 +588,29 @@
         <property name="toolTip">
          <string/>
         </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
         <property name="channel" stdset="0">
          <string>ca://${prefix}:SYS:BestConfigurationBitmask_RBV</string>
         </property>
         <property name="orientation" stdset="0">
          <enum>Qt::Horizontal</enum>
         </property>
+        <property name="showLabels" stdset="0">
+         <bool>true</bool>
+        </property>
         <property name="bigEndian" stdset="0">
          <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
         </property>
         <property name="labelPosition" stdset="0">
          <enum>QTabWidget::South</enum>
@@ -432,12 +618,15 @@
         <property name="numBits" stdset="0">
          <number>4</number>
         </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
         <property name="labels" stdset="0">
          <stringlist>
-          <string>04</string>
-          <string>03</string>
-          <string>02</string>
-          <string>01</string>
+          <string>Blade 04</string>
+          <string>Blade 03</string>
+          <string>Blade 02</string>
+          <string>Blade 01</string>
          </stringlist>
         </property>
        </widget>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Updates to the attenuator screens for AT1K4 and AT2K2.

## Motivation and Context
Closes #1079 by removing the rule entirely
Closes #1080 by showing all the filters and the number that will be inserted

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
PR text

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5139267/200091208-821aa7d7-c4f7-4e3e-a298-526daa204521.png)

Inserted filters and the configuration matrix of per-blade filters:
<img width="818" alt="image" src="https://user-images.githubusercontent.com/5139267/200091228-47d448f6-7d89-4a65-b463-419d55d04146.png">


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
