### PR TITLE
*settle_time* and *timeout* arguments on MultiderivedSignal.set()

### DIFF
--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -769,7 +769,8 @@ class MultiDerivedSignal(AggregateSignal):
                 f"{type(to_write).__name__}.  Please contact your POC to get "
                 f"this issue fixed."
             )
-        return utils.set_many(to_write, owner=self)
+        return utils.set_many(to_write, owner=self,
+                              timeout=timeout, settle_time=settle_time)
 
 
 class MultiDerivedSignalRO(SignalRO, MultiDerivedSignal):

--- a/pcdsdevices/tests/test_signal.py
+++ b/pcdsdevices/tests/test_signal.py
@@ -2,14 +2,14 @@ import logging
 import threading
 import time
 from typing import Any
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from ophyd import Component as Cpt
 from ophyd import Device
-from ophyd.status import Status
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
 from ophyd.sim import FakeEpicsSignal
+from ophyd.status import Status
 
 from .. import signal as signal_module
 from ..signal import (AggregateSignal, AvgSignal, MultiDerivedSignal,
@@ -436,7 +436,7 @@ def test_multi_derived_rw_timeout_settle_time(multi_derived_rw: Device, monkeypa
     monkeypatch.setattr(multi_derived_rw.b, "set", MagicMock(return_value=Status(done=True, success=True)))
     monkeypatch.setattr(multi_derived_rw.c, "set", MagicMock(return_value=Status(done=True, success=True)))
     # Set the derived signal
-    status = multi_derived_rw.cpt.set(12, timeout=1.1, settle_time=0.1).wait(timeout=2.)
+    multi_derived_rw.cpt.set(12, timeout=1.1, settle_time=0.1).wait(timeout=2.)
     # Check that the settle_time filtered down to the sub signals
     multi_derived_rw.a.set.assert_called_with(4., timeout=1.1, settle_time=0.1)
 

--- a/pcdsdevices/tests/test_signal.py
+++ b/pcdsdevices/tests/test_signal.py
@@ -2,11 +2,12 @@ import logging
 import threading
 import time
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 from ophyd import Component as Cpt
 from ophyd import Device
+from ophyd.status import Status
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
 from ophyd.sim import FakeEpicsSignal
 
@@ -425,6 +426,19 @@ def test_multi_derived_rw_basic(multi_derived_rw: Device):
 
     multi_derived_rw.cpt.set(24).wait(timeout=1)
     assert multi_derived_rw.get() == (24, 8., 8., 8.,)
+
+
+def test_multi_derived_rw_timeout_settle_time(multi_derived_rw: Device, monkeypatch):
+    multi_derived_rw.wait_for_connection()
+    assert multi_derived_rw.connected
+    # Set a monkey patch for monitoring how the signals are called
+    monkeypatch.setattr(multi_derived_rw.a, "set", MagicMock(return_value=Status(done=True, success=True)))
+    monkeypatch.setattr(multi_derived_rw.b, "set", MagicMock(return_value=Status(done=True, success=True)))
+    monkeypatch.setattr(multi_derived_rw.c, "set", MagicMock(return_value=Status(done=True, success=True)))
+    # Set the derived signal
+    status = multi_derived_rw.cpt.set(12, timeout=1.1, settle_time=0.1).wait(timeout=2.)
+    # Check that the settle_time filtered down to the sub signals
+    multi_derived_rw.a.set.assert_called_with(4., timeout=1.1, settle_time=0.1)
 
 
 def wait_until_value(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

The ``.set()`` method on the MultiDerivedSignal class accepts and documents the *settle_time* and *timeout* arguments. At the end of ``set()``, ``utils.set_many`` is used to do the actual work, however the *timeout* and *settle_time* arguments are not included.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change will make the ``set()`` method's behavior consistent with its documentation and how other signal classes' ``set()`` methods work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I wrote a test and included it in the test suite. I also tried this at my beamline on real hardware.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

No change. The documentation was correct, but the behavior was inconsistent with the documentation.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
