### PR TITLE
Add flow/press readouts to XOffsetMirrorSwitch for MR1K2.

### DIFF
--- a/docs/source/upcoming_release_notes/1166-xoffset-switch.rst
+++ b/docs/source/upcoming_release_notes/1166-xoffset-switch.rst
@@ -1,0 +1,31 @@
+1166 xoffset-switch
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- `XOffsetMirrorSwitch` gets `cool_flow1`, `cool_flow2`, `cool_press`
+- `XOffsetMirrorSwitch` gets component reordering.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -841,6 +841,14 @@ class XOffsetMirrorBend(XOffsetMirror):
 XOffsetMirror2 = XOffsetMirrorBend
 
 
+@reorder_components(
+    end_with=[
+        'x_up', 'pitch', 'x_dwn', 'y_left', 'y_right',
+        'gantry_x', 'gantry_y', 'couple_y', 'couple_x', 'decouple_y',
+        'decouple_x', 'couple_status_y', 'couple_status_x', 'y_enc_rms',
+        'x_enc_rms', 'pitch_enc_rms' , 'cool_flow1', 'cool_flow2', 'cool_press'
+    ]
+)
 class XOffsetMirrorSwitch(XOffsetMirror):
     """
     X-ray Offset Mirror with Yleft/Yright
@@ -871,6 +879,10 @@ class XOffsetMirrorSwitch(XOffsetMirror):
                  doc='Yleft master axis [um]')
     y_right = Cpt(BeckhoffAxisNoOffset, ':MMS:YRIGHT', kind='config',
                   doc='Yright slave axis [um]')
+    # Cooling
+    cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal')
+    cool_flow2 = Cpt(EpicsSignalRO, ':FWM:2_RBV', kind='normal')
+    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal')
 
     # Tab config: show components
     tab_component_names = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Added two flow and one pressure readout.
- Added function decorator to re-arrange typhos components.
<!--- Describe your changes in detail -->
- Added Components `cool_flow1`, `cool_flow2`, and `cool_press` to class `XOffsetMirrorSwitch`
- Added function decorator `reorder_components` to fix typhos component ordering for `XOffsetMirrorSwitch`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Added cooling flow and pressure sensors to MR1K2
- MR1K2 Typhos components not ordered correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Launched typhos screen using this branch, observed readouts and correct axes ordering.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-3821
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
