### PR TITLE
BLD: depend on lightpath-base to avoid ui dependencies in builds

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - bluesky-base >=1.6.4
     - happi
     - jsonschema
-    - lightpath >=1.0.0
+    - lightpath-base >=1.0.5
     - matplotlib-base
     - numpy
     - ophyd >=1.7.0

--- a/docs/source/upcoming_release_notes/1281-bld_lightpath_base.rst
+++ b/docs/source/upcoming_release_notes/1281-bld_lightpath_base.rst
@@ -1,0 +1,31 @@
+1281 bld_lightpath_base
+#######################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Switch build recipes to rely on lightpath >= 1.0.5 (and lightpath-base in conda)
+  to avoid unnecessary ui dependencies.
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bluesky>=1.6.4
 happi
 jsonschema
-lightpath>=1.0.0
+lightpath>=1.0.5
 numpy
 ophyd>=1.7.0
 pcdscalc>=0.2.0


### PR DESCRIPTION
## Description
- Swaps `lightpath` -> `lightpath-base` in conda recipe
- Specifies >1.0.5 for both, to ensure pypi builds pull from version with GUI extras separated
  - Conda builds will fail until the feedstock updates, but I figured it's better to keep the version numbers the same

## Motivation and Context
Stop depending on things we don't need!

## How Has This Been Tested?
go CI go

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
