### PR TITLE
removing st3k4 auto error

### DIFF
--- a/docs/source/upcoming_release_notes/1248-DOC:ST1K4_decoupling_ST3K4_when_ST3K4_OUT.rst
+++ b/docs/source/upcoming_release_notes/1248-DOC:ST1K4_decoupling_ST3K4_when_ST3K4_OUT.rst
@@ -1,0 +1,30 @@
+1248 DOC:ST1K4 decoupling ST3K4 when ST3K4 OUT
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Decoupling ST1K4 with ST3K4 when ST3K4 OUT
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- @tongju12

--- a/docs/source/upcoming_release_notes/1248-DOC:ST1K4_decoupling_ST3K4_when_ST3K4_OUT.rst
+++ b/docs/source/upcoming_release_notes/1248-DOC:ST1K4_decoupling_ST3K4_when_ST3K4_OUT.rst
@@ -7,11 +7,11 @@ API Breaks
 
 Features
 --------
-- Decoupling ST1K4 with ST3K4 when ST3K4 OUT
+- N/A
 
 Device Updates
 --------------
-- N/A
+- ST1K4 can move freely without automode
 
 New Devices
 -----------

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -34,10 +34,13 @@ class SxrTestAbsorberStates(TwinCATInOutPositioner):
         moved_cb: Callable | None = None,
         timeout: float | None = None,
     ):
+
+        """
         if self.st3k4_auto.get():
-            raise ST3K4AutoError(
-                "ST1K4 must follow ST3K4. Move rejected."
-            )
+           raise ST3K4AutoError(
+               "ST1K4 must follow ST3K4. Move rejected."
+           )
+        """
         return super().set(position, moved_cb=moved_cb, timeout=timeout)
 
 

--- a/pcdsdevices/sxr_test_absorber.py
+++ b/pcdsdevices/sxr_test_absorber.py
@@ -3,8 +3,6 @@ Module for the SXR Test Absorbers.
 """
 from __future__ import annotations
 
-from typing import Callable
-
 from ophyd.device import Component as Cpt
 
 from .digital_signals import J120K
@@ -27,21 +25,6 @@ class SxrTestAbsorberStates(TwinCATInOutPositioner):
     """
 
     st3k4_auto = Cpt(PytmcSignal, ':ST3K4_AUTO', io='io', kind='config')
-
-    def set(
-        self,
-        position: str | int,
-        moved_cb: Callable | None = None,
-        timeout: float | None = None,
-    ):
-
-        """
-        if self.st3k4_auto.get():
-           raise ST3K4AutoError(
-               "ST1K4 must follow ST3K4. Move rejected."
-           )
-        """
-        return super().set(position, moved_cb=moved_cb, timeout=timeout)
 
 
 class SxrTestAbsorber(BaseInterface, LightpathInOutCptMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
remove st3k4 auto error so that it will not show error when st1k4 is not flowing st3k4 when st3k4 is OUT
<!--- Describe your changes in detail -->
remove error message lines
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not give error while st1k4 is not out when ST3K4 is OUT
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Test it in tmo under dev_conda. It works as expected. 
<!--- Include details of your testing environment, and the tests you ran to -->
Dev_conda
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

(https://jira.slac.stanford.edu/browse/ECS-5586)
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
