### PR TITLE
Add TprTrigger default timing mode

### DIFF
--- a/docs/source/upcoming_release_notes/1241-Add_default_TprTrigger_timing_mode.rst
+++ b/docs/source/upcoming_release_notes/1241-Add_default_TprTrigger_timing_mode.rst
@@ -1,0 +1,30 @@
+1241 Add default TprTrigger timing mode
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- TprTrigger: Make LCLS2 timing the default timing_mode
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -59,7 +59,19 @@ class TprMotor(PVPositionerIsClose):
 
 
 class TprTrigger(BaseInterface, Device):
-    """Class for an individual TprTrigger."""
+    """
+    Class for an individual TprTrigger.
+
+    Parameters
+    ----------
+    timing_mode: int, str, or Enum
+        The timing mode the TPR is configured for. Can be an enum
+        (tpr.TimingMode.LCLS1 tpr.TimingMode.LCLS1) a str ("LCLS1" or "LCLS2")
+        or an int (1 or 2).
+
+    channel: int
+        The integer channel to be used (0 through 11).
+    """
     ratemode = FCpt(EpicsSignal, '{self.prefix}{self.ch}RATEMODE', kind="config", doc="Channel rate mode selector")
     group = FCpt(EpicsSignal, '{self.prefix}{self.ch}GROUP', kind="config", doc="Channel group Bit")
     seqcode = FCpt(EpicsSignal, '{self.prefix}{self.ch}SEQCODE', kind="config", doc="Channel sequence code")

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -103,8 +103,13 @@ class TprTrigger(BaseInterface, Device):
     tab_whitelist = ['enable', 'disable']
     tab_component_names = True
 
-    def __init__(self, prefix, *, channel, name, timing_mode=TimingMode.LCLS2,
-                 **kwargs):
+    def __init__(self, prefix, *, channel, name, timing_mode=TimingMode.LCLS2, **kwargs):
+        # Convert timing mode into Enum from Enum, string, or int
+        if isinstance(timing_mode, int) or isinstance(timing_mode, Enum):
+            timing_mode = TimingMode(timing_mode)
+        elif isinstance(timing_mode, str):
+            timing_mode = TimingMode[timing_mode]
+
         if timing_mode == TimingMode.LCLS1:
             self.sys = 'SYS0_'
         elif timing_mode == TimingMode.LCLS2:

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -103,7 +103,8 @@ class TprTrigger(BaseInterface, Device):
     tab_whitelist = ['enable', 'disable']
     tab_component_names = True
 
-    def __init__(self, prefix, *, channel, timing_mode, name, **kwargs):
+    def __init__(self, prefix, *, channel, name, timing_mode=TimingMode.LCLS2,
+                 **kwargs):
         if timing_mode == TimingMode.LCLS1:
             self.sys = 'SYS0_'
         elif timing_mode == TimingMode.LCLS2:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Make LCLS2 the default timing mode for the `TprTrigger` class. 

## Motivation and Context
closes #1241 

## How Has This Been Tested?
Tested interactively. 

## Where Has This Been Documented?
This PR. 


## Screenshots (if appropriate):
![image](https://github.com/pcdshub/pcdsdevices/assets/29102919/a9112f01-2487-40ea-b935-f0cb7ec59fd9)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
