### PR TITLE
MNT: interface whitelist

### DIFF
--- a/docs/source/upcoming_release_notes/1138-interface_whitelist.rst
+++ b/docs/source/upcoming_release_notes/1138-interface_whitelist.rst
@@ -1,0 +1,31 @@
+1138 interface_whitelist
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- ``.screen()`` and ``.post_elog_status()`` methods were added to the
+  BaseInterface whitelist for tab completion.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -50,6 +50,7 @@ Device_whitelist = ["stop"]
 Signal_whitelist = ["value", "put", "get"]
 Positioner_whitelist = ["settle_time", "timeout", "egu", "limits", "move",
                         "position", "moving", "set_current_position"]
+Interface_whitelist = ["screen", "post_elog_status"]
 
 
 class _TabCompletionHelper:
@@ -201,6 +202,7 @@ class BaseInterface:
         + Device_whitelist
         + Signal_whitelist
         + Positioner_whitelist
+        + Interface_whitelist
     )
 
     _class_tab: TabCompletionHelperClass

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -246,6 +246,13 @@ def test_tab_completion(cls):
     for name in getattr(cls, 'tab_whitelist', []):
         assert regex.match(name) is not None
 
+    # Make sure we're not letting through dunder methods unintentionally:
+    assert regex.match("__repr__") is None
+
+    # And check a couple specific ones that users will always want:
+    assert regex.match("screen") is not None
+    assert regex.match("post_elog_status") is not None
+
 
 _STATUS_PRINT_IGNORES = {
     '.AttenuatorCalculatorBase',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* `screen` and `post_elog_status` weren't specifically whitelisted
* Now they are

## Motivation and Context
Slack reported issue

## How Has This Been Tested?
Included tests

## Where Has This Been Documented?

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
