### PR TITLE
LasBasler User Presets

### DIFF
--- a/docs/source/upcoming_release_notes/1327-LasBasler_User_Presets.rst
+++ b/docs/source/upcoming_release_notes/1327-LasBasler_User_Presets.rst
@@ -1,0 +1,31 @@
+1327 LasBasler User Presets
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- Adds long_names to signals in LasBasler detector class
+- Adds UserPresetSelector and UserPresetDefaultSe signals to the class
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges-SLAC

--- a/docs/source/upcoming_release_notes/1327-LasBasler_User_Presets.rst
+++ b/docs/source/upcoming_release_notes/1327-LasBasler_User_Presets.rst
@@ -12,7 +12,7 @@ Library Features
 Device Features
 ---------------
 - LasBasler: Adds long_names to signals
-- LasBasler: Adds UserPresetSelector and UserPresetDefaultSe signals
+- LasBasler: Adds `save_setting` and `load_setting` signals for saving and loading settings
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1327-LasBasler_User_Presets.rst
+++ b/docs/source/upcoming_release_notes/1327-LasBasler_User_Presets.rst
@@ -11,8 +11,8 @@ Library Features
 
 Device Features
 ---------------
-- Adds long_names to signals in LasBasler detector class
-- Adds UserPresetSelector and UserPresetDefaultSe signals to the class
+- LasBasler: Adds long_names to signals
+- LasBasler: Adds UserPresetSelector and UserPresetDefaultSe signals
 
 New Devices
 -----------

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -502,6 +502,64 @@ class LasBasler(PCDSAreaDetectorTyphosBeamStats, BaslerBase):
     def _auto_configure(self, value):
         self.configure(self._conf_d)
 
+    # Handle UserPresets configuration
+    default_preset = Cpt(EpicsSignal, 'UserSetDefaultSe_RBV', write_pv='UserSetDefaultSe',
+                         kind='config',
+                         doc='Default Preset to use on startup. See UserSetSelector'
+                         ' for more options')
+    user_preset = Cpt(EpicsSignal, 'UserSetSelector_RBV', write_pv='UserSetSelector',
+                      kind='config',
+                      doc='Current User Preset to save/load')
+    save_preset = Cpt(EpicsSignal, 'UserSetSave.PROC', kind='config',
+                      doc='Save current settings into selected user preset')
+    set_metadata(save_preset, dict(variety='command-proc', value=1))
+    load_preset = Cpt(EpicsSignal, 'UserSetLoad.PROC', kind='config',
+                      doc='Load current settings into selected user preset')
+    set_metadata(load_preset, dict(variety='command-proc', value=1))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add some long_names
+        self.reset.long_name = 'Reset'
+        self.packet_size.long_name = 'Packet Size'
+        self.enet_bw.long_name = 'eNet Bandwidth'
+        self.manufacturer.long_name = 'Manufacturer'
+        self.camera_model.long_name = 'Camera Model'
+        self.sensor_size_x.long_name = 'Sensor Size (X)'
+        self.sensor_size_y.long_name = 'Sensor Size (Y)'
+        self.data_type.long_name = 'Data Type'
+        self.exposure.long_name = 'Exposure (s)'
+        self.gain.long_name = 'Gain'
+        self.num_images.long_name = 'Number of Images'
+        self.image_mode.long_name = 'Image Mode'
+        self.trigger_mode.long_name = 'Trigger Mode'
+        self.acquisition_period.long_name = 'Acquisition Period'
+        self.bin_x.long_name = 'Software Bin X'
+        self.bin_y.long_name = 'Software Bin Y'
+        self.region_start_x.long_name = 'Region Start (X)'
+        self.region_size_x.long_name = 'Region Size (X)'
+        self.region_start_y.long_name = 'Region Start (Y)'
+        self.region_size_y.long_name = 'Region Size (Y)'
+        self.acquire.long_name = 'Set Acquire'
+        self.acquire_rbv.long_name = 'Acquire State'
+        self.image_counter.long_name = 'Image Counter'
+        self.event_code.long_name = 'Event Code'
+        self.event_rate.long_name = 'Event Rate'
+        self.stats_enable.long_name = 'Enable Stats'
+        self.centroid_x.long_name = 'Centroid (X)'
+        self.centroid_y.long_name = 'Centroid (Y)'
+        self.sigma_x.long_name = 'Sigma (X)'
+        self.sigma_y.long_name = 'Sigma (Y)'
+        self.centroid_threshold.long_name = 'Centroid Threshold'
+        self.centroid_enable.long_name = 'Enable Centroid'
+        self.target_x.long_name = 'Target X'
+        self.target_y.long_name = 'Target Y'
+        self.auto_configure.long_name = 'Auto-configure'
+        self.default_preset.long_name = 'Default Preset'
+        self.user_preset.long_name = 'Current Preset'
+        self.save_preset.long_name = 'Save Preset'
+        self.load_preset.long_name = 'Load Preset'
+
 
 class LasBaslerNF(LasBasler):
     """

--- a/pcdsdevices/areadetector/detectors.py
+++ b/pcdsdevices/areadetector/detectors.py
@@ -503,19 +503,19 @@ class LasBasler(PCDSAreaDetectorTyphosBeamStats, BaslerBase):
         self.configure(self._conf_d)
 
     # Handle UserPresets configuration
-    default_preset = Cpt(EpicsSignal, 'UserSetDefaultSe_RBV', write_pv='UserSetDefaultSe',
-                         kind='config',
-                         doc='Default Preset to use on startup. See UserSetSelector'
-                         ' for more options')
-    user_preset = Cpt(EpicsSignal, 'UserSetSelector_RBV', write_pv='UserSetSelector',
-                      kind='config',
-                      doc='Current User Preset to save/load')
-    save_preset = Cpt(EpicsSignal, 'UserSetSave.PROC', kind='config',
-                      doc='Save current settings into selected user preset')
-    set_metadata(save_preset, dict(variety='command-proc', value=1))
-    load_preset = Cpt(EpicsSignal, 'UserSetLoad.PROC', kind='config',
-                      doc='Load current settings into selected user preset')
-    set_metadata(load_preset, dict(variety='command-proc', value=1))
+    default_setting = Cpt(EpicsSignal, 'UserSetDefaultSe_RBV', write_pv='UserSetDefaultSe',
+                          kind='config',
+                          doc='Default User Set to use on startup. See UserSetSelector'
+                          ' for more options')
+    user_setting = Cpt(EpicsSignal, 'UserSetSelector_RBV', write_pv='UserSetSelector',
+                       kind='config',
+                       doc='Current User Set to save/load')
+    save_setting = Cpt(EpicsSignal, 'UserSetSave.PROC', kind='config',
+                       doc='Save current settings into selected User Set')
+    set_metadata(save_setting, dict(variety='command-proc', value=1))
+    load_setting = Cpt(EpicsSignal, 'UserSetLoad.PROC', kind='config',
+                       doc='Load current settings into selected User Set')
+    set_metadata(load_setting, dict(variety='command-proc', value=1))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -555,10 +555,10 @@ class LasBasler(PCDSAreaDetectorTyphosBeamStats, BaslerBase):
         self.target_x.long_name = 'Target X'
         self.target_y.long_name = 'Target Y'
         self.auto_configure.long_name = 'Auto-configure'
-        self.default_preset.long_name = 'Default Preset'
-        self.user_preset.long_name = 'Current Preset'
-        self.save_preset.long_name = 'Save Preset'
-        self.load_preset.long_name = 'Load Preset'
+        self.default_setting.long_name = 'Default Preset'
+        self.user_setting.long_name = 'Current User Set'
+        self.save_setting.long_name = 'Save User Set'
+        self.load_setting.long_name = 'Load User Set'
 
 
 class LasBaslerNF(LasBasler):

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from os import path
 from typing import Optional
 
 import ophyd
@@ -29,10 +28,8 @@ class _SmarActTipTiltEmbeddedUI(QtWidgets.QWidget):
 class SmarActTipTiltWidget(Display, utils.TyphosBase):
     """Custom widget for controlling a tip-tilt with d-pad buttons"""
     ui: _SmarActTipTiltEmbeddedUI
-    # Seems confusing, but really just cleans up the call to pydm for setting self.ui
-    ui_template = path.join(path.dirname(path.realpath(__file__)), 'SmarActTipTilt.embedded.ui')
 
-    def __init__(self, parent=None, ui_filename=ui_template, **kwargs,):
+    def __init__(self, parent=None, ui_filename='SmarActTipTilt.embedded.ui', **kwargs,):
         super().__init__(parent=parent, ui_filename=ui_filename)
 
         self._omit_names = ['jog_fwd', 'jog_rev']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Added UserPresetSelector PVs for the default selector and current selector. This is a feature exposed in the gigecam IOC for Basler cameras that allows the user to save hardware settings to a preset for a given stream. There are also several factory settings available as well (high gain, color raw, etc.).

Changing `UserPresetDefaultSe` will load that preset upon `ARAVIS_RESET` commands.

## Motivation and Context
Try to fix day-to-day operations pains for Laser folks as it will make restoring giges after planned/unplanned power cycling of cams much easier.

Also closes #1327 

## How Has This Been Tested?
Tested on pretty much every chemRIXS Basler in their MODS, and a few in TMO IP1.

## Where Has This Been Documented?
In this PR and the code! See also https://jira.slac.stanford.edu/browse/ECS-4805 for quirks about how camera firmware messes with the behavior of these pvs due to hashtable nonsense.

## Screenshots (if appropriate):
Demo below

https://github.com/user-attachments/assets/096e11f8-0156-435c-8670-2186650a1186



## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
