### PR TITLE
ENH: Add camera binning and region size to PCDSAreaDetectorTyphos class.

### DIFF
--- a/docs/source/upcoming_release_notes/974-Add_binning_and_region_size_control_to_PCDSAreaDetectorTyphos.rst
+++ b/docs/source/upcoming_release_notes/974-Add_binning_and_region_size_control_to_PCDSAreaDetectorTyphos.rst
@@ -15,8 +15,7 @@ Device Updates
 
 New Devices
 -----------
-- PCDSAreaDetectorTyphos class: Add in signals for camera binning and region
-                                size control.
+- PCDSAreaDetectorTyphos class: Add in signals for camera binning and region size control.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/974-Add_binning_and_region_size_control_to_PCDSAreaDetectorTyphos.rst
+++ b/docs/source/upcoming_release_notes/974-Add_binning_and_region_size_control_to_PCDSAreaDetectorTyphos.rst
@@ -1,0 +1,31 @@
+974 Add binning and region size control to PCDSAreaDetectorTyphos
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- PCDSAreaDetectorTyphos class: Add in signals for camera binning and region
+                                size control.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -365,6 +365,12 @@ class PCDSAreaDetectorTyphos(Device):
     image_mode = Cpt(EpicsSignalWithRBV, 'ImageMode', kind='config')
     trigger_mode = Cpt(EpicsSignalWithRBV, 'TriggerMode', kind='config')
     acquisition_period = Cpt(EpicsSignalWithRBV, 'AcquirePeriod', kind='config')
+    bin_x = Cpt(EpicsSignalWithRBV, 'BinX', kind='config')
+    bin_y = Cpt(EpicsSignalWithRBV, 'BinY', kind='config')
+    region_start_x = Cpt(EpicsSignalWithRBV, 'MinX', kind='config')
+    region_size_x = Cpt(EpicsSignalWithRBV, 'SizeX', kind='config')
+    region_start_y = Cpt(EpicsSignalWithRBV, 'MinY', kind='config')
+    region_size_y = Cpt(EpicsSignalWithRBV, 'SizeY', kind='config')
 
     # Image collection settings
     acquire = Cpt(EpicsSignal, 'Acquire', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add in PVs for binning and camera image size modification. 

## Motivation and Context
Closes #974 

## How Has This Been Tested?
Tested locally on a live camera, as well as typhos screen generation.


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/29102919/232083023-837c48ee-cf05-4bbd-b7c6-04c0f8048af7.png)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
