### PR TITLE
PERF: delay preset sync until tab completion / attribute access, track file desync

### DIFF
--- a/docs/source/upcoming_release_notes/1317-perf_preset_loading.rst
+++ b/docs/source/upcoming_release_notes/1317-perf_preset_loading.rst
@@ -1,0 +1,31 @@
+1317 perf_preset_loading
+########################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adds option to defer preset path loading until needed.  Presets will
+  now load when tab-completion or preset-related attributes are accessed.
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -752,14 +752,14 @@ class FltMvInterface(MvInterface):
 
     def __dir__(self):
         # Initialize presets if tab-completion requested.
-        if self.presets.sync_needed:
+        if self.presets.sync_needed():
             self.presets.sync()
 
         return super().__dir__()
 
     def __getattribute__(self, name: str):
         if (any((name.startswith(prefix)) for prefix in ['mv_', 'wm_', 'umv_'])
-                and self.presets.sync_needed):
+                and self.presets.sync_needed()):
             self.presets.sync()
 
         return super().__getattribute__(name)
@@ -1328,7 +1328,6 @@ class Presets:
                     closest = diff
         return state
 
-    @property
     def sync_needed(self) -> bool:
         """True if this preset has fallen out of sync with backing files"""
         curr_mtimes = {}

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -904,7 +904,7 @@ class FltMvInterface(MvInterface):
         self.set_current_position(position)
 
 
-def setup_preset_paths(**kwargs):
+def setup_preset_paths(defer_loading: bool = False, **paths):
     """
     Prepare the :class:`Presets` class.
 
@@ -920,8 +920,6 @@ def setup_preset_paths(**kwargs):
         (Optional) "defer_loading": bool, whether or not to defer the loading
         of preset files until the first tab completion
     """
-    defer_loading = kwargs.pop("defer_loading", False)
-    paths = kwargs
     Presets._paths = {}
     for k, v in paths.items():
         Presets._paths[k] = Path(v)

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -912,11 +912,11 @@ def setup_preset_paths(defer_loading: bool = False, **paths):
 
     Parameters
     ----------
-    **kwargs: str keyword args
+    **paths : str keyword args
         A mapping from type of preset to destination path. These will be
         directories that contain the yaml files that define the preset
         positions.
-
+    defer_loading : bool, by default False
         (Optional) "defer_loading": bool, whether or not to defer the loading
         of preset files until the first tab completion
     """

--- a/pcdsdevices/tests/sim_fast_presets/sim_fast.yml
+++ b/pcdsdevices/tests/sim_fast_presets/sim_fast.yml
@@ -1,0 +1,17 @@
+directbeam:
+  active: true
+  history:
+    02 Nov 2022 19:02:48: '    8.4999'
+  value: 9.499946289065
+in:
+  active: true
+  history:
+    28 Feb 2024 14:59:31: '    0.0000'
+    28 Feb 2024 15:20:01: '    3.3000'
+  value: 3.3
+out:
+  active: true
+  history:
+    28 Feb 2024 15:00:08: '   15.0000'
+    28 Feb 2024 15:19:54: '   13.1800'
+  value: 13.18

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 import sys
 import threading
 import time
+from pathlib import Path
 
 import ophyd
 import pytest
@@ -29,6 +30,15 @@ def slow_motor():
 @pytest.fixture(scope='function')
 def fast_motor():
     return FastMotor(name='sim_fast')
+
+
+@pytest.fixture(scope="function")
+def deferred_fast_motor_presets():
+    """deferred loading fast_motor presets, backed by a file but unloaded"""
+    setup_preset_paths(defer_loading=True,
+                       hutch=Path(__file__).parent / 'sim_fast_presets')
+    yield
+    setup_preset_paths()
 
 
 @pytest.mark.timeout(5)
@@ -101,7 +111,7 @@ def test_mv_ginput(monkeypatch, fast_motor):
     sys.platform in ("win32", "darwin"),
     reason="Fails on Windows, no fcntl and different signal handling",
 )
-def test_presets(presets, fast_motor):
+def test_presets(presets, fast_motor: FastMotor):
     logger.debug('test_presets')
 
     fast_motor.mv(4, wait=True)
@@ -181,7 +191,7 @@ def test_presets(presets, fast_motor):
     assert hasattr(fast_motor, 'mv_sample')
 
 
-def test_presets_type(presets, fast_motor):
+def test_presets_type(presets, fast_motor: FastMotor):
     logger.debug('test_presets_type')
     # Mess up the input types, fail before opening the file
 
@@ -189,6 +199,55 @@ def test_presets_type(presets, fast_motor):
         fast_motor.presets.add_here_user(123)
     with pytest.raises(TypeError):
         fast_motor.presets.add_user(234234, 'cats')
+
+
+def test_presets_desync(presets, fast_motor: FastMotor):
+    assert not fast_motor.presets.sync_needed
+
+    fast_motor.mv(4, wait=True)
+    fast_motor.presets.add_hutch('four', comment='four!')
+
+    assert not fast_motor.presets.sync_needed
+
+    # modify preset from other object with the same, to force collision
+    fast_motor2 = FastMotor(name='sim_fast')
+    fast_motor2.mv(5, wait=True)
+    fast_motor2.presets.positions.four.update_pos()
+
+    # in-memory python objects have different preset positions
+    assert fast_motor.presets.positions.four.pos == 4
+    assert fast_motor2.presets.positions.four.pos == 5
+
+    # but point to the same file
+    assert fast_motor.presets._path("hutch") == fast_motor2.presets._path("hutch")
+
+    # original object needs a sync, but second does not
+    assert fast_motor.presets.sync_needed
+    assert not fast_motor2.presets.sync_needed
+
+
+def test_presets_tab_init(fast_motor: FastMotor, deferred_fast_motor_presets):
+    # deferred_fast_motor_preset must come last,
+    # to clear cache after motor is created (and sync-ed at init)
+    assert fast_motor.presets.sync_needed
+    fast_motor.__dir__()  # mimic tab completion request
+    assert not fast_motor.presets.sync_needed
+
+
+@pytest.mark.parametrize("attr,", [
+    "wm_dne", "wm_in", "mv_dne", "mv_in", "umv_dne, umv_in"
+])
+def test_presets_getattribute_init(
+    fast_motor: FastMotor, attr: str, deferred_fast_motor_presets
+):
+    # deferred_fast_motor_preset must come last,
+    # to clear cache after motor is created (and sync-ed at init)
+    assert fast_motor.presets.sync_needed
+    try:
+        getattr(fast_motor, attr)  # mimic completion request
+    except AttributeError:
+        pass
+    assert not fast_motor.presets.sync_needed
 
 
 def test_engineering_mode():

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -202,12 +202,12 @@ def test_presets_type(presets, fast_motor: FastMotor):
 
 
 def test_presets_desync(presets, fast_motor: FastMotor):
-    assert not fast_motor.presets.sync_needed
+    assert not fast_motor.presets.sync_needed()
 
     fast_motor.mv(4, wait=True)
     fast_motor.presets.add_hutch('four', comment='four!')
 
-    assert not fast_motor.presets.sync_needed
+    assert not fast_motor.presets.sync_needed()
 
     # modify preset from other object with the same, to force collision
     fast_motor2 = FastMotor(name='sim_fast')
@@ -222,16 +222,16 @@ def test_presets_desync(presets, fast_motor: FastMotor):
     assert fast_motor.presets._path("hutch") == fast_motor2.presets._path("hutch")
 
     # original object needs a sync, but second does not
-    assert fast_motor.presets.sync_needed
-    assert not fast_motor2.presets.sync_needed
+    assert fast_motor.presets.sync_needed()
+    assert not fast_motor2.presets.sync_needed()
 
 
 def test_presets_tab_init(fast_motor: FastMotor, deferred_fast_motor_presets):
     # deferred_fast_motor_preset must come last,
     # to clear cache after motor is created (and sync-ed at init)
-    assert fast_motor.presets.sync_needed
+    assert fast_motor.presets.sync_needed()
     fast_motor.__dir__()  # mimic tab completion request
-    assert not fast_motor.presets.sync_needed
+    assert not fast_motor.presets.sync_needed()
 
 
 @pytest.mark.parametrize("attr,", [
@@ -242,12 +242,12 @@ def test_presets_getattribute_init(
 ):
     # deferred_fast_motor_preset must come last,
     # to clear cache after motor is created (and sync-ed at init)
-    assert fast_motor.presets.sync_needed
+    assert fast_motor.presets.sync_needed()
     try:
         getattr(fast_motor, attr)  # mimic completion request
     except AttributeError:
         pass
-    assert not fast_motor.presets.sync_needed
+    assert not fast_motor.presets.sync_needed()
 
 
 def test_engineering_mode():

--- a/pcdsdevices/tests/test_lens.py
+++ b/pcdsdevices/tests/test_lens.py
@@ -116,9 +116,6 @@ def fake_lensstack(fake_att):
                                   E=sample_E,
                                   z_offset=.01, z_dir=1, att_obj=fake_att,
                                   lcls_obj=.01, mono_obj=.01)
-    # "activate" tab completion
-    for attr in ['x', 'y', 'z']:
-        getattr(fake_lensstack, attr)._tab_initialized = True
     return fake_lensstack
 
 

--- a/pcdsdevices/tests/test_lens.py
+++ b/pcdsdevices/tests/test_lens.py
@@ -116,6 +116,9 @@ def fake_lensstack(fake_att):
                                   E=sample_E,
                                   z_offset=.01, z_dir=1, att_obj=fake_att,
                                   lcls_obj=.01, mono_obj=.01)
+    # "activate" tab completion
+    for attr in ['x', 'y', 'z']:
+        getattr(fake_lensstack, attr)._tab_initialized = True
     return fake_lensstack
 
 


### PR DESCRIPTION
## Description
Delays preset file reading until tab-completion has been attempted.  Stashes this information on the device instance itself.  This is not the default behavior, and you must opt into this by supplying the optional argument `defer_loading` to `setup_presets_paths`

Also tracks the modification time of the preset file on sync, making the `Preset` instance the source of truth to see if the presets need to be synced.

## Motivation and Context
Presets have taken a very long time to load recently, and the first place to look is often file i/o.  This delays this as long as possible while attempting to preserve the behavior hutch scientists use: tab completion.

This has also been made optional.  Both `setup_presets_paths` and `Presets.sync()` now take an optional `defer_loading` argument, that if true will skip the preset data loading step

In a nutshell:
* the device's Preset instance tracks whether the preset is out of sync with the files.  This is done by tracking file modification times

* The device checks if a sync is necessary, and if so syncs with the files when:
  * `__dir__` is called (during tab-completion)
  * `__getattribute__` is called with a preset-related prefix (`wm_`, `umv_`, `mv_`)

`Presets.sync()` is also called on device init, since it's part of `Presets.__init__`.  This happens both on device-creation and `setup_presets_path`, though on device-creation we don't do any file loading.  This is a ~0.013s double-hit, split between the device load and presets load sections for `FltMvInterface` devices

## How Has This Been Tested?
Tests pass

Tested interactively through hutch-python, loading some subset of 559 xcs presets
* this PR: 7.53s (0.01345s / preset)
* current master: 16.21s (0.0289s / preset)

There's some variation but I'm not going to do a battery of tests here

### Why isn't this just 0 s?
There's still some path access going on in hutch-python, it's just stopping short of actually opening the presets file.

## Where Has This Been Documented?
This PR, a stray comment

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
