### PR TITLE
Add VBAS and VMAX signals to PCDSMotorBase

### DIFF
--- a/docs/source/upcoming_release_notes/1224-Move_VBAS_and_VMAX_into_PCDSMotorBase,_change_SmarAct_parent_class.rst
+++ b/docs/source/upcoming_release_notes/1224-Move_VBAS_and_VMAX_into_PCDSMotorBase,_change_SmarAct_parent_class.rst
@@ -11,8 +11,7 @@ Features
 
 Device Updates
 --------------
-- SmarAct: Change base class to PCDSMotorBase
-- IMS: Move VBAS and VMAX signals into PCDSMotorBase parent class
+- IMS: Move VBAS and VMAX signals into EpicsMotorInterface parent class
 - EpicsMotorInterface: Update tab_whitelist for VBAS and VMAX signals
 
 New Devices

--- a/docs/source/upcoming_release_notes/1224-Move_VBAS_and_VMAX_into_PCDSMotorBase,_change_SmarAct_parent_class.rst
+++ b/docs/source/upcoming_release_notes/1224-Move_VBAS_and_VMAX_into_PCDSMotorBase,_change_SmarAct_parent_class.rst
@@ -1,0 +1,32 @@
+1224 Move VBAS and VMAX into PCDSMotorBase, change SmarAct parent class
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- SmarAct: Change base class to PCDSMotorBase
+- IMS: Move VBAS and VMAX signals into PCDSMotorBase parent class
+- EpicsMotorInterface: Update tab_whitelist for VBAS and VMAX signals
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -108,6 +108,9 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     EpicsMotor.low_limit_travel.kind = Kind.config
     EpicsMotor.direction_of_travel.kind = Kind.normal
 
+    velocity_base = Cpt(EpicsSignal, '.VBAS', kind='omitted')
+    velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
+
     _alarm_filter_installed: ClassVar[bool] = False
     _moved_in_session: bool
     _egu: str
@@ -503,8 +506,6 @@ class PCDSMotorBase(EpicsMotorInterface):
     motor_spg = Cpt(EpicsSignal, '.SPG', kind='omitted')
 
     velocity = Cpt(EpicsSignal, '.VELO', kind='config')
-    velocity_base = Cpt(EpicsSignal, '.VBAS', kind='omitted')
-    velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1473,7 +1474,7 @@ class SmarActOpenLoopPositioner(PVPositionerComparator):
         return setpoint-self.atol < readback < setpoint+self.atol
 
 
-class SmarAct(PCDSMotorBase):
+class SmarAct(EpicsMotorInterface):
     """
     Class for encoded SmarAct motors controlled via the MCS2 controller.
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -83,7 +83,8 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
 
     tab_whitelist = ["set_current_position", "home", "velocity",
                      "check_limit_switches", "get_low_limit",
-                     "set_low_limit", "get_high_limit", "set_high_limit"]
+                     "set_low_limit", "get_high_limit", "set_high_limit",
+                     "velocity_base", "velocity_max"]
 
     set_metadata(EpicsMotor.home_forward, dict(variety='command-proc',
                                                tags={"confirm"},
@@ -501,6 +502,10 @@ class PCDSMotorBase(EpicsMotorInterface):
     # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, '.SPG', kind='omitted')
 
+    velocity = Cpt(EpicsSignal, '.VELO', kind='config')
+    velocity_base = Cpt(EpicsSignal, '.VBAS', kind='omitted')
+    velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.stage_sigs[self.motor_spg] = 2
@@ -639,8 +644,6 @@ class IMS(PCDSMotorBase):
 
     # IMS velocity has limits
     velocity = Cpt(EpicsSignal, '.VELO', limits=True, kind='config')
-    velocity_base = Cpt(EpicsSignal, '.VBAS', kind='omitted')
-    velocity_max = Cpt(EpicsSignal, '.VMAX', kind='config')
 
     tab_whitelist = [
         'reinitialize',
@@ -1470,7 +1473,7 @@ class SmarActOpenLoopPositioner(PVPositionerComparator):
         return setpoint-self.atol < readback < setpoint+self.atol
 
 
-class SmarAct(EpicsMotorInterface):
+class SmarAct(PCDSMotorBase):
     """
     Class for encoded SmarAct motors controlled via the MCS2 controller.
     """

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -505,8 +505,6 @@ class PCDSMotorBase(EpicsMotorInterface):
     # paused and ready to resume on Go 'Paused', and to resume a move 'Go'.
     motor_spg = Cpt(EpicsSignal, '.SPG', kind='omitted')
 
-    velocity = Cpt(EpicsSignal, '.VELO', kind='config')
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.stage_sigs[self.motor_spg] = 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Moves VBAS and VMAX signals to PCDSMotorBase for access by more sub-classes. 
Change SmarAct to use PCDSMotorBase. 

## Motivation and Context
Closes #1224 

## How Has This Been Tested?
Tested using the same test motor @aberges-SLAC had in his submitted issue. 

## Where Has This Been Documented?
This PR.


## Screenshots:
Typhos suite of that motor with "omitted" signals also shown. 

![image](https://github.com/pcdshub/pcdsdevices/assets/29102919/4f0a0dbe-f594-4dc1-8e45-e03c7e85382b)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
