### PR TITLE
Cooling/RTD Device Updates

### DIFF
--- a/docs/source/upcoming_release_notes/1156-RTD-Cooling.rst
+++ b/docs/source/upcoming_release_notes/1156-RTD-Cooling.rst
@@ -29,4 +29,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- nrwslac

--- a/docs/source/upcoming_release_notes/1156-RTD-Cooling.rst
+++ b/docs/source/upcoming_release_notes/1156-RTD-Cooling.rst
@@ -1,0 +1,32 @@
+1156 RTD-Cooling
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- added chin guard RTDs to `FFMirrorZ` in `mirror.py`
+
+New Devices
+-----------
+- `FDQ` Flow meter implemented in `analog_signals.py`
+- `PPMCOOL` added to `pim.py`
+- `KBOMirrorChin` added to `mirror.py`
+
+Bugfixes
+--------
+- `KBOMirrorHE` in `mirror.py` only has 1 flow sensor per mirror.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/1156-RTD-Cooling.rst
+++ b/docs/source/upcoming_release_notes/1156-RTD-Cooling.rst
@@ -21,7 +21,7 @@ New Devices
 
 Bugfixes
 --------
-- `KBOMirrorHE` in `mirror.py` only has 1 flow sensor per mirror.
+- `KBOMirrorHE` in `mirror.py` only has 1 flow sensor per mirror, so remove one.
 
 Maintenance
 -----------

--- a/pcdsdevices/analog_signals.py
+++ b/pcdsdevices/analog_signals.py
@@ -225,7 +225,7 @@ class Mesh(BaseInterface, Device):
 
 class FDQ(BaseInterface, Device):
     """
-        A collection of PVs to inteface python with a Keyance FDQ Flow Meter.
+    A collection of PVs to inteface python with a Keyence FDQ Flow Meter.
     """
     tab_whitelist = ['get_flow_rate', 'get_flow_offset',
                      'set_flow_offset']

--- a/pcdsdevices/analog_signals.py
+++ b/pcdsdevices/analog_signals.py
@@ -7,6 +7,7 @@ from ophyd import FormattedComponent as FCpt
 from . import utils as key_press
 from .device import GroupDevice
 from .interface import BaseInterface
+from .signal import PytmcSignal
 
 
 class Acromag(BaseInterface, GroupDevice):
@@ -220,3 +221,28 @@ class Mesh(BaseInterface, Device):
                 self.set_rel_mesh_voltage(-delta_hv_sp, wait=False)
             if test_flag:
                 return
+
+
+class FDQ(BaseInterface, Device):
+    """
+        A collection of PVs to inteface python with a Keyance FDQ Flow Meter.
+    """
+    tab_whitelist = ['get_flow_rate', 'get_flow_offset',
+                     'set_flow_offset']
+    flow_res = Cpt(PytmcSignal, ':FWM:RES', io='i', kind='config',
+                   doc='Flow meter resolution')
+    flow_off = Cpt(PytmcSignal, ':FWM:OFF', io='io', kind='config',
+                   doc='Flow meter offset')
+    flow_val = Cpt(PytmcSignal, ':FWM:VAL', io='i', kind='normal',
+                   doc='Flow meter value')
+
+    @property
+    def get_flow_rate(self):
+        return self.flow_val.get()
+
+    def set_flow_offset(self, offset):
+        return self.flow_off.put(offset)
+
+    @property
+    def get_flow_offset(self):
+        return self.flow_off.get()

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1206,7 +1206,7 @@ class FFMirrorZ(FFMirror):
     # RMS Cpts:
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
-    # RTDs
+    # Chin Guard RTDs
     chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
                         kind='normal')
     chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R', io='i',

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1505,7 +1505,7 @@ class KBOMirrorChin(KBOMirror):
     name : str
         Alias for the device.
     """
-    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i',
+    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
                         kind='normal')
-    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i',
+    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R', io='i',
                          kind='normal')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1497,7 +1497,7 @@ class KBOMirrorChin(KBOMirror):
 
     With 2 RTDs installed on the chin guard.
 
-  Parameters
+    Parameters
     ----------
     prefix : str
         Base PV for the mirror.

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1271,7 +1271,7 @@ class KBOMirrorStates(KBOMirror):
         'coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
         'x_enc_rms', 'y_enc_rms', 'pitch_enc_rms', 'bender_us_enc_rms',
         'bender_ds_enc_rms', 'us_rtd', 'ds_rtd', 'cool_flow1',
-        'cool_flow2', 'cool_press'
+        'cool_press'
     ]
 )
 class KBOMirrorHEStates(KBOMirrorHE):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1067,7 +1067,6 @@ class KBOMirrorHE(KBOMirror):
     """
     # Cooling water flow and pressure meters
     cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal')
-    cool_flow2 = Cpt(EpicsSignalRO, ':FWM:2_RBV', kind='normal')
     cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal')
 
     # Tab config: show components

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1487,3 +1487,25 @@ class OpticsPitchNotepad(BaseInterface, Device):
     mr2l3_pitch_w = Cpt(EpicsSignal, 'MR2L3:PITCH:Coating2')
     mr2l3_pitch_ccm_sic = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating1', doc="MR2L3 pitch coating 1 (Silicon) setpoint with CCM inserted")
     mr2l3_pitch_ccm_w = Cpt(EpicsSignal, 'MR2L3:PITCH:CCM:Coating2', doc="MR2L3 pitch coating 2 (Tungsten) setpoint with CCM inserted")
+
+
+class KBOMirrorChin(KBOMirror):
+    """
+    Kirkpatrick-Baez Mirror with Bender Axes.
+
+    1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
+
+    With 2 RTDs installed on the chin guard.
+
+  Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
+                        kind='normal')
+    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R', io='i',
+                         kind='normal')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1207,11 +1207,11 @@ class FFMirrorZ(FFMirror):
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
     # Chin Guard RTDs
-    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
+    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i',
                         kind='normal')
-    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R', io='i',
+    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i',
                          kind='normal')
-    chin_tail_rtd = Cpt(PytmcSignal, ':RTD:TAIL', io='i',
+    chin_tail_rtd = Cpt(PytmcSignal, ':RTD:TAIL:TEMP', io='i',
                         kind='normal')
 
 
@@ -1505,7 +1505,7 @@ class KBOMirrorChin(KBOMirror):
     name : str
         Alias for the device.
     """
-    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
+    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i',
                         kind='normal')
-    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R', io='i',
+    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i',
                          kind='normal')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1206,6 +1206,14 @@ class FFMirrorZ(FFMirror):
     # RMS Cpts:
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
+    # RTDs
+    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
+                        kind='normal')
+    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
+                         kind='normal')
+    chin_tail_rtd = Cpt(PytmcSignal, ':RTD:TAIL', io='i',
+                        kind='normal')
+
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):
     """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1209,7 +1209,7 @@ class FFMirrorZ(FFMirror):
     # RTDs
     chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
                         kind='normal')
-    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L', io='i',
+    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R', io='i',
                          kind='normal')
     chin_tail_rtd = Cpt(PytmcSignal, ':RTD:TAIL', io='i',
                         kind='normal')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -15,6 +15,7 @@ from ophyd.device import FormattedComponent as FCpt
 from ophyd.ophydobj import OphydObject
 from ophyd.signal import EpicsSignal
 
+from .analog_signals import FDQ
 from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
                                      PCDSAreaDetectorTyphosTrigger)
 from .device import GroupDevice
@@ -556,3 +557,11 @@ class IM2K0(LCLS2ImagerBase):
     led = Cpt(XPIMLED, ':CIL', kind='config',
               doc='LED for viewing the reticle.')
     # Nothing else! No power meter, no zoom/focus, no filter wheel...
+
+
+class PPMCOOL(PPM):
+    """
+    L2SI's Power and Profile Monitor design with cooling.
+    """
+    flow_meter = Cpt(FDQ, '', kind='normal',
+                     doc='Device that measures PCW Flow Rate.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add a new device for FDQ Flow Meter `FDQ` in `analog_signals.py`
- Make a new class for PPMs with FDQ Flow Meters: `PPMCOOL` currently serving IM3/4/5/6K4.
- Fix `KBOMirrorHE`; only needs one flow meter readout. These serve MR2/3K4
- Update `FFMirrorZ` to include chin guard RTDs serving MR4/5K4
- Add Class `KBOMirrorChin` for Optics currently without cooling but with Chin Guard RTDs. Serving MR3K2

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Newly installed flow meters and RTDs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `FDQ` class was ran locally in a hutch-python session with functions tested. The PLC still needs to stop writing the offset value, but that will be fixed in a different PLC PR for imagers in TMO.
- `PPMCOOL` was launched successfully in a typhos screen.
- `KBOMirrorHE` was launched successfully with MR2/3K4 - an issue of sharing a pressure readout here exist, currently 1 PV is being read out on MR2, but it needs to be readout on MR3 as well; for now, MR3 pressure readout PV shows disconnected because it doesnt exist.
- `KBOMirrorChin` was launched successfully in a typhos screen with MR3K2.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
