### PR TITLE
MNT: clean hxr diffractometer

### DIFF
--- a/docs/source/upcoming_release_notes/1274-Adding_base_class_for_hxr_diffractometer..rst
+++ b/docs/source/upcoming_release_notes/1274-Adding_base_class_for_hxr_diffractometer..rst
@@ -15,7 +15,8 @@ Device Features
 
 New Devices
 -----------
-- Adding base class for hxr diffractometer, this class needs the base prefix to be passed in e.g. HXR:GON:MMS. The stage suffixes are hardcoded.
+- Added `HxrDiffractometer` for the Beckhoff-based HXR diffractomoeter.
+  This controls the diffractometer in XPP with prefix ``"HXR:GON:MMS"``.
 
 Bugfixes
 --------
@@ -28,3 +29,4 @@ Maintenance
 Contributors
 ------------
 - c-tsoi
+- zllentz

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -660,15 +660,15 @@ x, y, z: {x}, {y}, {z} [{units}]
 
 class HxrDiffractometer(BaseInterface, Device):
     """
-    Class for diffractometer.
+    Class for Beckhoff-based diffractometer.
 
     Parameters
     ----------
-    name : str
-        A name to refer to the device
-
-    prefix_base : str
+    prefix : str
         The EPICS base PV of the diffractometer stages
+
+    name : str, keyword-only
+        A name to refer to the device
     """
 
     base_h = Cpt(BeckhoffAxis, 'BASE_H', kind='normal')
@@ -678,9 +678,6 @@ class HxrDiffractometer(BaseInterface, Device):
     chi = Cpt(BeckhoffAxis, 'CHI', kind='normal')
 
     tab_component_names = True
-
-    def __init__(self, prefix, name, **kwargs):
-        super().__init__(prefix, name=name, **kwargs)
 
 
 class SimSampleStage(KappaXYZStage):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Tiny tweaks to `HxrDiffractometer`'s documentation to make it more like other devices
- Remove the nearly no-op init method. Note that the original init method made it so you could pass in `name` as a position argument which is intentionally not allowed in most ophyd devices, this feature is removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `HxrDiffractometer` was added in #1274
- I forgot about this and rediscovered it during https://jira.slac.stanford.edu/browse/ECS-6333 since it's in xpp3 as a hotfix
- When evaluating the hotfix, I made a mental note of a few edits to make while submitting the hotfix
- I saw that it was already here so I applied the changes I intended in pcdsdevices
- I also cleaned up the language in the pre-release notes (for example, this isn't a base class, it's just a device, and other minor misapplication of terminology with specific meanings)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- No code changes

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- Cleaned up the pre-release notes too

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
