### PR TITLE
FIX: tmo spec satt has 6 states, not 7

### DIFF
--- a/docs/source/upcoming_release_notes/1173-fix_att_states.rst
+++ b/docs/source/upcoming_release_notes/1173-fix_att_states.rst
@@ -1,0 +1,32 @@
+1173 fix_att_states
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- The TMO Spectrometer (SP1K4) now correctly has 6 attenuator states
+  instead of 7, which was causing a myriad of issues due to other
+  internal bugs.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -324,10 +324,10 @@ class TMOSpectrometerSOLIDATTStates(TwinCATStatePMPS):
     """
     Spectrometer Solid Attenuator(FOIL X and Y) 2D States Setup
 
-    Here, we specify 7 states,(after adding an Unknown state), and 2 motors, for the X and Y
+    Here, we specify 6 states,(after adding an Unknown state), and 2 motors, for the X and Y
     axes.
     """
-    config = UpCpt(state_count=7, motor_count=2)
+    config = UpCpt(state_count=6, motor_count=2)
 
 
 class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Switch state count on this device from 7 to 6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This causes an error when we load the device and breaks the device in general
There is some deeper bug to fix in the library but this at least patches the surface-level behavior

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only (the big traceback goes away, the state enum gets set up properly)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
