### PR TITLE
[ENH]: Add embedded gui for beckhoff axis with custom eps screen

### DIFF
--- a/docs/source/upcoming_release_notes/1204-Add_embedded_gui_for_beckhoff_axis_with_custom_eps_screen.rst
+++ b/docs/source/upcoming_release_notes/1204-Add_embedded_gui_for_beckhoff_axis_with_custom_eps_screen.rst
@@ -7,8 +7,7 @@ API Breaks
 
 Features
 --------
-Adding the 'embedded' file allows for typhos screens to open using the compact
-controls.
+- Adding the 'embedded' file allows for typhos screens to open using the compact controls.
 
 Device Updates
 --------------
@@ -28,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-jozamudi
+- jozamudi

--- a/docs/source/upcoming_release_notes/1204-Add_embedded_gui_for_beckhoff_axis_with_custom_eps_screen.rst
+++ b/docs/source/upcoming_release_notes/1204-Add_embedded_gui_for_beckhoff_axis_with_custom_eps_screen.rst
@@ -1,0 +1,31 @@
+1204 Add embedded gui for beckhoff axis with custom eps screen
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+Adding the 'embedded' file allows for typhos screens to open using the compact
+controls.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+jozamudi

--- a/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>872</width>
+    <height>177</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>3</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="readback_attribute" stdset="0">
+      <string>user_readback</string>
+     </property>
+     <property name="setpoint_attribute" stdset="0">
+      <string>user_setpoint</string>
+     </property>
+     <property name="low_limit_switch_attribute" stdset="0">
+      <string>low_limit_switch</string>
+     </property>
+     <property name="high_limit_switch_attribute" stdset="0">
+      <string>high_limit_switch</string>
+     </property>
+     <property name="low_limit_travel_attribute" stdset="0">
+      <string>low_limit_travel</string>
+     </property>
+     <property name="high_limit_travel_attribute" stdset="0">
+      <string>high_limit_travel</string>
+     </property>
+     <property name="velocity_attribute" stdset="0">
+      <string>velocity</string>
+     </property>
+     <property name="acceleration_attribute" stdset="0">
+      <string>acceleration</string>
+     </property>
+     <property name="error_message_attribute" stdset="0">
+      <string>plc.status</string>
+     </property>
+     <property name="show_expert_button" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmKindLevel" stdset="0">
+      <enum>TyphosPositionerWidget::HINTED</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>EPS:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMShellCommand" name="PyDMShellCommand">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+       <property name="PyDMIcon" stdset="0">
+        <string/>
+       </property>
+       <property name="showConfirmDialog" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="runCommandsInFullShell" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="confirmMessage" stdset="0">
+        <string>Are you sure you want to proceed?</string>
+       </property>
+       <property name="environmentVariables" stdset="0">
+        <string/>
+       </property>
+       <property name="showIcon" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="redirectCommandOutput" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="allowMultipleExecutions" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="titles" stdset="0">
+        <stringlist/>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>pydm --hide-nav-bar --hide-menu-bar --hide-status-bar /cds/group/pcds/epics-dev/screens/pydm/eps_screens/${beamline}/${name}.ui</string>
+        </stringlist>
+       </property>
+       <property name="passwordProtected" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="password" stdset="0">
+        <string/>
+       </property>
+       <property name="protectedPassword" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMShellCommand</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.shell_command</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
@@ -128,7 +128,7 @@
         </stringlist>
        </property>
        <property name="openInNewWindow" stdset="0">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="passwordProtected" stdset="0">
         <bool>false</bool>

--- a/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>872</width>
-    <height>177</height>
+    <width>886</width>
+    <height>179</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
@@ -87,28 +87,12 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>EPS:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMShellCommand" name="PyDMShellCommand">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>0</height>
-        </size>
-       </property>
+      <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
        <property name="toolTip">
         <string/>
+       </property>
+       <property name="text">
+        <string>EPS</string>
        </property>
        <property name="alarmSensitiveContent" stdset="0">
         <bool>false</bool>
@@ -125,34 +109,26 @@
        <property name="PyDMIcon" stdset="0">
         <string/>
        </property>
-       <property name="showConfirmDialog" stdset="0">
-        <bool>false</bool>
+       <property name="filenames" stdset="0">
+        <stringlist>
+         <string>/cds/group/pcds/epics-dev/screens/pydm/eps_screens/${beamline}/${name}.ui</string>
+        </stringlist>
        </property>
-       <property name="runCommandsInFullShell" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="confirmMessage" stdset="0">
-        <string>Are you sure you want to proceed?</string>
-       </property>
-       <property name="environmentVariables" stdset="0">
-        <string/>
+       <property name="titles" stdset="0">
+        <stringlist>
+         <string>EPS</string>
+        </stringlist>
        </property>
        <property name="showIcon" stdset="0">
         <bool>true</bool>
        </property>
-       <property name="redirectCommandOutput" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="allowMultipleExecutions" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="titles" stdset="0">
-        <stringlist/>
-       </property>
-       <property name="commands" stdset="0">
+       <property name="macros" stdset="0">
         <stringlist>
-         <string>pydm --hide-nav-bar --hide-menu-bar --hide-status-bar /cds/group/pcds/epics-dev/screens/pydm/eps_screens/${beamline}/${name}.ui</string>
+         <string>{}</string>
         </stringlist>
+       </property>
+       <property name="openInNewWindow" stdset="0">
+        <bool>false</bool>
        </property>
        <property name="passwordProtected" stdset="0">
         <bool>false</bool>
@@ -162,6 +138,9 @@
        </property>
        <property name="protectedPassword" stdset="0">
         <string/>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -184,9 +163,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMShellCommand</class>
+   <class>PyDMRelatedDisplayButton</class>
    <extends>QPushButton</extends>
-   <header>pydm.widgets.shell_command</header>
+   <header>pydm.widgets.related_display_button</header>
   </customwidget>
   <customwidget>
    <class>TyphosPositionerRowWidget</class>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added 'embedded' ui file for motors that have custom eps screens.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding the 'embedded' file allows for typhos screens to open using the compact controls.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
![image](https://github.com/pcdshub/pcdsdevices/assets/55956919/305efcbd-c7ef-4451-9673-0f0f2ff9e18a)

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
