### PR TITLE
Added configurable rate for  open_viewer

### DIFF
--- a/docs/source/upcoming_release_notes/1309-PCDSAreaDetectorTyphos_camviewer_rate.rst
+++ b/docs/source/upcoming_release_notes/1309-PCDSAreaDetectorTyphos_camviewer_rate.rst
@@ -1,0 +1,32 @@
+1309 PCDSAreaDetectorTyphos_camviewer_rate
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- Added rate signal to PCDSAreaDetectorTyphos
+- Value is passed in open_viewer to open camViewer with the selected rate
+- Default is five, but can be changed from gui with a TyphosSlider
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- KaushikMalapati

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -410,7 +410,7 @@ class PCDSAreaDetectorTyphos(Device):
     # Make viewer available in Typhos screen
     cam_viewer = Cpt(AttributeSignal, attr='_open_screen', kind='normal')
     set_metadata(cam_viewer, dict(variety='command-proc', value=1))
-    viewer_rate = Cpt(Signal, value=5, kind='normal')
+    viewer_rate = Cpt(Signal, value=5, kind='normal', doc='Rate for camViewer')
     set_metadata(viewer_rate, dict(variety='scalar-range',
                                    range={'value': (0, 100), 'source': 'value'}))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added a rate signal that appears as a typhos slider on the screen which is passed as an argument to run_viewer which opens camviewer in open_viewer. Default is five hertz, which is also the default used by run_viewer. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1308 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
Left side is at one hertz, right is at twenty. You can see the left camviewer update about once a second and right update much faster, although maybe not quite at twenty because of lag.
https://github.com/user-attachments/assets/c3537c01-8e48-4b55-8583-9d82793fa1ff

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
upcoming-release notes

<!--
## Screenshots (if appropriate):
-->




## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
