### PR TITLE
Hxrsss filter wheel update

### DIFF
--- a/docs/source/upcoming_release_notes/1133-Hxrsss_filter_wheel_update.rst
+++ b/docs/source/upcoming_release_notes/1133-Hxrsss_filter_wheel_update.rst
@@ -1,0 +1,31 @@
+1133 Hxrsss filter wheel update
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Updated HXRSpectrometer filter wheel with its state PV
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- spencera
+- zlentz

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -2,6 +2,7 @@
 Module for the various spectrometers.
 """
 from lightpath import LightpathState
+from ophyd import EpicsSignal
 from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 
@@ -382,8 +383,8 @@ class HXRSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
                doc='camera y')
     iris = Cpt(IMS, ':445:MOTR', kind='normal',
                doc='camera iris')
-    filter = Cpt(IMS, ':446:MOTR', kind='normal',
-                 doc='filter wheel, tbd if necessary')
+    filter = EpicsSignal(write_pv='XRT:HXS:FILTER:GO', read_pv='XRT:HXS:FILTER',
+                         kind='normal', name='filter wheel')
 
     # Lightpath constants
     inserted = True

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -383,7 +383,7 @@ class HXRSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
                doc='camera y')
     iris = Cpt(IMS, ':445:MOTR', kind='normal',
                doc='camera iris')
-    filter = FCpt(StateRecordPositioner, 'XRT:HXS:FILTER')
+    filter = FCpt(StateRecordPositioner, 'XRT:HXS:FILTER', doc='filter wheel')
 
     # Lightpath constants
     inserted = True

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -2,7 +2,6 @@
 Module for the various spectrometers.
 """
 from lightpath import LightpathState
-from ophyd import EpicsSignal
 from ophyd.device import Component as Cpt
 from ophyd.device import FormattedComponent as FCpt
 
@@ -11,6 +10,7 @@ from .epics_motor import (IMS, BeckhoffAxis, BeckhoffAxisNoOffset,
                           EpicsMotorInterface)
 from .interface import BaseInterface, LightpathMixin
 from .signal import InternalSignal, PytmcSignal
+from .state import StateRecordPositioner
 
 
 class Kmono(BaseInterface, GroupDevice, LightpathMixin):
@@ -383,8 +383,7 @@ class HXRSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
                doc='camera y')
     iris = Cpt(IMS, ':445:MOTR', kind='normal',
                doc='camera iris')
-    filter = EpicsSignal(write_pv='XRT:HXS:FILTER:GO', read_pv='XRT:HXS:FILTER',
-                         kind='normal', name='filter wheel')
+    filter = FCpt(StateRecordPositioner, 'XRT:HXS:FILTER')
 
     # Lightpath constants
     inserted = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changed previous filter wheel PV that first defined the motor PV to the states PV.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Wanted to add the ability to change states using enums/state names from a hutch-python session instead of remembering motor positions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested from a hutch machine (xcs-control) in a hutch python session using a simplified conf.yml file and custom happi device file that contained the spectrometer device . Also tested physically to make sure the device moved between the desired states.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated doc name within filter attribute.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
