### PR TITLE
Update width and delay setpoints to "config".

### DIFF
--- a/docs/source/upcoming_release_notes/1232-Set_delay_setpoint_and_width_setpoint_as_TprTrigger_configuration_attrs.rst
+++ b/docs/source/upcoming_release_notes/1232-Set_delay_setpoint_and_width_setpoint_as_TprTrigger_configuration_attrs.rst
@@ -1,0 +1,30 @@
+1232 Set delay_setpoint and width_setpoint as TprTrigger configuration_attrs
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- TprTrigger: change delay_setpoint and width_setpoint to kind=config
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -73,7 +73,7 @@ class TprTrigger(BaseInterface, Device):
     label = FCpt(EpicsSignal, '{self.prefix}{self.ch}{self.sys}TCTL.DESC', kind="normal", doc="Channel description")
     delay_ticks = FCpt(EpicsSignal, '{self.prefix}{self.trg}TDESTICKS', kind="omitted", doc="Trigger delay in clock ticks")
     delay_taps = FCpt(EpicsSignal, '{self.prefix}{self.trg}TDESTAPS', kind="omitted", doc="Trigger delay in delay taps")
-    delay_setpoint = FCpt(EpicsSignal, '{self.prefix}{self.trg}{self.sys}TDES', kind="omitted", doc="Trigger delay setpoint in nsec")
+    delay_setpoint = FCpt(EpicsSignal, '{self.prefix}{self.trg}{self.sys}TDES', kind="config", doc="Trigger delay setpoint in nsec")
     ns_delay = Cpt(
         MultiDerivedSignal,
         attrs=['delay_ticks', 'delay_taps', 'delay_setpoint'],
@@ -85,7 +85,7 @@ class TprTrigger(BaseInterface, Device):
                          add_prefix=('suffix', 'write_pv', 'sys'),
                          kind="omitted", doc="Motor-like tpr interface")
     polarity = FCpt(EpicsSignal, '{self.prefix}{self.trg}TPOL', kind="config", doc="Trigger description")
-    width_setpoint = FCpt(EpicsSignal, '{self.prefix}{self.trg}{self.sys}TWID', kind="omitted", doc="Trigger width in ns")
+    width_setpoint = FCpt(EpicsSignal, '{self.prefix}{self.trg}{self.sys}TWID', kind="config", doc="Trigger width in ns")
     width_ticks = FCpt(EpicsSignalRO, '{self.prefix}{self.trg}TWIDTICKS', kind="omitted", doc="Trigger width in clock ticks")
     width = Cpt(
         MultiDerivedSignal,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Change TprTrigger `width_setpoint` and `delay_setpoint` to configuration attributes. 

## Motivation and Context
Closes #1232 
Threw in `delay_setpoint` for good measure. 

## How Has This Been Tested?
Tested interactively on a channel in the laser hall. 

![image](https://github.com/pcdshub/pcdsdevices/assets/29102919/869a02ac-3749-477d-9cbb-0d446e958cba)

## Where Has This Been Documented?
This PR.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
