### PR TITLE
TST: backcompat new py3.12 entrypoint types

### DIFF
--- a/docs/source/upcoming_release_notes/1230-tst_entrypoint_312.rst
+++ b/docs/source/upcoming_release_notes/1230-tst_entrypoint_312.rst
@@ -1,0 +1,30 @@
+1230 tst_entrypoint_312
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Modifies entrypoint tests to be forward-compatible with py3.12 entrypoint API
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/tests/test_entrypoints.py
+++ b/pcdsdevices/tests/test_entrypoints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import pathlib
+import sys
 
 import pytest
 import typhos
@@ -11,6 +12,10 @@ from .. import ui
 
 @pytest.fixture(scope="session")
 def entry_points() -> dict[str, importlib.metadata.EntryPoints]:
+    if sys.version_info[1] >= 12:
+        # re-organize entrypoints to match old
+        eps = importlib.metadata.entry_points()
+        return {group_name: eps.select(group=group_name) for group_name in eps.groups}
     return importlib.metadata.entry_points()
 
 


### PR DESCRIPTION
## Description
closes #1229 

## Motivation and Context
Entry point functional API changed back in 3.10, but the default used changed in 3.12.  Adjusts our tests to account for this.
 
## How Has This Been Tested?
CI

## Where Has This Been Documented?
#1229 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
