### PR TITLE
MAINT: minor positioner ui tweaks

### DIFF
--- a/docs/source/upcoming_release_notes/1244-maint_minor_ui.rst
+++ b/docs/source/upcoming_release_notes/1244-maint_minor_ui.rst
@@ -1,0 +1,30 @@
+1244 maint_minor_ui
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Replace the broken motor "disabled" (.DISP) typhos widget with a bitmask toggle button.
+
+Maintenance
+-----------
+- Allow motion uis to expand vertically once this functionality gets added to typhos.
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -75,7 +75,8 @@ class EpicsMotorInterface(FltMvInterface, EpicsMotor):
 
     # Enable/Disable puts
     disabled = Cpt(EpicsSignal, ".DISP", kind='omitted')
-    set_metadata(disabled, dict(variety='command-enum'))
+    set_metadata(disabled, dict(variety='bitmask',
+                                bits=1))
     # Description is valuable
     description = Cpt(EpicsSignal, '.DESC', kind='normal')
     # Current Dial position

--- a/pcdsdevices/ui/BeckhoffAxis.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxis.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>872</width>
-    <height>228</height>
+    <width>681</width>
+    <height>125</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,6 +46,18 @@
    </property>
    <item>
     <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>681</width>
+       <height>125</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>

--- a/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
+++ b/pcdsdevices/ui/BeckhoffAxisEPSCustom.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>886</width>
-    <height>179</height>
+    <width>681</width>
+    <height>152</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,6 +46,18 @@
    </property>
    <item>
     <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>681</width>
+       <height>125</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>

--- a/pcdsdevices/ui/StatePositioner.embedded.ui
+++ b/pcdsdevices/ui/StatePositioner.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>824</width>
-    <height>238</height>
+    <width>691</width>
+    <height>135</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -64,10 +64,16 @@
    </property>
    <item>
     <widget class="TyphosPositionerRowWidget" name="TyphosPositionerWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
-       <width>0</width>
-       <height>0</height>
+       <width>681</width>
+       <height>125</height>
       </size>
      </property>
      <property name="maximumSize">
@@ -112,13 +118,13 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosPositionerRowWidget</class>
-   <extends>TyphosPositionerWidget</extends>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>

--- a/pcdsdevices/ui/TwinCATStatePositioner.embedded.ui
+++ b/pcdsdevices/ui/TwinCATStatePositioner.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>872</width>
-    <height>228</height>
+    <width>681</width>
+    <height>125</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,6 +46,18 @@
    </property>
    <item>
     <widget class="TyphosPositionerRowWidget" name="TyphosPositionerRowWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>681</width>
+       <height>125</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -85,13 +97,13 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosPositionerWidget</class>
-   <extends>QWidget</extends>
+   <class>TyphosPositionerRowWidget</class>
+   <extends>TyphosPositionerWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
   <customwidget>
-   <class>TyphosPositionerRowWidget</class>
-   <extends>TyphosPositionerWidget</extends>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
    <header>typhos.positioner</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Replace the "disabled" broken setpoint widget with a simple bitmask clicker
- Tweak the positioner layouts to enable them to be expandable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- I went through all the options for disabled/DISP and this one looked the least bad
- Minor tweaks based on things I noticed while implementing https://github.com/pcdshub/typhos/pull/611

The other option that sort of worked for the disabled widget was simple text entry but:
- This had the unit attached (0mm is off, 1mm is on...)
- It was awkward to know to type 0 or 1

I couldn't get typhos to assign a custom enum combobox to this widget. There was an option to have two vertical buttons to click but I didn't like it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only, I need to make pre-release notes


## Screenshots (if appropriate):
Old "disabled" widget (completely inoperable):
![image](https://github.com/pcdshub/pcdsdevices/assets/10647860/bc42a3dc-77b1-43b2-86cc-e5e6573c8fa5)

New "disabled" widget:
![image](https://github.com/pcdshub/pcdsdevices/assets/10647860/4cacd125-e170-4413-8ad6-97335580a3cf)

New widget when disabled (click the right-hand bitmask widget to toggle):
![image](https://github.com/pcdshub/pcdsdevices/assets/10647860/da85c3e4-98ea-4e69-a45d-4b1e60c51cb7)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
