### PR TITLE
SmarActTipTilt updates

### DIFF
--- a/docs/source/upcoming_release_notes/1329-SmarActTipTilt_update.rst
+++ b/docs/source/upcoming_release_notes/1329-SmarActTipTilt_update.rst
@@ -1,0 +1,30 @@
+1329 SmarActTipTilt_update
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- SmarActTipTilt: added step_size to embedded screen
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges-SLAC

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -98,17 +98,26 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
         Once we have the tip-tilt device, set the TIP and TILT channels to
         the buttons and labels.
         """
+        def set_open_loop(self, axis: str):
+            """
+            A wrapper to set the open-loop widget channels.
+            Ironically more lines than just hard coding it.
+            """
+            _prefix = getattr(self.device, axis).prefix
+            _open_loop_dict = {'forward': ':STEP_FORWARD.PROC',
+                               'reverse': ':STEP_REVERSE.PROC',
+                               'step_count': ':TOTAL_STEP_COUNT',
+                               'step_size': ':STEP_COUNT'}
+            for obj, _suffix in _open_loop_dict.items():
+                _widget = getattr(self.ui, f'{axis}_{obj}')
+                _widget.set_channel(f'ca://{_prefix}{_suffix}')
 
         if self.device is None:
             print('No device set!')
             return
 
-        self.ui.tip_forward.set_channel(f'ca://{self.device.tip.prefix}:STEP_FORWARD.PROC')
-        self.ui.tip_reverse.set_channel(f'ca://{self.device.tip.prefix}:STEP_REVERSE.PROC')
-        self.ui.tip_step_count.set_channel(f'ca://{self.device.tip.prefix}:TOTAL_STEP_COUNT')
-        self.ui.tilt_forward.set_channel(f'ca://{self.device.tilt.prefix}:STEP_FORWARD.PROC')
-        self.ui.tilt_reverse.set_channel(f'ca://{self.device.tilt.prefix}:STEP_REVERSE.PROC')
-        self.ui.tilt_step_count.set_channel(f'ca://{self.device.tilt.prefix}:TOTAL_STEP_COUNT')
+        set_open_loop(self, axis='tip')
+        set_open_loop(self, axis='tilt')
 
     def get_names_to_omit(self) -> list[str]:
         """

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.ui
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>320</width>
-    <height>323</height>
+    <width>368</width>
+    <height>353</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,13 +38,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="step_count_row">
-     <item row="1" column="0">
-      <widget class="QLabel" name="step_count_label">
-       <property name="text">
-        <string>Step Count</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="QLabel" name="tilt_label">
        <property name="sizePolicy">
@@ -68,22 +61,73 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>5</width>
          <height>20</height>
         </size>
        </property>
       </spacer>
      </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="tip_label">
+     <item row="3" column="1">
+      <widget class="PyDMLineEdit" name="tip_step_size">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string>Tip</string>
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLineEdit" name="tilt_step_size">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLabel" name="tilt_step_count">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -112,25 +156,33 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="PyDMLabel" name="tilt_step_count">
+     <item row="0" column="1">
+      <widget class="QLabel" name="tip_label">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
+       <property name="text">
+        <string>Tip</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="step_count_label">
+       <property name="text">
+        <string>Step Count</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="step_size_label">
+       <property name="text">
+        <string>Step Size</string>
        </property>
       </widget>
      </item>
@@ -563,6 +615,11 @@
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
   </customwidget>
   <customwidget>
    <class>PyDMPushButton</class>

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.ui
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.ui
@@ -78,6 +78,9 @@
        <property name="toolTip">
         <string/>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
       </widget>
      </item>
      <item row="3" column="2">
@@ -96,6 +99,9 @@
        </property>
        <property name="toolTip">
         <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add the wrapper approach from SmarActEncodedTipTilt when adding PVs to layout objects. Technically more verbose, but more scalable?

Also adding line-edits for `step_size` signals without having to open the pop-up screen.

## Motivation and Context
Laser folks pointed out a good point about the tip-tilts:
* The tilt axis affects vertical, and while the vendor defines positive = piezo pushes away from the rear mechanical end stop, this necessarily steers the beam down
* Users want to be able to dictate if the "up" button corresponds to the motion they expect on some detector that is monitoring the steering
* Periscopes make simple inversion of `STEP_FORWARD` and `STEP_REVERSE` complicated, and we don't want to be too granular.

Solution:
Added the `step_size` signals to the embedded screen so users could invert the axes at will.

Since `STEP_FORWARD` and `STEP_REVERSE` in the ioc already handle the sign of the open-loop step, giving a negative `step_size` has the same effect as inverting the axis. This also prevents us from having to obfuscate the `pcdsdevices` class and the `TOTAL_STEP_COUNT` pv's previous behavior is maintained.

## How Has This Been Tested?
As always, tested this on my labrat STT50.8iv in the LRL. Behaves as expected.

## Where Has This Been Documented?
In the PR and in the code!

## Screenshots (if appropriate):
Looks like this now:
![image](https://github.com/user-attachments/assets/b4d154aa-7389-4b3c-af00-0a6f0a9ea21d)


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
