### PR TITLE
Change MR1K1 Coating State to 1d state mover

### DIFF
--- a/docs/source/upcoming_release_notes/1310-mr1k1-1d-state.rst
+++ b/docs/source/upcoming_release_notes/1310-mr1k1-1d-state.rst
@@ -1,0 +1,30 @@
+1310 mr1k1-1d-state
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- `XOffsetMirrorBend` `coating` changed to `TwinCATMirrorStripe` from `MirrorStripe2D2P`
+
+Contributors
+------------
+- nrwslac

--- a/pcdsdevices/mirror.py
+++ b/pcdsdevices/mirror.py
@@ -827,7 +827,7 @@ class XOffsetMirrorBend(XOffsetMirror):
     bender = None
     bender_enc_rms = None
 
-    coating = Cpt(MirrorStripe2D2P, ':COATING:STATE', kind='hinted',
+    coating = Cpt(TwinCATMirrorStripe, ':COATING:STATE', kind='hinted',
                   doc='Control of the coating states via saved positions.')
 
     # Motor components: can read/write positions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In `mirror.py` change `XOffsetMirrorBend`, `coating` to `TwinCATMirrorStripe` for 1D motion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
MR1K1 suffered a catastrophic motor failure on its X axis, so it can no longer move in 2 dimensions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
launch the typhos screen for local environment and made test state move.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-6792
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
