### PR TITLE
CI: unpin numpy in CI

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -18,7 +18,7 @@ jobs:
       # Extras that will be installed for both conda/pip:
       testing-extras: ""
       # Extras to be installed only for conda-based testing:
-      conda-testing-extras: "numpy=1.23"
+      conda-testing-extras: ""
       # Extras to be installed only for pip-based testing:
       pip-testing-extras: "PyQt5"
       # Set if using setuptools-scm for the conda-build workflow

--- a/docs/source/upcoming_release_notes/1223-bld_unpin_numpy.rst
+++ b/docs/source/upcoming_release_notes/1223-bld_unpin_numpy.rst
@@ -1,0 +1,30 @@
+1223 bld_unpin_numpy
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Unpins numpy in CI, build incompatibility has been fixed upstream
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Unpins numpy in CI

## Motivation and Context
Numpy was previously pinned due to a numba build not yet existing.  This was pinned in https://github.com/pcdshub/pcdsdevices/pull/1100

## How Has This Been Tested?
through CI in theory

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
