### PR TITLE
ENH: set alarm config to hinted only for beckhoff motors

### DIFF
--- a/docs/source/upcoming_release_notes/1187-enh_bk_alarm.rst
+++ b/docs/source/upcoming_release_notes/1187-enh_bk_alarm.rst
@@ -1,0 +1,31 @@
+1187 enh_bk_alarm
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where BeckhoffAxis typhos screens would overreport
+  known false alarm errors.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/ui/BeckhoffAxis.detailed.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.detailed.ui
@@ -56,6 +56,9 @@
      <property name="error_message_attribute" stdset="0">
       <string>plc.status</string>
      </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
+     </property>
     </widget>
    </item>
    <item>

--- a/pcdsdevices/ui/BeckhoffAxis.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.embedded.ui
@@ -79,19 +79,22 @@
      <property name="show_expert_button" stdset="0">
       <bool>true</bool>
      </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
+     </property>
     </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosPositionerRowWidget</class>
-   <extends>TyphosPositionerWidget</extends>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>

--- a/pcdsdevices/ui/QuadraticBeckhoffMotor.detailed.ui
+++ b/pcdsdevices/ui/QuadraticBeckhoffMotor.detailed.ui
@@ -74,6 +74,9 @@
      <property name="error_message_attribute" stdset="0">
       <string>real.plc.status</string>
      </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
+     </property>
     </widget>
    </item>
    <item>
@@ -333,9 +336,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosSignalPanel</class>
-   <extends>QWidget</extends>
-   <header>typhos.panel</header>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
   <customwidget>
    <class>TyphosPositionerWidget</class>
@@ -343,9 +346,9 @@
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosDisplayTitle</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
+   <class>TyphosSignalPanel</class>
+   <extends>QWidget</extends>
+   <header>typhos.panel</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/QuadraticBeckhoffMotor.embedded.ui
+++ b/pcdsdevices/ui/QuadraticBeckhoffMotor.embedded.ui
@@ -112,19 +112,22 @@
      <property name="show_expert_button" stdset="0">
       <bool>true</bool>
      </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
+     </property>
     </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosPositionerRowWidget</class>
-   <extends>TyphosPositionerWidget</extends>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
For the typhos templates that contain BeckhoffAxis instances, set the alarm widget to only check "hinted" signals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. All of the sub-fields of this motor record tend to go into an alarm state at the same time. This is very spammy and redundant.
2. Due to the bug described in https://jira.slac.stanford.edu/browse/ECS-847, a bunch of the fields can remain stuck in an alarm state indefinitely, even if the alarm is cleared. This can leave a lot of phantom errors that aren't real.
3. Today, I heard that this perma-alarm was upsetting people.

Due to the nature of the bug, the alarm states clear when the associated value updates.

One setting I can easily change in these widgets is to drop the alarm widget from checking all normal signals to only checking hinted signals. Typically, this is just the `.RBV` field which tends to have the correct alarm state due to how often it updates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only
- I compared sp1k1_mono before/after
- I found motors that still had an error state even after this change (see rtdsx01, still major but less spammy)
- I double-checked that the VLSOptics screens still ran and gave reasonable alarms (those look better now too, though still a major alarm)

Before and after for sp1k1_mono:
![image](https://github.com/pcdshub/pcdsdevices/assets/10647860/811e4d7b-4ee7-4f30-a9aa-9259df7e3546)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
pre-release docs

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [ ] ~Code contains descriptive docstrings, including context and API~
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
