### PR TITLE
ENH: for LCLS-I att, give proper error for uninterruptable move

### DIFF
--- a/docs/source/upcoming_release_notes/1183-fix_att_move_err.rst
+++ b/docs/source/upcoming_release_notes/1183-fix_att_move_err.rst
@@ -1,0 +1,33 @@
+1183 fix_att_move_err
+#####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Added `PVPositionerNoInterrupt`, a pv positioner base class whose moves
+  cannot be interrupted (and will loudly complain about any such attempts).
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- LCLSI attenuator classes (generated from the `Attenuator` factory function)
+  will now raise a much clearer error for when they cannot interrupt a
+  previous move, without trying (and failing) to interrupt the previous move.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -14,7 +14,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.device import DynamicDeviceComponent as DDC
 from ophyd.device import FormattedComponent as FCpt
-from ophyd.pv_positioner import PVPositioner, PVPositionerPC
+from ophyd.pv_positioner import PVPositionerPC
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal, SignalRO
 
 from . import utils
@@ -26,6 +26,7 @@ from .inout import InOutPositioner, TwinCATInOutPositioner
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutCptMixin,
                         LightpathMixin)
 from .pmps import TwinCATStatePMPS
+from .pv_positioner import PVPositionerNoInterrupt
 from .signal import InternalSignal, MultiDerivedSignal, MultiDerivedSignalRO
 from .type_hints import OphydDataType, SignalToValue
 from .utils import get_status_float, get_status_value
@@ -134,9 +135,9 @@ class FeeFilter(InOutPositioner):
             self.status.put(BladeStateEnum.Unknown, force=True)
 
 
-class AttBase(FltMvInterface, PVPositioner):
+class AttBase(FltMvInterface, PVPositionerNoInterrupt):
     """
-    Base class for attenuators with fundamental frequency.
+    Base class for pre-L2SI beam power attenuators.
 
     This is a device that puts an array of filters in or out to achieve a
     desired transmission ratio.

--- a/pcdsdevices/tests/test_attenuator.py
+++ b/pcdsdevices/tests/test_attenuator.py
@@ -83,6 +83,16 @@ def test_attenuator_motion(fake_att):
 
 
 @pytest.mark.timeout(5)
+def test_attenuator_no_interrupt(fake_att):
+    logger.debug('test_attenuator_no_interrupt')
+    att = fake_att
+    # Set as already moving
+    att.done.sim_put(1)
+    with pytest.raises(RuntimeError):
+        att.move(0.5)
+
+
+@pytest.mark.timeout(5)
 def test_attenuator_subscriptions(fake_att):
     logger.debug('test_attenuator_subscriptions')
     att = fake_att

--- a/pcdsdevices/tests/test_pv_positioner.py
+++ b/pcdsdevices/tests/test_pv_positioner.py
@@ -1,0 +1,34 @@
+import pytest
+from ophyd.device import Component as Cpt
+from ophyd.signal import Signal
+
+from pcdsdevices.pv_positioner import PVPositionerNoInterrupt
+
+
+class PVPositionerNoInterruptLocal(PVPositionerNoInterrupt):
+    setpoint = Cpt(Signal)
+    done = Cpt(Signal)
+
+
+@pytest.fixture(scope="function")
+def pvpos_no(request):
+    return PVPositionerNoInterruptLocal(name=request.node.name)
+
+
+def test_pvpos_no_motion(pvpos_no):
+    pvpos_no.done.put(1)
+    status = pvpos_no.move(100, wait=False)
+    # This is kind of silly but let's sim the full move
+    pvpos_no.done.put(0)
+    pvpos_no.done.put(1)
+    assert pvpos_no.setpoint.get() == 100
+    status.wait(timeout=1.0)
+    assert status.done
+    assert status.success
+
+
+def test_pvpos_no_interrupt(pvpos_no):
+    # Already moving, can't start a new one
+    pvpos_no.done.put(0)
+    with pytest.raises(RuntimeError):
+        pvpos_no.move(100, wait=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Adds `PVPositionerNoInterrupt`: a utility class for PV positioners that cannot start a new move until the previous move completes.
- Applies `PVPositionerNoInterrupt` to `AttBase` to gain this behavior for LCLS-I style attenuators.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For the LCLSI attenuators, if you try to start a new move during the previous move, you get a confusing and useless error. This new error makes it very clear that cannot do this.

As implemented, the IOC will not consider new move requests during the previous move, so nothing of value is lost here.

https://jira.slac.stanford.edu/browse/ECS-4099

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added a few unit tests
- Interactively checked the error message via the testclass
```
In [1]: from pcdsdevices.tests.test_pv_positioner import PVPositionerNoInterruptLocal

In [2]: loc = PVPositionerNoInterruptLocal(name='loc')

In [3]: loc.done.put(0)

In [4]: loc.move(100, wait=False)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 loc.move(100, wait=False)

File ~/github/pcdsdevices/pcdsdevices/pv_positioner.py:230, in PVPositionerNoInterrupt.move(self, position, wait, timeout, moved_cb)
    228     except Exception:
    229         progress = ""
--> 230     raise RuntimeError(
    231         f"The {self.name} device cannot start a new move because the "
    232         "previous move has not completed. This is not an "
    233         "interruptable positioner. Try waiting after the previous "
    234         f"move or for the move's status to complete. {progress}"
    235     )
    236 else:
    237     return super().move(position, wait=wait, timeout=timeout, moved_cb=moved_cb)

RuntimeError: The loc device cannot start a new move because the previous move has not completed. This is not an interruptable positioner. Try waiting after the previous move or for the move's status to complete. Position = None, goal = 0.0.
```
- It would be a good idea to try this in XPP if/when it is possible

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release notes and the aforementioned Jira ticket only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
