### PR TITLE
BUG: fully fill formatted kwargs in TprTrigger.ns_delay_scan

### DIFF
--- a/docs/source/upcoming_release_notes/1226-bug_tprtrigger_fcpt.rst
+++ b/docs/source/upcoming_release_notes/1226-bug_tprtrigger_fcpt.rst
@@ -1,0 +1,30 @@
+1226 bug_tprtrigger_fcpt
+########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Properly fill the `sys` keyword argument in ``TprTrigger.ns_delay_scan``
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -81,7 +81,9 @@ class TprTrigger(BaseInterface, Device):
         calculate_on_put=_put_last,
         doc="Get/set trigger delay in ns",
     )
-    ns_delay_scan = FCpt(TprMotor, '{self.prefix}{self.trg}', sys='{self.sys}', kind="omitted", doc="Motor-like tpr interface")
+    ns_delay_scan = FCpt(TprMotor, '{self.prefix}{self.trg}', sys='{sys}',
+                         add_prefix=('suffix', 'write_pv', 'sys'),
+                         kind="omitted", doc="Motor-like tpr interface")
     polarity = FCpt(EpicsSignal, '{self.prefix}{self.trg}TPOL', kind="config", doc="Trigger description")
     width_setpoint = FCpt(EpicsSignal, '{self.prefix}{self.trg}{self.sys}TWID', kind="omitted", doc="Trigger width in ns")
     width_ticks = FCpt(EpicsSignalRO, '{self.prefix}{self.trg}TWIDTICKS', kind="omitted", doc="Trigger width in clock ticks")


### PR DESCRIPTION
## Description
Fills the requested kwarg in a FormattedComponent of `TprTrigger`

## Motivation and Context
Closes #1225

## How Has This Been Tested?
Interactively

```python
In [1]: from pcdsdevices.tpr import TprTrigger, TimingMode

In [2]: trig0 = TprTrigger('LAS:LHN:TPR:02', name='trig0', channel=00, timing_mode=TimingMode.LCLS2)

In [3]: trig0.connected
Out[3]: True
```

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
