### PR TITLE
ENH: create RTDSX0ThreeStage for RTDSK0 solid drilling experiments

### DIFF
--- a/docs/source/upcoming_release_notes/1082-Add_3-stage_motion_on_RTDSK0.rst
+++ b/docs/source/upcoming_release_notes/1082-Add_3-stage_motion_on_RTDSK0.rst
@@ -1,0 +1,30 @@
+1082 Add 3-stage motion on RTDSK0
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+------------
+- RTDSX0ThreeStage class; 3DoF motion stage for SOlid Drilling experiments 
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- Mike Estrada (mkestra)

--- a/docs/source/upcoming_release_notes/1082-Add_3-stage_motion_on_RTDSK0.rst
+++ b/docs/source/upcoming_release_notes/1082-Add_3-stage_motion_on_RTDSK0.rst
@@ -15,7 +15,7 @@ Device Updates
 
 New Devices
 ------------
-- RTDSX0ThreeStage class; 3DoF motion stage for SOlid Drilling experiments 
+- RTDSX0ThreeStage class; 3DoF motion stage for Solid Drilling experiments
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1082-Add_3-stage_motion_on_RTDSK0.rst
+++ b/docs/source/upcoming_release_notes/1082-Add_3-stage_motion_on_RTDSK0.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- Mike Estrada (mkestra)
+- mkestra

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -54,7 +54,7 @@ class RTDSX0ThreeStage(BaseInterface, LightpathMixin):
     mmsz = Cpt(BeckhoffAxis, ':MMS:Z', kind='normal')
 
     # Determine if the y stage is at it's outer limit switch
-    open_limit = Cpt(EpicsSignalRO, ':MMS:Y:PLC:bLimitBackwardEnable_RBV', kind='normal',
+    open_limit = Cpt(EpicsSignalRO, ':MMS:Y.HLS', kind='normal',
                      doc='Reads if the y-stage is at its outer limit.')
     lightpath_cpts = ['open_limit']
 

--- a/pcdsdevices/rtds_ebd.py
+++ b/pcdsdevices/rtds_ebd.py
@@ -1,10 +1,12 @@
+from lightpath import LightpathState
 from ophyd import Component as Cpt
 from ophyd import Signal
 
 from .device import GroupDevice
+from .epics_motor import BeckhoffAxis
 from .inout import InOutPositioner
-from .interface import BaseInterface, LightpathInOutCptMixin
-from .signal import PytmcSignal
+from .interface import BaseInterface, LightpathInOutCptMixin, LightpathMixin
+from .signal import EpicsSignalRO, PytmcSignal
 
 
 class PneumaticActuator(InOutPositioner):
@@ -42,6 +44,27 @@ class PneumaticActuator(InOutPositioner):
             self.in_cmd.put(1)
         elif state.name == 'RETRACTED':
             self.out_cmd.put(1)
+
+
+class RTDSX0ThreeStage(BaseInterface, LightpathMixin):
+    """Three stages X,Y,Z, for solid drilling experiments"""
+
+    mmsx = Cpt(BeckhoffAxis, ':MMS:X', kind='normal')
+    mmsy = Cpt(BeckhoffAxis, ':MMS:Y', kind='normal')
+    mmsz = Cpt(BeckhoffAxis, ':MMS:Z', kind='normal')
+
+    # Determine if the y stage is at it's outer limit switch
+    open_limit = Cpt(EpicsSignalRO, ':MMS:Y:PLC:bLimitBackwardEnable_RBV', kind='normal',
+                     doc='Reads if the y-stage is at its outer limit.')
+    lightpath_cpts = ['open_limit']
+
+    def calc_lightpath_state(self, open_limit=None):
+        # Logic, calculations using open_limit for y-stage
+        status = LightpathState(
+            inserted=not open_limit, removed=open_limit,
+            output={'K0' : 0.0}
+        )
+        return status
 
 
 class RTDSBase(BaseInterface, GroupDevice, LightpathInOutCptMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Brief Description

Created a new, lightpath enabled class for the 3-stage actuator on RTDSK0 that will be used for solid drilling experiments.

<!--- Describe your changes in detail -->

##In-Depth Description

Added class, RTDSX0ThreeStage to rtds_ebd.py. This will track the lighpath status of the solid drilling experiment samples that will be held by the actuator. There are three stages but the only time there is potential to interfere with the beam is when the Y stage is not at it's outer limit. This is additionally tracked as a fast fault in the PMPS system. 

## Motivation and Context

This  setup will be used to conduct solid drilling experiments for SC readiness, we need a way to easily move multiple samples into and out of beam as needed, warranting the addition of this actuator. We further need some indication that it is not intering with the beam, hence inclusion of this device in lightpath and PMPS systems.

## How Has This Been Tested?
The class has been debugged, instantiated and used to create a dummy class that was tested and confirmed to show it was not interfering with beam in a local clone of light path. It will need to be further debugged when there is no beam. This is set to trigger as 'inserted' when the outer limit switch is not hit, the same logic as PMPS. If we tried to confirm that it logically switches while the beam was running on KFE, we would trigger a fast fault and potentially interfere with beam time.

update 11/9: tested and verified with PMPS and lightpath that this class functions to effectively determine if the y-stage is inserted.

## Where Has This Been Documented?

A brief docstring has been included in the class definition. Will add pre-lease-notes in the next day or two, but want to get feedback on the code in the mean time!

## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [X] New/changed functions and methods are covered in the test suite where possible
- [X] Test suite passes locally
- [X] Test suite passes on travis
- [X] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [X] Pre-release docs include context, functional descriptions, and contributors as appropriate
