### PR TITLE
REF: include row positioner templates for new typhos

### DIFF
--- a/docs/source/upcoming_release_notes/1159-row_positioner.rst
+++ b/docs/source/upcoming_release_notes/1159-row_positioner.rst
@@ -29,3 +29,4 @@ Maintenance
 Contributors
 ------------
 - klauer
+- zllentz

--- a/docs/source/upcoming_release_notes/1159-row_positioner.rst
+++ b/docs/source/upcoming_release_notes/1159-row_positioner.rst
@@ -1,0 +1,31 @@
+1159 row_positioner
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Updated supported positioner typhos templates to use the new row widget -
+  ``TyphosPositionerRowWidget``.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/pcdsdevices/ui/BeckhoffAxis.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.detailed.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>392</width>
-    <height>591</height>
+    <width>556</width>
+    <height>589</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,15 +22,24 @@
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
      </property>
     </widget>
    </item>
    <item>
     <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -38,7 +47,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>16777215</height>
+       <height>230</height>
       </size>
      </property>
      <property name="toolTip">
@@ -46,9 +55,6 @@
      </property>
      <property name="error_message_attribute" stdset="0">
       <string>plc.status</string>
-     </property>
-     <property name="alarmKindLevel" stdset="0">
-      <enum>TyphosPositionerWidget::HINTED</enum>
      </property>
     </widget>
    </item>
@@ -129,7 +135,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>364</width>
+            <width>528</width>
             <height>215</height>
            </rect>
           </property>
@@ -227,8 +233,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>528</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/pcdsdevices/ui/BeckhoffAxis.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>369</width>
-    <height>300</height>
+    <width>872</width>
+    <height>228</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,115 +22,76 @@
     <height>0</height>
    </size>
   </property>
-  <property name="maximumSize">
-   <size>
-    <width>600</width>
-    <height>300</height>
-   </size>
-  </property>
-  <property name="sizeIncrement">
-   <size>
-    <width>1</width>
-    <height>1</height>
-   </size>
-  </property>
-  <property name="baseSize">
-   <size>
-    <width>400</width>
-    <height>200</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,2">
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
     <number>3</number>
    </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
-   </property>
    <property name="leftMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <item>
-    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
      <property name="toolTip">
       <string/>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
+     <property name="readback_attribute" stdset="0">
+      <string>user_readback</string>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>230</height>
-      </size>
+     <property name="setpoint_attribute" stdset="0">
+      <string>user_setpoint</string>
      </property>
-     <property name="toolTip">
-      <string/>
+     <property name="low_limit_switch_attribute" stdset="0">
+      <string>low_limit_switch</string>
+     </property>
+     <property name="high_limit_switch_attribute" stdset="0">
+      <string>high_limit_switch</string>
+     </property>
+     <property name="low_limit_travel_attribute" stdset="0">
+      <string>low_limit_travel</string>
+     </property>
+     <property name="high_limit_travel_attribute" stdset="0">
+      <string>high_limit_travel</string>
+     </property>
+     <property name="velocity_attribute" stdset="0">
+      <string>velocity</string>
+     </property>
+     <property name="acceleration_attribute" stdset="0">
+      <string>acceleration</string>
      </property>
      <property name="error_message_attribute" stdset="0">
       <string>plc.status</string>
      </property>
-     <property name="alarmKindLevel" stdset="0">
-      <enum>TyphosPositionerWidget::HINTED</enum>
+     <property name="show_expert_button" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosPositionerWidget</class>
    <extends>QWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>

--- a/pcdsdevices/ui/QuadraticBeckhoffMotor.embedded.ui
+++ b/pcdsdevices/ui/QuadraticBeckhoffMotor.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>343</width>
-    <height>258</height>
+    <width>600</width>
+    <height>238</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -24,26 +24,26 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>600</width>
-    <height>300</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="sizeIncrement">
    <size>
-    <width>1</width>
-    <height>1</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="baseSize">
    <size>
-    <width>400</width>
-    <height>200</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,2">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -63,14 +63,7 @@
     <number>5</number>
    </property>
    <item>
-    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
-     <property name="toolTip">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget_2">
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -80,7 +73,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>230</height>
+       <height>16777215</height>
       </size>
      </property>
      <property name="toolTip">
@@ -116,33 +109,10 @@
      <property name="error_message_attribute" stdset="0">
       <string>real.plc.status</string>
      </property>
+     <property name="show_expert_button" stdset="0">
+      <bool>true</bool>
+     </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -153,9 +123,9 @@
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
+   <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/StatePositioner.embedded.ui
+++ b/pcdsdevices/ui/StatePositioner.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>337</width>
-    <height>220</height>
+    <width>824</width>
+    <height>238</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -24,26 +24,26 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>600</width>
-    <height>300</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="sizeIncrement">
    <size>
-    <width>1</width>
-    <height>1</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="baseSize">
    <size>
-    <width>400</width>
-    <height>200</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,2">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -63,14 +63,7 @@
     <number>5</number>
    </property>
    <item>
-    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
-     <property name="toolTip">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -80,7 +73,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>150</height>
+       <height>16777215</height>
       </size>
      </property>
      <property name="toolTip">
@@ -110,33 +103,10 @@
      <property name="acceleration_attribute" stdset="0">
       <string/>
      </property>
+     <property name="show_expert_button" stdset="0">
+      <bool>true</bool>
+     </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -147,9 +117,9 @@
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
+   <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/TwinCATStatePositioner.detailed.ui
+++ b/pcdsdevices/ui/TwinCATStatePositioner.detailed.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>556</width>
-    <height>487</height>
+    <height>591</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,8 +22,17 @@
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
      </property>
     </widget>
    </item>
@@ -38,7 +47,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>150</height>
+       <height>230</height>
       </size>
      </property>
      <property name="toolTip">
@@ -330,9 +339,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosSignalPanel</class>
-   <extends>QWidget</extends>
-   <header>typhos.panel</header>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
   <customwidget>
    <class>TyphosPositionerWidget</class>
@@ -340,9 +349,9 @@
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/TwinCATStatePositioner.embedded.ui
+++ b/pcdsdevices/ui/TwinCATStatePositioner.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>337</width>
-    <height>220</height>
+    <width>872</width>
+    <height>228</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,67 +22,30 @@
     <height>0</height>
    </size>
   </property>
-  <property name="maximumSize">
-   <size>
-    <width>600</width>
-    <height>300</height>
-   </size>
-  </property>
-  <property name="sizeIncrement">
-   <size>
-    <width>1</width>
-    <height>1</height>
-   </size>
-  </property>
-  <property name="baseSize">
-   <size>
-    <width>400</width>
-    <height>200</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,2">
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
     <number>3</number>
    </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
-   </property>
    <property name="leftMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <item>
-    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
-     <property name="toolTip">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>150</height>
-      </size>
-     </property>
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerRowWidget">
      <property name="toolTip">
       <string/>
      </property>
@@ -113,33 +76,10 @@
      <property name="moving_attribute" stdset="0">
       <string>busy</string>
      </property>
+     <property name="show_expert_button" stdset="0">
+      <bool>true</bool>
+     </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -150,9 +90,9 @@
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
+   <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Switch BeckhoffAxis and TwinCATStatePositioner to the new row positioner widget in typhos

## Motivation and Context
https://github.com/pcdshub/typhos/pull/563

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
