### PR TITLE
Empty IM3L0 subclass of PPM for device-specific screen

### DIFF
--- a/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
+++ b/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
@@ -1,4 +1,4 @@
-B1162 IM3L0_class_and_detailed_screen
+1162 IM3L0_class_and_detailed_screen
 #################
 
 API Changes

--- a/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
+++ b/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- kaushikm
+- KaushikMalapati

--- a/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
+++ b/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
@@ -12,7 +12,6 @@ Features
 
 Device Updates
 --------------
-- No updates at time of commit, but will change device_type of im3l0 from PPM to IM3L0
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
+++ b/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
@@ -1,4 +1,4 @@
-1162 IM3L0_class_and_detailed_screen
+B1162 IM3L0_class_and_detailed_screen
 #################
 
 API Changes
@@ -8,7 +8,7 @@ API Changes
 Features
 --------
 - Added blank subclass of PPM, IM3L0, to allow for screens specific to this device that don't interfere with other PPM devices
-- Added IM3L0.detailed.ui template to add embedded Keithley readout screen to detailed screen for IM3L0 
+- Added IM3L0.detailed.ui template to add embedded Keithley readout screen to detailed screen for IM3L0
 
 Device Updates
 --------------

--- a/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
+++ b/docs/source/upcoming_release_notes/1162-IM3L0_class_and_detailed_screen.rst
@@ -1,0 +1,31 @@
+1162 IM3L0_class_and_detailed_screen
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Added blank subclass of PPM, IM3L0, to allow for screens specific to this device that don't interfere with other PPM devices
+- Added IM3L0.detailed.ui template to add embedded Keithley readout screen to detailed screen for IM3L0 
+
+Device Updates
+--------------
+- No updates at time of commit, but will change device_type of im3l0 from PPM to IM3L0
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- kaushikm

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -559,6 +559,17 @@ class IM2K0(LCLS2ImagerBase):
     # Nothing else! No power meter, no zoom/focus, no filter wheel...
 
 
+class IM3L0(PPM):
+    """
+    One-off subclass of PPM to add Keithley readout to this device's detailed screen.
+
+    Identical to PPM class, but has an altered detailed screen that adds an embedded
+    pydm display that allows acces to the Keithley monitoring this device; subclass
+    allows for adding Keithley readout to only this device instead of all PPM instances.
+    """
+    pass
+
+
 class PPMCOOL(PPM):
     """
     L2SI's Power and Profile Monitor design with cooling.

--- a/pcdsdevices/ui/IM3L0.detailed.ui
+++ b/pcdsdevices/ui/IM3L0.detailed.ui
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>395</width>
+    <height>468</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="filename" stdset="0">
+      <string>/cds/group/pcds/epics-dev/zlentz/keithley_im3l0.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphosCompositeSignalPanel" name="signal_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Panel of Signals + Sub-Devices for Device
+    </string>
+     </property>
+     <property name="showOmitted" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosCompositeSignalPanel</class>
+   <extends>TyphosSignalPanel</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Description
I created a subclass of PPM called IM3L0 - no extra code, it just passes and has a comment explaining that it exists only so I can make a device-specific screen for the IM3L0 without changing the screen that all PPM devices use, which is the default detailed_tree.ui, especially since only the IM3L0 has a Keithley. 

## Motivation and Context
https://jira.slac.stanford.edu/browse/ECS-3778

## How Has This Been Tested?
This has been tested by exporting a my ~/typhos directory to PYDM_DISPLAYS_PATH, which contains PPM.detailed.ui, (called IM3L0.detailed.ui in this commit because I will change the type in the happi database after this is merged so the screen is available in the meantime) and running 'typhos im3l0' to ensure that the screen opens properly and looks like what I expect.

## Where Has This Been Documented?
This has not been documented.

<!--
## Screenshots (if appropriate):
-->
![image](https://github.com/pcdshub/pcdsdevices/assets/80156796/4d92b2ea-11df-48f9-8ad6-7eac0be900f2)

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate