### PR TITLE
lisK4-ip1 gui

### DIFF
--- a/pcdsdevices/lic_2d_tmo.py
+++ b/pcdsdevices/lic_2d_tmo.py
@@ -1,5 +1,5 @@
 """
-Module for the two dimention laser coupling in TMO.
+Module for the two dimension laser coupling in TMO.
 """
 from lightpath import LightpathState
 from ophyd.device import Component as Cpt
@@ -9,10 +9,10 @@ from .epics_motor import BeckhoffAxisEPS
 from .interface import BaseInterface, LightpathMixin
 
 
-class TMOLaserCouplingTwoDimention(BaseInterface, GroupDevice, LightpathMixin):
+class TMOLaserCouplingTwoDimension(BaseInterface, GroupDevice, LightpathMixin):
     """
 
-    TMO two dimention laser coupling LI2K4 class.
+    TMO two dimension laser coupling LI2K4 class.
 
 
     Parameters:

--- a/pcdsdevices/lic_2d_tmo.py
+++ b/pcdsdevices/lic_2d_tmo.py
@@ -5,20 +5,8 @@ from lightpath import LightpathState
 from ophyd.device import Component as Cpt
 
 from .device import GroupDevice
-from .device import UpdateComponent as UpCpt
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxisEPS
 from .interface import BaseInterface, LightpathMixin
-from .pmps import TwinCATStatePMPS
-
-
-class LaserCouplingTwoD(TwinCATStatePMPS):
-    """
-
-    Two Dimention laser coupling 2D States Setup
-
-    Here, we specify 2 states, which we can support in an EPICS enum and 2 motors for X and Y Axes.
-    """
-    config = UpCpt(state_count=2, motor_count=2)
 
 
 class TMOLaserCouplingTwoDimention(BaseInterface, GroupDevice, LightpathMixin):
@@ -40,9 +28,8 @@ class TMOLaserCouplingTwoDimention(BaseInterface, GroupDevice, LightpathMixin):
     tab_component_names = True
 
     # LaserCoupling LI2K4 x and Y
-    laser_coupling = Cpt(LaserCouplingTwoD, 'LI2K4:IP1', add_prefix=(), kind='normal')
-    li2k4_x = Cpt(BeckhoffAxis, ':MMS:X', doc="X-axis of lasercoupling li2k4", kind='normal')
-    li2k4_y = Cpt(BeckhoffAxis, ':MMS:Y', doc="Y-axis of lasercoupling li2k4", kind='normal')
+    li2k4_x = Cpt(BeckhoffAxisEPS, ':MMS:X', doc="X-axis of lasercoupling li2k4", kind='normal')
+    li2k4_y = Cpt(BeckhoffAxisEPS, ':MMS:Y', doc="Y-axis of lasercoupling li2k4", kind='normal')
     removed = False
     transmission = 1
     SUB_STATE = 'state'

--- a/pcdsdevices/lic_2d_tmo.py
+++ b/pcdsdevices/lic_2d_tmo.py
@@ -1,0 +1,59 @@
+"""
+Module for the two dimention laser coupling in TMO.
+"""
+from lightpath import LightpathState
+from ophyd.device import Component as Cpt
+
+from .device import GroupDevice
+from .device import UpdateComponent as UpCpt
+from .epics_motor import BeckhoffAxis
+from .interface import BaseInterface, LightpathMixin
+from .pmps import TwinCATStatePMPS
+
+
+class LaserCouplingTwoD(TwinCATStatePMPS):
+    """
+
+    Two Dimention laser coupling 2D States Setup
+
+    Here, we specify 2 states, which we can support in an EPICS enum and 2 motors for X and Y Axes.
+    """
+    config = UpCpt(state_count=2, motor_count=2)
+
+
+class TMOLaserCouplingTwoDimention(BaseInterface, GroupDevice, LightpathMixin):
+    """
+
+    TMO two dimention laser coupling LI2K4 class.
+
+
+    Parameters:
+    -----------
+    prefix : str
+        Base PV for the motion system
+
+    name : str
+        Alias for the device
+    """
+    # UI Representation
+    _icon = 'fa.minus-square'
+    tab_component_names = True
+
+    # LaserCoupling LI2K4 x and Y
+    laser_coupling = Cpt(LaserCouplingTwoD, 'LI2K4:IP1', add_prefix=(), kind='normal')
+    li2k4_x = Cpt(BeckhoffAxis, ':MMS:X', doc="X-axis of lasercoupling li2k4", kind='normal')
+    li2k4_y = Cpt(BeckhoffAxis, ':MMS:Y', doc="Y-axis of lasercoupling li2k4", kind='normal')
+    removed = False
+    transmission = 1
+    SUB_STATE = 'state'
+
+    # dummy signal, state is always the same
+    lightpath_cpts = ['li2k4_x.user_readback']
+
+    def calc_lightpath_state(self, **kwargs) -> LightpathState:
+        # TODO: get real logic here, instead of legacy hard-coding
+        return LightpathState(
+            inserted=True,
+            removed=False,
+            output={self.output_branches[0]: 1}
+        )

--- a/pcdsdevices/lic_2d_tmo.py
+++ b/pcdsdevices/lic_2d_tmo.py
@@ -9,7 +9,7 @@ from .epics_motor import BeckhoffAxisEPS
 from .interface import BaseInterface, LightpathMixin
 
 
-class TMOLaserCouplingTwoDimension(BaseInterface, GroupDevice, LightpathMixin):
+class TMOLaserInCouplingTwoDimension(BaseInterface, GroupDevice, LightpathMixin):
     """
 
     TMO two dimension laser coupling LI2K4 class.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Scientists want a screen for LI2K4 to move the motor out from IN position even though the PLC level sequent mover is not done. But PLC and EPS done though. 
<!--- Describe your changes in detail -->
Create LI2K4 state mover GUI
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists insist to have the screen
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
yes, test the screen locally by command:
pcds-5.8.2) [tongju@psbuild-rhel7-01 pcdsdevices]$ typhos 'pcdsdevices.lic_2d_tmo.TMOLaserCouplingTwoDimention[{"prefix":"LI2K4:IP1"}]'
/cds/group/pcds/pyps/conda/py39/envs/pcds-5.8.2/lib/python3.9/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
  warnings.warn(
[2024-03-26 14:40:11] - INFO - Loading 'pcdsdevices.lic_2d_tmo.TMOLaserCouplingTwoDimention[{"prefix":"LI2K4:IP1"}]' ...
[2024-03-26 14:40:12] - INFO - Loading Tools ...
[2024-03-26 14:40:12] - INFO - Adding devices ...
[2024-03-26 14:40:14] - INFO - Launching application ...
[2024-03-26 14:41:04] - INFO - Execution complete!
![Screenshot 2024-03-26 at 2 40 22 PM](https://github.com/pcdshub/pcdsdevices/assets/86085156/cfc53546-da2b-42fe-9bcc-f99bc646a5fd)
But I do not try to move yet. After screen is released, I will try to test with scientists. 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
[
](https://jira.slac.stanford.edu/browse/ECS-4410)
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
