### PR TITLE
Add variable cooling

### DIFF
--- a/docs/source/upcoming_release_notes/1206-var-cool.rst
+++ b/docs/source/upcoming_release_notes/1206-var-cool.rst
@@ -1,0 +1,30 @@
+1206 var-cool
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- `XOffsetMirrorStateCool` and `XOffsetMirrorNoBend` gets `variable_cool` for controlling 24V solenoid valve.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -756,6 +756,8 @@ class XOffsetMirrorNoBend(XOffsetMirror):
     bender = None
     bender_enc_rms = None
 
+    variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
+
 
 class XOffsetMirrorBend(XOffsetMirror):
     """
@@ -1419,9 +1421,11 @@ class XOffsetMirrorStateCool(XOffsetMirrorState):
         Alias for the device.
     """
     # Cooling
-    cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal')
-    cool_flow2 = Cpt(EpicsSignalRO, ':FWM:2_RBV', kind='normal')
-    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal')
+    cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
+    cool_flow2 = Cpt(EpicsSignalRO, ':FWM:2_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
+    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
+
+    variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
 
 
 class MirrorInsertState(TwinCATStatePMPS):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -743,6 +743,8 @@ class XOffsetMirrorNoBend(XOffsetMirror):
 
     2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
 
+    With variable cooling valve installed.
+
     Parameters
     ----------
     prefix : str
@@ -1412,6 +1414,8 @@ class XOffsetMirrorStateCool(XOffsetMirrorState):
 
     With cooling and pressure meters installed.
 
+    With variable cooling valve installed.
+
     Parameters
     ----------
     prefix : str
@@ -1423,7 +1427,7 @@ class XOffsetMirrorStateCool(XOffsetMirrorState):
     # Cooling
     cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
     cool_flow2 = Cpt(EpicsSignalRO, ':FWM:2_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
-    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
+    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc='Mirror cooling panel loop pressure sensor')
 
     variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds variable for activating variable cooling on:
`MR1L0`
`MR2L0`
`MR1L1`
`MR1K4`
`MR1K3`
`MR2K3`

in classes:
`XOffsetMirrorStateCool`
`XOffsetMirrorNoBend`

This currently covers all known mirrors that will receive variable cooling.

Added new test for cooling on offset mirrors: `test_mirror_cooling` in `test_mirror.py`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
24V Solenoid water cooling valves installed on listed mirrors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Currently have tested all valves via the Beckhoff IO.
Pulled up typhos screen for `MR1K4`. Output button appeared as expected. Toggled variable cooling. See screenshot below.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-1410

<!--
## Screenshots (if appropriate):
-->
![output-test](https://github.com/pcdshub/pcdsdevices/assets/79480290/88a320c8-6dfc-4ca3-bf3a-3cc7f1b6ae0f)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
