### PR TITLE
Fixing imprecise TPR_TICK_NS constant

### DIFF
--- a/docs/source/upcoming_release_notes/1306-Fixing-imprecise-TPR-TICK-NS-constant.rst
+++ b/docs/source/upcoming_release_notes/1306-Fixing-imprecise-TPR-TICK-NS-constant.rst
@@ -1,0 +1,31 @@
+1306 Fixing-imprecise-TPR-TICK-NS-constant
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- _get_delay, and by extension TprMotor.readback.get() and TprTrigger.ns_delay.get() will no longer calculate wrong delays
+because TPR_TICK_NS is now set to the "exact" 70/13 instead of the approximate 5.384.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- KaushikMalapati

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -10,7 +10,7 @@ from .signal import MultiDerivedSignal, MultiDerivedSignalRO
 from .type_hints import SignalToValue
 from .variety import set_metadata
 
-TPR_TICK_NS = 5.384
+TPR_TICK_NS = 70/13
 TPR_TAP_NS = 0.08
 
 

--- a/pcdsdevices/tpr.py
+++ b/pcdsdevices/tpr.py
@@ -10,6 +10,8 @@ from .signal import MultiDerivedSignal, MultiDerivedSignalRO
 from .type_hints import SignalToValue
 from .variety import set_metadata
 
+# This fraction comes from the accelerator phase reference line operating at
+# 1.3GHz divided by 7 to derive the TPR clock. It is approximately 5.384.
 TPR_TICK_NS = 70/13
 TPR_TAP_NS = 0.08
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changing TPR_TICK_NS from 5.384 to 70/13. 5.384 is imprecise enough to cause large errors in _get_delay used by TprMotor.readback.get() and TprTrigger.ns_delay.get().

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1302 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively (The error was due to a misspelling)
![image](https://github.com/user-attachments/assets/c4b69264-0a52-404f-8443-583260c9a2a2)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
