### PR TITLE
SmarAct updates

### DIFF
--- a/docs/source/upcoming_release_notes/1214-SmarAct_Updates.rst
+++ b/docs/source/upcoming_release_notes/1214-SmarAct_Updates.rst
@@ -1,0 +1,40 @@
+1214 SmarAct Updates
+#################
+
+API Breaks
+----------
+- If release < R1.0.20 then the EPICS signals will timeout on the new PVs.
+  Please make sure to update your children IOCs.
+
+Features
+--------
+- Adds the following temperature monitoring PVs:
+  - channel_temp
+  - module_temp
+- Adds the following hidden config PVs to encoded devices:
+  - log_scale_offset
+  - log_scale_inv
+  - def_range_min
+  - def_range_max
+- Adds SmarActEncodedTipTilt device to epics_motor.py
+
+Device Updates
+--------------
+- SmarActOpenLoop gets temp monitoring PVs
+- SmarAct gets temp monitoring PVs
+
+New Devices
+-----------
+- SmarActEncodedTipTilt
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -539,6 +539,8 @@ class SmarActMotor(LCLSItem):
 class SmarActTipTiltMotor(LCLSItem):
     """
     Container for SmarAct tip-tilt motor pairs.
+    Use pcdsdevices.epics_motor.SmarActEncodedTipTilt device_class for
+    encoded tip-tilts.
     """
     device_class = copy(LCLSItem.device_class)
     device_class.default = 'pcdsdevices.epics_motor.SmarActTipTilt'


### PR DESCRIPTION
## Description
Introduced a new device under `pcdsdevices/epics_motor.py` that bundles two stages together for a tip-tilt mirror arrangement: `SmarActEncodedTipTilt`. Just specify this device in your HAPPI entry to use it!

Added the following PVs from `ioc/common/smaract/R1.0.20` and newer to all SmarAct devices:
1. `channel_temp`
2. `module_temp` 

Added the following PVs from `ioc/common/smaract/R1.0.19` to `SmarAct` encoded devices as hidden configs:
1. `log_scale_offset`
2. `log_scale_inv`
3. `def_range_min`
4. `def_range_max`

Note: These PVs will timeout and hang if you have not updated your child IOC to these releases. For best results, use `ioc/common/smaract/R1.0.21` which corrected some off-by-one bugs and missing archiver items.

## Motivation and Context
Trying to bring the screens up to date with the latest IOC releases, as well as creating a tidy, user-friendly bundle for the new inductive encoded tip-tilt mirrors that we have deployed in the MODs and soon elsewhere.

## How Has This Been Tested?
Set-up
```
$ ssh las-console
$ cd <git-clone directory>
$ source pcds_conda
$ export PYTHONPATH=$PWD
$ ipython
```
Run the following script in the interactive session where the latest version of the IOC is running on the controller for this PV:
```
import time
from pcdsdevices.epics_motor import SmarActTipTilt, SmarActEncodedTipTilt

REAL_PV = 'LM1K2:LRL_OIP_MP1_MR1'

def header_text(*,text,symbol='='):
    """
    Just for pretty printing purposes. Centers heading in a text body
    """
    spacer=int((50-len(text))/2)-1
    print('+' + 48*f'{symbol}' + '+' + '\n',
    spacer*' '+text,
    '\n+' + 48*f'{symbol}' + '+' + '\n')

def test_unencoded_TT(pv_base=''):
    test_device = SmarActTipTilt(pv_base,name='TEST',
                                        tip_pv='_TIP1',tilt_pv='_TILT1')
    print('PV Prefix =',test_device.prefix)
    time.sleep(0.5)
    header_text(text='Temperature Monitoring PVs')
    # test the temperature PVs
    for axis in ['tip','tilt']:
        for attr in ['channel_temp','module_temp']:
            print(f'{axis}.{attr}','=',
                  eval(f'test_device.{axis}.{attr}.get()'))

def test_property(pv_base,axis:str,attr:str,
                  test_values:list=[0,1,-1,0]):
    """
    Iteratively set a list of values to the attr to test the
    getting and setting of the device property.
    """
    my_device=SmarActEncodedTipTilt(pv_base,name='TEST',
                                        tip_pv='_TIP1',tilt_pv='_TILT1')
    getter_str = f'my_device.{axis}.{attr}'+'.get()'
    setter_str = f'my_device.{axis}.{attr}.set'
    header_text(text=f'Testing {axis}.{attr}',symbol='-')
    print(f'Initial {axis}.{attr}:',
          eval(getter_str))
    eval(setter_str+'(0)')
    time.sleep(1)
    print(f'Testing the following values: {test_values}...')
    for value in test_values:
        print(f'Setting to {value}:')
        eval(setter_str+f'({value})')
        time.sleep(1)
        print(f'{attr}=',eval(getter_str))
        time.sleep(1)

def test_encoded_TT(pv_base=''):
    test_device = SmarActEncodedTipTilt(pv_base,name='TEST',
                                        tip_pv='_TIP1',tilt_pv='_TILT1')
    # Start by testing the read only PVs
    print('PV Prefix =',eval('test_device.prefix'))
    # test the temperature PVs
    header_text(text='Temperature Monitoring PVs')
    # test the temperature PVs
    for axis in ['tip','tilt']:
        for attr in ['channel_temp','module_temp']:
            print(f'{axis}.{attr}','=',
                  eval(f'test_device.{axis}.{attr}.get()'))
    # test the NVRAM PVs
    header_text(text='NVRAM PVs')
    for axis in test_device.component_names:
       test_property(pv_base,axis,'log_scale_offset',test_values=[0,1,-1,0])
       test_property(pv_base,axis,'log_scale_inv',test_values=[0,1,0])
       test_property(pv_base,axis,'def_range_min',test_values=[0,10,-10,0])
       test_property(pv_base,axis,'def_range_max',test_values=[0,50,-50,0])
       print('\n')
    header_text(text='Test Complete')

header_text(text='SmarActTipTilt',symbol='~')
test_unencoded_TT(REAL_PV)

header_text(text='SmarActEncodedTipTilt',symbol='~')
test_encoded_TT(REAL_PV)
```

If the signals timeout/cannot be reached, then the above should crash, but it doesn't :) See proof in screenshots

## Where Has This Been Documented?
All documentation is included in the source code. (lines 1502-1506)
Also ran `./pre-release-notes.sh 1213` to capture the changes and limitations.

## Screenshots:
![image](https://github.com/pcdshub/pcdsdevices/assets/149725219/e46b40c2-7ca2-47c0-a10c-9302d7f53926)

![image](https://github.com/pcdshub/pcdsdevices/assets/149725219/9f8a0b7e-37a0-4b67-add5-39f8f2510004)

![image](https://github.com/pcdshub/pcdsdevices/assets/149725219/57a7d908-2811-4742-83d4-f680f30332da)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
