### PR TITLE
Add mirror sensors to KBOMirrorHEStates

### DIFF
--- a/docs/source/upcoming_release_notes/1304-chin-rtds.rst
+++ b/docs/source/upcoming_release_notes/1304-chin-rtds.rst
@@ -3,7 +3,7 @@
 
 API Breaks
 ----------
-- N/A
+- `FFMirrorZ` components `chin_left_rtd`, `chin_right_rtd`, and `chin_tail_rtd` are renamed: `mirror_temp_[l,r,tail]`.
 
 Library Features
 ----------------
@@ -19,11 +19,12 @@ New Devices
 
 Bugfixes
 --------
-- reorder some components in `KBOMirrorHE`
+- N/A
 
 Maintenance
 -----------
-- `FFMirrorZ` same type of RTDs on mirrors, so standardize naming.
+- reorder `cool_flow1` and `cool_flow2` components in `KBOMirrorHE` to the end of the list.
+- reorder `mirror_temp_[l,r,tail]` components in `FFMirrorZ` to align with other temperature sensors.
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/1304-chin-rtds.rst
+++ b/docs/source/upcoming_release_notes/1304-chin-rtds.rst
@@ -1,0 +1,30 @@
+1304 chin-rtds
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- `KBOMirrorHE` gets 2 new RTD readouts for RTDs installed on the mirror inside vaccum.
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- reorder some components in `KBOMirrorHE`
+
+Maintenance
+-----------
+- `FFMirrorZ` same type of RTDs on mirrors, so standardize naming.
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1154,6 +1154,10 @@ class KBOMirrorHE(KBOMirror):
     cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal')
     cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal')
 
+    #
+    mirror_temp_l = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i', kind='normal', doc="mirror temperature left chin guard")
+    mirror_temp_r = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i', kind='normal', doc="mirror temperature right chin guard")
+
     # Tab config: show components
     tab_component_names = True
 
@@ -1279,7 +1283,7 @@ pitch: ({self.pitch.prefix})
 
 
 @reorder_components(
-    end_with=['x_enc_rms', 'y_enc_rms', 'z_enc_rms', 'pitch_enc_rms']
+    end_with=['x_enc_rms', 'y_enc_rms', 'z_enc_rms', 'pitch_enc_rms', 'cool_flow1', 'cool_press']
 )
 class FFMirrorZ(FFMirror):
     """
@@ -1306,12 +1310,12 @@ class FFMirrorZ(FFMirror):
     z_enc_rms = Cpt(PytmcSignal, ':ENC:Z:RMS', io='i', kind='normal')
 
     # Chin Guard RTDs
-    chin_left_rtd = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i',
-                        kind='normal')
-    chin_right_rtd = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i',
-                         kind='normal')
-    chin_tail_rtd = Cpt(PytmcSignal, ':RTD:TAIL:TEMP', io='i',
-                        kind='normal')
+    mirror_temp_l = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i',
+                        kind='normal', doc="mirror temperature left chin guard")
+    mirror_temp_r = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i',
+                        kind='normal', doc="mirror temperature right chin guard")
+    mirror_temp_tail = Cpt(PytmcSignal, ':RTD:TAIL:TEMP', io='i',
+                           kind='normal', doc="mirror temperature tail")
 
     cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal', doc="Axilon Panel Flow Meter Loop 1")
     cool_flow2 = None
@@ -1359,7 +1363,7 @@ class KBOMirrorStates(KBOMirror):
     end_with=[
         'coating', 'x', 'y', 'pitch', 'bender_us', 'bender_ds',
         'x_enc_rms', 'y_enc_rms', 'pitch_enc_rms', 'bender_us_enc_rms',
-        'bender_ds_enc_rms', 'us_rtd', 'ds_rtd', 'cool_flow1',
+        'bender_ds_enc_rms', 'mirror_temp_l', 'mirror_temp_r', 'us_rtd', 'ds_rtd', 'cool_flow1',
         'cool_press'
     ]
 )

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -1154,7 +1154,6 @@ class KBOMirrorHE(KBOMirror):
     cool_flow1 = Cpt(EpicsSignalRO, ':FWM:1_RBV', kind='normal')
     cool_press = Cpt(EpicsSignalRO, ':PRSM:1_RBV', kind='normal')
 
-    #
     mirror_temp_l = Cpt(PytmcSignal, ':RTD:CHIN:L:TEMP', io='i', kind='normal', doc="mirror temperature left chin guard")
     mirror_temp_r = Cpt(PytmcSignal, ':RTD:CHIN:R:TEMP', io='i', kind='normal', doc="mirror temperature right chin guard")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- add mirror sensor component to `KBOMirrorHE`
- this will affect:
```
| name             | mr3k2_kbh
| name             | mr4k2_kbv
| name             | mr2k4_kbo
| name             | mr3k4_kbo

```
All tested locally.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- RTDs installed on mirror

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ran locally and launched screens
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-6616
https://jira.slac.stanford.edu/browse/ECS-6705
<!--
## Screenshots (if appropriate):
-->
![cooling-readouts](https://github.com/user-attachments/assets/b0b62cca-2eac-4e7a-a739-4472d836e121)
## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
