### PR TITLE
BUG: Tpr ns_delay throwing error

### DIFF
--- a/docs/source/upcoming_release_notes/1216-Fixing_Tpr_Bug_For_MultiDerivedSignals.rst
+++ b/docs/source/upcoming_release_notes/1216-Fixing_Tpr_Bug_For_MultiDerivedSignals.rst
@@ -22,6 +22,7 @@ Bugfixes
 - Previously, calculate_on_get/put functions used in MultiDerivedSignals in tpr classes were not accessing
   their attrs correctly and would throw KeyErrors when called
 - Specifically, the name of the attr was being used as the key for items dictionary instead of the actual signal object
+- Also added unit tests for these MultiDerivedSignals
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/1216-Fixing_Tpr_Bug_For_MultiDerivedSignals.rst
+++ b/docs/source/upcoming_release_notes/1216-Fixing_Tpr_Bug_For_MultiDerivedSignals.rst
@@ -1,0 +1,32 @@
+1216 Fixing_Tpr_Bug_For_MultiDerivedSignals
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Previously, calculate_on_get/put functions used in MultiDerivedSignals in tpr classes were not accessing
+  their attrs correctly and would throw KeyErrors when called
+- Specifically, the name of the attr was being used as the key for items dictionary instead of the actual signal object
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- KaushikMalapati

--- a/pcdsdevices/tests/test_tpr.py
+++ b/pcdsdevices/tests/test_tpr.py
@@ -26,7 +26,7 @@ def test_disconnected_trigger():
 
 def put_equals_setpoint(mds, setpoint, ns_time):
     mds.put(ns_time)
-    return setpoint.value == ns_time
+    return setpoint.get() == ns_time
 
 
 def mds_get(mds, tick_signal, tap_signal, num_ticks, num_taps):

--- a/pcdsdevices/tests/test_tpr.py
+++ b/pcdsdevices/tests/test_tpr.py
@@ -1,7 +1,7 @@
 import pytest
 from ophyd.sim import make_fake_device
 
-from ..tpr import TimingMode, TprTrigger
+from ..tpr import TPR_TAP_NS, TPR_TICK_NS, TimingMode, TprTrigger
 
 
 @pytest.fixture(scope='function')
@@ -22,3 +22,29 @@ def test_enable(fake_trigger):
 @pytest.mark.timeout(5)
 def test_disconnected_trigger():
     TprTrigger('TST', channel=1, timing_mode=TimingMode.LCLS1, name='test')
+
+
+def put_equals_setpoint(mds, setpoint, ns_time):
+    mds.put(ns_time)
+    return setpoint.value == ns_time
+
+
+def mds_get(mds, tick_signal, tap_signal, num_ticks, num_taps):
+    tick_signal.put(num_ticks)
+    tap_signal.put(num_taps)
+    return mds.get() == (TPR_TICK_NS * num_ticks + TPR_TAP_NS * num_taps)
+
+
+def test_ns_delay(fake_trigger):
+    assert put_equals_setpoint(fake_trigger.ns_delay, fake_trigger.delay_setpoint, 100)
+    assert mds_get(fake_trigger.ns_delay, fake_trigger.delay_ticks, fake_trigger.delay_taps, 0, 7)
+
+
+def test_width(fake_trigger):
+    assert put_equals_setpoint(fake_trigger.width, fake_trigger.width_setpoint, 100)
+    assert fake_trigger.width.get() == fake_trigger.width_ticks.get() * TPR_TICK_NS
+
+
+def test_motor(fake_trigger):
+    assert mds_get(fake_trigger.ns_delay_scan.readback, fake_trigger.ns_delay_scan.delay_ticks,
+                   fake_trigger.ns_delay_scan.delay_taps, 3, 3)

--- a/pcdsdevices/tests/test_tpr.py
+++ b/pcdsdevices/tests/test_tpr.py
@@ -35,6 +35,7 @@ def mds_get(mds, tick_signal, tap_signal, num_ticks, num_taps):
     return mds.get() == (TPR_TICK_NS * num_ticks + TPR_TAP_NS * num_taps)
 
 
+@pytest.mark.timeout(5)
 def test_ns_delay(fake_trigger):
     assert put_equals_setpoint(fake_trigger.ns_delay, fake_trigger.delay_setpoint, 100)
     assert mds_get(fake_trigger.ns_delay, fake_trigger.delay_ticks, fake_trigger.delay_taps, 0, 7)

--- a/pcdsdevices/tests/test_tpr.py
+++ b/pcdsdevices/tests/test_tpr.py
@@ -26,6 +26,8 @@ def test_disconnected_trigger():
 
 def put_equals_setpoint(mds, setpoint, ns_time):
     mds.put(ns_time)
+    print("ns_time is", ns_time)
+    print("setpoint is", setpoint.get())
     return setpoint.get() == ns_time
 
 
@@ -36,12 +38,12 @@ def mds_get(mds, tick_signal, tap_signal, num_ticks, num_taps):
 
 
 def test_ns_delay(fake_trigger):
-    assert put_equals_setpoint(fake_trigger.ns_delay, fake_trigger.delay_setpoint, 100)
+    assert put_equals_setpoint(fake_trigger.ns_delay, fake_trigger.delay_setpoint, 538.4)
     assert mds_get(fake_trigger.ns_delay, fake_trigger.delay_ticks, fake_trigger.delay_taps, 0, 7)
 
 
 def test_width(fake_trigger):
-    assert put_equals_setpoint(fake_trigger.width, fake_trigger.width_setpoint, 100)
+    assert put_equals_setpoint(fake_trigger.width, fake_trigger.width_setpoint, 53.84)
     assert fake_trigger.width.get() == fake_trigger.width_ticks.get() * TPR_TICK_NS
 
 

--- a/pcdsdevices/tests/test_tpr.py
+++ b/pcdsdevices/tests/test_tpr.py
@@ -26,8 +26,6 @@ def test_disconnected_trigger():
 
 def put_equals_setpoint(mds, setpoint, ns_time):
     mds.put(ns_time)
-    print("ns_time is", ns_time)
-    print("setpoint is", setpoint.get())
     return setpoint.get() == ns_time
 
 
@@ -38,12 +36,12 @@ def mds_get(mds, tick_signal, tap_signal, num_ticks, num_taps):
 
 
 def test_ns_delay(fake_trigger):
-    assert put_equals_setpoint(fake_trigger.ns_delay, fake_trigger.delay_setpoint, 538.4)
+    assert put_equals_setpoint(fake_trigger.ns_delay, fake_trigger.delay_setpoint, 100)
     assert mds_get(fake_trigger.ns_delay, fake_trigger.delay_ticks, fake_trigger.delay_taps, 0, 7)
 
 
 def test_width(fake_trigger):
-    assert put_equals_setpoint(fake_trigger.width, fake_trigger.width_setpoint, 53.84)
+    assert put_equals_setpoint(fake_trigger.width, fake_trigger.width_setpoint, 100)
     assert fake_trigger.width.get() == fake_trigger.width_ticks.get() * TPR_TICK_NS
 
 

--- a/pcdsdevices/tests/test_tpr.py
+++ b/pcdsdevices/tests/test_tpr.py
@@ -25,7 +25,8 @@ def test_disconnected_trigger():
 
 
 def put_equals_setpoint(mds, setpoint, ns_time):
-    mds.put(ns_time)
+    status = mds.put(ns_time)
+    status.wait()
     return setpoint.get() == ns_time
 
 
@@ -41,6 +42,7 @@ def test_ns_delay(fake_trigger):
     assert mds_get(fake_trigger.ns_delay, fake_trigger.delay_ticks, fake_trigger.delay_taps, 0, 7)
 
 
+@pytest.mark.timeout(5)
 def test_width(fake_trigger):
     assert put_equals_setpoint(fake_trigger.width, fake_trigger.width_setpoint, 100)
     assert fake_trigger.width.get() == fake_trigger.width_ticks.get() * TPR_TICK_NS

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -21,17 +21,17 @@ class TimingMode(Enum):
 
 def _get_delay(mds: MultiDerivedSignal, items: SignalToValue) -> float:
     """Calculates delay in ns from ticks and taps"""
-    return items[mds.attrs[0]] * TPR_TICK_NS + items[mds.attrs[1] * TPR_TAP_NS]
+    return items[mds.signals[0]] * TPR_TICK_NS + items[mds.signals[1]] * TPR_TAP_NS
 
 
 def _get_width(mds: MultiDerivedSignal, items: SignalToValue) -> float:
     """Calculates width in ns from ticks"""
-    return items[mds.attrs[0]] * TPR_TICK_NS
+    return items[mds.signals[0]] * TPR_TICK_NS
 
 
 def _put_last(mds: MultiDerivedSignal, value: float) -> SignalToValue:
     """Only writes value to last attr"""
-    return {mds.attrs[-1]: value}
+    return {mds.signals[-1]: value}
 
 
 class TprMotor(PVPositionerIsClose):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changed _get_delay, _get_width, and _put_last in tpr.py to signals elements instead of attrs elements as keys for items, since it maps from signal objects to values, not the names of signals

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5093

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively, I made a tpr object and manually called the calculate_on_get/put functions for delay and width to make sure they gave the right values and didn't throw errors

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes made

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
