### PR TITLE
FIX: pseudopos readback desync issues

### DIFF
--- a/docs/source/upcoming_release_notes/1097-enh_readback_desync.rst
+++ b/docs/source/upcoming_release_notes/1097-enh_readback_desync.rst
@@ -1,0 +1,33 @@
+1097 enh_readback_desync
+########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where ``PseudoPositioner`` devices defined in this module
+  but running from separate terminals would fight over control of the
+  ``ophyd_readback`` helper signal, a PV that can be used to monitor
+  progress of the calculated readback.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -125,6 +125,9 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
     """ + ophyd.pseudopos.PseudoPositioner.__doc__
 
     def __init__(self, *args, **kwargs):
+        self.my_move = False
+        self._move_time = 0
+        self._my_move_timeout = 10
         super().__init__(*args, **kwargs)
 
         if len(self.RealPosition._fields) == 1:
@@ -132,10 +135,6 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
 
         if len(self.PseudoPosition._fields) == 1:
             self.PseudoPosition.__float__ = _as_float
-
-        self.my_move = False
-        self._move_time = 0
-        self._my_move_timeout = 10
 
     def _update_notepad_ioc(self, position, attr):
         """

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -125,7 +125,7 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
     """ + ophyd.pseudopos.PseudoPositioner.__doc__
 
     def __init__(self, *args, **kwargs):
-        self.my_move = False
+        self._my_move = False
         self._move_time = 0
         self._my_move_timeout = 10
         super().__init__(*args, **kwargs)
@@ -200,7 +200,7 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         RuntimeError
             If motion fails other than timing out.
         '''
-        self.my_move = True
+        self._my_move = True
         self._move_time = time.monotonic()
         status = super().move(position, wait=wait, timeout=timeout,
                               moved_cb=moved_cb)
@@ -210,7 +210,7 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
     def _update_position(self):
         """Update the pseudo position based on that of the real positioners."""
         position = super()._update_position()
-        if self.my_move:
+        if self._my_move:
             self._update_notepad_ioc(position, 'notepad_readback')
         return position
 
@@ -234,14 +234,14 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         """
         If a different session moves this device, it's not our move!
 
-        This callback will set the self.my_move flag to False if the setpoint
+        This callback will set the self._my_move flag to False if the setpoint
         updates far apart in time from our last move.
 
         This will stop this instance from updating the notepad_readback
         signals.
         """
         if time.monotonic() - self._move_time > self._my_move_timeout:
-            self.my_move = False
+            self._my_move = False
 
     def _sub_our_move_checks(self):
         """

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -136,6 +136,8 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         if len(self.PseudoPosition._fields) == 1:
             self.PseudoPosition.__float__ = _as_float
 
+        self._sub_our_move_checks()
+
     def _update_notepad_ioc(self, position, attr):
         """
         Update the notepad IOC with a fully-specified ``PseudoPos``.

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -1,6 +1,7 @@
 import copy
 import enum
 import logging
+import time
 import typing
 import warnings
 
@@ -132,6 +133,10 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         if len(self.PseudoPosition._fields) == 1:
             self.PseudoPosition.__float__ = _as_float
 
+        self.my_move = False
+        self._move_time = 0
+        self._my_move_timeout = 10
+
     def _update_notepad_ioc(self, position, attr):
         """
         Update the notepad IOC with a fully-specified ``PseudoPos``.
@@ -194,6 +199,8 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         RuntimeError
             If motion fails other than timing out.
         '''
+        self.my_move = True
+        self._move_time = time.monotonic()
         status = super().move(position, wait=wait, timeout=timeout,
                               moved_cb=moved_cb)
         self._update_notepad_ioc(position, 'notepad_setpoint')
@@ -202,7 +209,8 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
     def _update_position(self):
         """Update the pseudo position based on that of the real positioners."""
         position = super()._update_position()
-        self._update_notepad_ioc(position, 'notepad_readback')
+        if self.my_move:
+            self._update_notepad_ioc(position, 'notepad_readback')
         return position
 
     def set_current_position(self, position):
@@ -220,6 +228,35 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         real_pos = self.forward(position)
         for motor, pos in zip(self._real, real_pos):
             motor.set_current_position(pos)
+
+    def _our_move_check(self, **kwargs):
+        """
+        If a different session moves this device, it's not our move!
+
+        This callback will set the self.my_move flag to False if the setpoint
+        updates far apart in time from our last move.
+
+        This will stop this instance from updating the notepad_readback
+        signals.
+        """
+        if time.monotonic() - self._move_time > self._my_move_timeout:
+            self.my_move = False
+
+    def _sub_our_move_checks(self):
+        """
+        Set up subscriptions for self._our_move_check
+        """
+        for positioner in self._pseudo:
+            try:
+                signal = getattr(positioner, 'notepad_setpoint', None)
+                if signal is None:
+                    continue
+                signal.subscribe(self._our_move_check)
+            except Exception as ex:
+                self.log.debug(
+                    'Failed to set up _our_move_check subscriptions.',
+                    exc_info=ex,
+                )
 
 
 class SyncAxesBase(FltMvInterface, PseudoPositioner):

--- a/pcdsdevices/tests/test_pseudopos.py
+++ b/pcdsdevices/tests/test_pseudopos.py
@@ -292,34 +292,34 @@ def test_implicit_mutex(linked_delays: Tuple[FakeDelay, FakeDelay]):
     def assert_no_updates():
         value1 = delay_one.delay.notepad_readback.get()
         value2 = delay_two.delay.notepad_readback.get()
-        if not delay_one.my_move:
+        if not delay_one._my_move:
             delay_one._update_position()
-        if not delay_two.my_move:
+        if not delay_two._my_move:
             delay_two._update_position()
         assert delay_one.delay.notepad_readback.get() == value1
         assert delay_two.delay.notepad_readback.get() == value2
 
-    # Let's do moves and check my_move attribute
-    assert not delay_one.my_move
-    assert not delay_two.my_move
+    # Let's do moves and check _my_move attribute
+    assert not delay_one._my_move
+    assert not delay_two._my_move
     assert_no_updates()
 
-    # First move: delay_one should immediately grab my_move
+    # First move: delay_one should immediately grab _my_move
     delay_one.move(1, wait=False)
-    assert delay_one.my_move
-    assert not delay_two.my_move
+    assert delay_one._my_move
+    assert not delay_two._my_move
     assert_no_updates()
 
-    # Second move: after _my_move_tomeout, delay_one should drop my_move
+    # Second move: after _my_move_tomeout, delay_one should drop _my_move
     time.sleep(delay_one._my_move_timeout)
     delay_two.move(2, wait=False)
-    assert delay_two.my_move
-    wait_for(delay_one, 'my_move', False)
+    assert delay_two._my_move
+    wait_for(delay_one, '_my_move', False)
     assert_no_updates()
 
     # Do it again but the other way
     time.sleep(delay_two._my_move_timeout)
     delay_one.move(3, wait=False)
-    assert delay_one.my_move
-    wait_for(delay_two, 'my_move', False)
+    assert delay_one._my_move
+    wait_for(delay_two, '_my_move', False)
     assert_no_updates()

--- a/pcdsdevices/tests/test_pseudopos.py
+++ b/pcdsdevices/tests/test_pseudopos.py
@@ -1,9 +1,12 @@
 import logging
+import time
+from typing import Any, Tuple
 
 import numpy as np
 import pytest
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
+from ophyd.sim import make_fake_device
 
 from ..pseudopos import (DelayBase, LookupTablePositioner, OffsetMotorBase,
                          PseudoSingleInterface, SimDelayStage, SyncAxesBase,
@@ -228,3 +231,95 @@ def test_lut_positioner():
 
     assert lut.real.limits == (0, 9)
     assert lut.pseudo.limits == (40, 400)
+
+
+FakeDelayBase = make_fake_device(DelayBase)
+
+
+class FakeDelay(FakeDelayBase):
+    motor = Cpt(FastMotor, egu='mm')
+
+
+def link_two_signals(signal1, signal2):
+    def put_to_1(value, old_value, **kwargs):
+        if value != old_value:
+            signal1.put(value)
+
+    def put_to_2(value, old_value, **kwargs):
+        if value != old_value:
+            signal2.put(value)
+
+    signal1.subscribe(put_to_2)
+    signal2.subscribe(put_to_1)
+
+
+@pytest.fixture(scope='function')
+def linked_delays():
+    delay_one = FakeDelay('SIM', name='delay_one', n_bounces=1)
+    delay_two = FakeDelay('SIM', name='delay_two', n_bounces=2)
+    link_two_signals(
+        delay_one.delay.notepad_readback,
+        delay_two.delay.notepad_readback,
+    )
+    link_two_signals(
+        delay_one.delay.notepad_setpoint,
+        delay_two.delay.notepad_setpoint,
+    )
+    delay_one._my_move_timeout = 0.4
+    delay_two._my_move_timeout = 0.4
+    return delay_one, delay_two
+
+
+def wait_for(
+    obj: Any,
+    attr: str,
+    value: Any,
+    timeout: float = 1,
+    dt: float = 0.1,
+):
+    start_time = time.monotonic()
+    while time.monotonic() - start_time > timeout:
+        if getattr(obj, attr) == value:
+            return
+        time.sleep(dt)
+    assert getattr(obj, attr) == value
+
+
+def test_implicit_mutex(linked_delays: Tuple[FakeDelay, FakeDelay]):
+    # Previous bug: two delays could fight over control of ophyd_readback
+    delay_one, delay_two = linked_delays
+
+    def assert_no_updates():
+        value1 = delay_one.delay.notepad_readback.get()
+        value2 = delay_two.delay.notepad_readback.get()
+        if not delay_one.my_move:
+            delay_one._update_position()
+        if not delay_two.my_move:
+            delay_two._update_position()
+        assert delay_one.delay.notepad_readback.get() == value1
+        assert delay_two.delay.notepad_readback.get() == value2
+
+    # Let's do moves and check my_move attribute
+    assert not delay_one.my_move
+    assert not delay_two.my_move
+    assert_no_updates()
+
+    # First move: delay_one should immediately grab my_move
+    delay_one.move(1, wait=False)
+    assert delay_one.my_move
+    assert not delay_two.my_move
+    assert_no_updates()
+
+    # Second move: after _my_move_tomeout, delay_one should drop my_move
+    time.sleep(delay_one._my_move_timeout)
+    delay_two.move(2, wait=False)
+    assert delay_two.my_move
+    wait_for(delay_one, 'my_move', False)
+    assert_no_updates()
+
+    # Do it again but the other way
+    time.sleep(delay_two._my_move_timeout)
+    delay_one.move(3, wait=False)
+    assert delay_one.my_move
+    wait_for(delay_two, 'my_move', False)
+    assert_no_updates()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make `PseudoPositioner` devices defined in this module only write to the `ophyd_readback` signal if they were the most recent device to write to the `ophyd_setpoint` signal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If multiple python sessions are run with slightly different versions of the same pseudo positioner, they can fight over control of the ophyd_readback signal.

see https://jira.slac.stanford.edu/browse/LCLSECSD-1761

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a unit test here. This should also be tested in a hutch. It's possible that I'll need to make some tweaks.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Adding some release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
