### PR TITLE
Add New PVs for Channel Cut Monochromator Inserted

### DIFF
--- a/docs/source/upcoming_release_notes/1143-optics-notepad.rst
+++ b/docs/source/upcoming_release_notes/1143-optics-notepad.rst
@@ -1,0 +1,32 @@
+1143 optics-notepad
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- added two new PVS
+- `MR2L3:PITCH:CCM:Coating1`
+- `MR2L3:PITCH:CCM:Coating2`
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/docs/source/upcoming_release_notes/1143-optics-notepad.rst
+++ b/docs/source/upcoming_release_notes/1143-optics-notepad.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- added two new PVS
+- added two new PVS to `OpticsPitchNotepad`
 - `MR2L3:PITCH:CCM:Coating1`
 - `MR2L3:PITCH:CCM:Coating2`
 

--- a/docs/source/upcoming_release_notes/1143-optics-notepad.rst
+++ b/docs/source/upcoming_release_notes/1143-optics-notepad.rst
@@ -11,9 +11,7 @@ Features
 
 Device Updates
 --------------
-- added two new PVS to `OpticsPitchNotepad`
-- `MR2L3:PITCH:CCM:Coating1`
-- `MR2L3:PITCH:CCM:Coating2`
+- Added new PVS to ``OpticsPitchNotepad`` for storing the MR2L3 channel-cut monochromator (CCM) pitch position setpoints for its two coatings.
 
 New Devices
 -----------

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1478,5 +1478,5 @@ class OpticsPitchNotepad(BaseInterface, Device):
 
     mr2l3_pitch_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
     mr2l3_pitch_w = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')
-    mr2l3_pitch_ccm_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating1')
-    mr2l3_pitch_ccm_w = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating2')
+    mr2l3_pitch_ccm_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating1', doc="MR2L3 pitch coating 1 (Silicon) setpoint with CCM inserted")
+    mr2l3_pitch_ccm_w = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating2', doc="MR2L3 pitch coating 2 (Tungsten) setpoint with CCM inserted")

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1478,3 +1478,5 @@ class OpticsPitchNotepad(BaseInterface, Device):
 
     mr2l3_pitch_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating1')
     mr2l3_pitch_w = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')
+    mr2l3_pitch_ccm_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating1')
+    mr2l3_pitch_ccm_w = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating2')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add 2 New PVs for Auto pitching MR2L3 based on CCM inserted and Coating.
<!--- Describe your changes in detail -->
`MR2L3:PITCH:CCM:Coating1` and `MR2L3:PITCH:CCM:Coating2`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Beam Delivery wants to auto pitch  MR2L3 based on Coating and Whether or not the CCM is inserted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loaded branch and ran typhos optics_homs_notepad to see the new PVs on screen.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
