### PR TITLE
ENH: include states in SxrTestAbsorber and simplify lightpath handling

### DIFF
--- a/docs/source/upcoming_release_notes/1150-enh_update_test_absorber.rst
+++ b/docs/source/upcoming_release_notes/1150-enh_update_test_absorber.rst
@@ -1,0 +1,31 @@
+1150 enh_update_test_absorber
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add twincat states and the ST3K4 automation switch to the SXR test absorber.
+  This device is ``pcdsdevices.sxr_test_absorber.SxrTestAbsorber`` and is named ST1K4.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -1,6 +1,10 @@
 """
 Module for the SXR Test Absorbers.
 """
+from __future__ import annotations
+
+from typing import Callable
+
 from ophyd.device import Component as Cpt
 
 from .epics_motor import BeckhoffAxisNoOffset
@@ -20,9 +24,15 @@ class SxrTestAbsorberStates(TwinCATInOutPositioner):
     This has some automation where it tracks the position of ST3K4.
     Accordingly, it has a configuration parameter for enabling/disabling this.
     """
+
     st3k4_auto = Cpt(PytmcSignal, ':ST3K4_AUTO', io='io', kind='config')
 
-    def set(self, position, moved_cb=None, timeout=None):
+    def set(
+        self,
+        position: str | int,
+        moved_cb: Callable | None = None,
+        timeout: float | None = None,
+    ):
         if self.st3k4_auto.get():
             raise ST3K4AutoError(
                 "ST1K4 must follow ST3K4. Move rejected."

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -1,39 +1,28 @@
 """
 Module for the SXR Test Absorbers.
 """
-from lightpath import LightpathState
 from ophyd.device import Component as Cpt
 
 from .epics_motor import BeckhoffAxisNoOffset
-from .interface import BaseInterface, LightpathMixin
+from .inout import TwinCATInOutPositioner
+from .interface import BaseInterface, LightpathInOutCptMixin
 
 
-class SxrTestAbsorber(BaseInterface, LightpathMixin):
+class SxrTestAbsorber(BaseInterface, LightpathInOutCptMixin):
     """
     SXR Test Absorber: Used for testing the sxr beamline at high pulse rates.
 
-    This device has 1 main members: the stopper/absorber (diamond stopper).
+    This device has 1 main member: the stopper/absorber (diamond stopper).
 
     The vertical motor moves stopper in and out of the beam path in
     the +/- y direction.
+
+    It has a state selector that can be used to move in and out by state name.
     """
 
     tab_component_names = True
 
+    state = Cpt(TwinCATInOutPositioner, ':MMS:STATE', kind='hinted')
     absorber_vert = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
 
-    lightpath_cpts = ['absorber_vert.user_readback']
-
-    def calc_lightpath_state(self, absorber_vert: float) -> LightpathState:
-        pos = absorber_vert
-        # 0 is out, negative is in
-        # this device has never been inserted, so we don't know the in pos
-        self._inserted = pos < -1
-        self._removed = pos > -1
-        self._transmission = int(self._removed)
-
-        return LightpathState(
-            inserted=self._inserted,
-            removed=self._removed,
-            output={self.output_branches[0]: self._transmission}
-        )
+    lightpath_cpts = ['state']

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -22,13 +22,12 @@ class SxrTestAbsorberStates(TwinCATInOutPositioner):
     """
     st3k4_auto = Cpt(PytmcSignal, ':ST3K4_AUTO', io='io', kind='config')
 
-    def check_value(self, pos):
-        rval = super().check_value(pos)
+    def set(self, position, moved_cb=None, timeout=None):
         if self.st3k4_auto.get():
             raise ST3K4AutoError(
                 "ST1K4 must follow ST3K4. Move rejected."
             )
-        return rval
+        return super().set(position, moved_cb=moved_cb, timeout=timeout)
 
 
 class SxrTestAbsorber(BaseInterface, LightpathInOutCptMixin):

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -40,6 +40,9 @@ class SxrTestAbsorber(BaseInterface, LightpathInOutCptMixin):
     the +/- y direction.
 
     It has a state selector that can be used to move in and out by state name.
+
+    Instantiate me with:
+    st1k4 = SxrTestAbsorber("ST1K4:TEST", name="st1k4")
     """
 
     tab_component_names = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- ST1K4 has state-based controls now, add them
- include the controls for enabling/disabling auto mode
- include an error message for when you try to do a manual move in auto mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Class that shows the states motor + the epics motor will be useful
- There are other controls involved too
- Overall, scope should be slightly higher than just a state device

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- interactively via typhos:
![image](https://github.com/pcdshub/pcdsdevices/assets/10647860/cd7da65e-e10f-4d53-a32c-9cb394e6aaff)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I need to write pre-release notes tomorrow morning

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
