### PR TITLE
ENH: Add OPCPA lxt class

### DIFF
--- a/docs/source/upcoming_release_notes/1184-Add_opcpa_LXT_motor.rst
+++ b/docs/source/upcoming_release_notes/1184-Add_opcpa_LXT_motor.rst
@@ -1,0 +1,31 @@
+1184 Add opcpa LXT motor
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- Lcls2LaserTiming: New class supporting control of laser timing for the OPCPA
+  laser locker system.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -1,6 +1,5 @@
 """
 'lxe' position / pulse energy pseudopositioner support.
-
 Notes
 -----
 OPA::
@@ -482,11 +481,6 @@ class Lcls2LaserTiming(FltMvInterface, PVPositioner):
             self.log.debug('Failed to update notepad setpoint to position %s',
                            position, exc_info=ex)
         super()._setup_move(position)
-
-        # Something is wrong with done signal, just sleep and pretend
-        time.sleep(1)
-        self._move_changed(value=1-self.done_value)
-        self._move_changed(value=self.done_value)
 
     @done.sub_value
     def _update_position(self, old_value=None, value=None, **kwargs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
PR to add a class supporting the new OPCPA laser locker system. This is essentially a copy-paste of the old class, with new PVs, to keep a consistent user interface for the operators. 

I _would_ like to remove the notepad PV setup at some point, because I plan on having a user offset built in to the IOC eventually, but for now it's not there so I'll leave that in. Future PR. 

## Motivation and Context
closes #1184 

## How Has This Been Tested?
Tested on the OPCPA system in the laser hall this weekend.

## Where Has This Been Documented?
Comments in the code, with some testing details here: https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=407260134

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
