### PR TITLE
add preset support for SQR1

### DIFF
--- a/pcdsdevices/sqr1.py
+++ b/pcdsdevices/sqr1.py
@@ -21,6 +21,7 @@ from ophyd.pv_positioner import PVPositionerIsClose
 from ophyd.signal import EpicsSignal
 from ophyd.status import MoveStatus as StatusBase
 from ophyd.status import wait as status_wait
+from pcdsdevices.interface import FltMvInterface
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class Axis(str, enum.Enum):
     rZ = 'rZ'
 
 
-class SQR1Axis(PVPositionerIsClose):
+class SQR1Axis(FltMvInterface, PVPositionerIsClose):
     """
     Single axis of the square-one tri-sphere motion system.
 
@@ -290,6 +291,7 @@ class SQR1(Device):
 
     def multi_axis_move(
         self,
+        preset_pos: str | None = None,
         x_sp: float | None = None,
         y_sp: float | None = None,
         z_sp: float | None = None,
@@ -304,6 +306,8 @@ class SQR1(Device):
 
         Parameters
         ----------
+        preset_pos: str or None, optional
+            Move to a preset position labeled by the preset_pos string.
         x_sp : float or None, optional
             The desired position for the X-axis.If None (default), the current
             position is used.
@@ -343,6 +347,19 @@ class SQR1(Device):
         >>> tri_sphere = SQR1(prefix="SQR1:", name="tri_sphere")
         >>> status = tri_sphere.multi_axis_move(x_sp=1.0, y_sp=2.0, z_sp=3.0)
         """
+
+        if preset_pos is not None:
+            axis_list = [self.x, self.y, self.z, self.rz, self.ry, self.rz]
+            if any(hasattr(a.presets.positions, preset_pos) for a in axis_list):
+                x_sp = (getattr(self.x.presets.positions, preset_pos)).pos
+                y_sp = (getattr(self.y.presets.positions, preset_pos)).pos
+                z_sp = (getattr(self.z.presets.positions, preset_pos)).pos
+                rx_sp = (getattr(self.rx.presets.positions, preset_pos)).pos
+                ry_sp = (getattr(self.ry.presets.positions, preset_pos)).pos
+                rz_sp = (getattr(self.rz.presets.positions, preset_pos)).pos
+            else:
+                logger.error('One of the axes is missing the desired state.')
+
         x_sp = self.x.readback.get() if x_sp is None else x_sp
         y_sp = self.y.readback.get() if y_sp is None else y_sp
         z_sp = self.z.readback.get() if z_sp is None else z_sp
@@ -373,3 +390,13 @@ class SQR1(Device):
     def stop(self):
         """stop command for all axes."""
         self.stop_signal.put(self.stop_value)
+
+    def preset_list(self):
+        """return a list of preset positions."""
+        preset_list = []
+        axis_list = [self.x, self.y, self.z, self.rz, self.ry, self.rz]
+        for axis in axis_list:
+            for preset in list(vars(axis.presets.positions).keys()):
+                if preset not in preset_list:
+                    preset_list.append(preset)
+        return preset_list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
add preset support for SQR1 device
<!--- Describe your changes in detail -->

## Motivation and Context
James Cryan asked for preset feature so he can move lamp sqr1 to predefined positions where beam focus is the best
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
tested using hutch-python with TMO LAMP SQR1 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
