### PR TITLE
Add triggered signal

### DIFF
--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -839,6 +839,54 @@ class AvgSignal(Signal):
             # This takes a mean, skipping nan values.
             self.put(np.nanmean(self.values))
 
+class AvgSignalTriggered(AvgSignal):
+    """
+    Signal that acts as a rolling average of another signal, with the rolling average reset every
+    time the trigger method is called (e.g. at every point in a bluesky scan).
+
+    This will subscribe to a signal, and fill an internal buffer with values
+    from `SUB_VALUE`. It will update its own value to be the mean of the last n
+    accumulated values, up to the buffer size. If we haven't filled this
+    buffer, this will still report a mean value composed of all the values
+    we've receieved so far.
+
+    Warning: this means that if we only have recieved ONE value, the mean will
+    just be the mean of a single value!
+
+    Parameters
+    ----------
+    signal : Signal
+        Any subclass of `ophyd.signal.Signal` that returns a numeric value.
+        This signal will be subscribed to be `AvgSignal` to calculate the mean.
+
+    averages : int
+        The number of `SUB_VALUE` updates to include in the average. New values
+        after this number is reached will begin overriding old values.
+    
+    duration : float
+        The number of seconds to wait before returning complete. Nominally this
+        should be set to averages divided by the expected update rate of the signal.
+    """
+
+
+    def __init__(self, signal, averages, duration, *, name, parent=None, **kwargs):
+        super().__init__(signal, averages, name=name, parent=parent, **kwargs)
+        if isinstance(signal, str):
+            signal = getattr(parent, signal)
+        self.raw_sig = signal
+        self._lock = RLock()
+        self.averages = averages
+        self.duration = duration
+        self.raw_sig.subscribe(self._update_avg)
+    
+    def trigger(self):
+        # reset the averaging buffer
+        self.averages = self._avg
+        # set status to complete after duration
+        status = StatusBase(settle_time=self.duration)
+        status.set_finished()
+        return status
+
 
 class NotImplementedSignal(SignalRO):
     """Dummy signal for a not implemented feature."""

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -24,6 +24,7 @@ import ophyd
 from ophyd.signal import (DEFAULT_WRITE_TIMEOUT, DerivedSignal, EpicsSignal,
                           EpicsSignalBase, EpicsSignalRO, Signal, SignalRO)
 from ophyd.sim import FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache
+from ophyd.status import StatusBase
 from ophyd.utils import ReadOnlyError
 from pytmc.pragmas import normalize_io
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Subclassed AvgSignal in order to allow averaging of a signal within a bluesky scan.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes there are cases where one wants to average a signal before moving to the next scan point.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in xcs3 using 'XCS:SND:DIO:AMPL_8' wave8 signal, with the following test:
```
d1 = AvgSignalTriggered(EpicsSignalRO('XCS:SND:DIO:AMPL_8'),120,1,name='d1')
RE(scan([d1],sim.fast_motor1,0,120,num=11))

Transient Scan ID: 1     Time: 2024-10-11 12:23:24
Persistent Unique Scan ID: '567b8720-03ad-4ed6-a837-5effa5ac3058'
New stream: 'primary'
+-----------+------------+-------------+------------+
|   seq_num |       time | fast_motor1 |         d1 |
+-----------+------------+-------------+------------+
|         1 | 12:23:25.8 |           0 |      0.833 |
|         2 | 12:23:26.8 |          12 |       0.21 |
|         3 | 12:23:27.8 |          24 |     -0.371 |
|         4 | 12:23:28.8 |          36 |     0.0688 |
|         5 | 12:23:29.8 |          48 |      0.279 |
|         6 | 12:23:30.8 |          60 |     -0.285 |
|         7 | 12:23:31.8 |          72 |      -0.29 |
|         8 | 12:23:32.8 |          84 |      0.131 |
|         9 | 12:23:33.9 |          96 |     -0.152 |
|        10 | 12:23:34.9 |         108 |      0.635 |
|        11 | 12:23:35.9 |         120 |       -0.2 |
+-----------+------------+-------------+------------+
generator scan ['567b8720'] (scan num: 1)
```
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
AvgSignalTriggered docstring

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate