### PR TITLE
FIX: added signal to reset pump for the EVA

### DIFF
--- a/docs/source/upcoming_release_notes/1188-update_ebara_eva_class.rst
+++ b/docs/source/upcoming_release_notes/1188-update_ebara_eva_class.rst
@@ -7,7 +7,7 @@ API Breaks
 
 Features
 --------
-- Added RST_SW pv
+- Added RST_SW pv to Ebara EVA pumps. This PV is used to reset alarm errors.
 
 Device Updates
 --------------
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- ghalym

--- a/docs/source/upcoming_release_notes/1188-update_ebara_eva_class.rst
+++ b/docs/source/upcoming_release_notes/1188-update_ebara_eva_class.rst
@@ -1,0 +1,30 @@
+1188 update ebara eva class
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Added RST_SW pv
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -229,6 +229,7 @@ class Ebara_EV_A03_1(PROPLC):
     remote = Cpt(EpicsSignalWithRBV, ':REMOTE', kind='omitted')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')
     run_di = Cpt(EpicsSignalRO, ':RUN_DI_RBV', kind='omitted')
+    reset_di = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='omitted')
 
 
 class AgilentSerial(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The ebara EVA pump was missing the pv to reset alarm errors

## Motivation and Context
Need to ad the pv to the engineering screen

## How Has This Been Tested?
yes, followed steps in this confluence page https://confluence.slac.stanford.edu/display/PCDS/How+to+add+a+device+to+pcdsdevices#Howtoaddadevicetopcdsdevices-Adddocumentation,please!


![image](https://github.com/pcdshub/pcdsdevices/assets/43865116/9eed4c77-9816-40ce-875a-8f59f79f97b7)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
