### PR TITLE
pcdsdevices/sqr1.py: overwrite SQR1Axis set method

### DIFF
--- a/docs/source/upcoming_release_notes/1243-overwrite_SQR1Axis_set_method.rst
+++ b/docs/source/upcoming_release_notes/1243-overwrite_SQR1Axis_set_method.rst
@@ -1,0 +1,30 @@
+1243 overwrite SQR1Axis set method
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- `sqr1` overwrite SQR1Axis set method to avoid waiting and setpoints synchronization
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- baljamal

--- a/pcdsdevices/sqr1.py
+++ b/pcdsdevices/sqr1.py
@@ -141,11 +141,42 @@ class SQR1Axis(PVPositionerIsClose):
             self._sync_setpoints()
         return super().move(position, wait, timeout, moved_cb)
 
-    def set(self,
-            new_position: typing.Any,
-            *,
-            timeout: float = None,
-            moved_cb: typing.Callable = None) -> StatusBase:
+    def set(
+        self,
+        new_position: typing.Any,
+        *,
+        timeout: float = None,
+        moved_cb: typing.Callable = None,
+        wait: bool = False,
+    ) -> StatusBase:
+        """
+        Set SQR1 single axis new position.
+
+        Parameters
+        ----------
+        new_position : typing.Any
+            The target position to move to.
+        timeout : float, optional
+            The maximum time to wait for the move to complete.If None,
+            no timeout is applied.
+        moved_cb : typing.Callable, optional
+            A callback function that is called when the move is complete.
+        wait : bool, optional
+            always will be false. kept for consistent method signature
+            across future implementations.
+
+        Returns
+        -------
+        StatusBase
+            Status object to indicate when the motion is done.
+
+        Notes
+        -----
+        This method calls the `move` method with the provided parameters,
+        while keeping `wait=False` and `sync_enable=False` to allow multi-axis
+        scans without one axis blocking other axes.
+
+        """
         return self.move(new_position,
                          wait=False,
                          moved_cb=moved_cb,

--- a/pcdsdevices/sqr1.py
+++ b/pcdsdevices/sqr1.py
@@ -19,6 +19,7 @@ from ophyd.device import Device
 from ophyd.device import FormattedComponent as FCpt
 from ophyd.pv_positioner import PVPositionerIsClose
 from ophyd.signal import EpicsSignal
+from ophyd.status import MoveStatus as StatusBase
 from ophyd.status import wait as status_wait
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,17 @@ class SQR1Axis(PVPositionerIsClose):
         if sync_enable and self._sync_setpoints:
             self._sync_setpoints()
         return super().move(position, wait, timeout, moved_cb)
+
+    def set(self,
+            new_position: typing.Any,
+            *,
+            timeout: float = None,
+            moved_cb: typing.Callable = None) -> StatusBase:
+        return self.move(new_position,
+                         wait=False,
+                         moved_cb=moved_cb,
+                         timeout=timeout,
+                         sync_enable=False)
 
 
 class SQR1(Device):


### PR DESCRIPTION
to make it work with Bluesky multi axis scan

<!--- Provide a general summary of your changes in the Title above -->
## Description
overwrite SQR1Axis set method to avoid waiting and setpoints synchronization

<!--- Describe your changes in detail -->
## Motivation and Context
James Cryan reported an issue with Bluesky scan which happens with multi-axis scan (i.e.  zigzag scan)

<!--- Why is this change required? What problem does it solve? -->
when a Bluesky multi-axis scan starts only one motor moves.

<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5539

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This modification tested on TMO LAMP SQR1 using hutch-python

<!--- Include details of your testing environment, and the tests you ran to -->
I did the test using pcds conda 5.8.4 on TMO LAMP SQR1

<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
