### PR TITLE
TMO Cooling Sensor Updates MR1/4/5K4

### DIFF
--- a/docs/source/upcoming_release_notes/1247-optics-cooling.rst
+++ b/docs/source/upcoming_release_notes/1247-optics-cooling.rst
@@ -1,0 +1,30 @@
+1247 optics-cooling
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- `FFMirrorZ` updated to read out flow sensors for MR4K4 and MR5K4.
+
+New Devices
+-----------
+- `XOffsetMirrorStateCoolNoBend` is added to support MR1K4.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1436,6 +1436,25 @@ class XOffsetMirrorStateCool(XOffsetMirrorState):
     variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
 
 
+class XOffsetMirrorStateCoolNoBend(XOffsetMirrorStateCool):
+    """
+    X-ray offset Mirror with all the features of
+
+    XOffsetMirrorStateCool with no bender.
+
+    Currently (06/14/2024) services: mr1k4.
+
+    Parameters
+    ----------
+    prefix : str
+        Base PV for the mirror.
+
+    name : str
+        Alias for the device.
+    """
+    bender = None
+
+
 class MirrorInsertState(TwinCATStatePMPS):
     """
     A state positioner with two states (3 including Unknown) representing

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1257,10 +1257,10 @@ class FFMirrorZ(FFMirror):
                          kind='normal')
     chin_tail_rtd = Cpt(PytmcSignal, ':RTD:TAIL:TEMP', io='i',
                         kind='normal')
-    # Kill these until MR4 and MR5 K4 implement them.
-    cool_flow1 = None
+
+    cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal', doc="Axilon Panel Flow Meter Loop 1")
     cool_flow2 = None
-    cool_press = None
+    cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc="Axilon Panel Pressure Meter")
 
 
 class TwinCATMirrorStripe(TwinCATStatePMPS):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- MR4/5K4 are the only 2 devices using `FFMirrorZ`. Each mirror has 1 physical flow meter and shares the same physical pressure meter.
- MR1K4 bender is not used, cabled, or supported on the beckhoff DIN rail. Make a new class to get the dead bender readouts off the typhos screen. `XOffsetMirrorStateCoolNoBend`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Installed cooling sensors
- removed MR1K4 bender beckhoff motor terminal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- launched typhos screens from this branch.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-903
https://jira.slac.stanford.edu/browse/ECS-5569
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
