### PR TITLE
BLD: recipe test-requires, not test-requirements

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - xraydb <4.5.0
 
 test:
-  requirements:
+  requires:
     - pytest
     - pytest-timeout
     - matplotlib

--- a/docs/source/upcoming_release_notes/1140-bld_test_requires.rst
+++ b/docs/source/upcoming_release_notes/1140-bld_test_requires.rst
@@ -1,0 +1,30 @@
+1140 bld_test_requires
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- fix conda recipe test-requires
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Conda recipe needs test-requires, not test-requirements

## Motivation and Context
Ran into this looking at lucid

## How Has This Been Tested?
The test suite should now have all the necessary test packages (pytest-timeout, for example)

## Where Has This Been Documented?
this pr

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
