### PR TITLE
ENH: Added the piezo pitch motor to the exit slits

### DIFF
--- a/docs/source/upcoming_release_notes/1198-Modifying_Exit_Slits.rst
+++ b/docs/source/upcoming_release_notes/1198-Modifying_Exit_Slits.rst
@@ -1,0 +1,30 @@
+1198 Modifying Exit Slits
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- Piezo pitch motors for the crystals were added
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/1198-Modifying_Exit_Slits.rst
+++ b/docs/source/upcoming_release_notes/1198-Modifying_Exit_Slits.rst
@@ -11,7 +11,7 @@ Features
 
 Device Updates
 --------------
-- Piezo pitch motors for the crystals were added
+- Piezo pitch motors for the `ExitSlits` crystals were added
 
 New Devices
 -----------
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- ghalym

--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -30,7 +30,8 @@ from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
 from .digital_signals import J120K
-from .epics_motor import BeckhoffAxis, BeckhoffAxisNoOffset, PCDSMotorBase
+from .epics_motor import (BeckhoffAxis, BeckhoffAxisNoOffset, EpicsMotor,
+                          PCDSMotorBase)
 from .interface import (BaseInterface, FltMvInterface, LightpathInOutCptMixin,
                         LightpathMixin, MvInterface)
 from .pmps import TwinCATStatePMPS
@@ -646,16 +647,18 @@ class ExitSlits(BaseInterface, GroupDevice, LightpathInOutCptMixin):
                  doc='Control of the YAG  stack via saved positions.')
     yag_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:YAG', kind='normal',
                     doc='Direct control of the Yag Stack motor.')
-    pitch_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:PITCH', kind='normal',
-                      doc='Direct control of the slits assembly pitch  motor.')
-    vert_motor = Cpt(
-        BeckhoffAxisNoOffset, ':MMS:VERT', kind='normal',
-        doc='Direct control of the slits assembly vertical motor.'
-    )
-    roll_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:ROLL', kind='normal',
-                     doc='Direct control of the slits assembly roll motor.')
     gap_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:GAP', kind='normal',
                     doc='Direct control of the slits gap  motor.')
+    upper_crystal_pitch_motor = Cpt(EpicsMotor, ':MMZ:PITCH:TOP', kind='normal',
+                                    doc='Direct control of the upper slits assembly piezo pitch  motor.')
+    lower_crystal_pitch_motor = Cpt(EpicsMotor, ':MMZ:PITCH:BOTTOM', kind='normal',
+                                    doc='Direct control of the lower slits assembly piezo pitch  motor.')
+    pitch_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:PITCH', kind='normal',
+                      doc='Direct control of the slits assembly pitch  motor.')
+    vert_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:VERT', kind='normal',
+                     doc='Direct control of the slits assembly vertical motor.')
+    roll_motor = Cpt(BeckhoffAxisNoOffset, ':MMS:ROLL', kind='normal',
+                     doc='Direct control of the slits assembly roll motor.')
     detector = Cpt(PCDSAreaDetectorTyphosTrigger, ':CAM:', kind='normal',
                    doc='Area detector settings and readbacks.')
     cam_power = Cpt(PytmcSignal, ':CAM:PWR', io='io', kind='config',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The new exit slits unit is installed and it has two functional piezo motors.

## Motivation and Context
Added the two piezo motor to the ExitSlit class

## How Has This Been Tested?
yes, followed the confluence page

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [ ] ~Test suite passes locally~
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
