### PR TITLE
Add configuration method and dictionary for LasBasler cameras.

### DIFF
--- a/docs/source/upcoming_release_notes/1129-Add_configuration_method_to_LasBasler_camera.rst
+++ b/docs/source/upcoming_release_notes/1129-Add_configuration_method_to_LasBasler_camera.rst
@@ -1,0 +1,31 @@
+1129 Add configuration method to LasBasler camera
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- LasBasler: Add a new signal that can be used to auto-configure a camera based on an internal dictionary.
+
+New Devices
+-----------
+- LasBaslerNF: A Basler camera intended to be used as a near-field diagnostic.
+- LasBaslerFF: A Basler camera intended to be used as a far-field diagnostic.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -487,4 +487,35 @@ class LasBasler(PCDSAreaDetectorTyphosBeamStats, BaslerBase):
     """
     Class for the Basler cameras used in the laser control system.
     """
-    pass
+    # Configuration dictionary for camera
+    _conf_d = {}
+
+    # Make button available in Typhos screen
+    auto_configure = Cpt(AttributeSignal, attr='_auto_configure', kind='normal')
+    set_metadata(auto_configure, dict(variety='command-proc', value=1))
+
+    @property
+    def _auto_configure(self):
+        return 0
+
+    @_auto_configure.setter
+    def _auto_configure(self, value):
+        self.configure(self._conf_d)
+
+
+class LasBaslerNF(LasBasler):
+    """
+    Class for the near-field Basler cameras used in the laser control system.
+    """
+    _conf_d = {'data_type': 1, 'exposure': 0.005, 'trigger_mode': 0,
+               'acquisition_period': 0.5, 'centroid_enable': 1, 'bin_x': 2,
+               'bin_y': 2, 'stats_enable': 1, 'centroid_threshold': 1000}
+
+
+class LasBaslerFF(LasBasler):
+    """
+    Class for the far-field Basler cameras used in the laser control system.
+    """
+    _conf_d = {'data_type': 1, 'exposure': 0.010, 'trigger_mode': 0,
+               'acquisition_period': 0.5, 'centroid_enable': 1, 'bin_x': 1,
+               'bin_y': 1, 'stats_enable': 1, 'centroid_threshold': 50}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds in a method to use the `Device.configure()` method to apply a dictionary of PV settings to a camera. 

## Motivation and Context
This will make configuring cameras in the MODS system to common, default values easier. 

Closes #1128 

## How Has This Been Tested?
Tested live on a camera in IP1. 

## Where Has This Been Documented?
Some docstrings/comments. 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
