### PR TITLE
BLD: use compatible xraydb and sqlalchemy versions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,6 +41,10 @@ requirements:
     - pmgr >=2.0.2
     - pyqt <5.15
     - typhos >=2.4.0
+    # Note: these should be removed once a newer xraylib is available on conda-forge
+    # or moved to pcdscalc after testing
+    - sqlalchemy <2.0.0
+    - xraydb <4.5.0
 
 test:
   imports:

--- a/docs/source/upcoming_release_notes/1109-max_xraydb_version.rst
+++ b/docs/source/upcoming_release_notes/1109-max_xraydb_version.rst
@@ -1,0 +1,30 @@
+1109 max_xraydb_version
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Specified compatible xraydb and sqlalchemy versions in requirements files.
+
+Contributors
+------------
+- klauer

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ pytmc>=2.7.0
 pyyaml
 schema
 scipy
+sqlalchemy<2.0.0
+xraydb<4.5.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Specified compatible xraydb and sqlalchemy versions in requirements files.

See related issue: https://github.com/pcdshub/pcdscalc/issues/21

## Pre-merge checklist
- [ ] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
