### PR TITLE
ENH: add a setter to the epics motor interface limits attribute.

### DIFF
--- a/docs/source/upcoming_release_notes/1144-enh_limits_setter.rst
+++ b/docs/source/upcoming_release_notes/1144-enh_limits_setter.rst
@@ -1,0 +1,32 @@
+1144 enh_limits_setter
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- EPICS motors now support setattr on their ``limits`` attribute.
+  That is, you can do e.g. ``motor.limits = (0, 100)`` to set
+  the low limit to 0 and the high limit to 100.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -177,16 +177,26 @@ Limit Switch: {switch_limits}
 """
 
     @property
-    def limits(self):
+    def limits(self) -> tuple[float, float]:
         """Override the limits attribute"""
         return self._get_epics_limits()
 
-    def _get_epics_limits(self):
+    def _get_epics_limits(self) -> tuple[float, float]:
         limits = self.user_setpoint.limits
         if limits is None or limits == (None, None):
             # Not initialized
             return (0, 0)
         return limits
+
+    @limits.setter
+    def limits(self, lims: tuple[float, float]):
+        """
+        Write to the epics limits on setattr
+
+        Expects a tuple of two elements, the low and high limits to set.
+        """
+        self.low_limit_travel.put(min(lims))
+        self.high_limit_travel.put(max(lims))
 
     def enable(self):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -195,8 +195,24 @@ Limit Switch: {switch_limits}
 
         Expects a tuple of two elements, the low and high limits to set.
         """
-        self.low_limit_travel.put(min(lims))
-        self.high_limit_travel.put(max(lims))
+        # Wrong len is probably a bigger mistake
+        if len(lims) != 2:
+            raise ValueError("Limits should be a tuple of 2 values.")
+        # Adjust for moment of dsylexia
+        low = min(lims)
+        high = max(lims)
+        if low == high:
+            # User probably meant to disable limits
+            low = 0
+            high = 0
+        orig_high = self.high_limit_travel.get()
+        if low > orig_high:
+            # Set high first so we make room for low
+            self.high_limit_travel.put(high)
+            self.low_limit_travel.put(low)
+        else:
+            self.low_limit_travel.put(low)
+            self.high_limit_travel.put(high)
 
     def enable(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a setter to the epics motor interface limits attribute.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
XCS was having a problem with this line in `LookupTablePositioner`:
https://github.com/pcdshub/pcdsdevices/blob/af187b6b26235f95056cf9b168bb6decf6627c4c/pcdsdevices/pseudopos.py#L990
Where it sets the limits of the real motor.

Rather than consider ways that this could be done differently to avoid EPICS puts on init, I opted to add the missing limits setter as a quick fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live in XCS

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
