### PR TITLE
Fixing AT1K2 Ui

### DIFF
--- a/docs/source/upcoming_release_notes/1117-Adding_symbolic_links_for_AT1K2.rst
+++ b/docs/source/upcoming_release_notes/1117-Adding_symbolic_links_for_AT1K2.rst
@@ -1,0 +1,30 @@
+1117 Adding symbolic links for AT1K2
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adding symbolic links for AT1K2 so that screens generate in a nice, organized way (like other SXR Attenuators)
+
+Contributors
+------------
+- wwright-slac

--- a/pcdsdevices/ui/AT1K2.detailed.ui
+++ b/pcdsdevices/ui/AT1K2.detailed.ui
@@ -1,0 +1,1 @@
+detailed_tree.ui

--- a/pcdsdevices/ui/AT1K2.embedded.ui
+++ b/pcdsdevices/ui/AT1K2.embedded.ui
@@ -1,0 +1,1 @@
+detailed_tree.ui


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
AT1K2 screens were not generating with the cascading screen effect, similar to with the standard SXR Attenuator screens. I added symbolic links to the detailed_tree UI files to alleviate this issue.
 
<!--- Describe your changes in detail -->


## How Has This Been Tested?
Trying out these screens in my work area showed that this change was successful. 

## Where Has This Been Documented?
NA

<!--
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/100723754/218612994-c31aa06d-6188-4bdd-afd5-f6ff26994e46.png)

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
