### PR TITLE
MNT: Update xpp_lodcm lightpath logic

### DIFF
--- a/docs/source/upcoming_release_notes/1111-mnt_xpp_lp_logic.rst
+++ b/docs/source/upcoming_release_notes/1111-mnt_xpp_lp_logic.rst
@@ -1,0 +1,30 @@
+1111 mnt_xpp_lp_logic
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fixes lightpath logic for XPPLODCM to use the correct line and show full transmission when splitting beam.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -1947,11 +1947,14 @@ class XPPLODCM(LODCM):
         removed = self.tower1.h1n_state.check_removed(h1n_state)
 
         if inserted and not removed:
-            output = {'L0': 0.5,
-                      'L1': 0.5}
+            # ignore attenuation from the LODCM splitting beam
+            output = {'L0': 1,
+                      'L2': 1}
         elif not inserted and removed:
+            # if removed, full transmission through L
             output = {'L0': 1}
         else:
+            # for unknown states, mark as blocking
             output = {'L0': 0}
 
         return LightpathState(

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -1951,7 +1951,7 @@ class XPPLODCM(LODCM):
             output = {'L0': 1,
                       'L2': 1}
         elif not inserted and removed:
-            # if removed, full transmission through L
+            # if removed, full transmission through L0
             output = {'L0': 1}
         else:
             # for unknown states, mark as blocking


### PR DESCRIPTION
## Description
Fixes a typo and makes the xpp lodcm never attenuate any beam unless blocking

## Motivation and Context
In a quest for a more accurate lightpath displays

## How Has This Been Tested?
Interactively, though more testing should be done

## Where Has This Been Documented?
Here

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
