### PR TITLE
BUG: Prevent lightpath logic from over-scheduling threads

### DIFF
--- a/docs/source/upcoming_release_notes/1219-bug_lp_thread_overschedule.rst
+++ b/docs/source/upcoming_release_notes/1219-bug_lp_thread_overschedule.rst
@@ -22,7 +22,7 @@ Bugfixes
 - Prevent some devices from creating threads at high frequency when
   trying to get the lightpath state.  These devices classes include
   `XOffsetMirrorXYState`, `AttenuatorSXR_Ladder`,
-  `AttenuatorSXR_LadderTwoBladeLBD``, `AT2L0`, `XCSLODCM`, and `XPPLODCM`
+  `AttenuatorSXR_LadderTwoBladeLBD`, `AT2L0`, `XCSLODCM`, and `XPPLODCM`
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/1219-bug_lp_thread_overschedule.rst
+++ b/docs/source/upcoming_release_notes/1219-bug_lp_thread_overschedule.rst
@@ -1,0 +1,31 @@
+1219 bug_lp_thread_overschedule
+###############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Prevent ``XOffsetMirrorXYState`` from creating threads at high frequency when
+  trying to get the lightpath state.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/1219-bug_lp_thread_overschedule.rst
+++ b/docs/source/upcoming_release_notes/1219-bug_lp_thread_overschedule.rst
@@ -19,8 +19,10 @@ New Devices
 
 Bugfixes
 --------
-- Prevent ``XOffsetMirrorXYState`` from creating threads at high frequency when
-  trying to get the lightpath state.
+- Prevent some devices from creating threads at high frequency when
+  trying to get the lightpath state.  These devices classes include
+  `XOffsetMirrorXYState`, `AttenuatorSXR_Ladder`,
+  `AttenuatorSXR_LadderTwoBladeLBD``, `AT2L0`, `XCSLODCM`, and `XPPLODCM`
 
 Maintenance
 -----------

--- a/pcdsdevices/attenuator.py
+++ b/pcdsdevices/attenuator.py
@@ -1078,14 +1078,18 @@ class AttenuatorSXR_Ladder(FltMvInterface, PVPositionerPC,
             obj = getattr(self, sig_name).state
             if not obj._state_initialized:
                 # This would prevent make check_inserted, etc. fail
-                utils.schedule_task(self._calc_cache_lightpath_state,
-                                    delay=2.0)
+                if self._retry_lightpath:
+                    self._retry_lightpath = False
+                    utils.schedule_task(self._calc_cache_lightpath_state,
+                                        delay=2.0)
 
                 return LightpathState(
                     inserted=True,
                     removed=True,
                     output={self.output_branches[0]: 1}
                 )
+
+            self._retry_lightpath = True
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
             out_check.append(obj.check_removed(sig_value))
@@ -1245,14 +1249,18 @@ class AttenuatorSXR_LadderTwoBladeLBD(FltMvInterface, PVPositionerPC,
             obj = getattr(self, sig_name).state
             if not obj._state_initialized:
                 # This would prevent make check_inserted, etc. fail
-                utils.schedule_task(self._calc_cache_lightpath_state,
-                                    delay=2.0)
+                if self._retry_lightpath:
+                    self._retry_lightpath = False
+                    utils.schedule_task(self._calc_cache_lightpath_state,
+                                        delay=2.0)
 
                 return LightpathState(
                     inserted=True,
                     removed=True,
                     output={self.output_branches[0]: 1}
                 )
+
+            self._retry_lightpath = True
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
             out_check.append(obj.check_removed(sig_value))
@@ -1593,14 +1601,18 @@ class AT2L0(FltMvInterface, PVPositionerPC, LightpathMixin):
             obj = getattr(self, sig_name).state
             if not obj._state_initialized:
                 # This would prevent make check_inserted, etc. fail
-                utils.schedule_task(self._calc_cache_lightpath_state,
-                                    delay=2.0)
+                if self._retry_lightpath:
+                    self._retry_lightpath = False
+                    utils.schedule_task(self._calc_cache_lightpath_state,
+                                        delay=2.0)
 
                 return LightpathState(
                     inserted=True,
                     removed=True,
                     output={self.output_branches[0]: 1}
                 )
+
+            self._retry_lightpath = True
             # get state of the InOutPositioner and check status
             in_check.append(obj.check_inserted(sig_value))
             out_check.append(obj.check_removed(sig_value))

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -2110,12 +2110,17 @@ class XCSLODCM(LODCM):
         if not self.tower1.h1n_state._state_initialized:
             self.log.debug('tower1 state not initialized, scheduling '
                            'lightpath calc for later')
-            schedule_task(self._calc_cache_lightpath_state, delay=2.0)
+            if self._retry_lightpath:
+                self._retry_lightpath = False
+                schedule_task(self._calc_cache_lightpath_state, delay=2.0)
+
             return LightpathState(
                 inserted=True,
                 removed=True,
                 output={'L0': 0}
             )
+
+        self._retry_lightpath = True
         # avoid extra get calls in this method
         state_label = self.tower1.h1n_state.get_state(h1n_state).name
 
@@ -2177,13 +2182,16 @@ class XPPLODCM(LODCM):
         if not self.tower1.h1n_state._state_initialized:
             self.log.debug('tower1 state not initialized, scheduling '
                            'lightpath calc for later')
-            schedule_task(self._calc_cache_lightpath_state, delay=2.0)
+            if self._retry_lightpath:
+                self._retry_lightpath = False
+                schedule_task(self._calc_cache_lightpath_state, delay=2.0)
             return LightpathState(
                 inserted=True,
                 removed=True,
                 output={'L0': 0}
             )
 
+        self._retry_lightpath = True
         inserted = self.tower1.h1n_state.check_inserted(h1n_state)
         removed = self.tower1.h1n_state.check_removed(h1n_state)
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1463,7 +1463,6 @@ class XOffsetMirrorXYState(XOffsetMirrorState):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._retry_lightpath = True
 
     def _get_insertion_state(
         self,
@@ -1494,17 +1493,13 @@ class XOffsetMirrorXYState(XOffsetMirrorState):
             if self._retry_lightpath:
                 self._retry_lightpath = False
                 schedule_task(self._calc_cache_lightpath_state, delay=2.0)
-                schedule_task(self.reset_retry, delay=10.0)
             return True, True
 
+        self._retry_lightpath = True
         x_in = self.insertion.check_inserted(insertion_state)
         x_out = self.insertion.check_removed(insertion_state)
 
         return x_out, x_in
-
-    # Only queue up lightpath calcs once
-    def reset_retry(self):
-        self._retry_lightpath = True
 
     def calc_lightpath_state(
         self,

--- a/pcdsdevices/tests/test_mirror.py
+++ b/pcdsdevices/tests/test_mirror.py
@@ -198,23 +198,21 @@ def test_xy_mirror_lightpath(fake_xy_offset_mirror, monkeypatch):
     xym = fake_xy_offset_mirror
     mock_schedule = Mock()
     monkeypatch.setattr(mirror, 'schedule_task', mock_schedule)
-    mock_retry = Mock()
-    monkeypatch.setattr(xym, 'reset_retry', mock_retry)
 
     assert xym._retry_lightpath is True
     xym.insertion._state_initialized = False
     # try getting lightpath state once, which should fail and schedule
     xym.get_lightpath_state(use_cache=False)
-    assert mock_schedule.call_count == 2
+    assert mock_schedule.call_count == 1
     assert xym._retry_lightpath is False
 
     # subsequent calls to get_lightpath_state should not schedule
     xym.get_lightpath_state(use_cache=False)
-    assert mock_schedule.call_count == 2
+    assert mock_schedule.call_count == 1
     assert xym._retry_lightpath is False
 
     xym._retry_lightpath = True
     # After reset has completed, can retry
     xym.get_lightpath_state(use_cache=False)
-    assert mock_schedule.call_count == 4
+    assert mock_schedule.call_count == 2
     assert xym._retry_lightpath is False

--- a/pcdsdevices/tests/test_mirror.py
+++ b/pcdsdevices/tests/test_mirror.py
@@ -4,8 +4,10 @@ from unittest.mock import Mock
 import pytest
 from ophyd.sim import ReadOnlyError, make_fake_device
 
+from pcdsdevices import mirror
+
 from ..mirror import (KBOMirror, OffsetMirror, PointingMirror,
-                      XOffsetMirrorStateCool)
+                      XOffsetMirrorStateCool, XOffsetMirrorXYState)
 
 
 @pytest.fixture(scope='function')
@@ -145,6 +147,17 @@ def fake_offset_cooled_mirror():
     return FakeCooledOffsetMirror('TST:MR1', name="Test Mirror")
 
 
+@pytest.fixture(scope='function')
+def fake_xy_offset_mirror():
+    FakeCooledOffsetMirror = make_fake_device(XOffsetMirrorXYState)
+    fake_mirror = FakeCooledOffsetMirror('TST:MR1', name="Test Mirror")
+    # do lightpath setup
+    fake_mirror._init_summary_signal()
+    fake_mirror.output_branches = ['L0', 'L1']
+    fake_mirror.input_branches = ['L0']
+    return fake_mirror
+
+
 def test_kbomirror_lighpath(fake_kbo_mirror):
     km = fake_kbo_mirror
     lp_state = km.get_lightpath_state()
@@ -179,3 +192,29 @@ def test_mirror_cooling(fake_offset_cooled_mirror):
 
     with pytest.raises(ReadOnlyError):
         om.cool_press.put(0.34)
+
+
+def test_xy_mirror_lightpath(fake_xy_offset_mirror, monkeypatch):
+    xym = fake_xy_offset_mirror
+    mock_schedule = Mock()
+    monkeypatch.setattr(mirror, 'schedule_task', mock_schedule)
+    mock_retry = Mock()
+    monkeypatch.setattr(xym, 'reset_retry', mock_retry)
+
+    assert xym._retry_lightpath is True
+    xym.insertion._state_initialized = False
+    # try getting lightpath state once, which should fail and schedule
+    xym.get_lightpath_state(use_cache=False)
+    assert mock_schedule.call_count == 2
+    assert xym._retry_lightpath is False
+
+    # subsequent calls to get_lightpath_state should not schedule
+    xym.get_lightpath_state(use_cache=False)
+    assert mock_schedule.call_count == 2
+    assert xym._retry_lightpath is False
+
+    xym._retry_lightpath = True
+    # After reset has completed, can retry
+    xym.get_lightpath_state(use_cache=False)
+    assert mock_schedule.call_count == 4
+    assert xym._retry_lightpath is False


### PR DESCRIPTION
## Description
Summary: In the case where the mirror is not initialized, prevent pcdsdevices from scheduling a task every time lightpath_summary is updated.  

## Motivation and Context
https://jira.slac.stanford.edu/browse/ECS-5186

In some more detail: 
We encountered a case where `XOffsetMirrorXYState` would never initialize, so every call to `._get_insertion_state()` would try to schedule a retry thread.  This helper method gets called whenever `lightpath_summary` updates, so for a quickly changing set of `lightpath_cpts`, this would create threads until we hit the limit.  This isn't a problem if the IOC is properly responding, but we can make failure here less catastrophic

`LightpathMixin._retry_lightpath` seems to be a vestigial attribute I reclaimed for this PR.  It was used in the legacy lightpath behavior, for a similar purpose.

## How Has This Been Tested?
Added a test.  Live testing would require us to modify the device to never initialize its state and log thread creation events.  (assuming that disabling the IOC is out of the question)

## Where Has This Been Documented?
This PR, and the jira ticket

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
