### PR TITLE
ENH: Add Scanning Interface to Elliptec positioner

### DIFF
--- a/docs/source/upcoming_release_notes/1114-Update_elliptec_base_class_to_enable_scanning.rst
+++ b/docs/source/upcoming_release_notes/1114-Update_elliptec_base_class_to_enable_scanning.rst
@@ -1,0 +1,30 @@
+1114 Update elliptec base class to enable scanning
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- EllBase: Change the base class of EllBase to enable scanning via BlueSky. 
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/pcdsdevices/lasers/elliptec.py
+++ b/pcdsdevices/lasers/elliptec.py
@@ -4,13 +4,14 @@ Classes for ThorLabs Elliptec motors.
 
 
 from ophyd import Device
+from pcdsdevices.pv_positioner import PVPositionerIsClose
 from ophyd import FormattedComponent as FCpt
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 from pcdsdevices.variety import set_metadata
 
 
-class EllBase(Device):
+class EllBase(PVPositionerIsClose):
     """
     Base class for Elliptec stages.
     """
@@ -43,6 +44,16 @@ class EllBase(Device):
                     kind='omitted')
     _response = FCpt(EpicsSignalRO, '{prefix}:PORT{self._port}:RESPONSE',
                      kind='omitted')
+
+    # Scanning Interface
+    setpoint = FCpt(EpicsSignal, '{prefix}:M{self._channel}:MOVE',
+                    kind='omitted')
+    readback = FCpt(EpicsSignal, '{prefix}:M{self._channel}:CURPOS',
+                    kind='omitted')
+    user_setpoint = FCpt(EpicsSignal, '{prefix}:M{self._channel}:MOVE',
+                    kind='omitted')
+    user_readback = FCpt(EpicsSignal, '{prefix}:M{self._channel}:CURPOS',
+                    kind='omitted')
 
     def __init__(self, prefix, port=0, channel=1, **kwargs):
         self._port = port


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Updates the EllBase device base class and adds the scanning interface required for BlueSky scans. 

## Motivation and Context
closes #1114 

## How Has This Been Tested?
Tested with a stage in the laser lab via the las-dispersion-scan application. 

## Where Has This Been Documented?
Release notes?


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
