### PR TITLE
adding sp1k4 att and thorlab len x

### DIFF
--- a/docs/source/upcoming_release_notes/1153-add_spectrometer_solid_attenuator.rst
+++ b/docs/source/upcoming_release_notes/1153-add_spectrometer_solid_attenuator.rst
@@ -1,30 +1,23 @@
 1153 add spectrometer solid attenuator
 #################
-
 API Changes
 -----------
-Adding new TMOSpectrometerSOLIDATTStates class and thorlab_len_X axis in TMOSpectrometer
-
+- Remove lens motors
 Features
 --------
-Add three more new motors in GUI(two are spectrometer att and one is thorlab_len_x)
-
+- Add a new TMOSpectrometerSOLIDATTStates class
 Device Updates
 --------------
-SPectrometer SP1K4
-
+- Spectrometer SP1K4 add two new motors for solid attenuator and modify len x to thorlab len x
 New Devices
 -----------
 - N/A
-
 Bugfixes
 --------
 - N/A
-
 Maintenance
 -----------
 - N/A
-
 Contributors
 ------------
 @tongju12

--- a/docs/source/upcoming_release_notes/1153-add_spectrometer_solid_attenuator.rst
+++ b/docs/source/upcoming_release_notes/1153-add_spectrometer_solid_attenuator.rst
@@ -1,0 +1,30 @@
+1153 add spectrometer solid attenuator
+#################
+
+API Changes
+-----------
+Adding new TMOSpectrometerSOLIDATTStates class and thorlab_len_X axis in TMOSpectrometer
+
+Features
+--------
+Add three more new motors in GUI(two are spectrometer att and one is thorlab_len_x)
+
+Device Updates
+--------------
+SPectrometer SP1K4
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+@tongju12

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -350,20 +350,20 @@ class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
 
     # Motor components: can read/write positions
     zone_plate = Cpt(FZPStates, 'SP1K4:FZP:STATE', add_prefix=(), kind='normal')
-    zone_plate_x = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
-    zone_plate_y = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
-    zone_plate_z = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+    zone_plate_x = Cpt(BeckhoffAxis, ':MMS:03', doc="x-axis of FZP to define 15 targets position", kind='normal')
+    zone_plate_y = Cpt(BeckhoffAxis, ':MMS:04', doc="y-axis of FZP to define 15 targets position", kind='normal')
+    zone_plate_z = Cpt(BeckhoffAxis, ':MMS:05', doc="z-axis of FZP to define 15 targets position", kind='normal')
     solid_att = Cpt(TMOSpectrometerSOLIDATTStates, 'SP1K4:ATT:STATE', add_prefix=(), kind='normal')
     # Solid_att x and Y are FOIL x and y
     solid_att_x = Cpt(BeckhoffAxis, ':MMS:02', doc="X-axis of solid attenuator(FOIL) which protects FZP", kind='normal')
     solid_att_y = Cpt(BeckhoffAxis, ':MMS:13', doc="Y-axis of solid attenuator(FOIL) which protects FZP", kind='normal')
-    thorlab_lens_x = Cpt(BeckhoffAxis, ':MMS:12', kind='normal')
+    thorlab_lens_x = Cpt(BeckhoffAxis, ':MMS:12', doc="axis to move spectrometer intensifier", kind='normal')
     # lens_pitch_up_down = Cpt(BeckhoffAxis, ':MMS:10', kind='normal')
     # lens_yaw_left_right = Cpt(BeckhoffAxis, ':MMS:11', kind='normal')
-    yag_x = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
-    yag_y = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
-    yag_z = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')
-    yag_theta = Cpt(BeckhoffAxis, ':MMS:09', kind='normal')
+    yag_x = Cpt(BeckhoffAxis, ':MMS:06', doc="x-axis of spectrometer detector", kind='normal')
+    yag_y = Cpt(BeckhoffAxis, ':MMS:07', doc="y-axis of spectrometer detector", kind='normal')
+    yag_z = Cpt(BeckhoffAxis, ':MMS:08', doc="z-axis of spectrometer detector", kind='normal')
+    yag_theta = Cpt(BeckhoffAxis, ':MMS:09', doc="theta axis to rotate spectrometer detector", kind='normal')
 
     # Lightpath constants
     inserted = True

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -320,6 +320,16 @@ class FZPStates(TwinCATStatePMPS):
     config = UpCpt(state_count=15, motor_count=3)
 
 
+class SOLIDATTStates(TwinCATStatePMPS):
+    """
+    Spectrometer Solid Attenuator(FOIL X and Y) 2D States Setup
+
+    Here, we specify 7 states,(after adding an Unknown state), and 2 motors, for the X and Y
+    axes.
+    """
+    config = UpCpt(state_count=7, motor_count=2)
+
+
 class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     """
     TMO Fresnel Photon Spectrometer Motion components class.
@@ -339,14 +349,17 @@ class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     tab_component_names = True
 
     # Motor components: can read/write positions
-    lens_x = Cpt(BeckhoffAxis, ':MMS:01', kind='normal')
-    lens_pitch_up_down = Cpt(BeckhoffAxis, ':MMS:10', kind='normal')
-    lens_yaw_left_right = Cpt(BeckhoffAxis, ':MMS:11', kind='normal')
-    foil_x = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
     zone_plate = Cpt(FZPStates, 'SP1K4:FZP:STATE', add_prefix=(), kind='normal')
     zone_plate_x = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
     zone_plate_y = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
     zone_plate_z = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
+    solid_att = Cpt(SOLIDATTStates, 'SP1K4:ATT:STATE', add_prefix=(), kind='normal')
+    # Solid_att x and Y are FOIL x and y
+    solid_att_x = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
+    solid_att_y = Cpt(BeckhoffAxis, ':MMS:13', kind='normal')
+    thorlab_lens_x = Cpt(BeckhoffAxis, ':MMS:12', kind='normal')
+    # lens_pitch_up_down = Cpt(BeckhoffAxis, ':MMS:10', kind='normal')
+    # lens_yaw_left_right = Cpt(BeckhoffAxis, ':MMS:11', kind='normal')
     yag_x = Cpt(BeckhoffAxis, ':MMS:06', kind='normal')
     yag_y = Cpt(BeckhoffAxis, ':MMS:07', kind='normal')
     yag_z = Cpt(BeckhoffAxis, ':MMS:08', kind='normal')

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -320,7 +320,7 @@ class FZPStates(TwinCATStatePMPS):
     config = UpCpt(state_count=15, motor_count=3)
 
 
-class SOLIDATTStates(TwinCATStatePMPS):
+class TMOSpectrometerSOLIDATTStates(TwinCATStatePMPS):
     """
     Spectrometer Solid Attenuator(FOIL X and Y) 2D States Setup
 
@@ -353,10 +353,10 @@ class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):
     zone_plate_x = Cpt(BeckhoffAxis, ':MMS:03', kind='normal')
     zone_plate_y = Cpt(BeckhoffAxis, ':MMS:04', kind='normal')
     zone_plate_z = Cpt(BeckhoffAxis, ':MMS:05', kind='normal')
-    solid_att = Cpt(SOLIDATTStates, 'SP1K4:ATT:STATE', add_prefix=(), kind='normal')
+    solid_att = Cpt(TMOSpectrometerSOLIDATTStates, 'SP1K4:ATT:STATE', add_prefix=(), kind='normal')
     # Solid_att x and Y are FOIL x and y
-    solid_att_x = Cpt(BeckhoffAxis, ':MMS:02', kind='normal')
-    solid_att_y = Cpt(BeckhoffAxis, ':MMS:13', kind='normal')
+    solid_att_x = Cpt(BeckhoffAxis, ':MMS:02', doc="X-axis of solid attenuator(FOIL) which protects FZP", kind='normal')
+    solid_att_y = Cpt(BeckhoffAxis, ':MMS:13', doc="Y-axis of solid attenuator(FOIL) which protects FZP", kind='normal')
     thorlab_lens_x = Cpt(BeckhoffAxis, ':MMS:12', kind='normal')
     # lens_pitch_up_down = Cpt(BeckhoffAxis, ':MMS:10', kind='normal')
     # lens_yaw_left_right = Cpt(BeckhoffAxis, ':MMS:11', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adding 2D motors state move GUI of Sp1K4 solid attenuator the same as Sp1K4 FZP
<!--- Describe your changes in detail -->
Adding one class of SOLIDATTStates. Inside TMOSpectrometer class,  shift all the motors sequence per James request. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists request to add SP1K4 solid attenuator 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
not yet. Plan to test the GUI after it is build. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

https://jira.slac.stanford.edu/browse/ECS-1576

<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
