### PR TITLE
Add SmarAct Picoscale device

### DIFF
--- a/docs/source/upcoming_release_notes/1238-Add_SmarActPicoscale.rst
+++ b/docs/source/upcoming_release_notes/1238-Add_SmarActPicoscale.rst
@@ -1,0 +1,33 @@
+1238 Add SmarActPicoscale subclass
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Includes new PV RBVs for Picoscale at motor level:
+- pico_present, pico_exists, pico_sig_qual, pico_enable
+- Includes new PV RBVs for Picoscale at controller level:
+- pico_stable, pico_name, pico_wmin (working distance min), pico_wmax (working distance max)
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- added SmarActPicoscale subclass of SmarAct
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges-SLAC

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1526,28 +1526,51 @@ class SmarActEncodedTipTilt(Device):
 class SmarActPicoscale(SmarAct):
     """
     Class for encoded SmarAct motors controller via the MCS2 controller
-    which use the Picoscale sensor heads for encoded positions.
-    Child of SmarAct device.
+    which use the PicoScale sensor heads for encoded positions.
+    Instantiating a device requires inclusion of the ioc_base in order to
+    properly access PicoScale properties.
+
+    Example
+    -------
+    SmarActPicoscale('prefix': 'LAS:MCS2:02:m1', 'name': 'Delay 1',
+                     'ioc_base': 'LAS:MCS2:02').
     """
     # configuration settings and readbacks
-    pico_present = Cpt(EpicsSignalRO, ':PS_PRESENT', kind='config')
-    pico_exists = Cpt(EpicsSignalRO, ':HAVE_PS', kind='config')
-    pico_valid = Cpt(EpicsSignalRO, ':PS_DATA_VALID', kind='config')
-    pico_sig_qual = Cpt(EpicsSignalRO, ':PS_SIG_QUALITY', kind='config')
+    pico_present = Cpt(EpicsSignalRO, ':PS_PRESENT', kind='config',
+                       doc='PicoScale is on and connected')
+    pico_exists = Cpt(EpicsSignalRO, ':HAVE_PS', kind='config',
+                      doc='Does this channel have a PicoScale assigned to it?')
+    pico_valid = Cpt(EpicsSignalRO, ':PS_DATA_VALID', kind='config',
+                     doc='Is the data valid and ready for accurate msmts?')
+    pico_sig_qual = Cpt(EpicsSignalRO, ':PS_SIG_QUALITY', kind='config',
+                        doc='Quality of interferometer signal. Higher = better')
+
+    # auto and manual adjustment related PVs
+    pico_adj_state = FCpt(EpicsSignal, '{self._ioc_base}:PS:CUR_ADJ_STATE',
+                          write_pv='{self._ioc_base}:PS:REQ_ADJ_STATE',
+                          kind='config', doc='Set to Manual or Auto adjustment '
+                          'mode')
+    pico_curr_adj_prog = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:CUR_ADJ_PROGRESS',
+                              kind='config', doc='Estimate of current adjustment '
+                              'progress')
+    pico_adj_done = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:ADJ_DONE',
+                         kind='config', doc='Is the auto adjustment done?')
 
     # Validation that Picoscale is working properly
-    pico_enable = Cpt(EpicsSignalRO, ':PS_ENABLE_RBV', kind='normal')
-    pico_stable = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:STABLE', kind='normal')
+    pico_enable = Cpt(EpicsSignalRO, ':PS_ENABLE_RBV', kind='normal',
+                      doc='Is the PicoScale enabled for this channel?')
+    pico_stable = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:STABLE', kind='normal',
+                       doc='Is system stable and ready for accurate msmts?')
 
     # Diagnostic information from PS controller
     pico_name = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:LOCATOR',
-                     kind='config')
+                     kind='config', doc='Name of the PicoScale')
     pico_wmin = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:WORKING_MIN',
-                     kind='config')
+                     kind='config', doc='Working distance minimum')
     pico_wmax = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:WORKING_MAX',
-                     kind='config')
+                     kind='config', doc='Working distance maximum')
 
-    def __init__(self, prefix='', *, ioc_base, **kwargs):
+    def __init__(self, prefix, *, ioc_base, **kwargs):
         self._ioc_base = ioc_base
         super().__init__(prefix, **kwargs)
 

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1523,6 +1523,35 @@ class SmarActEncodedTipTilt(Device):
         super().__init__(prefix, **kwargs)
 
 
+class SmarActPicoscale(SmarAct):
+    """
+    Class for encoded SmarAct motors controller via the MCS2 controller
+    which use the Picoscale sensor heads for encoded positions.
+    Child of SmarAct device.
+    """
+    # configuration settings and readbacks
+    pico_present = Cpt(EpicsSignalRO, ':PS_PRESENT', kind='config')
+    pico_exists = Cpt(EpicsSignalRO, ':HAVE_PS', kind='config')
+    pico_valid = Cpt(EpicsSignalRO, ':PS_DATA_VALID', kind='config')
+    pico_sig_qual = Cpt(EpicsSignalRO, ':PS_SIG_QUALITY', kind='config')
+
+    # Validation that Picoscale is working properly
+    pico_enable = Cpt(EpicsSignalRO, ':PS_ENABLE_RBV', kind='normal')
+    pico_stable = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:STABLE', kind='normal')
+
+    # Diagnostic information from PS controller
+    pico_name = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:LOCATOR',
+                     kind='config')
+    pico_wmin = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:WORKING_MIN',
+                     kind='config')
+    pico_wmax = FCpt(EpicsSignalRO, '{self._ioc_base}:PS:WORKING_MAX',
+                     kind='config')
+
+    def __init__(self, prefix='', *, ioc_base, **kwargs):
+        self._ioc_base = ioc_base
+        super().__init__(prefix, **kwargs)
+
+
 def _GetMotorClass(basepv):
     """
     Function to determine the appropriate motor class based on the PV.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Added a SmarActPicoscale device as a subclass of SmarAct in `pcdsdevices.epics_motor`. This pulls some Picoscale specific PVs to the display that are necessary for debugging. 

## Motivation and Context
The Out of Loop Mechanical Delay Lines use the Picoscale interferometers and sensor heads for the position encoding in their systems. Picoscale has it own quirks that will render the stages inoperable if violated (i.e. beam interrupted). This is not transparent to the user in the current SmarAct device class. This new subclass of a device brings the necessary diagnostic information forward.

Closes: https://github.com/pcdshub/pcdsdevices/issues/1238

## How Has This Been Tested?
I tested this screen on a currently deployed stage in the FTL and was able to retain normal functionality of the SmarAct and read the Picoscale specific PVs. 

I did the following in las-console:
```bash
$ cd /cds/group/pcds/epics-dev/aberges/pcdshub/pcdsdevices
$ source pcds_conda; export PYTHONPATH=$PWD
$ typhos "pcdsdevices.epics_motor.SmarActPicoscale[{'prefix': 'LAS:FTL:MCS:02:m2', 'name':'OL-MDL 5', 'ioc_base': 'LAS:FTL:MCS:02'}]" &
```

## Where Has This Been Documented?
In this pull request.

## Screenshots (if appropriate):
![image](https://github.com/pcdshub/pcdsdevices/assets/149725219/bad1b024-cae9-48bf-87f4-478c09a201e0)

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
