### PR TITLE
PPM Screen Changes

### DIFF
--- a/docs/source/upcoming_release_notes/1303-PowerMeter_responsivity_update.rst
+++ b/docs/source/upcoming_release_notes/1303-PowerMeter_responsivity_update.rst
@@ -1,0 +1,31 @@
+1303 PowerMeter_responsivity_update
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- Added the ability to add custom units for convert_unit
+
+Device Features
+---------------
+- Added calibrated_uj and manual_in_progress
+- Renamed manual-collections components to have manual in their name to distinguish them from auto-background collection
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Made responsivity component input only like the pytmc pragma so the connection does not fail when looking for the non-RBV pv
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- KaushikMalapati

--- a/docs/source/upcoming_release_notes/1303-PowerMeter_responsivity_update.rst
+++ b/docs/source/upcoming_release_notes/1303-PowerMeter_responsivity_update.rst
@@ -7,7 +7,7 @@ API Breaks
 
 Library Features
 ----------------
-- Added the ability to add custom units for convert_unit
+- Added the ability to add custom units for convert_unit with a unit test
 
 Device Features
 ---------------

--- a/pcdsdevices/custom_units.py
+++ b/pcdsdevices/custom_units.py
@@ -1,0 +1,7 @@
+import sympy.physics.units as units
+
+millijoule = mJ = units.quantities.Quantity("millijoule", abbrev='mJ')
+millijoule.set_global_relative_scale_factor(units.prefixes.milli, units.joule)
+
+microjoule = uJ = units.quantities.Quantity("microjoule", abbrev='uJ')
+microjoule.set_global_relative_scale_factor(units.prefixes.micro, units.joule)

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -374,8 +374,6 @@ class PPMPowerMeter(BaseInterface, Device):
 
     `calibrated_mj` = (Signal - Background) / (Responsivity * Beam_Rate)
     """
-    def __init__(self, prefix, *, name, **kwargs):
-        super().__init__(prefix, name=name, **kwargs)
 
     tab_component_names = True
 

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -400,6 +400,7 @@ class PPMPowerMeter(BaseInterface, Device):
 
     manual_in_progress = Cpt(PytmcSignal, ':BACK:MANUAL_COLLECTING', io='i', kind='normal',
                              doc='Manual collection currntly in progress')
+    set_metadata(manual_in_progress, dict(variety='command'))
 
     manual_collect_time = Cpt(PytmcSignal, ':BACK:TIME', io='io', kind='normal',
                               doc='Time to collect background voltages for.')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -397,10 +397,10 @@ class PPMPowerMeter(BaseInterface, Device):
 
     background_mode = Cpt(PytmcSignal, ':BACK:MODE', io='io', kind='normal', doc='Can be manual or auto In manual mode, you can collect for a specified number of seconds. In auto mode, a buffer of automatically collected background voltages will be used to calculate the background voltage.')
 
-    background_collect = Cpt(PytmcSignal, ':BACK:COLL', io='io', kind='normal', doc='Start collecting background voltages for specified time.')
-    set_metadata(background_collect, dict(variety='command-proc', value=1))
-
-    background_collect_time = Cpt(PytmcSignal, ':BACK:TIME', io='io', kind='normal', doc='Time to collect background voltages for.')
+    manual_collect = Cpt(PytmcSignal, ':BACK:COLL', io='io', kind='normal', doc='Start collecting background voltages for specified time.')
+    set_metadata(manual_collect, dict(variety='command-proc', value=1))
+    manual_in_progress = Cpt(PytmcSignal, 'BACK:MANUAL_COLLECTING', io='i', kind='normal', doc='Manual collection currntly in progress')
+    manual_collect_time = Cpt(PytmcSignal, ':BACK:TIME', io='io', kind='normal', doc='Time to collect background voltages for.')
 
     raw_voltage = Cpt(PytmcSignal, ':VOLT', io='i', kind='normal',
                       doc='Raw readback from the power meter.')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -388,19 +388,30 @@ class PPMPowerMeter(BaseInterface, Device):
 
     tab_component_names = True
 
-    responsivity = Cpt(PytmcSignal, ':RES', io='i', kind='normal', doc='Responsivity in  V/W, unique for every power meter.')
+    responsivity = Cpt(PytmcSignal, ':RES', io='i', kind='normal',
+                       doc='Responsivity in  V/W, unique for every power meter.')
 
-    background_voltage = Cpt(PytmcSignal, ':BACK:VOLT', io='io', kind='normal', doc='Background voltage value used to calculate pulse energy.')
+    background_voltage = Cpt(PytmcSignal, ':BACK:VOLT', io='io', kind='normal',
+                             doc='Background voltage value used to calculate pulse energy.')
 
-    auto_background_reset = Cpt(PytmcSignal, ':BACK:RESET', io='io', kind='normal', doc='Set to reset auto background voltage collection.')
+    auto_background_reset = Cpt(PytmcSignal, ':BACK:RESET', io='io', kind='normal',
+                                doc='Set to reset auto background voltage collection.')
     set_metadata(auto_background_reset, dict(variety='command-proc', value=1))
 
-    background_mode = Cpt(PytmcSignal, ':BACK:MODE', io='io', kind='normal', doc='Can be manual or auto In manual mode, you can collect for a specified number of seconds. In auto mode, a buffer of automatically collected background voltages will be used to calculate the background voltage.')
+    background_mode = Cpt(PytmcSignal, ':BACK:MODE', io='io', kind='normal',
+                          doc='Can be manual or auto In manual mode, you can collect '
+                          'for a specified number of seconds. In auto mode, a buffer of '
+                          'automatically collected background voltages will be used to calculate the background voltage.')
 
-    manual_collect = Cpt(PytmcSignal, ':BACK:COLL', io='io', kind='normal', doc='Start collecting background voltages for specified time.')
+    manual_collect = Cpt(PytmcSignal, ':BACK:COLL', io='io', kind='normal',
+                         doc='Start collecting background voltages for specified time.')
     set_metadata(manual_collect, dict(variety='command-proc', value=1))
-    manual_in_progress = Cpt(PytmcSignal, 'BACK:MANUAL_COLLECTING', io='i', kind='normal', doc='Manual collection currntly in progress')
-    manual_collect_time = Cpt(PytmcSignal, ':BACK:TIME', io='io', kind='normal', doc='Time to collect background voltages for.')
+
+    manual_in_progress = Cpt(PytmcSignal, 'BACK:MANUAL_COLLECTING', io='i', kind='normal',
+                             doc='Manual collection currntly in progress')
+
+    manual_collect_time = Cpt(PytmcSignal, ':BACK:TIME', io='io', kind='normal',
+                              doc='Time to collect background voltages for.')
 
     raw_voltage = Cpt(PytmcSignal, ':VOLT', io='i', kind='normal',
                       doc='Raw readback from the power meter.')
@@ -408,8 +419,12 @@ class PPMPowerMeter(BaseInterface, Device):
     calibrated_mj = Cpt(PytmcSignal, ':MJ', io='i', kind='normal',
                         doc='Calibrated absolute measurement of beam '
                             'power in physics units.')
-    calibrated_uj = Cpt(UnitConversionDerivedSignal, derived_from='calibrated_mj', derived_units='uJ', original_units='mJ', write_access=False)
-    wattage = Cpt(PytmcSignal, ':WATT', io='i', kind='normal', doc='Wattage measured by power meter, equals MJ times Beamrate.')
+
+    calibrated_uj = Cpt(UnitConversionDerivedSignal, derived_from='calibrated_mj',
+                        derived_units='uJ', original_units='mJ', write_access=False)
+
+    wattage = Cpt(PytmcSignal, ':WATT', io='i', kind='normal',
+                  doc='Wattage measured by power meter, equals MJ times Beamrate.')
 
     thermocouple = Cpt(TwinCATThermocouple, '', kind='normal',
                        doc='Thermocouple on the power meter holder.')

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -379,7 +379,7 @@ class PPMPowerMeter(BaseInterface, Device):
 
     tab_component_names = True
 
-    responsivity = Cpt(PytmcSignal, ':RES', io='i', kind='normal',
+    responsivity = Cpt(PytmcSignal, ':RESP', io='i', kind='normal',
                        doc='Responsivity in  V/W, unique for every power meter.')
 
     background_voltage = Cpt(PytmcSignal, ':BACK:VOLT', io='io', kind='normal',

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -398,7 +398,7 @@ class PPMPowerMeter(BaseInterface, Device):
                          doc='Start collecting background voltages for specified time.')
     set_metadata(manual_collect, dict(variety='command-proc', value=1))
 
-    manual_in_progress = Cpt(PytmcSignal, 'BACK:MANUAL_COLLECTING', io='i', kind='normal',
+    manual_in_progress = Cpt(PytmcSignal, ':BACK:MANUAL_COLLECTING', io='i', kind='normal',
                              doc='Manual collection currntly in progress')
 
     manual_collect_time = Cpt(PytmcSignal, ':BACK:TIME', io='io', kind='normal',

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -27,7 +27,7 @@ from .interface import BaseInterface, LightpathInOutCptMixin
 from .keithley import IM3L0_K2700
 from .pmps import TwinCATStatePMPS
 from .sensors import TwinCATThermocouple
-from .signal import PytmcSignal
+from .signal import PytmcSignal, UnitConversionDerivedSignal
 from .state import StatePositioner
 from .utils import get_status_float, get_status_value, reorder_components
 from .variety import set_metadata
@@ -372,19 +372,30 @@ class PPMPowerMeter(BaseInterface, Device):
     calibrated for each power meter in units of volts per watt
     is used to calculate the actual energy in the following way:
 
-    `calibrated_mj` = 1000 * (Signal - Background) / (Responsivity * Beam_Rate)
+    `calibrated_mj` = (Signal - Background) / (Responsivity * Beam_Rate)
     """
+    def __init__(self, prefix, *, name, **kwargs):
+        import sympy.physics.units as units
+        from sympy.physics.units.prefixes import micro, milli
+        from sympy.physics.units.quantities import Quantity
+        millijoule = mJ = Quantity("millijoule", abbrev='mJ')
+        millijoule.set_global_relative_scale_factor(milli, units.joule)
+        microjoule = uJ = Quantity("microjoule", abbrev='uJ')
+        microjoule.set_global_relative_scale_factor(micro, units.joule)
+        setattr(units, 'mJ', mJ)
+        setattr(units, 'uJ', uJ)
+        super().__init__(prefix, name=name, **kwargs)
 
     tab_component_names = True
 
-    responsivity = Cpt(PytmcSignal, ':RES', io='io', kind='normal', doc='Responsivity in  V/W, unique for every power meter.')
+    responsivity = Cpt(PytmcSignal, ':RES', io='i', kind='normal', doc='Responsivity in  V/W, unique for every power meter.')
 
     background_voltage = Cpt(PytmcSignal, ':BACK:VOLT', io='io', kind='normal', doc='Background voltage value used to calculate pulse energy.')
 
     auto_background_reset = Cpt(PytmcSignal, ':BACK:RESET', io='io', kind='normal', doc='Set to reset auto background voltage collection.')
     set_metadata(auto_background_reset, dict(variety='command-proc', value=1))
 
-    background_mode = Cpt(PytmcSignal, ':BACK:MODE', io='io', kind='normal', doc='Can be manual or passive. In manual mode, you can collect for a specified number of seconds. In passive mode, a buffer of automatically collected background voltages will be used to calculate the background voltage.')
+    background_mode = Cpt(PytmcSignal, ':BACK:MODE', io='io', kind='normal', doc='Can be manual or auto In manual mode, you can collect for a specified number of seconds. In auto mode, a buffer of automatically collected background voltages will be used to calculate the background voltage.')
 
     background_collect = Cpt(PytmcSignal, ':BACK:COLL', io='io', kind='normal', doc='Start collecting background voltages for specified time.')
     set_metadata(background_collect, dict(variety='command-proc', value=1))
@@ -397,7 +408,7 @@ class PPMPowerMeter(BaseInterface, Device):
     calibrated_mj = Cpt(PytmcSignal, ':MJ', io='i', kind='normal',
                         doc='Calibrated absolute measurement of beam '
                             'power in physics units.')
-
+    calibrated_uj = Cpt(UnitConversionDerivedSignal, derived_from='calibrated_mj', derived_units='uJ', original_units='mJ', write_access=False)
     wattage = Cpt(PytmcSignal, ':WATT', io='i', kind='normal', doc='Wattage measured by power meter, equals MJ times Beamrate.')
 
     thermocouple = Cpt(TwinCATThermocouple, '', kind='normal',

--- a/pcdsdevices/pim.py
+++ b/pcdsdevices/pim.py
@@ -375,15 +375,6 @@ class PPMPowerMeter(BaseInterface, Device):
     `calibrated_mj` = (Signal - Background) / (Responsivity * Beam_Rate)
     """
     def __init__(self, prefix, *, name, **kwargs):
-        import sympy.physics.units as units
-        from sympy.physics.units.prefixes import micro, milli
-        from sympy.physics.units.quantities import Quantity
-        millijoule = mJ = Quantity("millijoule", abbrev='mJ')
-        millijoule.set_global_relative_scale_factor(milli, units.joule)
-        microjoule = uJ = Quantity("microjoule", abbrev='uJ')
-        microjoule.set_global_relative_scale_factor(micro, units.joule)
-        setattr(units, 'mJ', mJ)
-        setattr(units, 'uJ', uJ)
         super().__init__(prefix, name=name, **kwargs)
 
     tab_component_names = True

--- a/pcdsdevices/tests/test_units.py
+++ b/pcdsdevices/tests/test_units.py
@@ -1,10 +1,16 @@
 from ..utils import convert_unit
 
 
-def test_convert_unit():
+def test_standard_units():
+    assert convert_unit(1, 'm', 'mm') == 1000
+    assert convert_unit(10, 'kilograms', 'gram') == 10000
+
+
+def test_custom_units():
+    assert convert_unit(1, 'J', 'joule') == 1
     assert convert_unit(0.5, 'J', 'mJ') == 500
-    assert convert_unit(2, 'J', 'uJ') == 2000000
-    assert convert_unit(1, 'mJ', 'J') == 0.001
-    assert convert_unit(0.1, 'mJ', 'uJ') == 100
+    assert convert_unit(2, 'joule', 'uJ') == 2000000
+    assert convert_unit(1, 'millijoule', 'J') == 0.001
+    assert convert_unit(0.1, 'mJ', 'microjoule') == 100
     assert convert_unit(1000, 'uJ', 'J') == 0.001
-    assert convert_unit(10, 'uJ', 'mJ') == 0.01
+    assert convert_unit(10, 'microjoule', 'millijoule') == 0.01

--- a/pcdsdevices/tests/test_units.py
+++ b/pcdsdevices/tests/test_units.py
@@ -1,0 +1,10 @@
+from ..utils import convert_unit
+
+
+def test_convert_unit():
+    assert convert_unit(0.5, 'J', 'mJ') == 500
+    assert convert_unit(2, 'J', 'uJ') == 2000000
+    assert convert_unit(1, 'mJ', 'J') == 0.001
+    assert convert_unit(0.1, 'mJ', 'uJ') == 100
+    assert convert_unit(1000, 'uJ', 'J') == 0.001
+    assert convert_unit(10, 'uJ', 'mJ') == 0.01

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -22,6 +22,7 @@ from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.ophydobj import Kind
 
+from . import custom_units
 from ._html import collapse_list_head, collapse_list_tail
 from .type_hints import Number, OphydDataType
 
@@ -155,8 +156,15 @@ def convert_unit(value: float, unit: str, new_unit: str):
     new_value : float
         The starting value, but converted to the new unit.
     """
-    unit = getattr(units, unit)
-    new_unit = getattr(units, new_unit)
+    try:
+        unit = getattr(units, unit)
+    except Exception:
+        unit = getattr(custom_units, unit)
+
+    try:
+        new_unit = getattr(units, new_unit)
+    except Exception:
+        new_unit = getattr(custom_units, new_unit)
 
     if unit == new_unit:
         return value

--- a/pcdsdevices/utils.py
+++ b/pcdsdevices/utils.py
@@ -158,12 +158,12 @@ def convert_unit(value: float, unit: str, new_unit: str):
     """
     try:
         unit = getattr(units, unit)
-    except Exception:
+    except AttributeError:
         unit = getattr(custom_units, unit)
 
     try:
         new_unit = getattr(units, new_unit)
-    except Exception:
+    except AttributeError:
         new_unit = getattr(custom_units, new_unit)
 
     if unit == new_unit:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changing responsivity io to be input only so it displays without a connection error
Renaming manual pvs to be less similar to auto background pvs
Adding microjoule mirror of calibrated_mj
Added manual collection in progress indicator
Replaced references to passive mode with auto mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-875

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
upcoming-release notes

<!--
## Screenshots (if appropriate):
-->
![image](https://github.com/user-attachments/assets/e9344a41-1277-443d-9c77-6fd5e84faa61)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
