### PR TITLE
DOC: specify k2700 cpts are for ranges

### DIFF
--- a/docs/source/upcoming_release_notes/1174-k2700_specify_cpts_are_for_ranges.rst
+++ b/docs/source/upcoming_release_notes/1174-k2700_specify_cpts_are_for_ranges.rst
@@ -3,7 +3,10 @@
 
 API Breaks
 ----------
-- N/A
+- K2700.dcv renamed to K2700.dcv_range
+- K2700.acv renamed to K2700.acv_range
+- K2700.dci renamed to K2700.dci_range
+- K2700.aci renamed to K2700.aci_range
 
 Features
 --------

--- a/docs/source/upcoming_release_notes/1174-k2700_specify_cpts_are_for_ranges.rst
+++ b/docs/source/upcoming_release_notes/1174-k2700_specify_cpts_are_for_ranges.rst
@@ -1,0 +1,30 @@
+1174 k2700_specify_cpts_are_for_ranges
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Added 'range' to names/docs of dcv, acv, dci, and aci components of K2700
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -572,14 +572,14 @@ class K2700(BaseInterface, Device):
               doc='Identity (name) of this device')
     reading = Cpt(EpicsSignalRO, ":Reading", kind="normal",
                   doc='Trigger and return a new measurement')
-    dcv = Cpt(EpicsSignalRO, ":GetDCV", kind="normal",
-              doc='DC voltage')
-    acv = Cpt(EpicsSignalRO, ":GetACV", kind="normal",
-              doc='AC voltage')
-    dci = Cpt(EpicsSignalRO, ":GetDCI", kind="normal",
-              doc='DC current')
-    aci = Cpt(EpicsSignalRO, ":GetACI", kind="normal",
-              doc='AC current')
+    dcv_range = Cpt(EpicsSignalRO, ":GetDCV", kind="normal",
+                    doc='DC voltage range')
+    acv_range = Cpt(EpicsSignalRO, ":GetACV", kind="normal",
+                    doc='AC voltage range')
+    dci_range = Cpt(EpicsSignalRO, ":GetDCI", kind="normal",
+                    doc='DC current range')
+    aci_range = Cpt(EpicsSignalRO, ":GetACI", kind="normal",
+                    doc='AC current range')
 
 
 class IM3L0_K2700(K2700):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I added 'range' to the doc attributes and names of the components dcv, acv, dci, and aci of the K2700 class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I originally thought that the pvs associated with these components were to readback the values in their names, i.e. GetDCV would read the direct current voltage, but they actually get the range configured for each measurement. You use :Reading to get the actually measurement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
New upcoming release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
