### PR TITLE
ENH/FIX: apply TMO's mpod apalis hotfixes, adding features and fixing a major bug

### DIFF
--- a/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
+++ b/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
@@ -1,0 +1,34 @@
+1293 enh_tmo_mpod_apalis_hotfix
+###############################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- Add the ``desc``, ``voltage_setpoint``, and ``is_trip`` component signals to
+  `MPODApalisChannel`. These have been helpful during operations at TMO.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where arbitrarily large negative values were permitted to be
+  passed during the `MPODApalisChannel.set_voltage` method, and where
+  small values passed to a negative-polarity channel would clamp to the
+  most negative value.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
+++ b/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
@@ -15,6 +15,9 @@ Device Features
   `MPODApalisChannel`. These have been helpful during operations at TMO.
   ``last_voltage_set`` will also get a ``voltage_setpoint`` alias, which is the
   original name as used in TMO's scripts.
+- Add proper control limits to `MPODApalisChannel.voltage` and `MPODApalisChannel.current`.
+  This will give useful errors when someone tries to put values outside of the
+  channel's supported range.
 
 New Devices
 -----------
@@ -25,7 +28,8 @@ Bugfixes
 - Fix an issue where arbitrarily large negative values were permitted to be
   passed during the `MPODApalisChannel.set_voltage` method, and where
   small values passed to a negative-polarity channel would jump to the
-  most negative value.
+  most negative value. Now, this function will clamp all values between
+  zero and the maximum channel voltage.
 
 Maintenance
 -----------

--- a/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
+++ b/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
@@ -33,7 +33,7 @@ Bugfixes
 
 Maintenance
 -----------
-- N/A
+- Added unit tests to cover the `MPODApalisChannel` changes.
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
+++ b/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
@@ -11,8 +11,10 @@ Library Features
 
 Device Features
 ---------------
-- Add the ``desc``, ``voltage_setpoint``, and ``is_trip`` component signals to
+- Add the ``desc``, ``last_voltage_set``, and ``is_trip`` component signals to
   `MPODApalisChannel`. These have been helpful during operations at TMO.
+  ``last_voltage_set`` will also get a ``voltage_setpoint`` alias, which is the
+  original name as used in TMO's scripts.
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
+++ b/docs/source/upcoming_release_notes/1293-enh_tmo_mpod_apalis_hotfix.rst
@@ -22,7 +22,7 @@ Bugfixes
 --------
 - Fix an issue where arbitrarily large negative values were permitted to be
   passed during the `MPODApalisChannel.set_voltage` method, and where
-  small values passed to a negative-polarity channel would clamp to the
+  small values passed to a negative-polarity channel would jump to the
   most negative value.
 
 Maintenance

--- a/pcdsdevices/mpod_apalis.py
+++ b/pcdsdevices/mpod_apalis.py
@@ -45,8 +45,16 @@ class MPODApalisChannel(BaseInterface, Device):
     desc = Cpt(EpicsSignal, ':VoltageMeasure.DESC', kind='normal',
                doc='MPOD Channel Description')
 
-    voltage_setpoint = Cpt(EpicsSignalRO, ':VoltageSet', kind='normal',
-                           doc='MPOD Channel Voltage Setpoint [V]')
+    last_voltage_set = Cpt(
+        EpicsSignalRO, ':VoltageSet', kind='normal',
+        doc=(
+            'Readback to verify the MPOD Channel Voltage Setpoint [V]. '
+            'This is used to compare the measured readback voltage with '
+            'the last value we set to the channel. '
+            'To change the voltage, use the voltage signal or the '
+            'set_voltage helper method.'
+        )
+    )
 
     is_trip = Cpt(EpicsSignalRO, ':isTrip', kind='omitted',
                   doc='True if MPOD channel is tripped.')
@@ -54,6 +62,11 @@ class MPODApalisChannel(BaseInterface, Device):
     tab_component_names = True
     tab_whitelist = ['on', 'off',
                      'set_voltage', 'set_current']
+
+    @property
+    def voltage_setpoint(self) -> EpicsSignalRO:
+        """Name alias for backwards compatibility."""
+        return self.last_voltage_set
 
     def on(self):
         """Set mpod channel On."""

--- a/pcdsdevices/mpod_apalis.py
+++ b/pcdsdevices/mpod_apalis.py
@@ -141,7 +141,7 @@ def _put_clamped(signal: EpicsSignal, value: float) -> None:
     """
     Force put value to be within the limits of the signal.
 
-    Warn if the value is outside the range and needed to be clampted
+    Warn if the value is outside the range and needed to be clamped
     """
     low_val = min(signal.limits)
     high_val = max(signal.limits)

--- a/pcdsdevices/mpod_apalis.py
+++ b/pcdsdevices/mpod_apalis.py
@@ -42,6 +42,15 @@ class MPODApalisChannel(BaseInterface, Device):
                 kind='normal', string=True,
                 doc='MPOD Channel State [Off/On]')
 
+    desc = Cpt(EpicsSignal, ':VoltageMeasure.DESC', kind='normal',
+               doc='MPOD Channel Description')
+
+    voltage_setpoint = Cpt(EpicsSignalRO, ':VoltageSet', kind='normal',
+                           doc='MPOD Channel Voltage Setpoint [V]')
+
+    is_trip = Cpt(EpicsSignalRO, ':isTrip', kind='omitted',
+                  doc='True if MPOD channel is tripped.')
+
     tab_component_names = True
     tab_whitelist = ['on', 'off',
                      'set_voltage', 'set_current']
@@ -64,7 +73,7 @@ class MPODApalisChannel(BaseInterface, Device):
         """
         max_voltage = self.max_voltage.get()
 
-        if voltage_number <= max_voltage:
+        if abs(voltage_number) <= abs(max_voltage):
             self.voltage.put(voltage_number)
         else:
             self.voltage.put(max_voltage)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the following components to `MPODApalisChannel`:

- `desc` signal: Description of the mpod channel, used to configure what gets showed on the screen and to check the description during experiments.
- `last_voltage_set` signal: The setpoint of the MPOD channel, again. When we `put` to the `voltage` signal it also uses the setpoint PV, but having this as a separate signal lets you quickly see what the last value set was, and compare it to the apparent readback voltage of the channel. This is aliased to `voltage_setpoint` for some dev-time backwards compatibility for tmo. The new name is more clear.
- `is_trip` signal: `True` if the channel is tripped, which is helpful for some recovery automation and error reporting.
- Add long docstrings in various places to explain how signals are used.

Fix a bug:
- Voltage set bounding was implemented assuming voltages were always positive.
- One thing this did was allow unbounded voltage sets in the negative direction.
- Another thing this did was cause any voltage sets to negative-polarity channels to be immediately jumped to the most-negative possible value.
- Now, the voltage and current signals will have proper limits for error reporting and the `set_voltage` and `set_current` utilities will be properly clamped to the valid range.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TMO's hutch-python has these updates in `mpod_apalis.py`.
It's not clear who originally implemented these, but they are used by tmo.

Some time recently, these were accidentally removed.
So, let's formally introduce these into pcdsdevices proper.

One of these is a major bugfix and the others are niceties.

I added some additional changes on top of these as well as associated documentation and unit test updates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The original hotfix was tested interactively at TMO.
The updated hotfix was tested interactively by me and the new unit tests are now passing.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only, in the code and in the pre-release notes.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
