### PR TITLE
TXI Mirror Cooling, SP1K1 Mono RTDs

### DIFF
--- a/docs/source/upcoming_release_notes/1221-rtds_and_cooling_readouts.rst
+++ b/docs/source/upcoming_release_notes/1221-rtds_and_cooling_readouts.rst
@@ -1,0 +1,31 @@
+1221 rtds and cooling readouts
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- `XOffsetMirrorNoBend` in mirror.py gets 3 new cooling readout components.
+- `Mono` in spectrometer.py gets 4 new RTD components and re-named RTDs 1-8.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/docs/source/upcoming_release_notes/1221-rtds_and_cooling_readouts.rst
+++ b/docs/source/upcoming_release_notes/1221-rtds_and_cooling_readouts.rst
@@ -12,7 +12,7 @@ Features
 Device Updates
 --------------
 - `XOffsetMirrorNoBend` in mirror.py gets 3 new cooling readout components.
-- `Mono` in spectrometer.py gets 4 new RTD components and re-named RTDs 1-8.
+- `Mono` in spectrometer.py gets 4 new RTD components and re-named RTDs 1-8. Also, Made cooling component names consistent with mirror cooling component names.
 
 New Devices
 -----------

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -752,7 +752,7 @@ class XOffsetMirrorNoBend(XOffsetMirror):
 
     name : str
 
-    Currently (10/11/2023) services: mr1l1, mr1k3, mr2k3
+    Currently (5/15/2024) services: mr1l1, mr1k3, mr2k3
 
     """
     bender = None

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -752,11 +752,15 @@ class XOffsetMirrorNoBend(XOffsetMirror):
 
     name : str
 
-    Currently (10/11/2023) services: mr1l1
+    Currently (10/11/2023) services: mr1l1, mr1k3, mr2k3
 
     """
     bender = None
     bender_enc_rms = None
+
+    cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
+    cool_flow2 = Cpt(EpicsSignalRO, ':FWM:2_RBV', kind='normal', doc='Mirror cooling panel loop flow sensor')
+    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc='Mirror cooling panel loop pressure sensor')
 
     variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
 

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -275,22 +275,30 @@ class Mono(BaseInterface, GroupDevice, LightpathMixin):
                  doc='pressure meter 1')
 
     # RTDs
-    rtd_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
-                doc='RTD 1 [deg C]')
-    rtd_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='normal',
-                doc='RTD 2 [deg C]')
-    rtd_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='normal',
-                doc='RTD 3 [deg C]')
-    rtd_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='normal',
-                doc='RTD 4 [deg C]')
-    rtd_5 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='normal',
-                doc='RTD 5 [deg C]')
-    rtd_6 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='normal',
-                doc='RTD 6 [deg C]')
-    rtd_7 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='normal',
-                doc='RTD 7 [deg C]')
-    rtd_8 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='normal',
-                doc='RTD 8 [deg C]')
+    rtd_grating_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
+                        doc='[deg C]')
+    rtd_grating_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='normal',
+                        doc='[deg C]')
+    rtd_grating_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='normal',
+                        doc='[deg C]')
+    rtd_grating_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='normal',
+                        doc='[deg C]')
+    rtd_grating_mask_1 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='normal',
+                             doc='[deg C]')
+    rtd_grating_mask_2 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='normal',
+                             doc='[deg C]')
+    rtd_grating_mask_3 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='normal',
+                             doc='[deg C]')
+    rtd_grating_mask_4 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='normal',
+                             doc='[deg C]')
+    rtd_mirror_mask = Cpt(PytmcSignal, ':RTD:09:TEMP', io='i', kind='normal',
+                          doc='[deg C]')
+    rtd_mirror_cooling = Cpt(PytmcSignal, ':RTD:11:TEMP', io='i', kind='normal',
+                             doc='[deg C]')
+    rtd_exit_mask_r = Cpt(PytmcSignal, ':RTD:10:TEMP', io='i', kind='normal',
+                          doc='mask right [deg C]')
+    rtd_exit_mask_l = Cpt(PytmcSignal, ':RTD:12:TEMP', io='i', kind='normal',
+                          doc='mask left [deg C]')
 
     # Lightpath constants
     inserted = True

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -275,30 +275,30 @@ class Mono(BaseInterface, GroupDevice, LightpathMixin):
                      doc='pressure meter 1')
 
     # RTDs
-    rtd_grating_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
-                        doc='[deg C]')
-    rtd_grating_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='normal',
-                        doc='[deg C]')
-    rtd_grating_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='normal',
-                        doc='[deg C]')
-    rtd_grating_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='normal',
-                        doc='[deg C]')
-    rtd_grating_mask_1 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='normal',
-                             doc='[deg C]')
-    rtd_grating_mask_2 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='normal',
-                             doc='[deg C]')
-    rtd_grating_mask_3 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='normal',
-                             doc='[deg C]')
-    rtd_grating_mask_4 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='normal',
-                             doc='[deg C]')
-    rtd_mirror_mask = Cpt(PytmcSignal, ':RTD:09:TEMP', io='i', kind='normal',
-                          doc='[deg C]')
-    rtd_mirror_cooling = Cpt(PytmcSignal, ':RTD:11:TEMP', io='i', kind='normal',
-                             doc='[deg C]')
-    rtd_exit_mask_r = Cpt(PytmcSignal, ':RTD:10:TEMP', io='i', kind='normal',
-                          doc='mask right [deg C]')
-    rtd_exit_mask_l = Cpt(PytmcSignal, ':RTD:12:TEMP', io='i', kind='normal',
-                          doc='mask left [deg C]')
+    grating_temp_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',
+                         doc='[deg C]')
+    grating_temp_2 = Cpt(PytmcSignal, ':RTD:02:TEMP', io='i', kind='normal',
+                         doc='[deg C]')
+    grating_temp_3 = Cpt(PytmcSignal, ':RTD:03:TEMP', io='i', kind='normal',
+                         doc='[deg C]')
+    grating_temp_4 = Cpt(PytmcSignal, ':RTD:04:TEMP', io='i', kind='normal',
+                         doc='[deg C]')
+    grating_mask_temp_1 = Cpt(PytmcSignal, ':RTD:05:TEMP', io='i', kind='normal',
+                              doc='[deg C]')
+    grating_mask_temp_2 = Cpt(PytmcSignal, ':RTD:06:TEMP', io='i', kind='normal',
+                              doc='[deg C]')
+    grating_mask_temp_3 = Cpt(PytmcSignal, ':RTD:07:TEMP', io='i', kind='normal',
+                              doc='[deg C]')
+    grating_mask_temp_4 = Cpt(PytmcSignal, ':RTD:08:TEMP', io='i', kind='normal',
+                              doc='[deg C]')
+    mirror_mask_temp = Cpt(PytmcSignal, ':RTD:09:TEMP', io='i', kind='normal',
+                           doc='[deg C]')
+    mirror_cooling_temp = Cpt(PytmcSignal, ':RTD:11:TEMP', io='i', kind='normal',
+                              doc='[deg C]')
+    exit_mask_right_temp = Cpt(PytmcSignal, ':RTD:10:TEMP', io='i', kind='normal',
+                               doc='[deg C]')
+    exit_mask_left_temp = Cpt(PytmcSignal, ':RTD:12:TEMP', io='i', kind='normal',
+                              doc='[deg C]')
 
     # Lightpath constants
     inserted = True

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -267,12 +267,12 @@ class Mono(BaseInterface, GroupDevice, LightpathMixin):
                       doc='LED power supply controls.')
 
     # Flow meters
-    flow_1 = Cpt(PytmcSignal, ':FWM:1', io='i', kind='normal',
-                 doc='flow meter 1')
-    flow_2 = Cpt(PytmcSignal, ':FWM:2', io='i', kind='normal',
-                 doc='flow meter 2')
-    pres_1 = Cpt(PytmcSignal, ':PRSM:1', io='i', kind='normal',
-                 doc='pressure meter 1')
+    cool_flow1 = Cpt(PytmcSignal, ':FWM:1', io='i', kind='normal',
+                     doc='flow meter 1')
+    cool_flow2 = Cpt(PytmcSignal, ':FWM:2', io='i', kind='normal',
+                     doc='flow meter 2')
+    cool_press = Cpt(PytmcSignal, ':PRSM:1', io='i', kind='normal',
+                     doc='pressure meter 1')
 
     # RTDs
     rtd_grating_1 = Cpt(PytmcSignal, ':RTD:01:TEMP', io='i', kind='normal',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- `XOffsetMirrorNoBend` in mirror.py gets 3 new cooling readout components.
- `Mono` in spectrometer.py gets 4 new RTD components and re-named RTDs 1-8. Make cooling component names consistent with mirror cooling component names.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Wired up cooling panel sensors.
- Found new information about the RTD positions on SP1K1 MONO.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran typhos screens locally.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-4588
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
