### PR TITLE
Added new VCN_OpenLoop device class

### DIFF
--- a/docs/source/upcoming_release_notes/848-create_new_VCNOpenLoop_device_class.rst
+++ b/docs/source/upcoming_release_notes/848-create_new_VCNOpenLoop_device_class.rst
@@ -1,4 +1,4 @@
-848 create new VFV device class
+848 create new VCN_OpenLoop device class
 #################
 
 API Breaks
@@ -15,8 +15,8 @@ Device Features
 
 New Devices
 -----------
-- VFV: similar to VCN w/ the removal of 'open' and 'position_readback'
-  commands. The 'state' member vairable has been renamed to 'control_mode' and
+- VCN_OpenLoop: similar to VCN w/ the removal of 'open' and 'position_readback'
+  commands. The 'state' member variable has been renamed to 'control_mode' and
   the associated doc string was been updated.
 
 Bugfixes

--- a/docs/source/upcoming_release_notes/848-create_new_VFV_device_class.rst
+++ b/docs/source/upcoming_release_notes/848-create_new_VFV_device_class.rst
@@ -15,7 +15,9 @@ Device Features
 
 New Devices
 -----------
-- VFV
+- VFV: similar to VCN w/ the removal of 'open' and 'position_readback'
+  commands. The 'state' member vairable has been renamed to 'control_mode' and
+  the associated doc string was been updated.
 
 Bugfixes
 --------
@@ -27,4 +29,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- jozamudi

--- a/docs/source/upcoming_release_notes/848-create_new_VFV_device_class.rst
+++ b/docs/source/upcoming_release_notes/848-create_new_VFV_device_class.rst
@@ -1,0 +1,30 @@
+848 create new VFV device class
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- VFV
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -860,10 +860,11 @@ class VCN_VAT590(BaseInterface, Device):
     status = Cpt(VCN_VAT590_Status, '',)
 
 
-class VFV(Device):
+class VCN_OpenLoop(Device):
     """
-    VFV = Variable Frequency Valves
+    VCN = Variable Controlled Needle
 
+    VCN w/ open loop control
     It corresponds to ST_VCN in the lcls-twincat-vacuum library.
     """
     position_control = Cpt(

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -858,3 +858,41 @@ class VCN_VAT590(BaseInterface, Device):
     )
 
     status = Cpt(VCN_VAT590_Status, '',)
+
+
+class VFV(Device):
+    """
+    VFV = Variable Controlled Needle valve
+
+    """
+    position_control = Cpt(
+        EpicsSignalWithRBV,
+        ':POS_REQ',
+        kind='normal',
+        doc=('requested positition to control the valve '
+             '0-100%')
+    )
+    upper_limit = Cpt(
+        EpicsSignalWithRBV,
+        ':Limit',
+        kind='normal',
+        doc=('max upper limit position to open the valve '
+             '0-100%')
+    )
+    interlock_ok = Cpt(
+        EpicsSignalRO,
+        ':ILK_OK_RBV',
+        kind='normal',
+        doc='interlock ok status'
+    )
+    control_mode = Cpt(
+        EpicsSignalWithRBV,
+        ':STATE',
+        kind='normal',
+        doc='Open mode will open valve to upper limit'
+    )
+    pos_ao = Cpt(
+        EpicsSignalRO,
+        ':POS_AO_R_RBV',
+        kind='normal'
+    )

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -863,6 +863,8 @@ class VCN_VAT590(BaseInterface, Device):
 class VFV(Device):
     """
     VFV = Variable Frequency Valves
+
+    It corresponds to ST_VCN in the lcls-twincat-vacuum library.
     """
     position_control = Cpt(
         EpicsSignalWithRBV,

--- a/pcdsdevices/valve.py
+++ b/pcdsdevices/valve.py
@@ -862,8 +862,7 @@ class VCN_VAT590(BaseInterface, Device):
 
 class VFV(Device):
     """
-    VFV = Variable Controlled Needle valve
-
+    VFV = Variable Frequency Valves
     """
     position_control = Cpt(
         EpicsSignalWithRBV,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Added VCN_OpenLoop device class to pcdsdevices valve.py. VCN_OpenLoop uses VCN as a template w/ the removal of 'open' and 'position_readback' commands. The 'state' member vairable has been renamed to 'control_mode' and the associated doc string was been updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECSENG-848

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used Typhos to check if device would load correctly.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
![Screenshot from 2024-09-24 13-44-06](https://github.com/user-attachments/assets/e771eadf-21b9-4fb7-81eb-aa6998e23bca)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
