### PR TITLE
change lxt limits to +/-100us

### DIFF
--- a/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
+++ b/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
@@ -23,7 +23,7 @@ Bugfixes
 
 Maintenance
 -----------
-- Update limits from +/-10us to +/-100us
+- N/A
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
+++ b/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
@@ -11,9 +11,7 @@ Features
 
 Device Updates
 --------------
-- LaserTiming
-- LaserTimingCompensation
-- LxtTtcExample
+- Updates limits for LaserTiming, LaserTimingCompensation, and LxtTtcExample from +/-10us to +/-100us
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
+++ b/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- espov
+- vespos

--- a/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
+++ b/docs/source/upcoming_release_notes/1160-Update_lxt_limits.rst
@@ -1,0 +1,32 @@
+1160 Update lxt limits
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- LaserTiming
+- LaserTimingCompensation
+- LxtTtcExample
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Update limits from +/-10us to +/-100us
+
+Contributors
+------------
+- espov

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -269,7 +269,7 @@ class LaserTiming(FltMvInterface, PVPositioner):
                    original_units='ns',
                    kind='hinted',
                    doc='Setpoint which handles the timing conversion.',
-                   limits=(-10e-6, 10e-6),
+                   limits=(-100e-6, 100e-6),
                    )
     notepad_setpoint = Cpt(NotepadLinkedSignal, ':lxt:OphydSetpoint',
                            notepad_metadata={'record': 'ao',
@@ -464,7 +464,7 @@ class LaserTimingCompensation(SyncAxesBase):
     ``txt`` and ``lxt``, respectively.
     """
     tab_component_names = True
-    pseudo = Cpt(PseudoSingleInterface, limits=(-10e-6, 10e-6))
+    pseudo = Cpt(PseudoSingleInterface, limits=(-100e-6, 100e-6))
     delay = UCpt(_ReversedTimeToolDelay, doc='The **reversed** txt motor')
     laser = UCpt(LaserTiming, doc='The lxt motor')
 
@@ -489,7 +489,7 @@ class LxtTtcExample(SyncAxis):
     scales = {'txt': -1}
     warn_deadband = 5e-14
     fix_sync_keep_still = 'lxt'
-    sync_limits = (-10e-6, 10e-6)
+    sync_limits = (-100e-6, 100e-6)
 
 
 class FakeLxtTtc(LxtTtcExample):

--- a/pcdsdevices/tests/test_lxe.py
+++ b/pcdsdevices/tests/test_lxe.py
@@ -175,12 +175,12 @@ def test_laser_timing_delay(lxt):
 
 def test_laser_timing_limits(lxt):
     logger.debug('test_laser_timing_limits')
-    assert lxt.limits == (-10e-6, 10e-6)
+    assert lxt.limits == (-100e-6, 100e-6)
 
     with pytest.raises(ValueError):
-        lxt.mv(11e-6)
+        lxt.mv(110e-6)
     with pytest.raises(ValueError):
-        lxt.mv(-11e-6)
+        lxt.mv(-110e-6)
 
     with pytest.raises(TypeError):
         lxt.limits = 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Update the lxt default limits to 100us.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is needed when laser timing is far back for some reason

## How Has This Been Tested?
Live when laser timing was bad.

## Where Has This Been Documented?
N/A

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
