### PR TITLE
Add coating states to FFMirror and kill them in FFMirrorZ

### DIFF
--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1164,6 +1164,8 @@ class FFMirror(BaseInterface, GroupDevice, LightpathMixin):
 
     1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
 
+    MR2K2
+
     Parameters
     ----------
     prefix : str
@@ -1174,6 +1176,10 @@ class FFMirror(BaseInterface, GroupDevice, LightpathMixin):
     """
     # UI representation
     _icon = 'fa.minus-square'
+
+    # Basic 2 Coating State Selection
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
+                  doc='Control of the coating states via saved positions.')
 
     # Motor components: can read/write positions
     x = Cpt(BeckhoffAxisNoOffset, ':MMS:X', kind='hinted')
@@ -1281,6 +1287,8 @@ class FFMirrorZ(FFMirror):
 
     1st gen Toyama designs with LCLS-II Beckhoff motion architecture.
 
+    MR4/5K4
+
     Parameters
     ----------
     prefix : str
@@ -1289,6 +1297,8 @@ class FFMirrorZ(FFMirror):
     name : str
         Alias for the device.
     """
+    # Coating States not implemented yet.
+    coating = None
     # Motor components: can read/write positions
     z = Cpt(BeckhoffAxisNoOffset, ':MMS:Z', kind='hinted')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add coating states to `FFMirror` and kill them in `FFMirrorZ`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
MR2K2 is the only mirror using the `FFMirror` base class. The mirrors using `FFMirrorZ` are scheduled to receive coating states, so set them `None` for now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran `typhos` with this branch referenced in the python environment.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-936
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
