### PR TITLE
FIX: IMS class set_current_position limits issue

### DIFF
--- a/docs/source/upcoming_release_notes/1228-fix_ims_set_current_position.rst
+++ b/docs/source/upcoming_release_notes/1228-fix_ims_set_current_position.rst
@@ -1,0 +1,33 @@
+1228 fix_ims_set_current_position
+#################################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue with classes like `IMS` and `Newport` where calling
+  ``set_current_position`` on a position outside of the user limits
+  would fail, rather than change the limits to support the new
+  offsets.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In the `IMS` class and in similar motor classes, `set_current_position` had a bug where it would refuse to let you set a position that is outside of the limits span.
See https://jira.slac.stanford.edu/browse/ECS-5354
This has been fixed by replacing the deprecated `set_and_wait` call (which threw a warning) with a `put(x, force=True)`, which ignores the limit. This is followed by a manual confirmation because `put` doesn't return a status object and the waiting doesn't work anyway for these specific devices (hence the special function override). I would have preferred to do something like `set(x, force=True).wait(timeout=1)` but `set` doesn't currently support the `force` kwarg. I think this is also a bug, but one I'm less motivated to look into.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5354

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in XPP
I'll think at least for a moment if there's a reasonable unit test to add but there might not be

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here, jira, + later release notes
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
