### PR TITLE
add single blades control by making a new LusiSlitsWithBlades class

### DIFF
--- a/docs/source/upcoming_release_notes/1085-Add_blades_to_LusiSlits.rst
+++ b/docs/source/upcoming_release_notes/1085-Add_blades_to_LusiSlits.rst
@@ -11,11 +11,11 @@ Features
 
 Device Updates
 --------------
-- N/A
+- Update LusiSlits to include individual blade controls.
 
 New Devices
 -----------
-- LusiSlitsWithBlades
+- N/A
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1085-Add_blades_to_LusiSlits.rst
+++ b/docs/source/upcoming_release_notes/1085-Add_blades_to_LusiSlits.rst
@@ -1,0 +1,30 @@
+1085 Add blades to LusiSlits
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- LusiSlitsWithBlades
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- espov, Robert Tang-Kong

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -41,7 +41,7 @@ from .sample_delivery import (HPLC, PCM, CoolerShaker, FlowIntegrator,
                               GasManifold, Selector)
 from .sensors import RTD, TwinCATThermocouple
 from .sequencer import EventSequencer
-from .slits import Slits
+from .slits import Slits, LusiSlitsWithBlades
 from .spectrometer import Gen1VonHamos4Crystal, Kmono, VonHamos4Crystal
 from .timetool import Timetool, TimetoolWithNav
 from .valve import GateValve, Stopper

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -41,7 +41,7 @@ from .sample_delivery import (HPLC, PCM, CoolerShaker, FlowIntegrator,
                               GasManifold, Selector)
 from .sensors import RTD, TwinCATThermocouple
 from .sequencer import EventSequencer
-from .slits import Slits, LusiSlitsWithBlades
+from .slits import Slits
 from .spectrometer import Gen1VonHamos4Crystal, Kmono, VonHamos4Crystal
 from .timetool import Timetool, TimetoolWithNav
 from .valve import GateValve, Stopper

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -475,6 +475,8 @@ class LusiSlitsWithBlades(LusiSlits):
     blade_north = FCpt(IMS, '{self._mms_prefix}:{self._blade_pvs[2]}')
     blade_south = FCpt(IMS, '{self._mms_prefix}:{self._blade_pvs[3]}')
 
+    tab_whitelist = ['blade_up', 'blade_down', 'blade_north', 'blade_south']
+
     def __init__(self, prefix, blade_pvs_idx, **kwargs):
         self._blade_pvs = blade_pvs_idx
         self._mms_prefix = prefix.removesuffix(':JAWS')+':MMS'

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -16,7 +16,6 @@ import logging
 from collections import OrderedDict
 
 from lightpath import LightpathState
-from ophyd import Device
 from ophyd import Component as Cpt
 from ophyd import DynamicDeviceComponent as DDCpt
 from ophyd import EpicsSignal, EpicsSignalRO
@@ -30,7 +29,6 @@ from ophyd.status import wait as status_wait
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
-from .device import UnrelatedComponent as UCpt
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutCptMixin,
                         LightpathMixin, MvInterface)
 from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset, IMS
@@ -433,7 +431,7 @@ class LusiSlits(SlitsBase):
     block_cmd = Cpt(EpicsSignal, ':BLOCK', kind='omitted')
 
     lightpath_cpts = ['xwidth.readback', 'ywidth.readback']
- 
+
     def open(self):
         """Uses the built-in 'OPEN' record to move open the aperture."""
         self.open_cmd.put(1)
@@ -455,36 +453,19 @@ class LusiSlits(SlitsBase):
         return super().calc_lightpath_state(xwidth=xwidth_readback,
                                             ywidth=ywidth_readback)
 
-class SlitsBlades(BaseInterface, GroupDevice):
-
-    up = FCpt(IMS,'{self._pv_up}')
-    down = FCpt(IMS,'{self._pv_down}')
-    north = FCpt(IMS,'{self._pv_north}')
-    south = FCpt(IMS,'{self._pv_south}')
-
-    def __init__(self, blade_pvs, **kwargs):
-        """
-        blade_pvs: list of the blades' PVs in the following order:
-            up, down, north, south
-        """
-        #self._pv_up = blade_pvs[0] 
-        #self._pv_down = blade_pvs[1]
-        #self._pv_north = blade_pvs[2]
-        #self._pv_south = blade_pvs[3]
-        self._pv_up = blade_pvs.split('\'')[1]
-        self._pv_down = blade_pvs.split('\'')[3]
-        self._pv_north = blade_pvs.split('\'')[5]
-        self._pv_south = blade_pvs.split('\'')[7]
-        super().__init__('', **kwargs)
-
 
 class LusiSlitsWithBlades(LusiSlits):
-    
-    # blade motors
-    blades = FCpt(SlitsBlades, '{self._blade_pvs}')
-    
+
+    # blade motors, eg. `XPP:SB3:MMS:01
+    blade_up = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[0]}')
+    blade_down = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[1]}')
+    blade_north = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[2]}')
+    blade_south = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[3]}')
+
     def __init__(self, prefix, blade_pvs, **kwargs):
         self._blade_pvs = blade_pvs
+        self._mms_prefix = prefix.removesuffix(':JAWS')+':MMS'
+        # initialize combined motors (width, center) via `JAWS`
         super().__init__(prefix, **kwargs)
         
 

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -455,19 +455,32 @@ class LusiSlits(SlitsBase):
 
 
 class LusiSlitsWithBlades(LusiSlits):
+    """
+    LusiSlits with additional components for individual blade control.
 
-    # blade motors, eg. `XPP:SB3:MMS:01
-    blade_up = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[0]}')
-    blade_down = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[1]}')
-    blade_north = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[2]}')
-    blade_south = FCpt(IMS,'{self._mms_prefix}:{self._blade_pvs[3]}')
+    Additional parameters to LusiSlits:
+    blade_pvs_idx: list
+        index of the MMS motor of the blade in the following order:
+            up, down, north, south
 
-    def __init__(self, prefix, blade_pvs, **kwargs):
-        self._blade_pvs = blade_pvs
+    The blades are assumend to have the same prefix as the Jaws, with the ":JAWS"
+    suffix replaced by ":MMS".
+
+    Example for xpp_sb3_slits: blade_pvs_idx = ['08','10,'08,'07']
+    """
+
+    # blade motors, eg. `XPP:SB3:MMS:08
+    blade_up = FCpt(IMS, '{self._mms_prefix}:{self._blade_pvs[0]}')
+    blade_down = FCpt(IMS, '{self._mms_prefix}:{self._blade_pvs[1]}')
+    blade_north = FCpt(IMS, '{self._mms_prefix}:{self._blade_pvs[2]}')
+    blade_south = FCpt(IMS, '{self._mms_prefix}:{self._blade_pvs[3]}')
+
+    def __init__(self, prefix, blade_pvs_idx, **kwargs):
+        self._blade_pvs = blade_pvs_idx
         self._mms_prefix = prefix.removesuffix(':JAWS')+':MMS'
         # initialize combined motors (width, center) via `JAWS`
         super().__init__(prefix, **kwargs)
-        
+
 
 class Slits(LusiSlits):
     # Should Probably Deprecate this name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add controls of the single blades in a slit as per scientists request.

## Motivation and Context
When aligning the slits, it is sometimes desirables to move a single blade a a time. For example when doing precise clipping of all four slits.

## How Has This Been Tested?
Tested with s4 at XPP.

## Where Has This Been Documented?
TBD

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
