### PR TITLE
Swap LS4 and LS3 on the BTPS/BTMS to match real mapping.

### DIFF
--- a/docs/source/upcoming_release_notes/1261-Fix_mis-match_of_LS3_and_LS4.rst
+++ b/docs/source/upcoming_release_notes/1261-Fix_mis-match_of_LS3_and_LS4.rst
@@ -1,0 +1,30 @@
+1261 Fix mis-match of LS3 and LS4
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- BtpsState: Fix mis-match of LS3 and LS4 PVs.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/lasers/btps.py
+++ b/pcdsdevices/lasers/btps.py
@@ -671,18 +671,18 @@ class BtpsState(BaseInterface, Device):
         BtpsSourceStatus,
         "LTLHN:LS3:",
         source_pos=SourcePosition.ls3,
-        linear_prefix="LAS:BTS:MCS2:01:m10",
-        rotary_prefix="LAS:BTS:MCS2:01:m12",
-        goniometer_prefix="LAS:BTS:MCS2:01:m11",
+        linear_prefix="LAS:BTS:MCS2:01:m15",
+        rotary_prefix="LAS:BTS:MCS2:01:m14",
+        goniometer_prefix="LAS:BTS:MCS2:01:m13",
         doc="Source status for LS3 (Bay 2 1um)"
     )
     ls4 = Cpt(
         BtpsSourceStatus,
         "LTLHN:LS4:",
         source_pos=SourcePosition.ls4,
-        linear_prefix="LAS:BTS:MCS2:01:m15",
-        rotary_prefix="LAS:BTS:MCS2:01:m14",
-        goniometer_prefix="LAS:BTS:MCS2:01:m13",
+        linear_prefix="LAS:BTS:MCS2:01:m10",
+        rotary_prefix="LAS:BTS:MCS2:01:m12",
+        goniometer_prefix="LAS:BTS:MCS2:01:m11",
         doc="Source status for LS3 (Bay 2 800m)"
     )
     ls5 = Cpt(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixes a mis-match between LS3 and LS4 in the BTMS/BTPS. 

## Motivation and Context
Closes #1261 

## How Has This Been Tested?
Tested on the stages in the laser hall. 

## Where Has This Been Documented?
This PR. 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
