### PR TITLE
recover sp1k4-att target from 3 to 5

### DIFF
--- a/docs/source/upcoming_release_notes/1292-recoving_sp1k4-att_targets.rst
+++ b/docs/source/upcoming_release_notes/1292-recoving_sp1k4-att_targets.rst
@@ -1,0 +1,30 @@
+1292 recoving sp1k4-att targets
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- recover target number from 3 to 5
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tongju12

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -374,10 +374,10 @@ class TMOSpectrometerSOLIDATTStates(TwinCATStatePMPS):
     """
     Spectrometer Solid Attenuator(FOIL X and Y) 2D States Setup
 
-    Here, we specify 4 states,(after adding an Unknown state), and 2 motors, for the X and Y
+    Here, we specify 6 states,(after adding an Unknown state), and 2 motors, for the X and Y
     axes.
     """
-    config = UpCpt(state_count=4, motor_count=2)
+    config = UpCpt(state_count=6, motor_count=2)
 
 
 class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
SP1K4-ATT targets change from three targets to five targets so I need to update the devices
<!--- Describe your changes in detail -->
Change state count from 4 to 6
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists add target 4 and 5 back after swapping hardware
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
