### PR TITLE
ENH: merge AvgSignalTriggered into AvgSignal

### DIFF
--- a/docs/source/upcoming_release_notes/1297-avgsignal_trigger.rst
+++ b/docs/source/upcoming_release_notes/1297-avgsignal_trigger.rst
@@ -1,0 +1,35 @@
+1297 avgsignal_trigger
+######################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- Add the capability for `AvgSignal` to reset itself on trigger,
+  then wait a duration before marking the trigger as complete.
+  This lets you use `AvgSignal` in a bluesky plan as a way to
+  accumulate the time average of a fast-updating signal at each
+  scan point. To enable this, provide a ``duration`` argument.
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- mseaberg
+- zllentz

--- a/docs/source/upcoming_release_notes/1297-avgsignal_trigger.rst
+++ b/docs/source/upcoming_release_notes/1297-avgsignal_trigger.rst
@@ -27,7 +27,7 @@ Bugfixes
 
 Maintenance
 -----------
-- N/A
+- Add unit tests for the new `AvgSignal` features.
 
 Contributors
 ------------

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -27,7 +27,7 @@ from ophyd.device import Device
 from ophyd.signal import (DEFAULT_WRITE_TIMEOUT, DerivedSignal, EpicsSignal,
                           EpicsSignalBase, EpicsSignalRO, Signal, SignalRO)
 from ophyd.sim import FakeEpicsSignal, FakeEpicsSignalRO, fake_device_cache
-from ophyd.status import StatusBase
+from ophyd.status import Status
 from ophyd.utils import ReadOnlyError
 from pytmc.pragmas import normalize_io
 
@@ -869,13 +869,13 @@ class AvgSignal(Signal):
             # This takes a mean, skipping nan values.
             self.put(np.nanmean(self.values))
 
-    def trigger(self):
+    def trigger(self) -> Status:
         if self.duration is None:
             return super().trigger()
         # reset the averaging buffer
         self.reset_buffer()
         # set status to complete after duration
-        status = StatusBase(settle_time=self.duration)
+        status = Status(obj=self, settle_time=self.duration)
         status.set_finished()
         return status
 

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -1,6 +1,8 @@
 """
 Module to define ophyd Signal subclass utilities.
 """
+from __future__ import annotations
+
 # Catch semi-frequent issue with scripts accidentally run from inside module
 if __name__ != 'pcdsdevices.signal':
     raise RuntimeError('A script tried to import pcdsdevices.signal '

--- a/pcdsdevices/signal.py
+++ b/pcdsdevices/signal.py
@@ -784,7 +784,7 @@ class MultiDerivedSignalRO(SignalRO, MultiDerivedSignal):
 
 class AvgSignal(Signal):
     """
-    Signal that acts as a rolling average of another signal
+    Signal that acts as a rolling average of another signal.
 
     Optionally, the rolling average can be reset every time the ``trigger`` method
     is called (e.g. at every point in a bluesky scan).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Take the features implemented by @mseaberg in #1297 and pull them into the parent class.
- Refactor the original class slightly to make `reset_buffer` usable directly.
- Fix some old documentation issues and add type annotations
- Add unit tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The features in #1297 are useful and fit seamlessly into the main class, this consolidates the similar features in one place.
- Avoids the small oddity of setting the average count back to itself in order to reset the buffer
- I like type annotations
- Unit tests protect us against regressions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I added unit tests
- I redid the tests Matt did in xcs in #1297 and had similar results.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- I added release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
