### PR TITLE
BUG: make Presets.status more tolerant of unknown/uninitialized positions

### DIFF
--- a/docs/source/upcoming_release_notes/1319-bug_preset_error.rst
+++ b/docs/source/upcoming_release_notes/1319-bug_preset_error.rst
@@ -1,0 +1,30 @@
+1319 bug_preset_error
+#####################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- Improves error handling for presets when the position is unknown or uninitialized.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1331,7 +1331,7 @@ class Presets:
                 state_name = method_name.replace('wm_', '', 1)
                 wm_state = getattr(device, method_name)
                 state_val = wm_state()
-                if not isinstance(state_val, (int, float)):
+                if not isinstance(state_val, numbers.Real):
                     continue
                 diff = abs(state_val)
                 if diff < closest:

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1277,14 +1277,22 @@ class Presets:
 
             Returns
             -------
-            offset : float
+            offset : Optional[float, str]
                 How far we are from the preset position. If this is near zero,
                 we are at the position. If this positive, the preset position
                 is in the positive direction from us.
+                If the current position is unknown, return "Unknown".
             """
+            preset_pos = self.presets._cache[preset_type][name]['value']
+            # here we expect self: FltMvInterface
+            curr_pos = self.wm()
+            try:
+                pos = preset_pos - curr_pos
+            except Exception:
+                # current position is not known or unset
+                pos = "Unknown"
 
-            pos = self.presets._cache[preset_type][name]['value']
-            return pos - self.wm()
+            return pos
 
         wm_pre.__doc__ = wm_pre.__doc__.format(name)
         return wm_pre
@@ -1322,7 +1330,10 @@ class Presets:
             if method_name.startswith('wm_'):
                 state_name = method_name.replace('wm_', '', 1)
                 wm_state = getattr(device, method_name)
-                diff = abs(wm_state())
+                state_val = wm_state()
+                if not isinstance(state_val, (int, float)):
+                    continue
+                diff = abs(state_val)
                 if diff < closest:
                     state = state_name
                     closest = diff


### PR DESCRIPTION
## Description
Makes Preset `Preset.device.wm_*` and `Presets.state` methods more tolerant of missing or uninitialized device positions.  

This changes the signature of the `wm_*` methods slightly to also return "Unknown" if the position cannot be resolved.  

## Motivation and Context
closes #1236 

As these are autogenerated methods, it's a little harder to confirm that this return type change won't break downstream consumers.  At least within `pcdsdevices`, the only method that calls a `device.wm_*` method is `Presets.state`.  It's possible that some script very strictly requires the output of a preset to be a numeric, but if the position was uninitialized, those scripts would throw exceptions anyway (no return would be reached)

## How Has This Been Tested?
Checking that CI passes. 

By manually setting `device.postition` to `None` and seeing the output not explode
```python
In [1]: xcs_dg3_pim.y.position
Out[1]: -51.99951171875

In [2]: xcs_dg3_pim.y.wm_ccm()
Out[2]: 59.49951171875

In [3]: xcs_dg3_pim.y.presets.state()
Out[3]: 'Unknown'

In [4]: xcs_dg3_pim.y._position = None

In [5]: xcs_dg3_pim.y.wm_ccm()
Out[5]: 'Unknown'

In [6]: xcs_dg3_pim.y.presets.state()
Out[6]: 'Unknown'
```

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
