### PR TITLE
BLD: use bluesky-base instead of bluesky(all)

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.9
-    - bluesky >=1.6.4
+    - bluesky-base >=1.6.4
     - happi
     - jsonschema
     - lightpath >=1.0.0
@@ -45,7 +45,7 @@ test:
   requires:
     - pytest
     - pytest-timeout
-    - matplotlib
+    - matplotlib <3.9  # avoid installing qt6
     - typhos
   imports:
     - {{ import_name }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -45,7 +45,6 @@ test:
   requires:
     - pytest
     - pytest-timeout
-    - matplotlib <3.9  # avoid installing qt6
     - typhos
   imports:
     - {{ import_name }}


### PR DESCRIPTION
## Description
Use bluesky-base in conda recipe instead of bluesky to avoid qt6-main

## Motivation and Context
NOTE: this will require a change in the conda-feedstock.  Without this other packages will fail by installing qt6 dependencies

## How Has This Been Tested?
N/A

## Where Has This Been Documented?
This PR. 

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
