### PR TITLE
Added PI_M824 motor class for MEC hexapod motors.

### DIFF
--- a/docs/source/upcoming_release_notes/4500-Add_motor_class_for_MEC_hexapod_axis.rst
+++ b/docs/source/upcoming_release_notes/4500-Add_motor_class_for_MEC_hexapod_axis.rst
@@ -1,0 +1,30 @@
+4500 Add motor class for MEC hexapod axis
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Added PI_M824 motor class for MEC hexapod motors
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- jozamudi

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1578,6 +1578,20 @@ class SmarActPicoscale(SmarAct):
         self._ioc_base = ioc_base
         super().__init__(prefix, **kwargs)
 
+class PI_M824(PVPositionerComparator):
+    """
+    Axis subclass for PI_M824_Hexapod class.
+    """
+    setpoint = Cpt(EpicsSignal, '')
+    readback = Cpt(EpicsSignal, ':rbv')
+    # one micron seems close enough
+    atol = 0.001
+
+    def done_comparator(self, readback, setpoint):
+        if setpoint - self.atol < readback and readback < setpoint + self.atol:
+            return True
+        else:
+            return False
 
 def _GetMotorClass(basepv):
     """
@@ -1593,7 +1607,9 @@ def _GetMotorClass(basepv):
                    ('MMB', BeckhoffAxis),
                    ('PIC', PCDSMotorBase),
                    ('MCS', SmarAct),
-                   ('MCS2', SmarAct))
+                   ('MCS2', SmarAct),
+                   ('HEX', PI_M824))
+
     # Search for component type in prefix
     for cpt_abbrev, _type in motor_types:
         if f':{cpt_abbrev}:' in basepv:
@@ -1635,6 +1651,8 @@ def Motor(prefix, **kwargs):
     | MCS           | :class:`.SmarAct`       |
     +---------------+-------------------------+
     | MCS2          | :class:`.SmarAct`       |
+    +---------------+-------------------------+
+    | HEX           | :class:`.PI_M824`       |
     +---------------+-------------------------+
 
     Parameters

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -22,7 +22,8 @@ from ophyd.utils.epics_pvs import raise_if_disconnected
 from pcdsutils.ext_scripts import get_hutch_name
 from prettytable import PrettyTable
 
-from pcdsdevices.pv_positioner import PVPositionerComparator
+from pcdsdevices.pv_positioner import (PVPositionerComparator,
+                                       PVPositionerIsClose)
 
 from .device import UpdateComponent as UpCpt
 from .doc_stubs import basic_positioner_init
@@ -1579,20 +1580,14 @@ class SmarActPicoscale(SmarAct):
         super().__init__(prefix, **kwargs)
 
 
-class PI_M824(PVPositionerComparator):
+class PI_M824(PVPositionerIsClose):
     """
-    Axis subclass for PI_M824_Hexapod class.
+    class for hexapod PI axis
     """
     setpoint = Cpt(EpicsSignal, '')
     readback = Cpt(EpicsSignal, ':rbv')
     # one micron seems close enough
     atol = 0.001
-
-    def done_comparator(self, readback, setpoint):
-        if setpoint - self.atol < readback and readback < setpoint + self.atol:
-            return True
-        else:
-            return False
 
 
 def _GetMotorClass(basepv):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1578,6 +1578,7 @@ class SmarActPicoscale(SmarAct):
         self._ioc_base = ioc_base
         super().__init__(prefix, **kwargs)
 
+
 class PI_M824(PVPositionerComparator):
     """
     Axis subclass for PI_M824_Hexapod class.
@@ -1592,6 +1593,7 @@ class PI_M824(PVPositionerComparator):
             return True
         else:
             return False
+
 
 def _GetMotorClass(basepv):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added PI_M824 motor class into epics_motor.py. Modified _getMotorClass to allow PVs with 'HEX' match with available motor types. Added doc string to Motor Class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-4500

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created a ipython instance and ran:
```
In [1]: from pcdsdevices.epics_motor import Motor
In [2]: m = Motor(prefix='MEC:HEX:01:Xpr',name='tc_hexapod')
In [3]: print(m)
PI_M824(MEC:HEX:01:Xpr, name=tc_hexapod)
In [4]: m.tweak()
tc_hexapod: -1.3220, scale: 0.1
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
