### PR TITLE
FIX: drop tmo fzp att from 6 states to 4 to match plc update

### DIFF
--- a/docs/source/upcoming_release_notes/1245-fix_fzp_att_state_count.rst
+++ b/docs/source/upcoming_release_notes/1245-fix_fzp_att_state_count.rst
@@ -1,0 +1,32 @@
+1245 fix_fzp_att_state_count
+############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Remove two targets from the tmo spectrometer's foil attenuator.
+  These were removed from the PLC/IOC.
+  This fixes an issue where the state device was not moveable.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -332,10 +332,10 @@ class TMOSpectrometerSOLIDATTStates(TwinCATStatePMPS):
     """
     Spectrometer Solid Attenuator(FOIL X and Y) 2D States Setup
 
-    Here, we specify 6 states,(after adding an Unknown state), and 2 motors, for the X and Y
+    Here, we specify 4 states,(after adding an Unknown state), and 2 motors, for the X and Y
     axes.
     """
-    config = UpCpt(state_count=6, motor_count=2)
+    config = UpCpt(state_count=4, motor_count=2)
 
 
 class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
See title
The fzp attenuator lost two targets due to space concerns and this new state count had not propagated down to the Python code. I made the required change here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some confusing errors if the state count doesn't match. This is probably also something to fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ming Fu says he can move the device again

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Will make brief pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
