### PR TITLE
FIX: make PIM use auto state discovery

### DIFF
--- a/docs/source/upcoming_release_notes/1105-fix_cxi_pim.rst
+++ b/docs/source/upcoming_release_notes/1105-fix_cxi_pim.rst
@@ -1,0 +1,33 @@
+1105 fix_cxi_pim
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Certain PIMs, such as cxi_dg1_pim, did not work properly because pcdsdevices
+  assumed that these devices had a "DIODE" state, which is not necessarily
+  true. This has been fixed by making all PIMs autodiscover their states from
+  EPICS.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -40,8 +40,9 @@ class PIMY(InOutRecordPositioner, BaseInterface):
     beam path.
     """
 
-    states_list = ['DIODE', 'YAG', 'OUT']
-    in_states = ['YAG', 'DIODE']
+    # Automatically discover states (not all PIMs have DIODE)
+    states_list = []
+    _in_if_not_out = True
 
     _states_alias = {'YAG': 'IN'}
     # QIcon for UX

--- a/pcdsdevices/tests/test_pim.py
+++ b/pcdsdevices/tests/test_pim.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import make_fake_device
 
-from ..pim import PIM, PIMY, PPM, XPIM, PIMWithBoth, PIMWithFocus, PIMWithLED
+from ..pim import PIM, PPM, XPIM, PIMWithBoth, PIMWithFocus, PIMWithLED
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ def fake_pim():
     FakePIM = make_fake_device(PIM)
     pim = FakePIM('Test:Yag', name='test')
     pim.state.state.sim_put(0)
-    pim.state.state.sim_set_enum_strs(['Unknown'] + PIMY.states_list)
+    pim.state.state.sim_set_enum_strs(['Unknown', 'DIODE', 'YAG', 'OUT'])
     pim.y.error_severity.sim_put(0)
     pim.y.bit_status.sim_put(0)
     pim.y.motor_spg.sim_put(2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There is an automatic state discovery mechanism in the state mover code, but this was added after the PIMs were done. This patch activates it for the PIMs.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In CXI, there is a PIM that does not have a "DIODE" state, so the existing hard-coded references to a "DIODE" state were causing issues. See https://jira.slac.stanford.edu/browse/LCLSECSD-1849

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've interactively confirmed that the CXI PIM works now and that at least one other PIM has not been interfered with.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes, this pull request, and Jira only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
