### PR TITLE
BTMS/BTPS Updates

### DIFF
--- a/docs/source/upcoming_release_notes/1256-Add_new_source_lines_to_BTMS_and_BTPS.rst
+++ b/docs/source/upcoming_release_notes/1256-Add_new_source_lines_to_BTMS_and_BTPS.rst
@@ -1,0 +1,35 @@
+1256 Add new source lines to BTMS and BTPS
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- btps.BtpsState: add LS3, LS4, and LS6
+- btps.DestinationConfig: add LS3, LS4, and LS6
+- btms_config.SourcePosition: add LS3, LS4, and LS6
+- btms_config.valid_sources: add LS3, LS4, and LS6
+- UI file updates to support above device updates
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- btms_config.DestinationPosition: fix description of RIX IP3
+- btms_config.valid_destinations: fix description of RIX IP3
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/lasers/btms_config.py
+++ b/pcdsdevices/lasers/btms_config.py
@@ -166,7 +166,10 @@ class SourcePosition(str, enum.Enum):
         """
         return {
             SourcePosition.ls1: "Bay 1",
-            SourcePosition.ls5: "Bay 3",
+            SourcePosition.ls3: "Bay 2 800nm",
+            SourcePosition.ls4: "Bay 2 1um",
+            SourcePosition.ls5: "Bay 3 800nm",
+            SourcePosition.ls6: "Bay 3 1um",
             SourcePosition.ls8: "Bay 4",
         }.get(self, "Unknown")
 
@@ -190,7 +193,10 @@ class SourcePosition(str, enum.Enum):
         """The near field camera prefix associated with this source position."""
         return {
             SourcePosition.ls1: 1,
+            SourcePosition.ls3: 2,
+            SourcePosition.ls4: 2,
             SourcePosition.ls5: 3,
+            SourcePosition.ls6: 3,
             SourcePosition.ls8: 4,
         }.get(self, None)
 
@@ -332,7 +338,10 @@ PORT_SPACING_MM = 215.9  # 8.5 in
 # PV source index (bay) to installed LS port
 valid_sources: tuple[SourcePosition, ...] = (
     SourcePosition.ls1,  # Bay 1
-    SourcePosition.ls5,  # Bay 3
+    SourcePosition.ls3,  # Bay 2 800nm
+    SourcePosition.ls4,  # Bay 2 1um
+    SourcePosition.ls5,  # Bay 3 800nm
+    SourcePosition.ls6,  # Bay 3 1um
     SourcePosition.ls8,  # Bay 4
 )
 # PV destination index (bay) to installed LD port

--- a/pcdsdevices/lasers/btms_config.py
+++ b/pcdsdevices/lasers/btms_config.py
@@ -166,8 +166,8 @@ class SourcePosition(str, enum.Enum):
         """
         return {
             SourcePosition.ls1: "Bay 1",
-            SourcePosition.ls3: "Bay 2 800nm",
-            SourcePosition.ls4: "Bay 2 1um",
+            SourcePosition.ls3: "Bay 2 1um",
+            SourcePosition.ls4: "Bay 2 800nm",
             SourcePosition.ls5: "Bay 3 800nm",
             SourcePosition.ls6: "Bay 3 1um",
             SourcePosition.ls8: "Bay 4",
@@ -338,8 +338,8 @@ PORT_SPACING_MM = 215.9  # 8.5 in
 # PV source index (bay) to installed LS port
 valid_sources: tuple[SourcePosition, ...] = (
     SourcePosition.ls1,  # Bay 1
-    SourcePosition.ls3,  # Bay 2 800nm
-    SourcePosition.ls4,  # Bay 2 1um
+    SourcePosition.ls3,  # Bay 2 1um
+    SourcePosition.ls4,  # Bay 2 800nm
     SourcePosition.ls5,  # Bay 3 800nm
     SourcePosition.ls6,  # Bay 3 1um
     SourcePosition.ls8,  # Bay 4

--- a/pcdsdevices/lasers/btms_config.py
+++ b/pcdsdevices/lasers/btms_config.py
@@ -264,7 +264,7 @@ class DestinationPosition(str, enum.Enum):
         # NOTE: Add new descriptions here.
         return {
             DestinationPosition.ld1: "Diagnostics",
-            DestinationPosition.ld2: "TMO IP3",
+            DestinationPosition.ld2: "RIX IP3",
             DestinationPosition.ld4: "RIX ChemRIXS",
             DestinationPosition.ld6: "RIX QRIXS",
             DestinationPosition.ld8: "TMO IP1",
@@ -347,7 +347,7 @@ valid_sources: tuple[SourcePosition, ...] = (
 # PV destination index (bay) to installed LD port
 valid_destinations: tuple[DestinationPosition, ...] = (
     DestinationPosition.ld1,   # Diagnostics box
-    DestinationPosition.ld2,   # TMO IP3
+    DestinationPosition.ld2,   # RIX IP3
     DestinationPosition.ld4,   # RIX ChemRIXS
     DestinationPosition.ld6,   # RIX QRIXS
     DestinationPosition.ld8,   # TMO IP1

--- a/pcdsdevices/lasers/btps.py
+++ b/pcdsdevices/lasers/btps.py
@@ -344,11 +344,29 @@ class DestinationConfig(BaseInterface, Device):
         source_pos=SourcePosition.ls1,
         doc="Settings for source LS1 (bay 1) to this destination",
     )
+    ls3 = Cpt(
+        SourceToDestinationConfig,
+        "LS3:",
+        source_pos=SourcePosition.ls3,
+        doc="Settings for source LS3 (bay 2 800nm) to this destination",
+    )
+    ls4 = Cpt(
+        SourceToDestinationConfig,
+        "LS4:",
+        source_pos=SourcePosition.ls4,
+        doc="Settings for source LS4 (bay 2 1um) to this destination",
+    )
     ls5 = Cpt(
         SourceToDestinationConfig,
         "LS5:",
         source_pos=SourcePosition.ls5,
-        doc="Settings for source LS5 (bay 3) to this destination",
+        doc="Settings for source LS5 (bay 3 800nm) to this destination",
+    )
+    ls6 = Cpt(
+        SourceToDestinationConfig,
+        "LS6:",
+        source_pos=SourcePosition.ls6,
+        doc="Settings for source LS6 (bay 3 1um) to this destination",
     )
     ls8 = Cpt(
         SourceToDestinationConfig,
@@ -356,7 +374,8 @@ class DestinationConfig(BaseInterface, Device):
         source_pos=SourcePosition.ls8,
         doc="Settings for source LS8 (bay 4) to this destination",
     )
-    exit_valve = Cpt(BtpsVGC, "VGC:01", kind="normal", doc="Destination exit valve")
+    exit_valve = Cpt(BtpsVGC, "VGC:01", kind="normal",
+                     doc="Destination exit valve")
 
     @property
     def sources(self) -> dict[SourcePosition, SourceToDestinationConfig]:
@@ -369,7 +388,8 @@ class DestinationConfig(BaseInterface, Device):
         """
         return {
             source.source_pos: source
-            for source in (self.ls1, self.ls5, self.ls8)
+            for source in (self.ls1, self.ls3, self.ls4, self.ls5, self.ls6,
+                           self.ls8)
         }
 
 
@@ -647,6 +667,24 @@ class BtpsState(BaseInterface, Device):
         goniometer_prefix="LAS:BTS:MCS2:01:m3",
         doc="Source status for LS1 (Bay 1)"
     )
+    ls3 = Cpt(
+        BtpsSourceStatus,
+        "LTLHN:LS3:",
+        source_pos=SourcePosition.ls3,
+        linear_prefix="LAS:BTS:MCS2:01:m10",
+        rotary_prefix="LAS:BTS:MCS2:01:m12",
+        goniometer_prefix="LAS:BTS:MCS2:01:m11",
+        doc="Source status for LS3 (Bay 2 800nm)"
+    )
+    ls4 = Cpt(
+        BtpsSourceStatus,
+        "LTLHN:LS4:",
+        source_pos=SourcePosition.ls4,
+        linear_prefix="LAS:BTS:MCS2:01:m15",
+        rotary_prefix="LAS:BTS:MCS2:01:m14",
+        goniometer_prefix="LAS:BTS:MCS2:01:m13",
+        doc="Source status for LS3 (Bay 2 1um)"
+    )
     ls5 = Cpt(
         BtpsSourceStatus,
         "LTLHN:LS5:",
@@ -654,7 +692,16 @@ class BtpsState(BaseInterface, Device):
         linear_prefix="LAS:BTS:MCS2:01:m4",
         rotary_prefix="LAS:BTS:MCS2:01:m6",
         goniometer_prefix="LAS:BTS:MCS2:01:m5",
-        doc="Source status for LS5 (Bay 3)"
+        doc="Source status for LS5 (Bay 3 800nm)"
+    )
+    ls6 = Cpt(
+        BtpsSourceStatus,
+        "LTLHN:LS6:",
+        source_pos=SourcePosition.ls6,
+        linear_prefix="LAS:BTS:MCS2:01:m16",
+        rotary_prefix="LAS:BTS:MCS2:01:m17",
+        goniometer_prefix="LAS:BTS:MCS2:01:m18",
+        doc="Source status for LS3 (Bay 3 1um)"
     )
     ls8 = Cpt(
         BtpsSourceStatus,

--- a/pcdsdevices/lasers/btps.py
+++ b/pcdsdevices/lasers/btps.py
@@ -348,13 +348,13 @@ class DestinationConfig(BaseInterface, Device):
         SourceToDestinationConfig,
         "LS3:",
         source_pos=SourcePosition.ls3,
-        doc="Settings for source LS3 (bay 2 800nm) to this destination",
+        doc="Settings for source LS3 (bay 2 1um) to this destination",
     )
     ls4 = Cpt(
         SourceToDestinationConfig,
         "LS4:",
         source_pos=SourcePosition.ls4,
-        doc="Settings for source LS4 (bay 2 1um) to this destination",
+        doc="Settings for source LS4 (bay 2 800m) to this destination",
     )
     ls5 = Cpt(
         SourceToDestinationConfig,
@@ -674,7 +674,7 @@ class BtpsState(BaseInterface, Device):
         linear_prefix="LAS:BTS:MCS2:01:m10",
         rotary_prefix="LAS:BTS:MCS2:01:m12",
         goniometer_prefix="LAS:BTS:MCS2:01:m11",
-        doc="Source status for LS3 (Bay 2 800nm)"
+        doc="Source status for LS3 (Bay 2 1um)"
     )
     ls4 = Cpt(
         BtpsSourceStatus,
@@ -683,7 +683,7 @@ class BtpsState(BaseInterface, Device):
         linear_prefix="LAS:BTS:MCS2:01:m15",
         rotary_prefix="LAS:BTS:MCS2:01:m14",
         goniometer_prefix="LAS:BTS:MCS2:01:m13",
-        doc="Source status for LS3 (Bay 2 1um)"
+        doc="Source status for LS3 (Bay 2 800m)"
     )
     ls5 = Cpt(
         BtpsSourceStatus,

--- a/pcdsdevices/ui/btps-camera-summary.ui
+++ b/pcdsdevices/ui/btps-camera-summary.ui
@@ -256,6 +256,76 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="2">
+        <widget class="PyDMLabel" name="PyDMLabel_10">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="precision" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS2:FF:FrameTime_RBV</string>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS2:FF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="bigEndian" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="numBits" stdset="0">
+          <number>1</number>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist>
+           <string>Bit 0</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item row="3" column="0">
@@ -469,6 +539,76 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_2">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="precision" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS2:NF:FrameTime_RBV</string>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS2:NF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="bigEndian" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="numBits" stdset="0">
+          <number>1</number>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist>
+           <string>Bit 0</string>
+          </stringlist>
          </property>
         </widget>
        </item>

--- a/pcdsdevices/ui/btps-camera-summary.ui
+++ b/pcdsdevices/ui/btps-camera-summary.ui
@@ -6,9 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>945</width>
-    <height>231</height>
+    <width>1045</width>
+    <height>232</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>1000</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>

--- a/pcdsdevices/ui/btps-camera-summary.ui
+++ b/pcdsdevices/ui/btps-camera-summary.ui
@@ -41,7 +41,7 @@
         <set>Qt::AlignCenter</set>
        </property>
        <property name="precision" stdset="0">
-        <number>0</number>
+        <number>3</number>
        </property>
        <property name="showUnits" stdset="0">
         <bool>false</bool>
@@ -72,7 +72,7 @@
         <string/>
        </property>
        <property name="precision" stdset="0">
-        <number>0</number>
+        <number>3</number>
        </property>
        <property name="showUnits" stdset="0">
         <bool>false</bool>
@@ -109,7 +109,7 @@
      </item>
      <item row="1" column="3">
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="4">
+       <item row="0" column="6">
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
@@ -118,34 +118,6 @@
          </property>
          <property name="text">
           <string>Bay 4</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4">
-        <widget class="PyDMLabel" name="PyDMLabel_8">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS8:FF:FrameTime_RBV</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QLabel" name="label_8">
-         <property name="font">
-          <font>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Bay 3</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -168,23 +140,37 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="4">
-        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
-         <property name="toolTip">
-          <string/>
+       <item row="0" column="1">
+        <widget class="QLabel" name="label_9">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
          </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS8:FF:IsUpdating_RBV</string>
+         <property name="text">
+          <string>Bay 1</string>
          </property>
-         <property name="showLabels" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="circles" stdset="0">
-          <bool>true</bool>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>
-       <item row="2" column="3">
+       <item row="0" column="4">
+        <widget class="QLabel" name="label_8">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 3 - 800nm</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
         <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
          <property name="toolTip">
           <string/>
@@ -200,22 +186,20 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="label_10">
-         <property name="font">
-          <font>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Bay 2</string>
+       <item row="1" column="6">
+        <widget class="PyDMLabel" name="PyDMLabel_8">
+         <property name="toolTip">
+          <string/>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS8:FF:FrameTime_RBV</string>
+         </property>
         </widget>
        </item>
-       <item row="1" column="3">
+       <item row="1" column="4">
         <widget class="PyDMLabel" name="PyDMLabel_7">
          <property name="toolTip">
           <string/>
@@ -228,15 +212,158 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_9">
+       <item row="2" column="3">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_10">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS3:FF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="bigEndian" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="numBits" stdset="0">
+          <number>1</number>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist>
+           <string>Bit 0</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS4:FF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="bigEndian" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="numBits" stdset="0">
+          <number>1</number>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist>
+           <string>Bit 0</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="PyDMLabel" name="PyDMLabel_12">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS3:FF:FrameTime_RBV</string>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="6">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS8:FF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="label_14">
          <property name="font">
           <font>
            <underline>true</underline>
           </font>
          </property>
          <property name="text">
-          <string>Bay 1</string>
+          <string>Bay 2 - 1um</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_10">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 2 - 800nm</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -261,8 +388,11 @@
          <property name="toolTip">
           <string/>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
          <property name="precision" stdset="0">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="showUnits" stdset="0">
           <bool>false</bool>
@@ -280,15 +410,15 @@
           <string/>
          </property>
          <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS2:FF:FrameTime_RBV</string>
+          <string>ca://LTLHN:BTPS:Chk:LS4:FF:FrameTime_RBV</string>
          </property>
          <property name="enableRichText" stdset="0">
           <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="2" column="2">
-        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <item row="2" column="5">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_12">
          <property name="toolTip">
           <string/>
          </property>
@@ -302,7 +432,7 @@
           <string/>
          </property>
          <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS2:FF:IsUpdating_RBV</string>
+          <string>ca://LTLHN:BTPS:Chk:LS6:FF:IsUpdating_RBV</string>
          </property>
          <property name="showLabels" stdset="0">
           <bool>false</bool>
@@ -323,6 +453,55 @@
           <stringlist>
            <string>Bit 0</string>
           </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <widget class="PyDMLabel" name="PyDMLabel_14">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS6:FF:FrameTime_RBV</string>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QLabel" name="label_16">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 3 - 1um</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -395,66 +574,7 @@
      </item>
      <item row="1" column="0">
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_6">
-         <property name="font">
-          <font>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Bay 2</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="label_5">
-         <property name="font">
-          <font>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Bay 3</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS5:NF:IsUpdating_RBV</string>
-         </property>
-         <property name="showLabels" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="circles" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="PyDMLabel" name="PyDMLabel_4">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS5:NF:FrameTime_RBV</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="3">
+       <item row="2" column="5">
         <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
          <property name="toolTip">
           <string/>
@@ -470,85 +590,16 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="3">
-        <widget class="QLabel" name="label_7">
-         <property name="font">
-          <font>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Bay 4</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="3">
-        <widget class="PyDMLabel" name="PyDMLabel_5">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS8:NF:FrameTime_RBV</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS1:NF:IsUpdating_RBV</string>
-         </property>
-         <property name="showLabels" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="circles" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="PyDMLabel" name="PyDMLabel_3">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS1:NF:FrameTime_RBV</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="font">
-          <font>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Bay 1</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="1">
         <widget class="PyDMLabel" name="PyDMLabel_2">
          <property name="toolTip">
           <string/>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
          <property name="precision" stdset="0">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="showUnits" stdset="0">
           <bool>false</bool>
@@ -566,7 +617,7 @@
           <string/>
          </property>
          <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS2:NF:FrameTime_RBV</string>
+          <string>ca://LTLHN:BTPS:Chk:LS4:NF:FrameTime_RBV</string>
          </property>
          <property name="enableRichText" stdset="0">
           <bool>false</bool>
@@ -588,7 +639,314 @@
           <string/>
          </property>
          <property name="channel" stdset="0">
-          <string>ca://LTLHN:BTPS:Chk:LS2:NF:IsUpdating_RBV</string>
+          <string>ca://LTLHN:BTPS:Chk:LS4:NF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="bigEndian" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="numBits" stdset="0">
+          <number>1</number>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist>
+           <string>Bit 0</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <widget class="PyDMLabel" name="PyDMLabel_5">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS8:NF:FrameTime_RBV</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QLabel" name="label_7">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 4</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="PyDMLabel" name="PyDMLabel_3">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS1:NF:FrameTime_RBV</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 3 - 800nm</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="label_13">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 2 - 1um</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="label_6">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 2 - 800nm</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS5:NF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="PyDMLabel" name="PyDMLabel_11">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS3:NF:FrameTime_RBV</string>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS1:NF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 1</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="PyDMLabel" name="PyDMLabel_4">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS5:NF:FrameTime_RBV</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_9">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS3:NF:IsUpdating_RBV</string>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="bigEndian" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="numBits" stdset="0">
+          <number>1</number>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="labels" stdset="0">
+          <stringlist>
+           <string>Bit 0</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="PyDMLabel" name="PyDMLabel_13">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS6:NF:FrameTime_RBV</string>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QLabel" name="label_15">
+         <property name="font">
+          <font>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Bay 3 - 1um</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_11">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string/>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://LTLHN:BTPS:Chk:LS6:NF:IsUpdating_RBV</string>
          </property>
          <property name="showLabels" stdset="0">
           <bool>false</bool>

--- a/pcdsdevices/ui/btps-overview.ui
+++ b/pcdsdevices/ui/btps-overview.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>798</width>
-    <height>108</height>
+    <width>2012</width>
+    <height>147</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -31,8 +31,8 @@
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="5" column="11">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_22">
+     <item row="3" column="11">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_32">
        <property name="toolTip">
         <string/>
        </property>
@@ -43,7 +43,7 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD9:LS8:BTPS:ChecksOK_RBV</string>
+        <string>ca://LTLHN:LD9:LS1:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -57,86 +57,6 @@
        </property>
        <property name="circles" stdset="0">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="6">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_38">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD10:LS8:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QLabel" name="label_9">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>NF Cam</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="11">
-      <widget class="PyDMLabel" name="PyDMLabel_7">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD9:BTPS:Name_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::String</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="5">
-      <widget class="PyDMLabel" name="PyDMLabel">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD8:BTPS:Name_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::String</enum>
        </property>
       </widget>
      </item>
@@ -163,19 +83,13 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="11">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_29">
+     <item row="8" column="4">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
        <property name="toolTip">
         <string/>
        </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD9:LS5:BTPS:ChecksOK_RBV</string>
+        <string>ca://LTLHN:BTPS:Chk:LS8:FF:IsUpdating_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -192,8 +106,8 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="8">
-      <widget class="PyDMLabel" name="PyDMLabel_4">
+     <item row="2" column="5">
+      <widget class="PyDMLabel" name="PyDMLabel">
        <property name="font">
         <font>
          <underline>true</underline>
@@ -203,15 +117,15 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD6:BTPS:Name_RBV</string>
+        <string>ca://LTLHN:LD8:BTPS:Name_RBV</string>
        </property>
        <property name="displayFormat" stdset="0">
         <enum>PyDMLabel::String</enum>
        </property>
       </widget>
      </item>
-     <item row="5" column="8">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_33">
+     <item row="3" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_26">
        <property name="toolTip">
         <string/>
        </property>
@@ -222,7 +136,7 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD6:LS8:BTPS:ChecksOK_RBV</string>
+        <string>ca://LTLHN:LD2:LS1:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -275,26 +189,8 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="7">
-      <widget class="PyDMLabel" name="PyDMLabel_3">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD2:BTPS:Name_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::String</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_44">
+     <item row="6" column="11">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_29">
        <property name="toolTip">
         <string/>
        </property>
@@ -305,43 +201,7 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LS5:BTPS:LSS:OpenRequest_RBV</string>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>1</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="7">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_26">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD2:LS1:BTPS:ChecksOK_RBV</string>
+        <string>ca://LTLHN:LD9:LS5:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -355,490 +215,6 @@
        </property>
        <property name="circles" stdset="0">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="4">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:BTPS:Chk:LS5:FF:IsUpdating_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:BTPS:Chk:LS5:NF:IsUpdating_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:BTPS:Chk:LS8:NF:IsUpdating_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="5">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_39">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD8:LS1:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="10">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_24">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD14:LS8:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>LS5 (Bay 3)</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:BTPS:Chk:LS1:NF:IsUpdating_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="label_7">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>LS8 (Bay 4)</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="10">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_31">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD14:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="7">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_41">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD2:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="5">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_34">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD8:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="8">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_42">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD6:LS1:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1" alignment="Qt::AlignHCenter">
-      <widget class="QLabel" name="label_4">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>LS1 (Bay 1)</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="9">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_35">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD4:LS1:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="6">
-      <widget class="PyDMLabel" name="PyDMLabel_2">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD10:BTPS:Name_RBV</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::String</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="2">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_45">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LS8:BTPS:LSS:OpenRequest_RBV</string>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>1</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="12">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_47">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD1:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>1</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="9">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_36">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD4:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="4">
-      <widget class="QLabel" name="label_10">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>FF Cam</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -878,61 +254,18 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="6">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_28">
-       <property name="toolTip">
-        <string/>
+     <item row="2" column="4">
+      <widget class="QLabel" name="label_10">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
        </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
+       <property name="text">
+        <string>FF Cam</string>
        </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD10:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="7">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_25">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD2:LS8:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -982,8 +315,23 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="10">
-      <widget class="PyDMLabel" name="PyDMLabel_6">
+     <item row="6" column="1">
+      <widget class="QLabel" name="label_5">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>LS5 (Bay 3 800nm)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="11">
+      <widget class="PyDMLabel" name="PyDMLabel_7">
        <property name="font">
         <font>
          <underline>true</underline>
@@ -993,10 +341,253 @@
         <string/>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD14:BTPS:Name_RBV</string>
+        <string>ca://LTLHN:LD9:BTPS:Name_RBV</string>
        </property>
        <property name="displayFormat" stdset="0">
         <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="label_8">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>Shutter</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_44">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LS5:BTPS:LSS:OpenRequest_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="6">
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD10:BTPS:Name_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_25">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD2:LS8:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_41">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD2:LS5:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="9">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_35">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD4:LS1:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="11">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_22">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD9:LS8:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="5">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_37">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD8:LS8:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="5">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_34">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD8:LS5:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -1013,6 +604,79 @@
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD14:LS1:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1" alignment="Qt::AlignHCenter">
+      <widget class="QLabel" name="label_4">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>LS1 (Bay 1)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_42">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:LS1:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="9">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_40">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD4:LS8:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -1047,6 +711,366 @@
        </property>
       </widget>
      </item>
+     <item row="6" column="12">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_47">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD1:LS5:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QLabel" name="label_9">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>NF Cam</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="10">
+      <widget class="PyDMLabel" name="PyDMLabel_6">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD14:BTPS:Name_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="6">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_28">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD10:LS5:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="10">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_24">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD14:LS8:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_33">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:LS8:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS1:NF:IsUpdating_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_27">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:LS5:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLabel" name="label_7">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>LS8 (Bay 4)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="8">
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:BTPS:Name_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="9">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_36">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD4:LS5:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>LS6 (Bay 3 1um)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_45">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LS8:BTPS:LSS:OpenRequest_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="6">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_38">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD10:LS8:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="6">
       <widget class="PyDMByteIndicator" name="PyDMByteIndicator_23">
        <property name="toolTip">
@@ -1076,8 +1100,77 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="11">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_32">
+     <item row="6" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS5:NF:IsUpdating_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS8:NF:IsUpdating_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="4">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS5:FF:IsUpdating_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_39">
        <property name="toolTip">
         <string/>
        </property>
@@ -1088,7 +1181,7 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD9:LS1:BTPS:ChecksOK_RBV</string>
+        <string>ca://LTLHN:LD8:LS1:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -1105,46 +1198,8 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="4">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:BTPS:Chk:LS8:FF:IsUpdating_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QLabel" name="label_8">
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
-       <property name="text">
-        <string>Shutter</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="5">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_37">
+     <item row="6" column="10">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_31">
        <property name="toolTip">
         <string/>
        </property>
@@ -1155,7 +1210,7 @@
         <bool>false</bool>
        </property>
        <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD8:LS8:BTPS:ChecksOK_RBV</string>
+        <string>ca://LTLHN:LD14:LS5:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="offColor" stdset="0">
         <color>
@@ -1172,65 +1227,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="9">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_40">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD4:LS8:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="8">
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_27">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://LTLHN:LD6:LS5:BTPS:ChecksOK_RBV</string>
-       </property>
-       <property name="offColor" stdset="0">
-        <color>
-         <red>255</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="12">
+     <item row="8" column="12">
       <widget class="PyDMByteIndicator" name="PyDMByteIndicator_48">
        <property name="toolTip">
         <string/>
@@ -1253,6 +1250,1341 @@
          <green>0</green>
          <blue>0</blue>
         </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>LS4 (Bay 2 1um)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="7">
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD2:BTPS:Name_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="label_3">
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>LS3 (Bay 2 800nm)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LS3:BTPS:LSS:OpenRequest_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS3:NF:IsUpdating_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="4">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_9">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS3:FF:IsUpdating_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="5">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_10">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD8:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="6">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_11">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD10:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_12">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD2:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_13">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="9">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_14">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD4:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="10">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_15">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD14:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="11">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_16">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD9:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="12">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_17">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD1:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="12">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_18">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD1:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="11">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_19">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD9:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="10">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_20">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD14:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="9">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_21">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD4:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_49">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_50">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD2:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="6">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_51">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD10:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="5">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_52">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD8:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="4">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_53">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS4:FF:IsUpdating_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_54">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS4:NF:IsUpdating_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_55">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LS4:BTPS:LSS:OpenRequest_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_56">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LS6:BTPS:LSS:OpenRequest_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_57">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS6:NF:IsUpdating_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="4">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_58">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:BTPS:Chk:LS6:FF:IsUpdating_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="5">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_59">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD8:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="6">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_60">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD10:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="7">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_61">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD2:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="8">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_62">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD6:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="9">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_63">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD4:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="10">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_64">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD14:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="11">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_65">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD9:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="12">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_66">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://LTLHN:LD1:LS6:BTPS:ChecksOK_RBV</string>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>

--- a/pcdsdevices/ui/btps-overview.ui
+++ b/pcdsdevices/ui/btps-overview.ui
@@ -1447,13 +1447,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD8:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1486,13 +1493,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD10:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1525,13 +1539,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD2:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1564,13 +1585,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD6:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1603,13 +1631,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD4:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1642,13 +1677,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD14:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1681,13 +1723,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD9:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1720,13 +1769,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD1:LS3:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1759,13 +1815,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD1:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1798,13 +1861,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD9:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1837,13 +1907,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD14:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1876,13 +1953,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD4:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1915,13 +1999,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD6:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1954,13 +2045,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD2:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -1993,13 +2091,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD10:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2032,13 +2137,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD8:LS4:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2305,13 +2417,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD8:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2344,13 +2463,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD10:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2383,13 +2509,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD2:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2422,13 +2555,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD6:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2461,13 +2601,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD4:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2500,13 +2647,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD14:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2539,13 +2693,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD9:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>
@@ -2578,13 +2739,20 @@
         <bool>false</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="PyDMToolTip" stdset="0">
         <string/>
        </property>
        <property name="channel" stdset="0">
         <string>ca://LTLHN:LD1:LS6:BTPS:ChecksOK_RBV</string>
+       </property>
+       <property name="offColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
        </property>
        <property name="showLabels" stdset="0">
         <bool>false</bool>

--- a/pcdsdevices/ui/btps-overview.ui
+++ b/pcdsdevices/ui/btps-overview.ui
@@ -1281,7 +1281,7 @@
         </font>
        </property>
        <property name="text">
-        <string>LS4 (Bay 2 1um)</string>
+        <string>LS4 (Bay 2 800nm)</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -1314,7 +1314,7 @@
         </font>
        </property>
        <property name="text">
-        <string>LS3 (Bay 2 800nm)</string>
+        <string>LS3 (Bay 2 1um)</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/pcdsdevices/ui/btps-source-tabs-config.ui
+++ b/pcdsdevices/ui/btps-source-tabs-config.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>781</width>
+    <width>983</width>
     <height>580</height>
    </rect>
   </property>
@@ -23,19 +23,19 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
-      <cstring></cstring>
+      <cstring>ca://${DEST}LS1:BTPS:ChecksOK_RBV</cstring>
      </property>
      <property name="alarmChannels">
       <stringlist>
-       <string></string>
-       <string></string>
-       <string></string>
-       <string></string>
-       <string></string>
-       <string></string>
+       <string>ca://${DEST}LS1:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS3:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS4:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS5:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS6:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS8:BTPS:ChecksOK_RBV</string>
       </stringlist>
      </property>
      <widget class="QWidget" name="source_ls1">

--- a/pcdsdevices/ui/btps-source-tabs-config.ui
+++ b/pcdsdevices/ui/btps-source-tabs-config.ui
@@ -23,17 +23,13 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
-      <cstring>ca://${DEST}LS1:BTPS:ChecksOK_RBV</cstring>
+      <cstring></cstring>
      </property>
      <property name="alarmChannels">
-      <stringlist>
-       <string>ca://${DEST}LS1:BTPS:ChecksOK_RBV</string>
-       <string>ca://${DEST}LS5:BTPS:ChecksOK_RBV</string>
-       <string>ca://${DEST}LS8:BTPS:ChecksOK_RBV</string>
-      </stringlist>
+      <stringlist/>
      </property>
      <widget class="QWidget" name="source_ls1">
       <attribute name="title">
@@ -64,9 +60,81 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="source_ls3">
+      <attribute name="title">
+       <string>LS3 (Bay 2 800nm)</string>
+      </attribute>
+      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>741</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="macros" stdset="0">
+        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS3:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS3:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
+       </property>
+       <property name="filename" stdset="0">
+        <string>btps-source-dest.ui</string>
+       </property>
+       <property name="loadWhenShown" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="disconnectWhenHidden" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="source_ls4">
+      <attribute name="title">
+       <string>LS4 (Bay 2 1um)</string>
+      </attribute>
+      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>741</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="macros" stdset="0">
+        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS4:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS4:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
+       </property>
+       <property name="filename" stdset="0">
+        <string>btps-source-dest.ui</string>
+       </property>
+       <property name="loadWhenShown" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="disconnectWhenHidden" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </widget>
      <widget class="QWidget" name="source_ls5">
       <attribute name="title">
-       <string>LS5 (Bay 3)</string>
+       <string>LS5 (Bay 3 800nm)</string>
       </attribute>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
@@ -92,6 +160,42 @@
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="source_ls6">
+      <attribute name="title">
+       <string>LS6 (Bay 3 1um)</string>
+      </attribute>
+      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>741</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="macros" stdset="0">
+        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS6:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS6:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
+       </property>
+       <property name="filename" stdset="0">
+        <string>btps-source-dest.ui</string>
+       </property>
+       <property name="loadWhenShown" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="disconnectWhenHidden" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
      </widget>
      <widget class="QWidget" name="source_ls8">
       <attribute name="title">
@@ -131,11 +235,13 @@
    <class>PyDMTabWidget</class>
    <extends>QTabWidget</extends>
    <header>pydm.widgets.tab_bar</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>PyDMEmbeddedDisplay</class>
    <extends>QFrame</extends>
    <header>pydm.widgets.embedded_display</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/btps-source-tabs-config.ui
+++ b/pcdsdevices/ui/btps-source-tabs-config.ui
@@ -23,7 +23,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>4</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
       <cstring></cstring>
@@ -71,73 +71,65 @@
       <attribute name="title">
        <string>LS3 (Bay 2 1um)</string>
       </attribute>
-      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>741</width>
-         <height>514</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="macros" stdset="0">
-        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS3:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS3:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
-       </property>
-       <property name="filename" stdset="0">
-        <string>btps-source-dest.ui</string>
-       </property>
-       <property name="loadWhenShown" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="disconnectWhenHidden" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="followSymlinks" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="macros" stdset="0">
+          <string>{&quot;SOURCE&quot;: &quot;${DEST}LS3:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS3:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
+         </property>
+         <property name="filename" stdset="0">
+          <string>btps-source-dest.ui</string>
+         </property>
+         <property name="loadWhenShown" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="disconnectWhenHidden" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="followSymlinks" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="source_ls4">
       <attribute name="title">
        <string>LS4 (Bay 2 800nm)</string>
       </attribute>
-      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>741</width>
-         <height>514</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="macros" stdset="0">
-        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS4:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS4:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
-       </property>
-       <property name="filename" stdset="0">
-        <string>btps-source-dest.ui</string>
-       </property>
-       <property name="loadWhenShown" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="disconnectWhenHidden" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="followSymlinks" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="macros" stdset="0">
+          <string>{&quot;SOURCE&quot;: &quot;${DEST}LS4:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS4:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
+         </property>
+         <property name="filename" stdset="0">
+          <string>btps-source-dest.ui</string>
+         </property>
+         <property name="loadWhenShown" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="disconnectWhenHidden" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="followSymlinks" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="source_ls5">
       <attribute name="title">
@@ -172,37 +164,33 @@
       <attribute name="title">
        <string>LS6 (Bay 3 1um)</string>
       </attribute>
-      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>741</width>
-         <height>514</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="macros" stdset="0">
-        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS6:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS6:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
-       </property>
-       <property name="filename" stdset="0">
-        <string>btps-source-dest.ui</string>
-       </property>
-       <property name="loadWhenShown" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="disconnectWhenHidden" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="followSymlinks" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <item>
+        <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="macros" stdset="0">
+          <string>{&quot;SOURCE&quot;: &quot;${DEST}LS6:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS6:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-config.ui&quot;}</string>
+         </property>
+         <property name="filename" stdset="0">
+          <string>btps-source-dest.ui</string>
+         </property>
+         <property name="loadWhenShown" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="disconnectWhenHidden" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="followSymlinks" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="source_ls8">
       <attribute name="title">

--- a/pcdsdevices/ui/btps-source-tabs-config.ui
+++ b/pcdsdevices/ui/btps-source-tabs-config.ui
@@ -23,13 +23,20 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>2</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
       <cstring></cstring>
      </property>
      <property name="alarmChannels">
-      <stringlist/>
+      <stringlist>
+       <string></string>
+       <string></string>
+       <string></string>
+       <string></string>
+       <string></string>
+       <string></string>
+      </stringlist>
      </property>
      <widget class="QWidget" name="source_ls1">
       <attribute name="title">
@@ -62,7 +69,7 @@
      </widget>
      <widget class="QWidget" name="source_ls3">
       <attribute name="title">
-       <string>LS3 (Bay 2 800nm)</string>
+       <string>LS3 (Bay 2 1um)</string>
       </attribute>
       <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
        <property name="geometry">
@@ -98,7 +105,7 @@
      </widget>
      <widget class="QWidget" name="source_ls4">
       <attribute name="title">
-       <string>LS4 (Bay 2 1um)</string>
+       <string>LS4 (Bay 2 800nm)</string>
       </attribute>
       <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
        <property name="geometry">

--- a/pcdsdevices/ui/btps-source-tabs.ui
+++ b/pcdsdevices/ui/btps-source-tabs.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>781</width>
+    <width>983</width>
     <height>580</height>
    </rect>
   </property>
@@ -23,7 +23,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>4</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
       <cstring></cstring>
@@ -42,7 +42,7 @@
       <attribute name="title">
        <string>LS1 (Bay 1)</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
         <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay">
          <property name="toolTip">
@@ -71,73 +71,74 @@
       <attribute name="title">
        <string>LS3 (Bay 2 1um)</string>
       </attribute>
-      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>741</width>
-         <height>514</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="macros" stdset="0">
-        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS3:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS3:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m10&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m12&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m11&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;2&quot;}</string>
-       </property>
-       <property name="filename" stdset="0">
-        <string>btps-source-dest.ui</string>
-       </property>
-       <property name="loadWhenShown" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="disconnectWhenHidden" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="followSymlinks" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="macros" stdset="0">
+          <string>{&quot;SOURCE&quot;: &quot;${DEST}LS3:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS3:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m10&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m12&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m11&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;2&quot;}</string>
+         </property>
+         <property name="filename" stdset="0">
+          <string>btps-source-dest.ui</string>
+         </property>
+         <property name="loadWhenShown" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="disconnectWhenHidden" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="followSymlinks" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="source_ls4">
       <attribute name="title">
        <string>LS4 (Bay 2 800nm)</string>
       </attribute>
-      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>741</width>
-         <height>514</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="macros" stdset="0">
-        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS4:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS4:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m15&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m14&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m13&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;2&quot;}</string>
-       </property>
-       <property name="filename" stdset="0">
-        <string>btps-source-dest.ui</string>
-       </property>
-       <property name="loadWhenShown" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="disconnectWhenHidden" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="followSymlinks" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <item>
+        <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="macros" stdset="0">
+          <string>{&quot;SOURCE&quot;: &quot;${DEST}LS4:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS4:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m15&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m14&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m13&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;2&quot;}</string>
+         </property>
+         <property name="filename" stdset="0">
+          <string>btps-source-dest.ui</string>
+         </property>
+         <property name="loadWhenShown" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="disconnectWhenHidden" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="followSymlinks" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="source_ls5">
       <attribute name="title">
@@ -172,37 +173,33 @@
       <attribute name="title">
        <string>LS6 (Bay 3 1um)</string>
       </attribute>
-      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>741</width>
-         <height>514</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="macros" stdset="0">
-        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS6:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS6:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m16&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m17&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m18&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;3&quot;}</string>
-       </property>
-       <property name="filename" stdset="0">
-        <string>btps-source-dest.ui</string>
-       </property>
-       <property name="loadWhenShown" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="disconnectWhenHidden" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="followSymlinks" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <item>
+        <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="macros" stdset="0">
+          <string>{&quot;SOURCE&quot;: &quot;${DEST}LS6:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS6:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m16&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m17&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m18&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;3&quot;}</string>
+         </property>
+         <property name="filename" stdset="0">
+          <string>btps-source-dest.ui</string>
+         </property>
+         <property name="loadWhenShown" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="disconnectWhenHidden" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="followSymlinks" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="source_ls8">
       <attribute name="title">

--- a/pcdsdevices/ui/btps-source-tabs.ui
+++ b/pcdsdevices/ui/btps-source-tabs.ui
@@ -23,19 +23,20 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>5</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
-      <cstring></cstring>
+      <cstring>ca://${DEST}LS8:BTPS:ChecksOK_RBV</cstring>
      </property>
      <property name="alarmChannels">
       <stringlist>
-       <string></string>
-       <string></string>
-       <string></string>
-       <string></string>
-       <string></string>
-       <string></string>
+       <string>ca://${DEST}LS1:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS3:BTPS:ChecksOK_RBV
+</string>
+       <string>ca://${DEST}LS4:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS5:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS6:BTPS:ChecksOK_RBV</string>
+       <string>ca://${DEST}LS8:BTPS:ChecksOK_RBV</string>
       </stringlist>
      </property>
      <widget class="QWidget" name="source_ls1">

--- a/pcdsdevices/ui/btps-source-tabs.ui
+++ b/pcdsdevices/ui/btps-source-tabs.ui
@@ -23,13 +23,20 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>2</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
       <cstring></cstring>
      </property>
      <property name="alarmChannels">
-      <stringlist/>
+      <stringlist>
+       <string></string>
+       <string></string>
+       <string></string>
+       <string></string>
+       <string></string>
+       <string></string>
+      </stringlist>
      </property>
      <widget class="QWidget" name="source_ls1">
       <attribute name="title">
@@ -62,7 +69,7 @@
      </widget>
      <widget class="QWidget" name="source_ls3">
       <attribute name="title">
-       <string>LS3 (Bay 2 800nm)</string>
+       <string>LS3 (Bay 2 1um)</string>
       </attribute>
       <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
        <property name="geometry">
@@ -98,7 +105,7 @@
      </widget>
      <widget class="QWidget" name="source_ls4">
       <attribute name="title">
-       <string>LS4 (Bay 2 1um)</string>
+       <string>LS4 (Bay 2 800nm)</string>
       </attribute>
       <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
        <property name="geometry">

--- a/pcdsdevices/ui/btps-source-tabs.ui
+++ b/pcdsdevices/ui/btps-source-tabs.ui
@@ -23,17 +23,13 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
-      <cstring>ca://${DEST}LS1:BTPS:ChecksOK_RBV</cstring>
+      <cstring></cstring>
      </property>
      <property name="alarmChannels">
-      <stringlist>
-       <string>ca://${DEST}LS1:BTPS:ChecksOK_RBV</string>
-       <string>ca://${DEST}LS5:BTPS:ChecksOK_RBV</string>
-       <string>ca://${DEST}LS8:BTPS:ChecksOK_RBV</string>
-      </stringlist>
+      <stringlist/>
      </property>
      <widget class="QWidget" name="source_ls1">
       <attribute name="title">
@@ -64,9 +60,81 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="source_ls3">
+      <attribute name="title">
+       <string>LS3 (Bay 2 800nm)</string>
+      </attribute>
+      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_4">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>741</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="macros" stdset="0">
+        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS3:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS3:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m10&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m12&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m11&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;2&quot;}</string>
+       </property>
+       <property name="filename" stdset="0">
+        <string>btps-source-dest.ui</string>
+       </property>
+       <property name="loadWhenShown" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="disconnectWhenHidden" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="source_ls4">
+      <attribute name="title">
+       <string>LS4 (Bay 2 1um)</string>
+      </attribute>
+      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_5">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>741</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="macros" stdset="0">
+        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS4:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS4:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m15&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m14&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m13&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;2&quot;}</string>
+       </property>
+       <property name="filename" stdset="0">
+        <string>btps-source-dest.ui</string>
+       </property>
+       <property name="loadWhenShown" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="disconnectWhenHidden" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </widget>
      <widget class="QWidget" name="source_ls5">
       <attribute name="title">
-       <string>LS5 (Bay 3)</string>
+       <string>LS5 (Bay 3 800nm)</string>
       </attribute>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
@@ -92,6 +160,42 @@
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="source_ls6">
+      <attribute name="title">
+       <string>LS6 (Bay 3 1um)</string>
+      </attribute>
+      <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay_6">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>741</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="macros" stdset="0">
+        <string>{&quot;SOURCE&quot;: &quot;${DEST}LS6:&quot;, &quot;SHUTTER&quot;: &quot;LTLHN:LS6:BTPS:&quot;, &quot;RANGE_SCREEN&quot;: &quot;btps-range-summary.ui&quot;, &quot;HAPPI_LINEAR&quot;: &quot;las_bts_mcs2_01_m16&quot;, &quot;HAPPI_ROTARY&quot;: &quot;las_bts_mcs2_01_m17&quot;, &quot;HAPPI_GONIOMETER&quot;: &quot;las_bts_mcs2_01_m18&quot;, &quot;HAPPI_NF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_nf&quot;, &quot;HAPPI_FF_CAM&quot;: &quot;las_lhn_bay${BAY}_cam_ff&quot;, &quot;BAY&quot;: &quot;3&quot;}</string>
+       </property>
+       <property name="filename" stdset="0">
+        <string>btps-source-dest.ui</string>
+       </property>
+       <property name="loadWhenShown" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="disconnectWhenHidden" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="followSymlinks" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
      </widget>
      <widget class="QWidget" name="source_ls8">
       <attribute name="title">
@@ -131,11 +235,13 @@
    <class>PyDMTabWidget</class>
    <extends>QTabWidget</extends>
    <header>pydm.widgets.tab_bar</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>PyDMEmbeddedDisplay</class>
    <extends>QFrame</extends>
    <header>pydm.widgets.embedded_display</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pcdsdevices/ui/btps-source-tabs.ui
+++ b/pcdsdevices/ui/btps-source-tabs.ui
@@ -23,10 +23,10 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>5</number>
+      <number>0</number>
      </property>
      <property name="currentTabAlarmChannel" stdset="0">
-      <cstring>ca://${DEST}LS8:BTPS:ChecksOK_RBV</cstring>
+      <cstring>ca://${DEST}LS1:BTPS:ChecksOK_RBV</cstring>
      </property>
      <property name="alarmChannels">
       <stringlist>

--- a/pcdsdevices/ui/btps.ui
+++ b/pcdsdevices/ui/btps.ui
@@ -107,7 +107,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="alarmChannels">
       <stringlist>
@@ -200,9 +200,9 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="ld2_tmo_ip3_tab">
+     <widget class="QWidget" name="ld2_rix_ip3_tab">
       <attribute name="title">
-       <string>TMO IP3</string>
+       <string>RIX IP3</string>
       </attribute>
       <layout class="QHBoxLayout" name="horizontalLayout_11">
        <property name="leftMargin">
@@ -218,7 +218,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="PyDMEmbeddedDisplay" name="ld2_tmo_ip3_embed">
+        <widget class="PyDMEmbeddedDisplay" name="ld2_rix_ip3_embed">
          <property name="toolTip">
           <string/>
          </property>

--- a/pcdsdevices/ui/btps.ui
+++ b/pcdsdevices/ui/btps.ui
@@ -107,7 +107,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="alarmChannels">
       <stringlist>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Update BTMS code to support new bay 2/bay 3 source lines
Update BTPS screens to support new bay 2/bay 3 source lines

## Motivation and Context
Closes #1256 

## How Has This Been Tested?
Tested interactively on the system.

## Where Has This Been Documented?
The code, this PR, and (soon) Confluence

## Screenshots:
New BTPS Screen: 
![image](https://github.com/user-attachments/assets/b22b2191-6f88-4d8b-b3b6-f017e3363187)

New BTMS Screen (with supporting updates in this PR: https://github.com/pcdshub/btms-ui/pull/12):
![image](https://github.com/user-attachments/assets/34d37884-d479-4cd3-83ae-f0bce1fe9a45)



## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
