### PR TITLE
adding one more target for TM1K4

### DIFF
--- a/docs/source/upcoming_release_notes/1305-Adding_one_more_target_into_TM1K4.rst
+++ b/docs/source/upcoming_release_notes/1305-Adding_one_more_target_into_TM1K4.rst
@@ -1,0 +1,30 @@
+1305 Adding one more target into TM1K4
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- adding one more target into TM1K4
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- @tongju12

--- a/pcdsdevices/atm.py
+++ b/pcdsdevices/atm.py
@@ -50,10 +50,10 @@ class TM1K4Target(ATMTarget):
     """
     Controls TM1K4's states, and ATM in TMO.
 
-    Defines the state count as 8 (OUT and 7 targets), two more than the
+    Defines the state count as 9 (OUT and 8 targets), three more than the
     standard ATM.
     """
-    config = UpCpt(state_count=8)
+    config = UpCpt(state_count=9)
 
 
 class TM1K4(ArrivalTimeMonitor):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## TMO add one more SiN target into TM1K4 so it is up to 9 targets including OUT
<!--- Describe your changes in detail -->
target number changes from 8 to 9
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
TMO laser scientists put a new paddle and it holds 9 targets instead of 8.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
GUI works already.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

https://jira.slac.stanford.edu/browse/ECS-6744
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
