### PR TITLE
Add in PVs related to calibrating SmarAct encoded stages.

### DIFF
--- a/docs/source/upcoming_release_notes/925-Add_pvs_for_SmarAct_calibration.rst
+++ b/docs/source/upcoming_release_notes/925-Add_pvs_for_SmarAct_calibration.rst
@@ -1,0 +1,31 @@
+925 Add pvs for SmarAct calibration
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- SmarAct: Add signals for performing axis calibration and checking
+           calibration status.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tjohnson

--- a/docs/source/upcoming_release_notes/925-Add_pvs_for_SmarAct_calibration.rst
+++ b/docs/source/upcoming_release_notes/925-Add_pvs_for_SmarAct_calibration.rst
@@ -28,4 +28,4 @@ Maintenance
 
 Contributors
 ------------
-- tjohnson
+- slactjohnson

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1417,6 +1417,12 @@ class SmarAct(EpicsMotorInterface):
     # Positioner type - only useful for encoded stages
     pos_type = Cpt(EpicsSignal, ':PTYPE_RBV', write_pv=':PTYPE', kind='config')
 
+    # Calibration - only works for encoded stages
+    needs_calib = Cpt(EpicsSignalRO, ':NEED_CALIB', kind='config')
+
+    do_calib = Cpt(EpicsSignal, ':DO_CALIB.PROC', kind='config')
+    set_metadata(do_calib, dict(variety='command-proc', value=1))
+
     # These PVs will probably not be needed for most encoded motors, but can be
     # useful
     open_loop = Cpt(SmarActOpenLoop, '', kind='omitted')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adding in PVs related to calibrating encoded SmarAct axes. 

## Motivation and Context
We want this on the Typhos screen.

closes #925 (FINALLY)

## How Has This Been Tested?
Tested on a motor in TMO. 

## Where Has This Been Documented?
The code, this PR. 

## Screenshots (if appropriate):
![image](https://github.com/pcdshub/pcdsdevices/assets/29102919/e2fb6fde-80b6-4aa9-a4e8-dcb878fc2f6a)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
