### PR TITLE
Add j120k flowswitch, insert flow switch in appropriate classes.

### DIFF
--- a/docs/source/upcoming_release_notes/1189-flow-switch.rst
+++ b/docs/source/upcoming_release_notes/1189-flow-switch.rst
@@ -17,7 +17,7 @@ New Devices
 -----------
 - `PPMCoolSwitch` ppms with cooling switch not a meter.
 - `WavefrontSensorTargetCool` WaveFrontSensors with a cooling switch.
-- `J120k` a device class for a cooling switch.
+- `J120K` a device class for a cooling switch.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/1189-flow-switch.rst
+++ b/docs/source/upcoming_release_notes/1189-flow-switch.rst
@@ -7,7 +7,7 @@ API Breaks
 
 Features
 --------
-- N/A
+- pcdsdevices now has a `digital_signals.py` module for simple digital io.
 
 Device Updates
 --------------

--- a/docs/source/upcoming_release_notes/1189-flow-switch.rst
+++ b/docs/source/upcoming_release_notes/1189-flow-switch.rst
@@ -1,0 +1,31 @@
+1189 flow-switch
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- added `J120K` to `SxrTestAbsorber`, `XPIM`, `IM2K0`, `PowerSlits`
+
+New Devices
+-----------
+- `PPMCoolSwitch`
+- `WavefrontSensorTargetCool`
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/1189-flow-switch.rst
+++ b/docs/source/upcoming_release_notes/1189-flow-switch.rst
@@ -7,7 +7,7 @@ API Breaks
 
 Features
 --------
-- pcdsdevices now has a `digital_signals.py` module for simple digital io.
+- pcdsdevices now has a `digital_signals` module for simple digital io.
 
 Device Updates
 --------------
@@ -16,7 +16,7 @@ Device Updates
 New Devices
 -----------
 - `PPMCoolSwitch` ppms with cooling switch not a meter.
-- `WavefrontSensorTargetCool` WaveFrontSensors with a cooling switch.
+- `WaveFrontSensorTargetCool` WaveFrontSensors with a cooling switch.
 - `J120K` a device class for a cooling switch.
 
 Bugfixes
@@ -29,4 +29,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- nrwslac

--- a/docs/source/upcoming_release_notes/1189-flow-switch.rst
+++ b/docs/source/upcoming_release_notes/1189-flow-switch.rst
@@ -15,8 +15,9 @@ Device Updates
 
 New Devices
 -----------
-- `PPMCoolSwitch`
-- `WavefrontSensorTargetCool`
+- `PPMCoolSwitch` ppms with cooling switch not a meter.
+- `WavefrontSensorTargetCool` WaveFrontSensors with a cooling switch.
+- `J120k` a device class for a cooling switch.
 
 Bugfixes
 --------

--- a/pcdsdevices/digital_signals.py
+++ b/pcdsdevices/digital_signals.py
@@ -1,0 +1,20 @@
+from ophyd import Component as Cpt
+from ophyd import Device
+
+from .interface import BaseInterface
+from .signal import PytmcSignal
+
+
+class J120K(BaseInterface, Device):
+    """
+    A class representing the J120K 24V dry contact cooling flow switch.
+    """
+    flow_ok = Cpt(PytmcSignal, 'FSW:FLOW_OK', io='i',
+                  kind='normal', doc='flow rate nominal')
+
+    @property
+    def get_flow_ok(self):
+        """
+        returns True if flow rate is nominal
+        """
+        return self.flow_ok.get()

--- a/pcdsdevices/digital_signals.py
+++ b/pcdsdevices/digital_signals.py
@@ -11,10 +11,3 @@ class J120K(BaseInterface, Device):
     """
     flow_ok = Cpt(PytmcSignal, ':FSW:FLOW_OK', io='i',
                   kind='normal', doc='flow rate nominal')
-
-    @property
-    def get_flow_ok(self):
-        """
-        returns True if flow rate is nominal
-        """
-        return bool(self.flow_ok.get())

--- a/pcdsdevices/digital_signals.py
+++ b/pcdsdevices/digital_signals.py
@@ -17,4 +17,4 @@ class J120K(BaseInterface, Device):
         """
         returns True if flow rate is nominal
         """
-        return self.flow_ok.get()
+        return bool(self.flow_ok.get())

--- a/pcdsdevices/digital_signals.py
+++ b/pcdsdevices/digital_signals.py
@@ -9,7 +9,7 @@ class J120K(BaseInterface, Device):
     """
     A class representing the J120K 24V dry contact cooling flow switch.
     """
-    flow_ok = Cpt(PytmcSignal, 'FSW:FLOW_OK', io='i',
+    flow_ok = Cpt(PytmcSignal, ':FSW:FLOW_OK', io='i',
                   kind='normal', doc='flow rate nominal')
 
     @property

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -20,6 +20,7 @@ from .areadetector.detectors import (PCDSAreaDetectorEmbedded,
                                      PCDSAreaDetectorTyphosTrigger)
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
+from .digital_signals import J120K
 from .epics_motor import IMS, BeckhoffAxisNoOffset
 from .inout import InOutRecordPositioner
 from .interface import BaseInterface, LightpathInOutCptMixin
@@ -541,6 +542,8 @@ class XPIM(LCLS2ImagerBase):
     filter_wheel = Cpt(XPIMFilterWheel, ':MFW', kind='config',
                        doc='Optical filter wheel in front of the camera '
                            'to prevent saturation.')
+    flow_switch = Cpt(J120K, '', kind='normal',
+                      doc='Device that indicates nominal PCW Flow Rate.')
 
     set_metadata(zoom_lock, dict(variety='command-enum'))
     set_metadata(focus_lock, dict(variety='command-enum'))
@@ -557,6 +560,8 @@ class IM2K0(LCLS2ImagerBase):
     # XPIM illuminator
     led = Cpt(XPIMLED, ':CIL', kind='config',
               doc='LED for viewing the reticle.')
+    flow_switch = Cpt(J120K, '', kind='normal',
+                      doc='Device that indicates nominal PCW Flow Rate.')
     # Nothing else! No power meter, no zoom/focus, no filter wheel...
 
 
@@ -580,3 +585,11 @@ class PPMCOOL(PPM):
     """
     flow_meter = Cpt(FDQ, '', kind='normal',
                      doc='Device that measures PCW Flow Rate.')
+
+
+class PPMCoolSwitch(PPM):
+    """
+    L2SI's Power and Profile Monitor design with cooling switch.
+    """
+    flow_switch = Cpt(J120K, '', kind='normal',
+                      doc='Device that indicates nominal PCW Flow Rate.')

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -29,12 +29,13 @@ from ophyd.status import wait as status_wait
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
+from .digital_signals import J120K
 from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset, PCDSMotorBase
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutCptMixin,
                         LightpathMixin, MvInterface)
 from .pmps import TwinCATStatePMPS
 from .sensors import RTD, TwinCATTempSensor
-from .signal import NotImplementedSignal, PytmcSignal
+from .signal import PytmcSignal
 from .sim import FastMotor
 from .utils import get_status_float, get_status_value, schedule_task
 from .variety import set_metadata
@@ -622,7 +623,8 @@ class PowerSlits(BeckhoffSlits):
     """
 
     rtds = DDCpt(_rtd_fields(RTD, 'rtd', range(1, 9)))
-    fsw = Cpt(NotImplementedSignal, ':FSW', kind='normal')
+    flow_switch = Cpt(J120K, '', kind='normal',
+                      doc='Device that indicates nominal PCW Flow Rate.')
 
 
 class ExitSlitTarget(TwinCATStatePMPS):

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 from ophyd.device import Component as Cpt
 
+from .digital_signals import J120K
 from .epics_motor import BeckhoffAxisNoOffset
 from .inout import TwinCATInOutPositioner
 from .interface import BaseInterface, LightpathInOutCptMixin
@@ -59,5 +60,7 @@ class SxrTestAbsorber(BaseInterface, LightpathInOutCptMixin):
 
     state = Cpt(SxrTestAbsorberStates, ':MMS:STATE', kind='hinted')
     absorber_vert = Cpt(BeckhoffAxisNoOffset, ':MMS:01', kind='normal')
+    flow_switch = Cpt(J120K, '', kind='normal',
+                      doc='Device that indicates nominal PCW Flow Rate.')
 
     lightpath_cpts = ['state']

--- a/pcdsdevices/wfs.py
+++ b/pcdsdevices/wfs.py
@@ -2,6 +2,7 @@ from ophyd import Component as Cpt
 
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
+from .digital_signals import J120K
 from .epics_motor import BeckhoffAxisNoOffset
 from .interface import BaseInterface, LightpathInOutCptMixin
 from .pmps import TwinCATStatePMPS
@@ -43,3 +44,13 @@ class WaveFrontSensorTarget(BaseInterface, GroupDevice,
                         doc='First thermocouple.')
     thermocouple2 = Cpt(TwinCATTempSensor, ':STC:02', kind='normal',
                         doc='Second thermocouple.')
+
+
+class WaveFrontSensorTargetCool(WaveFrontSensorTarget):
+    """
+    An array of targets used to determine the beam's wavefront.
+
+    This array has a cooling indication switch.
+    """
+    flow_switch = Cpt(J120K, '', kind='normal',
+                      doc='Device that indicates nominal PCW Flow Rate.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- added new module digital_signals.py
- added new class `J120K`
- added `J120K` to `SxrTestAbsorber`, `XPIM`, `IM2K0`, `PowerSlits`
- created new class `PPMCoolSwitch`, `WaveFrontSensorTargetCool`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Where all devices in the happi database will get the cooling switch added `J120K` to the class. For devices who otherwise aren't all the same I inherited the base class. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Opened typhos screen from happi database where class name didn't change with local python environment and checked for flow_ok signal
- Opened typhos screens with manual module declaration where class name was different than happi database.
- All screens opened correctly.
- Opened a hutch python session with local python module and checked flow switch property reports:
-  `In [8]: sw.flow_switch.get_flow_ok`
-  `Out[8]: 1`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
[https://github.com/pcdshub/lcls-plc-kfe-motion/pull/120](https://github.com/pcdshub/lcls-plc-kfe-motion/pull/120)
[https://docs.google.com/spreadsheets/d/1UAVYuG5my1ic51wRrpq9xJfvT5X7NX-nF4QzPtAUaPg/edit#gid=0](https://docs.google.com/spreadsheets/d/1UAVYuG5my1ic51wRrpq9xJfvT5X7NX-nF4QzPtAUaPg/edit#gid=0)
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
