### PR TITLE
fix for Newport for velocity-max and velocity-base

### DIFF
--- a/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
+++ b/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
@@ -1,0 +1,30 @@
+1254 Newport velocity PV fixes
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Over-write default velocity signals
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- vespos, rcjwoods

--- a/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
+++ b/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
@@ -19,7 +19,8 @@ New Devices
 
 Bugfixes
 --------
-- Over-write default velocity signals for Newport class
+- Overwrite ``velocity_max`` and ``velocity_base`` signals for ``Newport``
+  class to fix a bug that prevented these motors from moving.
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
+++ b/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
@@ -19,7 +19,7 @@ New Devices
 
 Bugfixes
 --------
-- Over-write default velocity signals
+- Over-write default velocity signals for Newport class
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
+++ b/docs/source/upcoming_release_notes/1254-Newport_velocity_PV_fixes.rst
@@ -28,4 +28,5 @@ Maintenance
 
 Contributors
 ------------
-- vespos, rcjwoods
+- vespos
+- rcjwoods

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -998,6 +998,9 @@ class Newport(PCDSMotorBase):
     motor_prec = Cpt(EpicsSignalRO, '.PREC', kind='omitted',
                      auto_monitor=True)
 
+    velocity_max = Cpt(EpicsSignalRO, '.SVEL', kind='config')
+    velocity_base = Cpt(Signal, kind='omitted')
+
     def home(self, *args, **kwargs):
         # This function should eventually be used. There is a way to home
         # Newport motors to a reference mark


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail --> 
The signals for velocity-max (VMAX) and velocity-base (VBAS) were added recently to the EpicsMotorInterface class, but do not connect for the Newport class, causing issues. The proposed changes overwrite these signals to make them compatible with the Newport IOC.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> The Newport Epics Motor Record does not have PVs for VMAX and VBAS, but they are expected by the Newport device in hutch-python, as defined in class EpicsMotorInterface. This causes a timeout/crash when calling a Newport device in hutch-python.
<!--- If it fixes an open issue, please link to the issue here. --> 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> We tested the changes in the MFX hutch-python, which uses the dev version of pcdsdevices. We were able to control the Newport motors again without errors.
<!--- Include details of your testing environment, and the tests you ran to --> 
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
