### PR TITLE
MAINT: include a precision on the state_velo signal

### DIFF
--- a/docs/source/upcoming_release_notes/1167-maint_state_velo_prec.rst
+++ b/docs/source/upcoming_release_notes/1167-maint_state_velo_prec.rst
@@ -1,0 +1,33 @@
+1167 maint_state_velo_prec
+##########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- TwinCAT state devices now properly report that their state_velo
+  should be visualized with 3 decimal places instead of with 0.
+  This caused no issues in hutch-python and was patched as a bug in
+  typhos, and is done for completeness here.
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/state.py
+++ b/pcdsdevices/state.py
@@ -837,7 +837,11 @@ class TwinCATStatePositioner(StatePositioner):
         calculate_on_put=_set_state_velo,
         kind='config',
         # Real PV has no unit info yet, assume mm/s
-        metadata={'units': 'mm/s'},
+        # Set precision to 3 so UI shows 3 digits
+        metadata={
+            'units': 'mm/s',
+            'precision': 3,
+        },
         doc=(
             'State mover velocity. Displays the highest velocity of all the '
             'state move destinations and allows bulk writes to all of these '


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Set the precision of state_velo to 3, instead of the default 0.

This signal shows up in typhos with a default precision of 0, which means the ui doesn't show any details past the decimal point.

This is also fixed generically in typhos itself, but it's good to set it here too for the benefit of other applications and to make it work cleanly with older versions of typhos.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to see floats as floats and not as ints

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only, see the following which is this PR + typhos's tag without the typhos-side fix:
![image](https://github.com/pcdshub/pcdsdevices/assets/10647860/6949bcce-2719-4012-a4ab-3a67558fdec3)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
