### PR TITLE
FIX: TwinCATInOutPositioner should have 2 states by default

### DIFF
--- a/docs/source/upcoming_release_notes/1148-tcinout_2state.rst
+++ b/docs/source/upcoming_release_notes/1148-tcinout_2state.rst
@@ -1,0 +1,32 @@
+1148 tcinout_2state
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- ``TwinCATInOutPositioner`` by default now uses 2 states as its name implies
+  (excluding the "unknown" transition sate), with one representing the "out"
+  state and one representing the "in" state.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/inout.py
+++ b/pcdsdevices/inout.py
@@ -13,6 +13,7 @@ from ophyd.sim import NullStatus
 
 from pcdsdevices.interface import LightpathInOutMixin
 
+from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init, insert_remove
 from .state import (CombinedStateRecordPositioner, PVStatePositioner,
                     StatePositioner, StateRecordPositioner,
@@ -263,3 +264,4 @@ class TwinCATInOutPositioner(TwinCATStatePositioner, InOutPositioner):
     states_list = []
     # In should be everything except state 0 (Unknown) and state 1 (Out)
     _in_if_not_out = True
+    config = UpCpt(state_count=2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

 ``TwinCATInOutPositioner`` by default now uses 2 states as its name implies
  (excluding the "unknown" transition sate), with one representing the "out"
  state and one representing the "in" state.

## Motivation and Context
I recommended Tong use this class directly with st1k4 as the docstring indicated it was ready for usage without subclassing.

Closes #1148 

## How Has This Been Tested?
Interactively with st1k4

## Where Has This Been Documented?
Issue and PR text

## Screenshots (if appropriate):

```
In [3]: import pcdsdevices

In [4]: pcdsdevices.__file__
Out[4]: '/cds/home/k/klauer/Repos/pcdsdevices/pcdsdevices/__init__.py'

In [5]: st1k4.wait_for_connection()
```

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
