### PR TITLE
Making ExitSlits subclass with FDQ component, only for SL1K2 for now

### DIFF
--- a/pcdsdevices/slits.py
+++ b/pcdsdevices/slits.py
@@ -26,6 +26,7 @@ from ophyd.signal import Signal, SignalRO
 from ophyd.status import Status
 from ophyd.status import wait as status_wait
 
+from .analog_signals import FDQ
 from .areadetector.detectors import PCDSAreaDetectorTyphosTrigger
 from .device import GroupDevice
 from .device import UpdateComponent as UpCpt
@@ -693,6 +694,13 @@ class ExitSlits(BaseInterface, GroupDevice, LightpathInOutCptMixin):
     def y_states(self):
         """Alias old name. Will deprecate."""
         return self.target
+
+
+class ExitSlitsFDQ(ExitSlits):
+    """
+    ExitSlits with a Keyence FDQ Flow Meter.
+    """
+    flow_meter = Cpt(FDQ, '', kind='normal')
 
 
 class SimLusiSlits(LusiSlits):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
ExitSlitsFDQ has an FDQ component so we can see flow meter readings on the typhos screen for SL1K2. I did not name this SL1K2 in case an ExitSlits+FDQ class is ever wanted in the future

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-6745

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
