### PR TITLE
API/ENH: cull state PVs, include helpful motor PVs

### DIFF
--- a/docs/source/upcoming_release_notes/1157-api_motion_pv_cull.rst
+++ b/docs/source/upcoming_release_notes/1157-api_motion_pv_cull.rst
@@ -1,0 +1,43 @@
+1157 api_motion_pv_cull
+#######################
+
+API Changes
+-----------
+- Remove rarely-used TwinCAT state config PVs from `TwinCATStateConfigOne`
+  that are also being removed from the IOCs.
+  These are still available on the PLC itself.
+
+  - ``delta``
+  - ``accl``
+  - ``dccl``
+  - ``locked``
+  - ``valid``
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Add the following signals to `BeckhoffAxis`:
+
+  - ``enc_count``: the raw encoder count.
+  - ``pos_diff``: the distance between the readback and trajectory setpoint.
+  - ``hardware_enable``: an indicator for hardware enable signals, such as STO buttons.
+
+New Devices
+-----------
+- Add `BeckhoffAxisEPS`, which has the new-style EPS PVs on its directional and power enables.
+  These correspond to structured EPS logic on the PLC that can be inspected from higher level applications.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -24,6 +24,7 @@ from pcdsdevices.pv_positioner import PVPositionerComparator
 
 from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init
+from .eps import EPS
 from .interface import FltMvInterface
 from .pseudopos import OffsetMotorBase, delay_class_factory
 from .registry import device_registry
@@ -1083,15 +1084,23 @@ class MMC100(PCDSMotorBase):
 
 
 class BeckhoffAxisPLC(Device):
-    """Error handling for the Beckhoff Axis PLC code."""
+    """
+    Error handling, debug, and aux functions for the Beckhoff Axis PLC code.
+    """
     status = Cpt(PytmcSignal, 'sErrorMessage', io='i', kind='normal',
                  string=True, doc='PLC error or warning')
     err_bool = Cpt(PytmcSignal, 'bError', io='i', kind='normal',
                    doc='True if there is some sort of error.')
     err_code = Cpt(PytmcSignal, 'nErrorId', io='i', kind='normal',
                    doc='Current NC error code')
-    cmd_err_reset = Cpt(EpicsSignal, 'bReset', kind='normal',
+    cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='io', kind='normal',
                         doc='Command to reset an active error')
+    enc_count = Cpt(PytmcSignal, 'nEncoderCount', io='io', kind='normal',
+                    doc='Raw encoder count for this motor.')
+    posdiff = Cpt(PytmcSignal, 'fPosDiff', io='io', kind='normal',
+                  doc='Difference between trajectory setpoint and readback.')
+    hardware_enable = Cpt(PytmcSignal, 'bHardwareEnable', io='io', kind='normal',
+                          doc='TRUE if motor has its hardware enable.')
     cmd_home = Cpt(PytmcSignal, 'bHomeCmd', io='o', kind='normal',
                    doc='Start TwinCAT homing routine.')
     home_pos = Cpt(PytmcSignal, 'fHomePosition', io='io', kind='config',
@@ -1104,6 +1113,19 @@ class BeckhoffAxisPLC(Device):
     set_metadata(cmd_home, dict(variety='command-proc',
                                 value=1,
                                 tags={"confirm"}))
+
+
+class BeckhoffAxisPLCEPS(BeckhoffAxisPLC):
+    """
+    Extended BeckhoffAxisPLC with relevant EPS fields.
+
+    This is to be used in BeckhoffAxisEPS for cases when the motor
+    has EPS considerations. Otherwise, these fields are not active
+    in PLC logic and are distracting or confusing.
+    """
+    eps_forward = Cpt(EPS, "stEPSF:", doc="EPS forward enables.")
+    eps_backward = Cpt(EPS, "stEPSB:", doc="EPS backward enables.")
+    eps_power = Cpt(EPS, "stEPSP:", doc="EPS power enables.")
 
 
 class BeckhoffAxis(EpicsMotorInterface):
@@ -1120,7 +1142,7 @@ class BeckhoffAxis(EpicsMotorInterface):
     tab_whitelist = ['clear_error']
 
     plc = Cpt(BeckhoffAxisPLC, ':PLC:', kind='normal',
-              doc='PLC error handling.')
+              doc='PLC error handling and aux functions.')
     motor_spmg = Cpt(EpicsSignal, '.SPMG', kind='config',
                      doc='Stop, Pause, Move, Go')
 
@@ -1265,10 +1287,23 @@ class BeckhoffAxis(EpicsMotorInterface):
             )
 
 
+class BeckhoffAxisEPS(BeckhoffAxis):
+    """
+    A beckhoff axis where the EPS indicators are relevant.
+
+    This is to be used for cases when the motor has EPS considerations.
+    Otherwise, these fields are not active in PLC logic and are distracting
+    or confusing.
+    """
+    plc = Cpt(BeckhoffAxisPLCEPS, ':PLC:', kind='normal',
+              doc='PLC error handling, aux functions, and EPS.')
+
+
 class BeckhoffAxisPLC_Pre140(BeckhoffAxisPLC):
     """
     Disable some newly introduced signals.
     """
+    posdiff = None
     cmd_home = None
     home_pos = None
     user_enable = None
@@ -1283,7 +1318,7 @@ class BeckhoffAxis_Pre140(BeckhoffAxis):
     introduced.
     """
     plc = Cpt(BeckhoffAxisPLC_Pre140, ':PLC:', kind='normal',
-              doc='PLC error handling.')
+              doc='PLC error handling and aux functions.')
 
     def home(self, *args, **kwargs):
         """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1095,11 +1095,11 @@ class BeckhoffAxisPLC(Device):
                    doc='Current NC error code')
     cmd_err_reset = Cpt(PytmcSignal, 'bReset', io='io', kind='normal',
                         doc='Command to reset an active error')
-    enc_count = Cpt(PytmcSignal, 'nEncoderCount', io='io', kind='normal',
+    enc_count = Cpt(PytmcSignal, 'nEncoderCount', io='i', kind='normal',
                     doc='Raw encoder count for this motor.')
-    posdiff = Cpt(PytmcSignal, 'fPosDiff', io='io', kind='normal',
+    posdiff = Cpt(PytmcSignal, 'fPosDiff', io='i', kind='normal',
                   doc='Difference between trajectory setpoint and readback.')
-    hardware_enable = Cpt(PytmcSignal, 'bHardwareEnable', io='io', kind='normal',
+    hardware_enable = Cpt(PytmcSignal, 'bHardwareEnable', io='i', kind='normal',
                           doc='TRUE if motor has its hardware enable.')
     cmd_home = Cpt(PytmcSignal, 'bHomeCmd', io='o', kind='normal',
                    doc='Start TwinCAT homing routine.')

--- a/pcdsdevices/eps.py
+++ b/pcdsdevices/eps.py
@@ -19,7 +19,7 @@ class EPS(BaseInterface, Device):
     why their motor cannot move, why their valve cannot open,
     etc.
     """
-    eps_ok = Cpt(PytmcSignal, "bEPS_OK", io="io", kind="normal",
+    eps_ok = Cpt(PytmcSignal, "bEPS_OK", io="i", kind="normal",
                  doc="EPS summary: true if everything is OK")
     message = Cpt(PytmcSignal, "sMessage", io="i", kind="normal",
                   doc="Message from EPS to the user.")

--- a/pcdsdevices/eps.py
+++ b/pcdsdevices/eps.py
@@ -1,5 +1,9 @@
 """
-Classes for EPS readbacks.
+Classes for Equipment Protection System (EPS) readbacks.
+
+This covers generalized ways that we can protect hardware from
+damaging itself. For example: we can prevent a motor from moving
+forward if moving forward would collide with another motor.
 """
 from ophyd import Component as Cpt
 from ophyd import Device

--- a/pcdsdevices/eps.py
+++ b/pcdsdevices/eps.py
@@ -5,7 +5,8 @@ from ophyd import Component as Cpt
 from ophyd import Device
 
 from .interface import BaseInterface
-from .signal import PytmcSignal
+from .signal import InternalSignal, PytmcSignal
+from .variety import set_metadata
 
 
 class EPS(BaseInterface, Device):
@@ -18,12 +19,46 @@ class EPS(BaseInterface, Device):
     by higher level applications so that the user knows exactly
     why their motor cannot move, why their valve cannot open,
     etc.
+
+    This has a corresponding EPS widget in pcdswidgets, so
+    this class only makes minimal adjustments to make the default
+    typhos view usable.
     """
     eps_ok = Cpt(PytmcSignal, "bEPS_OK", io="i", kind="normal",
                  doc="EPS summary: true if everything is OK")
     message = Cpt(PytmcSignal, "sMessage", io="i", kind="normal",
+                  string=True,
                   doc="Message from EPS to the user.")
-    flags = Cpt(PytmcSignal, "nFlags", io="i", kind="omitted",
-                doc="Raw EPS bitmask")
+    flags_raw = Cpt(PytmcSignal, "nFlags", io="i", kind="omitted",
+                    doc="Raw EPS bitmask")
+    flags = Cpt(InternalSignal, kind="normal")
     flag_desc = Cpt(PytmcSignal, "sFlagDesc", io="i", kind="omitted",
+                    string=True,
                     doc="Semicolon-delimited descriptions of each flag")
+
+    # See _update_flag docstring
+    set_metadata(flags, dict(variety="bitmask", bits=8))
+
+    @flags_raw.sub_value
+    def _update_flag(self, value, *args, **kwargs):
+        """
+        Update the flags value to a form that is usable in a pydm bitmask.
+
+        If bit 32 is TRUE, this comes as a negative number because EPICS CA has
+        no unsigned types, so the 32-bit UINT is cast to a 32-bit int.
+
+        For some reason, the PyDM bitmask widget reapplies this conversion, so
+        I can't actually display the 32nd bit without blanking out the whole
+        bitmask widget.
+
+        The 32nd bit will literally never be used, but we can truncate at the 31st
+        bit so that we get a usable widget.
+
+        Further, most of these are unlikely to get use. What kind of motor has
+        31 EPS considerations? Surely that motor would have a special screen.
+
+        For this case we'll truncate all the way to 8 bits.
+        """
+        if value < 0:
+            value = 2**8 + value
+        self.flags.put(value, force=True)

--- a/pcdsdevices/eps.py
+++ b/pcdsdevices/eps.py
@@ -1,0 +1,29 @@
+"""
+Classes for EPS readbacks.
+"""
+from ophyd import Component as Cpt
+from ophyd import Device
+
+from .interface import BaseInterface
+from .signal import PytmcSignal
+
+
+class EPS(BaseInterface, Device):
+    """
+    Corresponds to DUT_EPS from lcls-twincat-general.
+
+    This struct represents a combined EPS status that can be
+    made up of many independent protection factors. It summarizes
+    all of the EPS information in a way that can be consumed
+    by higher level applications so that the user knows exactly
+    why their motor cannot move, why their valve cannot open,
+    etc.
+    """
+    eps_ok = Cpt(PytmcSignal, "bEPS_OK", io="io", kind="normal",
+                 doc="EPS summary: true if everything is OK")
+    message = Cpt(PytmcSignal, "sMessage", io="i", kind="normal",
+                  doc="Message from EPS to the user.")
+    flags = Cpt(PytmcSignal, "nFlags", io="i", kind="omitted",
+                doc="Raw EPS bitmask")
+    flag_desc = Cpt(PytmcSignal, "sFlagDesc", io="i", kind="omitted",
+                    doc="Semicolon-delimited descriptions of each flag")

--- a/pcdsdevices/example.py
+++ b/pcdsdevices/example.py
@@ -8,7 +8,7 @@ from ophyd.device import FormattedComponent as FCpt
 from ophyd.signal import EpicsSignal
 
 from .device import UpdateComponent as UpCpt
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxis, BeckhoffAxisEPS
 from .inout import TwinCATInOutPositioner
 from .interface import BaseInterface
 from .pim import XPIM
@@ -90,7 +90,7 @@ class PLCExampleMotion(BaseInterface, Device):
     """
     mot1 = Cpt(BeckhoffAxis, "01")
     mot2 = Cpt(BeckhoffAxis, "02")
-    mot3 = Cpt(BeckhoffAxis, "03")
+    mot3 = Cpt(BeckhoffAxisEPS, "03")
     xpim = FCpt(PLCOnlyXPIM, "IMTST:XTES")
     sim3d = Cpt(Example3D, "3D:")
     siml2l = Cpt(ExampleL2L, "L2L:")

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -509,21 +509,10 @@ class TwinCATStateConfigOne(Device):
                      doc='The defined state name.')
     setpoint = Cpt(PytmcSignal, ':SETPOINT', io='io', kind='config',
                    doc='The corresponding motor set position.')
-    delta = Cpt(PytmcSignal, ':DELTA', io='io', kind='config',
-                doc='The deviation from setpoint that still counts '
-                    'as at the position.')
     velo = Cpt(PytmcSignal, ':VELO', io='io', kind='config',
                doc='Velocity to move to the state at.')
-    accl = Cpt(PytmcSignal, ':ACCL', io='io', kind='omitted',
-               doc='Acceleration to move to the state with.')
-    dccl = Cpt(PytmcSignal, ':DCCL', io='io', kind='omitted',
-               doc='Deceleration to move to the state with.')
     move_ok = Cpt(PytmcSignal, ':MOVE_OK', io='i', kind='omitted',
                   doc='True if a move to this state is allowed.')
-    locked = Cpt(PytmcSignal, ':LOCKED', io='i', kind='omitted',
-                 doc='True if the PLC will not permit config edits here.')
-    valid = Cpt(PytmcSignal, ':VALID', io='i', kind='omitted',
-                doc='True if the state is defined (not empty).')
 
 
 class TwinCATStateConfigDynamic(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Based on the discussions in https://docs.google.com/spreadsheets/d/1xfSB1mJwVu4tXvxBT85TEYVi29Z7VoQ4w5CXw13rV8A/edit#gid=0, make changes to pcdsdevices to:
- remove PVs that will be removed
- add PVs that were not removed that were kept because they are helpful (so, long overdue inclusions)

This includes the EPS classes added to the PLCs earlier this year.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want the python classes to match the overall IOCs as much as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Everything looks good on existing screens for the normal BeckhoffAxis case for all the motors I've checked.
- I couldn't find a live, running case to check for the old version of the class. Comment is below.
- I've adjusted the example PLC to include an EPS example for that variant.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Just this PR so far. I'll make pre-release notes.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
