### PR TITLE
Offset Mirror with 2D State Movers and PMPS.

### DIFF
--- a/docs/source/upcoming_release_notes/1272-2d-states.rst
+++ b/docs/source/upcoming_release_notes/1272-2d-states.rst
@@ -15,7 +15,7 @@ Device Updates
 
 New Devices
 -----------
-- adds `MirrorStripe2D4P` for coatings states with 2 dimensional position states movers with PMPS.
+- adds `MirrorStripe2D4P` for coating states with 2 dimensional position states movers with PMPS.
 - adds `XOffsetMirror2D4PState` for OffsetMirrors with 2D 4Position coating states.
 
 Bugfixes

--- a/docs/source/upcoming_release_notes/1272-2d-states.rst
+++ b/docs/source/upcoming_release_notes/1272-2d-states.rst
@@ -1,0 +1,31 @@
+1272 2d-states
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- adds `MirrorStripe2D4P` for coatings states with 2 dimensional position states movers with PMPS.
+- adds `XOffsetMirror2D4PState` for OffsetMirrors with 2D 4Position coating states.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/docs/source/upcoming_release_notes/1272-2d-states.rst
+++ b/docs/source/upcoming_release_notes/1272-2d-states.rst
@@ -15,7 +15,7 @@ Device Updates
 
 New Devices
 -----------
-- adds `MirrorStripe2D4P` for coating states with 2 dimensional position states movers with PMPS.
+- adds `MirrorStripe2D4P` for coating states with 2 dimensional position state movers with PMPS.
 - adds `XOffsetMirror2D4PState` for OffsetMirrors with 2D 4Position coating states.
 
 Bugfixes

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1286,7 +1286,7 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
         return 1
 
 
-class TwoDim4PosCoatStatesPMPS(TwinCATMirrorStripe):
+class CoatStatesPMPS2D4P(TwinCATMirrorStripe):
     """
     2D Coatings states with 4 positons and PMPS.
 
@@ -1417,7 +1417,7 @@ class XOffsetMirrorState(XOffsetMirror):
         return self._calc_lightpath_state(x_up, coating_state, pitch)
 
 
-class XoffsetMirror2D4PosState(XOffsetMirrorState):
+class XoffsetMirror2D4PState(XOffsetMirrorState):
     """
     X-ray Offset Mirror with coating states that have 4 positions.
 
@@ -1425,7 +1425,7 @@ class XoffsetMirror2D4PosState(XOffsetMirrorState):
 
     Currently services MR1L0.
     """
-    coating = Cpt(TwoDim4PosCoatStatesPMPS, ':COATING:STATE', kind='hinted',
+    coating = Cpt(CoatStatesPMPS2D4P, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')
 
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1417,7 +1417,7 @@ class XOffsetMirrorState(XOffsetMirror):
         return self._calc_lightpath_state(x_up, coating_state, pitch)
 
 
-class MR1L0(XOffsetMirrorState):
+class XoffsetMirror2D4PosState(XOffsetMirrorState):
     """
     X-ray Offset Mirror with coating states that have 4 positions.
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1417,7 +1417,7 @@ class XOffsetMirrorState(XOffsetMirror):
         return self._calc_lightpath_state(x_up, coating_state, pitch)
 
 
-class XoffsetMirror2D4PState(XOffsetMirrorState):
+class XOffsetMirror2D4PState(XOffsetMirrorState):
     """
     X-ray Offset Mirror with coating states that have 4 positions.
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1419,9 +1419,9 @@ class XOffsetMirrorState(XOffsetMirror):
 
 class MR1L0(XOffsetMirrorState):
     """
-    X-ray Offset Mirror with whos coating state has 4 positions.
+    X-ray Offset Mirror with coating states that have 4 positions.
 
-    The coating states use 2 dimensional state moves with PMPS.
+    The coating states use 2 dimensional state movers with PMPS.
 
     Currently services MR1L0
     """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1288,9 +1288,9 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
 
 class TwoDim4PosCoatStatesPMPS(TwinCATMirrorStripe):
     """
-    2D Coatings states with 4 positons and PMPS
+    2D Coatings states with 4 positons and PMPS.
 
-    Currently services MR1L0
+    Currently services MR1L0.
     """
     config = UpCpt(state_count=4, motor_count=4)
 
@@ -1423,7 +1423,7 @@ class MR1L0(XOffsetMirrorState):
 
     The coating states use 2 dimensional state movers with PMPS.
 
-    Currently services MR1L0
+    Currently services MR1L0.
     """
     coating = Cpt(TwoDim4PosCoatStatesPMPS, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1292,7 +1292,7 @@ class MirrorStripe2D4P(TwinCATMirrorStripe):
 
     Currently services MR1L0.
     """
-    config = UpCpt(state_count=4, motor_count=4)
+    config = UpCpt(state_count=4, motor_count=2)
 
 
 @reorder_components(

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1286,7 +1286,7 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
         return 1
 
 
-class CoatStatesPMPS2D4P(TwinCATMirrorStripe):
+class MirrorStripe2D4P(TwinCATMirrorStripe):
     """
     2D Coatings states with 4 positons and PMPS.
 
@@ -1425,7 +1425,7 @@ class XoffsetMirror2D4PState(XOffsetMirrorState):
 
     Currently services MR1L0.
     """
-    coating = Cpt(CoatStatesPMPS2D4P, ':COATING:STATE', kind='hinted',
+    coating = Cpt(MirrorStripe2D4P, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')
 
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1286,6 +1286,15 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
         return 1
 
 
+class MR1L0CoatingStates(TwinCATMirrorStripe):
+    """
+    2D Coatings states with 4 positons and PMPS
+
+    Currently services MR1L0
+    """
+    config = UpCpt(state_count=4, motor_count=4)
+
+
 @reorder_components(
     end_with=[
         'coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
@@ -1406,6 +1415,18 @@ class XOffsetMirrorState(XOffsetMirror):
         pitch: float
     ) -> LightpathState:
         return self._calc_lightpath_state(x_up, coating_state, pitch)
+
+
+class MR1L0(XOffsetMirrorState):
+    """
+    X-ray Offset Mirror with whos coating state has 4 positions.
+
+    The coating states use 2 dimensional state moves with PMPS.
+
+    Currently services MR1L0
+    """
+    coating = Cpt(MR1L0CoatingStates, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
 
 class XOffsetMirrorStateCool(XOffsetMirrorState):

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1286,7 +1286,7 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
         return 1
 
 
-class MR1L0CoatingStates(TwinCATMirrorStripe):
+class TwoDim4PosCoatStatesPMPS(TwinCATMirrorStripe):
     """
     2D Coatings states with 4 positons and PMPS
 
@@ -1425,7 +1425,7 @@ class MR1L0(XOffsetMirrorState):
 
     Currently services MR1L0
     """
-    coating = Cpt(MR1L0CoatingStates, ':COATING:STATE', kind='hinted',
+    coating = Cpt(TwoDim4PosCoatStatesPMPS, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')
 
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1288,7 +1288,7 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
 
 class MirrorStripe2D4P(TwinCATMirrorStripe):
     """
-    2D Coatings states with 4 positons and PMPS.
+    2D Coating states with 4 positons and PMPS.
 
     Currently services MR1L0.
     """

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1417,18 +1417,6 @@ class XOffsetMirrorState(XOffsetMirror):
         return self._calc_lightpath_state(x_up, coating_state, pitch)
 
 
-class XOffsetMirror2D4PState(XOffsetMirrorState):
-    """
-    X-ray Offset Mirror with coating states that have 4 positions.
-
-    The coating states use 2 dimensional state movers with PMPS.
-
-    Currently services MR1L0.
-    """
-    coating = Cpt(MirrorStripe2D4P, ':COATING:STATE', kind='hinted',
-                  doc='Control of the coating states via saved positions.')
-
-
 class XOffsetMirrorStateCool(XOffsetMirrorState):
     """
     X-ray Offset Mirror with Yleft/Yright
@@ -1455,6 +1443,18 @@ class XOffsetMirrorStateCool(XOffsetMirrorState):
     cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc='Mirror cooling panel loop pressure sensor')
 
     variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
+
+
+class XOffsetMirror2D4PState(XOffsetMirrorStateCool):
+    """
+    X-ray Offset Mirror with coating states that have 4 positions.
+
+    The coating states use 2 dimensional state movers with PMPS.
+
+    Currently services MR1L0.
+    """
+    coating = Cpt(MirrorStripe2D4P, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
 
 class XOffsetMirrorStateCoolNoBend(XOffsetMirrorStateCool):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Implements a `TwinCATMirrorStripe` with 2D state movers and 4 positions to support MR1L0. This mirror implements 2 Dimensional state mover with 4 positions and PMPS. 2 of the positions are meant to send beam to TXI and are currently invalidated. 
<!--- Describe your changes in detail -->
- Add new class `MirrorStripe2D4P` derived from `TwinCATMirrorStripe`
- Add new class to implement `MirrorStripe2D4P`: `XOffsetMirror2D4PState`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- MR1L0 will send beam to TXI and thus the coating and pitch define a single state. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran PLC program and ensured PMPS parameter neVRanges were loaded according to definitions in the database.
- Ran State position movers from epics and ensured mirrors travel to desired positions.
- Loaded a local copy of pcdsdevices and launched the typhos screen.
- Set state positions from typhos and ensured the mirror began traveling toward desired state positions.
- Loaded MR1L0 into a hutch python session using local pcdsdevices. Checked the `coating.states_list` to ensure properly listed states.
- I tried to move to the invalidated L1 positions via Typhos and got `Position state invalid for L1B4C` as intended.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- https://jira.slac.stanford.edu/browse/ECS-5254
- https://jira.slac.stanford.edu/browse/ECSENG-517

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
