### PR TITLE
ENH: BTMS Camera Updates

### DIFF
--- a/docs/source/upcoming_release_notes/1264-Make_SourcePosition_cameras_more_flexible.rst
+++ b/docs/source/upcoming_release_notes/1264-Make_SourcePosition_cameras_more_flexible.rst
@@ -1,0 +1,32 @@
+1264 Make SourcePosition cameras more flexible
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- lasers.btms_config.SourcePosition: Add a new method to get the happi device
+    name, turn the PV name into a dictionary rather than generating from bay
+    number.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- slactjohnson

--- a/pcdsdevices/lasers/btms_config.py
+++ b/pcdsdevices/lasers/btms_config.py
@@ -201,20 +201,56 @@ class SourcePosition(str, enum.Enum):
         }.get(self, None)
 
     @property
+    def nf_camera_device(self) -> str | None:
+        """
+        The near field camera happi entry associated with this source position.
+        """
+        return {
+            SourcePosition.ls1: "las_lhn_bay1_cam_nf",
+            SourcePosition.ls3: "las_lhn_bay2_amphos_nf",
+            SourcePosition.ls4: "las_lhn_bay2_amphos_nf",
+            SourcePosition.ls5: "las_lhn_bay3_amphos_nf",
+            SourcePosition.ls6: "las_lhn_bay3_amphos_nf",
+            SourcePosition.ls8: "las_lhn_bay4_cam_nf",
+        }.get(self, None)
+
+    @property
+    def ff_camera_device(self) -> str | None:
+        """
+        The far field camera happi entry associated with this source position.
+        """
+        return {
+            SourcePosition.ls1: "las_lhn_bay1_cam_ff",
+            SourcePosition.ls3: "las_lhn_bay2_amphos_ff",
+            SourcePosition.ls4: "las_lhn_bay2_amphos_ff",
+            SourcePosition.ls5: "las_lhn_bay3_amphos_ff",
+            SourcePosition.ls6: "las_lhn_bay3_amphos_ff",
+            SourcePosition.ls8: "las_lhn_bay4_cam_ff",
+        }.get(self, None)
+
+    @property
     def near_field_camera_prefix(self) -> str | None:
         """The near field camera prefix associated with this source position."""
-        bay = self.bay
-        if bay is not None:
-            return f"LAS:LHN:BAY{bay}:CAM:01:"
-        return None
+        return {
+            SourcePosition.ls1: "LAS:LHN:BAY1:CAM:01:",
+            SourcePosition.ls3: "LAS:LHN:BAY2:CAM:01:",
+            SourcePosition.ls4: "LAS:LHN:BAY2:CAM:01:",
+            SourcePosition.ls5: "LAS:LHN:BAY3:CAM:01:",
+            SourcePosition.ls6: "LAS:LHN:BAY3:CAM:01:",
+            SourcePosition.ls8: "LAS:LHN:BAY4:CAM:01:",
+        }.get(self, None)
 
     @property
     def far_field_camera_prefix(self) -> str | None:
         """The far field camera prefix associated with this source position."""
-        bay = self.bay
-        if bay is not None:
-            return f"LAS:LHN:BAY{bay}:CAM:02:"
-        return None
+        return {
+            SourcePosition.ls1: "LAS:LHN:BAY1:CAM:02:",
+            SourcePosition.ls3: "LAS:LHN:BAY2:CAM:02:",
+            SourcePosition.ls4: "LAS:LHN:BAY2:CAM:02:",
+            SourcePosition.ls5: "LAS:LHN:BAY3:CAM:02:",
+            SourcePosition.ls6: "LAS:LHN:BAY3:CAM:02:",
+            SourcePosition.ls8: "LAS:LHN:BAY4:CAM:02:",
+        }.get(self, None)
 
 
 class DestinationPosition(str, enum.Enum):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds new methods to return the defined happi database names for the cameras in each bay. Updates existing methods to get camera prefixes. This PR extends the flexibility of the existing implementation and adds some new properties while being backwards compatible. 

## Motivation and Context
closes #1264 

## How Has This Been Tested?
Tested interactively using the BTMS in the laser hall. 

## Where Has This Been Documented?
This PR, and a related PR on pcdshub/btms-ui. 

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
