### PR TITLE
ENH: las timing configurables (cxi3 hotfix)

### DIFF
--- a/docs/source/upcoming_release_notes/1301-enh_config_las_timing.rst
+++ b/docs/source/upcoming_release_notes/1301-enh_config_las_timing.rst
@@ -1,0 +1,31 @@
+1301 enh_config_las_timing
+##########################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- Allow init-time configuration of phase shifter inversion and setpoint limits
+  for `LaserTiming` and `LCLS2LaserTiming` devices.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -291,7 +291,7 @@ class LaserTiming(FltMvInterface, PVPositioner):
     done = Cpt(EpicsSignal, ':MMS:PH.DMOV', auto_monitor=True, kind='omitted')
     done_value = 1
 
-    def __init__(self, prefix='', *, egu=None, invert=True, **kwargs):
+    def __init__(self, prefix='', *, egu=None, invert=True, limits=None, **kwargs):
         if egu not in (None, 's'):
             raise ValueError(
                 f'{self.__class__.__name__} is pre-configured to work in units'
@@ -302,6 +302,8 @@ class LaserTiming(FltMvInterface, PVPositioner):
             self.setpoint.scale = -1
         else:
             self.setpoint.scale = 1
+        if limits is not None:
+            self.limits = limits
 
     @user_offset.sub_value
     def _offset_changed(self, value, **kwargs):
@@ -459,7 +461,7 @@ class Lcls2LaserTiming(FltMvInterface, PVPositioner):
     done = Cpt(EpicsSignal, ':PHASCTL:DELAY_MOVING', auto_monitor=True, kind='omitted')
     done_value = 0
 
-    def __init__(self, prefix='', *, egu=None, invert=True, **kwargs):
+    def __init__(self, prefix='', *, egu=None, invert=True, limits=None, **kwargs):
         if egu not in (None, 's'):
             raise ValueError(
                 f'{self.__class__.__name__} is pre-configured to work in units'
@@ -470,6 +472,8 @@ class Lcls2LaserTiming(FltMvInterface, PVPositioner):
             self.setpoint.scale = -1
         else:
             self.setpoint.scale = 1
+        if limits is not None:
+            self.limits = limits
 
     @user_offset.sub_value
     def _offset_changed(self, value, **kwargs):

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -291,13 +291,17 @@ class LaserTiming(FltMvInterface, PVPositioner):
     done = Cpt(EpicsSignal, ':MMS:PH.DMOV', auto_monitor=True, kind='omitted')
     done_value = 1
 
-    def __init__(self, prefix='', *, egu=None, **kwargs):
+    def __init__(self, prefix='', *, egu=None, invert=True, **kwargs):
         if egu not in (None, 's'):
             raise ValueError(
                 f'{self.__class__.__name__} is pre-configured to work in units'
                 f' of seconds.'
             )
         super().__init__(prefix, egu='s', **kwargs)
+        if invert:
+            self.setpoint.scale = -1
+        else:
+            self.setpoint.scale = 1
 
     @user_offset.sub_value
     def _offset_changed(self, value, **kwargs):

--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -459,13 +459,17 @@ class Lcls2LaserTiming(FltMvInterface, PVPositioner):
     done = Cpt(EpicsSignal, ':PHASCTL:DELAY_MOVING', auto_monitor=True, kind='omitted')
     done_value = 0
 
-    def __init__(self, prefix='', *, egu=None, **kwargs):
+    def __init__(self, prefix='', *, egu=None, invert=True, **kwargs):
         if egu not in (None, 's'):
             raise ValueError(
                 f'{self.__class__.__name__} is pre-configured to work in units'
                 f' of seconds.'
             )
         super().__init__(prefix, egu='s', **kwargs)
+        if invert:
+            self.setpoint.scale = -1
+        else:
+            self.setpoint.scale = 1
 
     @user_offset.sub_value
     def _offset_changed(self, value, **kwargs):

--- a/pcdsdevices/tests/test_lxe.py
+++ b/pcdsdevices/tests/test_lxe.py
@@ -9,7 +9,7 @@ from ophyd.status import StatusTimeoutError
 from ophyd.status import wait as wait_status
 
 from ..lxe import (LaserEnergyPlotContext, LaserEnergyPositioner, LaserTiming,
-                   LaserTimingCompensation)
+                   LaserTimingCompensation, Lcls2LaserTiming)
 from ..utils import convert_unit
 from .conftest import MODULE_PATH
 
@@ -236,6 +236,29 @@ def test_laser_timing_notepad(lxt):
     lxt.mv(5e-6)
     assert lxt.notepad_setpoint.get() == 5e-6
     assert lxt.notepad_readback.get() == 5e-6
+
+
+def test_laser_timing_init_configurables():
+    logger.debug("test_laser_timing_init_configurables")
+
+    lcls1_lxt = LaserTiming("notarealpvplease", name="lcls1_lxt", invert=False, limits=(-1, 1))
+    lcls2_lxt = Lcls2LaserTiming("notarealpvplease", name="lcls1_lxt", invert=False, limits=(-1, 1))
+
+    # The limits we put in should read back
+    assert lcls1_lxt.limits == (-1, 1)
+    assert lcls2_lxt.limits == (-1, 1)
+    assert lcls1_lxt.setpoint.limits == (-1, 1)
+    assert lcls2_lxt.setpoint.limits == (-1, 1)
+
+    # The next test assumes user offset is zero
+    assert lcls1_lxt.setpoint.user_offset == 0
+    assert lcls2_lxt.setpoint.user_offset == 0
+
+    # No inversions -> should stay positive
+    assert lcls1_lxt.setpoint.forward(10) > 0
+    assert lcls2_lxt.setpoint.forward(10) > 0
+    assert lcls1_lxt.setpoint.inverse(10) > 0
+    assert lcls2_lxt.setpoint.inverse(10) > 0
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add cxi3's `invert` argument for `LaserTiming` that allows them to un-invert their laser timing device.
- Add init-time configuration of the `LaserTiming` limits so cxi3 doesn't need to override the class limits
- Add the above to `Lcls2LaserTiming` too while I'm here
- Ignore cxi3's other hotfix- it isn't actually needed to achieve these

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Apply cxi3's hotfix so they don't have to run out of dev in the future
- Add limit handling for the same reason

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I made unit tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- I made pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
