### PR TITLE
ENH: Add MSTA Bits

### DIFF
--- a/docs/source/upcoming_release_notes/1205-Add_MSTA_field_and_homed_status_to_EpicsMotorInterface.rst
+++ b/docs/source/upcoming_release_notes/1205-Add_MSTA_field_and_homed_status_to_EpicsMotorInterface.rst
@@ -8,13 +8,20 @@ API Breaks
 Features
 --------
 - MstaEnum: Enum describing the motor record MSTA bits
+- NewportMstaEnum: Enum describing the special Newport motor record MSTA bits
+- IMSMstaEnum: Enum describing the special IMS motor record MSTA bits
 
 Device Updates
 --------------
 - EpicsMotorInterface: Add a "raw" MSTA value, as well as the interpreted
                        values as a dictionary. Adds a "homed" property based
-                       based on this.
-
+                       on this. Uses a "generic" MstaEnum class.
+- Newport: Add a "raw" MSTA value, as well as the interpreted values as a
+           dictionary. Adds a "homed" property based on this. Uses the
+           "NewportMstaEnum" class.
+- IMS: Add a "raw" MSTA value, as well as the interpreted values as a
+       dictionary. Adds a "homed" property based on this. Uses the
+       "IMSMstaEnum" class.
 New Devices
 -----------
 - N/A

--- a/docs/source/upcoming_release_notes/1205-Add_MSTA_field_and_homed_status_to_EpicsMotorInterface.rst
+++ b/docs/source/upcoming_release_notes/1205-Add_MSTA_field_and_homed_status_to_EpicsMotorInterface.rst
@@ -1,0 +1,32 @@
+1205 Add MSTA field and homed status to EpicsMotorInterface
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- MstaEnum: Enum describing the motor record MSTA bits
+
+Device Updates
+--------------
+- EpicsMotorInterface: Add a "raw" MSTA value, as well as the interpreted
+                       values as a dictionary. Adds a "homed" property based
+                       based on this.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -63,6 +63,67 @@ class MstaEnum(Enum):
     homed = 14          # the motor has been homed
 
 
+class NewportMstaEnum(Enum):
+    """
+    Enum for the LCLS Newport XPS8 EPICS motor record .MSTA field bits.
+    """
+    # Note: the motor record docs start bit numbering at 1, but the MSTA bits
+    # start at 0.
+    direction = 0       # last raw move direction (0: negative, 1: positive)
+    done = 1            # motion is complete
+    plus_ls = 2         # plus limit switch is hit
+    home_ls = 3         # state of the home limit switch
+    slip = 4            # continue of slip stall
+    # closed-loop positioning enabled, called "position" in the docs
+    closed_loop = 5
+    slip_stall = 6      # slip stall is detected
+    home = 7            # at the home position
+    enc_present = 8     # encoder is present. Called "present" in the docs.
+    problem = 9         # driver stopped polling, or there's a hardware problem
+    moving = 10         # the motor has a non-zero velocity (it's moving)
+    gain_support = 11   # the motor supports closed loop control
+    comm_error = 12     # controller communication error
+    minus_ls = 13       # minus limit switch is hit
+    homed = 14          # the motor has been homed
+    powerup = 15        # the motor has been homed
+    mchb = 16           # MCode heart-beat
+    stall = 17          # stall detected
+    # 6 un-used bits for byte alignment
+    errno = 24          # error number
+
+
+class ImsMstaEnum(Enum):
+    """
+    Enum for the LCLS IMS EPICS motor record .MSTA field bits.
+    """
+    # Note: the motor record docs start bit numbering at 1, but the MSTA bits
+    # start at 0.
+    direction = 0       # last raw move direction (0: negative, 1: positive)
+    done = 1            # motion is complete
+    plus_ls = 2         # plus limit switch is hit
+    home_ls = 3         # state of the home limit switch
+    slip = 4            # continue of slip stall detect
+    # closed-loop positioning enabled, called "position" in the docs
+    closed_loop = 5
+    slip_stall = 6      # slip stall is detected
+    home = 7            # at the home position
+    enc_enable = 8      # encoder is enabled ("EE")
+    problem = 9         # driver stopped polling, or there's a hardware problem
+    moving = 10         # the motor has a non-zero velocity (it's moving)
+    gain_support = 11   # the motor supports closed loop control
+    comm_error = 12     # controller communication error
+    minus_ls = 13       # minus limit switch is hit
+    homed = 14          # the motor has been homed
+    errno = 15          # error number (7 bits)
+    stall = 22          # stall detected
+    trip_enabled = 23   # trip enabled
+    powerup = 24        # power cycled
+    ne = 25             # numeric enable
+    by0 = 26            # MCode not running (BY = 0)
+    # 4 un-used bits for byte alignment
+    not_init = 31          # initializaton not finished
+
+
 class EpicsMotorInterface(FltMvInterface, EpicsMotor):
     """
     The standard EpicsMotor class, but with our interface attached.

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -840,6 +840,21 @@ class IMS(PCDSMotorBase):
             status_wait(st)
         return st
 
+    @property
+    def msta(self):
+        """
+        Returns the msta fields as a dictionary.
+        """
+        # the MSTA field is a float for some reason...
+        val = int(self.msta_raw.get())
+        d = dict()
+        for bit in ImsMstaEnum:
+            if bit.name == 'errno':
+                d[bit.name] = (val >> bit.value) & 0x7F  # 7 bit error number
+            else:
+                d[bit.name] = (val >> bit.value) & 0x1
+        return d
+
     def clear_all_flags(self):
         """Clear all the flags from the IMS motor."""
         # Clear all flags
@@ -1116,6 +1131,21 @@ class Newport(PCDSMotorBase):
         # Newport motors to a reference mark
         raise NotImplementedError("Homing is not yet implemented for Newport "
                                   "motors")
+
+    @property
+    def msta(self):
+        """
+        Returns the msta fields as a dictionary.
+        """
+        # the MSTA field is a float for some reason...
+        val = int(self.msta_raw.get())
+        d = dict()
+        for bit in NewportMstaEnum:
+            if bit.name == 'errno':
+                d[bit.name] = (val >> bit.value) & 0xFF  # 8 bit error number
+            else:
+                d[bit.name] = (val >> bit.value) & 0x1
+        return d
 
     @motor_egu.sub_value
     def _update_units(self, value, **kwargs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds in an EPICS signal to bring the the motor MSTA bits. This signal is used to create a dictionary of interpreted values, as well as a "homed" property. 

## Motivation and Context
I would like to implement some automated homing on some finicky motor stacks. I need a way to check that the homing routine has completed.  

## How Has This Been Tested?
Tested live on one of the stages of interest (a SmarAct linear stage). 

## Where Has This Been Documented?
This PR. 

## Screenshots:
Live session (standard motor record):
![image](https://github.com/user-attachments/assets/2f43c7f4-0296-4233-830c-266a6239aa88)

IMS Motor:

<img width="996" alt="happy_ims" src="https://github.com/user-attachments/assets/35beed14-602c-4705-bb8e-ae64326f3c62">

<img width="1215" alt="sad_ims" src="https://github.com/user-attachments/assets/5c18d573-1a76-4272-b1bf-f0755c489fb1">

<img width="1186" alt="sad_ims_2" src="https://github.com/user-attachments/assets/9c6c2c18-a7fa-4e20-8fce-ed5a1d9e971e">

![image](https://github.com/user-attachments/assets/1607eca8-b1ea-4f5b-bb1a-c3855e76094e)

Newport Motor:

<img width="1033" alt="happy_newport" src="https://github.com/user-attachments/assets/03cd7766-e8cd-4954-b182-1eb4fe59095e">

<img width="1055" alt="sad_newport" src="https://github.com/user-attachments/assets/827e985d-cb84-44a3-8078-f3175f53dbc5">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
