### PR TITLE
Add state support for MR1K2, SP1K1, and MR1K1

### DIFF
--- a/docs/source/upcoming_release_notes/1290-rix-states.rst
+++ b/docs/source/upcoming_release_notes/1290-rix-states.rst
@@ -1,0 +1,33 @@
+1290 rix-states
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- `Mono` in `spectrometer.py` gets `MonoGratingStates`
+- `XOffsetMirrorSwitch` in `mirror.py` gets `TwinCATMirrorStripe`
+- `XOffsetMirrorBend` in `mirror.py` gets `MirrorStripe2D2P`
+
+New Devices
+-----------
+- `MonoGratingStates`
+- `MirrorStripe2D2P`
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -790,9 +790,9 @@ class TwinCATMirrorStripe(TwinCATStatePMPS):
 
 class MirrorStripe2D2P(TwinCATMirrorStripe):
     """
-    2D Coating states with 4 positons and PMPS.
+    2D Coating states with 2 positons and PMPS.
 
-    Currently services MR1L0.
+    Currently services MR1K1.
     """
     config = UpCpt(state_count=2, motor_count=2)
 

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -765,6 +765,43 @@ class XOffsetMirrorNoBend(XOffsetMirror):
     variable_cool = Cpt(PytmcSignal, ':VCV', kind='normal', io='io', doc='Activates variable cooling valve')
 
 
+class TwinCATMirrorStripe(TwinCATStatePMPS):
+    """
+    Subclass of TwinCATStatePMPS for the mirror coatings.
+
+    Unless most TwinCATStatePMPS, we have:
+    - Only in_states
+    - No in_states block the beam
+
+    We also clear the states_list and set _in_if_not_out to True
+    to automatically pick up the coatings from each mirror enum.
+    """
+    states_list = []
+    in_states = []
+    out_states = []
+    _in_if_not_out = True
+    config = UpCpt(state_count=2)
+
+    @property
+    def transmission(self):
+        """The mirror coating never blocks the beam."""
+        return 1
+
+
+class MirrorStripe2D2P(TwinCATMirrorStripe):
+    """
+    2D Coating states with 4 positons and PMPS.
+
+    Currently services MR1L0.
+    """
+    config = UpCpt(state_count=2, motor_count=2)
+
+
+@reorder_components(
+    start_with=[
+        'coating'
+    ]
+)
 class XOffsetMirrorBend(XOffsetMirror):
     """
     X-ray Offset Mirror with 2 bender acutators.
@@ -772,6 +809,8 @@ class XOffsetMirrorBend(XOffsetMirror):
     1st and 2nd gen Axilon designs with LCLS-II Beckhoff motion architecture.
 
     Currently (09/28/2022) services: mr1k1
+
+    With 2 dimensional coating selection and OUT state.
 
     Parameters
     ----------
@@ -787,6 +826,9 @@ class XOffsetMirrorBend(XOffsetMirror):
     # Do a dumb thing and kill inherited single bender
     bender = None
     bender_enc_rms = None
+
+    coating = Cpt(MirrorStripe2D2P, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
     # Motor components: can read/write positions
     bender_us = Cpt(BeckhoffAxisNoOffset, ':MMS:US', kind='hinted')
@@ -901,6 +943,9 @@ class XOffsetMirrorSwitch(XOffsetMirror):
     y_dwn = None
     bender = None
     bender_enc_rms = None
+
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
     # Motor components: can read/write positions
     y_left = Cpt(BeckhoffAxisNoOffset, ':MMS:YLEFT', kind='hinted',
@@ -1261,29 +1306,6 @@ class FFMirrorZ(FFMirror):
     cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal', doc="Axilon Panel Flow Meter Loop 1")
     cool_flow2 = None
     cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal', doc="Axilon Panel Pressure Meter")
-
-
-class TwinCATMirrorStripe(TwinCATStatePMPS):
-    """
-    Subclass of TwinCATStatePMPS for the mirror coatings.
-
-    Unless most TwinCATStatePMPS, we have:
-    - Only in_states
-    - No in_states block the beam
-
-    We also clear the states_list and set _in_if_not_out to True
-    to automatically pick up the coatings from each mirror enum.
-    """
-    states_list = []
-    in_states = []
-    out_states = []
-    _in_if_not_out = True
-    config = UpCpt(state_count=2)
-
-    @property
-    def transmission(self):
-        """The mirror coating never blocks the beam."""
-        return 1
 
 
 class MirrorStripe2D4P(TwinCATMirrorStripe):

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -252,11 +252,19 @@ class VonHamos6Crystal(BaseInterface, GroupDevice):
     x_top = Cpt(BeckhoffAxis, ':T3', kind='normal')
 
 
+class MonoGratingStates(TwinCATStatePMPS):
+    """
+    SP1K1 Mono Grating States Axis G_H with PMPS.
+
+    """
+    config = UpCpt(state_count=6)
+
+
 class Mono(BaseInterface, GroupDevice, LightpathMixin):
     """
     L2S-I NEH 2.X Monochromator
 
-    Axilon mechatronic desig with LCLS-II Beckhoff motion architecture.
+    Axilon mechatronic design with LCLS-II Beckhoff motion architecture.
 
     Parameters:
     -----------
@@ -268,7 +276,9 @@ class Mono(BaseInterface, GroupDevice, LightpathMixin):
     """
     # UI representation
     _icon = 'fa.minus-square'
-
+    # G_H states
+    grating_states = Cpt(MonoGratingStates, ':GRATING:STATE', kind='normal',
+                         doc="mono grating states g_h")
     # Motor components: can read/write positions
     m_pi = Cpt(BeckhoffAxisNoOffset, ':MMS:M_PI', kind='normal',
                doc='mirror pitch [urad]')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- add `MonoGratingStates` Class for use in `Mono`.
- add `grating_states` to `Mono` in `spectrometer.py` for `SP1K1`
- add `coating` to `XOffsetMirrorSwitch` for `MR1K2`
- add `MirrorStripe2D2P` for use in `XOffsetMirrorBend`
- add `coating` to `XOffsetMirrorBend` `for MR1K1`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
rix request state movers and PMPS for X-Ray Optics
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Launched all typhos screens and moved between states
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-936
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
