### PR TITLE
adding OUT state in pcdsdevice so that the last target name will be override by uppercase Letter

### DIFF
--- a/docs/source/upcoming_release_notes/1287-fix_lowercase_error.rst
+++ b/docs/source/upcoming_release_notes/1287-fix_lowercase_error.rst
@@ -1,0 +1,30 @@
+1287 fix lowercase error
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Change statecount from 7 to 8 to fix target name lower case issue
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tongju12

--- a/pcdsdevices/tmo_ip1.py
+++ b/pcdsdevices/tmo_ip1.py
@@ -13,9 +13,9 @@ class CalibrationAxis(TwinCATStatePMPS):
     """
     Sample calibration 1D State Setup
     Here, we specify 7 states, and 1 motor, for Y
-    axe.
+    axe.Add OUT states IN, total is 8
     """
-    config = UpCpt(state_count=7, motor_count=1)
+    config = UpCpt(state_count=8, motor_count=1)
 
 
 class SCaFoil(BaseInterface, GroupDevice, LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Currently the last target in the GUI shows lowercase letter, the way to fix that is adding one more state OUT in the code to fix it
<!--- Describe your changes in detail -->
Change state_count from 7 to 8 to add OUT position
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix the last target name lower case issue. All other targets are uppercase in the GUI
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
yes, it works now. attach picture here.
![Screenshot 2024-09-17 at 2 45 57 PM](https://github.com/user-attachments/assets/be872c23-cefb-4674-8ff4-25587c839d52)

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://jira.slac.stanford.edu/browse/ECS-4824)
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
