### PR TITLE
TST: reproduce and fix pypi failures

### DIFF
--- a/docs/source/upcoming_release_notes/1311-tst_failing_on_pip.rst
+++ b/docs/source/upcoming_release_notes/1311-tst_failing_on_pip.rst
@@ -1,0 +1,31 @@
+1311 tst_failing_on_pip
+#######################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Make test_at2l0_clear_errors pass more consistently on CI.
+- Add a utility for checking signal values that don't update promptly.
+
+Contributors
+------------
+- zllentz

--- a/pcdsdevices/tests/test_attenuator.py
+++ b/pcdsdevices/tests/test_attenuator.py
@@ -9,6 +9,7 @@ from ophyd.status import wait as status_wait
 
 from ..attenuator import (AT1K2, AT1K4, AT2K2, AT2L0, MAX_FILTERS, AttBase,
                           Attenuator, _att_classes)
+from .conftest import wait_and_assert
 
 logger = logging.getLogger(__name__)
 
@@ -261,8 +262,4 @@ def test_at2l0_clear_errors(at2l0):
         assert not sig.get()
     at2l0.clear_errors()
     for sig in signals:
-        for _ in range(10):
-            if sig.get():
-                break
-            time.sleep(0.1)
-        assert sig.get()
+        wait_and_assert(sig, 1)

--- a/pcdsdevices/tests/test_attenuator.py
+++ b/pcdsdevices/tests/test_attenuator.py
@@ -261,5 +261,8 @@ def test_at2l0_clear_errors(at2l0):
         assert not sig.get()
     at2l0.clear_errors()
     for sig in signals:
-        # temporary comment
+        for _ in range(10):
+            if sig.get():
+                break
+            time.sleep(0.1)
         assert sig.get()

--- a/pcdsdevices/tests/test_attenuator.py
+++ b/pcdsdevices/tests/test_attenuator.py
@@ -261,4 +261,5 @@ def test_at2l0_clear_errors(at2l0):
         assert not sig.get()
     at2l0.clear_errors()
     for sig in signals:
+        # temporary comment
         assert sig.get()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix an issue where one of the attenuator tests started failing in the pypi builds.
This is done by waiting a bit, so the background threads have time to update all the metadata etc. or whatever they're doing. The fake epics signals do similar background thread work to what the real epics signals do which causes issues sometimes that can be solved by waiting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pcdshub/pcdsdevices/pull/1307#issuecomment-2518532901

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests pass now.
I made a little utility function because it was simple to do and it may be used again.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
