### PR TITLE
link MCS2 PVs to the smaract class

### DIFF
--- a/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
+++ b/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
@@ -7,7 +7,7 @@ API Changes
 
 Features
 --------
-- _GetMotorClass: Add MSC2 PV to motor_types and link it to SmarAct device class
+- _GetMotorClass: Add MCS2 PV to motor_types and link it to SmarAct device class
 
 Device Updates
 --------------

--- a/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
+++ b/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- espov
+- vespos

--- a/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
+++ b/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
@@ -1,4 +1,4 @@
-1161 MSC2 PV returning SmarAct device class
+1161 MCS2 PV returning SmarAct device class
 #################
 
 API Changes

--- a/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
+++ b/docs/source/upcoming_release_notes/1161-MSC2_PV_returning_SmarAct_device_class.rst
@@ -1,0 +1,30 @@
+1161 MSC2 PV returning SmarAct device class
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- _GetMotorClass: Add MSC2 PV to motor_types and link it to SmarAct device class
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- espov

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1476,7 +1476,8 @@ def _GetMotorClass(basepv):
                    ('MMC', MMC100),
                    ('MMB', BeckhoffAxis),
                    ('PIC', PCDSMotorBase),
-                   ('MCS', SmarAct))
+                   ('MCS', SmarAct),
+                   ('MCS2', SmarAct))
     # Search for component type in prefix
     for cpt_abbrev, _type in motor_types:
         if f':{cpt_abbrev}:' in basepv:
@@ -1516,6 +1517,8 @@ def Motor(prefix, **kwargs):
     | PIC           | :class:`.PCDSMotorBase` |
     +---------------+-------------------------+
     | MCS           | :class:`.SmarAct`       |
+    +---------------+-------------------------+
+    | MCS2          | :class:`.SmarAct`       |
     +---------------+-------------------------+
 
     Parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Link MCS2 PVs to the SmarAct class.
<!--- Describe your changes in detail -->

## Motivation and Context
SmarAct IOCs are defined either with MSC or MSC2 PVs base.

## How Has This Been Tested?
xpp3 with a MSC2 PV defined in the questionnaire

## Where Has This Been Documented?
N/A

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
