### PR TITLE
SmarActTipTilt Invert Open-loop Axes

### DIFF
--- a/docs/source/upcoming_release_notes/1329-SmarActTipTilt_update.rst
+++ b/docs/source/upcoming_release_notes/1329-SmarActTipTilt_update.rst
@@ -1,0 +1,30 @@
+1329 SmarActTipTilt_update
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- SmarActTipTilt: added step_size to embedded screen
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges-SLAC

--- a/docs/source/upcoming_release_notes/1331-SmarActTipTilt_invert_axes.rst
+++ b/docs/source/upcoming_release_notes/1331-SmarActTipTilt_invert_axes.rst
@@ -1,0 +1,31 @@
+1331 SmarActTipTilt_invert_axes
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- SmarActTipTilt: Added invert_tip and invert_tilt check boxes
+- SmarActTipTilt: Added methods to flip which button corresponds to STEP_FORWARD and STEP_REVERSE respectively
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges-SLAC

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -19,9 +19,11 @@ class _SmarActTipTiltEmbeddedUI(QtWidgets.QWidget):
     tip_forward: pydm.widgets.pushbutton.PyDMPushButton
     tip_reverse: pydm.widgets.pushbutton.PyDMPushButton
     tip_step_count: pydm.widgets.label.PyDMLabel
+    invert_tip: QtWidgets.QCheckBox
     tilt_forward: pydm.widgets.pushbutton.PyDMPushButton
     tilt_reverse: pydm.widgets.pushbutton.PyDMPushButton
     tilt_step_count: pydm.widgets.label.PyDMLabel
+    invert_tilt: QtWidgets.QCheckBox
     settings_button: pydm.widgets.pushbutton.PyDMPushButton
 
 
@@ -118,6 +120,41 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
 
         set_open_loop(self, axis='tip')
         set_open_loop(self, axis='tilt')
+
+        self.ui.invert_tip.stateChanged.connect(self._invert_tip_axis)
+        self.ui.invert_tilt.stateChanged.connect(self._invert_tilt_axis)
+
+    def _invert_tip_axis(self):
+        """
+        Shenanigans to invert the directional buttons to reflect physical space, as determined by the user.
+        """
+        _prefix = self.device.tip.prefix
+        _axis = 'tip'
+        _forward = getattr(self.ui, f'{_axis}_forward')
+        _reverse = getattr(self.ui, f'{_axis}_reverse')
+        if getattr(self.ui, f'invert_{_axis}').isChecked():
+            _forward.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+            _reverse.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+        else:
+            _forward.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+            _reverse.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+
+        print('new forward channel:', _forward.channels())
+        print('new forward value:', _forward._pressValue)
+        print('new reverse channel:', _reverse.channels())
+        print('new reverse value:', _reverse._pressValue)
+
+    def _invert_tilt_axis(self):
+        """
+        Shenanigans to invert the directional buttons to reflect physical space, as determined by the user.
+        """
+        _prefix = self.device.tilt.prefix
+        if self.ui.invert_tilt.isChecked():
+            self.ui.tilt_forward.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+            self.ui.tilt_reverse.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+        else:
+            self.ui.tilt_forward.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+            self.ui.tilt_reverse.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
 
     def get_names_to_omit(self) -> list[str]:
         """

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -106,13 +106,18 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
             Ironically more lines than just hard coding it.
             """
             _prefix = getattr(self.device, axis).prefix
-            _open_loop_dict = {'forward': ':STEP_FORWARD.PROC',
-                               'reverse': ':STEP_REVERSE.PROC',
+            _open_loop_dict = {'forward': '_jog_fwd',
+                               'reverse': '_jog_rev',
                                'step_count': ':TOTAL_STEP_COUNT',
                                'step_size': ':STEP_COUNT'}
             for obj, _suffix in _open_loop_dict.items():
                 _widget = getattr(self.ui, f'{axis}_{obj}')
-                _widget.set_channel(f'ca://{_prefix}{_suffix}')
+                if ':' in _suffix:
+                    _widget.set_channel(f'ca://{_prefix}{_suffix}')
+                elif type(_widget) is pydm.widgets.pushbutton.PyDMPushButton:
+                    # Set the slots for the jog buttons
+                    _signal = getattr(self, f'_{axis}{_suffix}')
+                    _widget.clicked.connect(_signal)
 
         if self.device is None:
             print('No device set!')
@@ -121,59 +126,50 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
         set_open_loop(self, axis='tip')
         set_open_loop(self, axis='tilt')
 
-        self.ui.invert_tip.stateChanged.connect(self._invert_tip_axis)
-        self.ui.invert_tilt.stateChanged.connect(self._invert_tilt_axis)
-
-    def invert_axis(self, axis: str, invert: bool = False):
+    def _jog_wrapper(self, axis: str, direction: str):
         """
-        Invert the jog pushbuttons
+        Need to abstract the jog functions from simple channel access due to strange
+        pydm callback bugs when reassigning channels. Kind of defeats the point of
+        using pydm buttons, but whenever that bug is fixed we can use set_channel.
 
         Parameters
         -----------
         axis: str
-            Name of axis
-        invert: bool
-            Whether or not to invert. Default is False.
+            Name of the axis, i.e. 'tip' or 'tilt'
+        direction: str
+            Direction of move, i.e. 'tip' or 'tilt'
         """
+        invert = getattr(self.ui, f'invert_{axis}').isChecked()
+        stage = getattr(self.device, axis)
+        _fwd = getattr(stage, 'jog_fwd')
+        _rev = getattr(stage, 'jog_rev')
 
-        def clear_channels():
-            """
-            You MUST explicitly clear channels before reassigning if you
-            want to avoid any duplicate callback bugs.
-            """
-            _forward.set_channel('')
-            _reverse.set_channel('')
+        if direction == 'Forward':
+            _jog = _rev if invert else _fwd
+            _jog.put(1)
+        if direction == 'Reverse':
+            _jog = _fwd if invert else _rev
+            _jog.put(1)
 
-        _prefix = getattr(self.device, axis).prefix
-        _forward = getattr(self.ui, f'{axis}_forward')
-        _reverse = getattr(self.ui, f'{axis}_reverse')
+    @QtCore.Slot()
+    def _tip_jog_fwd(self):
+        """Jog tip axis forward by tip.jog_step_size"""
+        self._jog_wrapper(axis='tip', direction='Forward')
 
-        if invert:
-            clear_channels()
-            _forward.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
-            _reverse.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
-        else:
-            clear_channels()
-            _forward.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
-            _reverse.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+    @QtCore.Slot()
+    def _tip_jog_rev(self):
+        """Jog tip axis backwards by tip.jog_step_size"""
+        self._jog_wrapper(axis='tip', direction='Reverse')
 
-    def _invert_tip_axis(self):
-        """
-        Shenanigans to invert the directional buttons to reflect physical space, as determined by the user.
-        """
-        if self.ui.invert_tip.isChecked():
-            self.invert_axis(axis='tip', invert=True)
-        else:
-            self.invert_axis(axis='tip', invert=False)
+    @QtCore.Slot()
+    def _tilt_jog_fwd(self):
+        """Jog tilt axis forward by tilt.jog_step_size"""
+        self._jog_wrapper(axis='tilt', direction='Forward')
 
-    def _invert_tilt_axis(self):
-        """
-        Shenanigans to invert the directional buttons to reflect physical space, as determined by the user.
-        """
-        if self.ui.invert_tilt.isChecked():
-            self.invert_axis(axis='tilt', invert=True)
-        else:
-            self.invert_axis(axis='tilt', invert=False)
+    @QtCore.Slot()
+    def _tilt_jog_rev(self):
+        """Jog tilt axis backwards by tilt.jog_step_size"""
+        self._jog_wrapper(axis='tilt', direction='Reverse')
 
     def get_names_to_omit(self) -> list[str]:
         """

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -130,10 +130,10 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
 
         Parameters
         -----------
-            axis: str
-                Name of axis
-            invert: bool
-                Whether or not to invert. Default is False.
+        axis: str
+            Name of axis
+        invert: bool
+            Whether or not to invert. Default is False.
         """
 
         def clear_channels():

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -112,12 +112,12 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
                                'step_size': ':STEP_COUNT'}
             for obj, _suffix in _open_loop_dict.items():
                 _widget = getattr(self.ui, f'{axis}_{obj}')
-                if ':' in _suffix:
-                    _widget.set_channel(f'ca://{_prefix}{_suffix}')
-                elif type(_widget) is pydm.widgets.pushbutton.PyDMPushButton:
+                if isinstance(_widget, pydm.widgets.pushbutton.PyDMPushButton):
                     # Set the slots for the jog buttons
                     _signal = getattr(self, f'_{axis}{_suffix}')
                     _widget.clicked.connect(_signal)
+                else:
+                    _widget.set_channel(f'ca://{_prefix}{_suffix}')
 
         if self.device is None:
             print('No device set!')

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.py
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.py
@@ -124,37 +124,56 @@ class SmarActTipTiltWidget(Display, utils.TyphosBase):
         self.ui.invert_tip.stateChanged.connect(self._invert_tip_axis)
         self.ui.invert_tilt.stateChanged.connect(self._invert_tilt_axis)
 
+    def invert_axis(self, axis: str, invert: bool = False):
+        """
+        Invert the jog pushbuttons
+
+        Parameters
+        -----------
+            axis: str
+                Name of axis
+            invert: bool
+                Whether or not to invert. Default is False.
+        """
+
+        def clear_channels():
+            """
+            You MUST explicitly clear channels before reassigning if you
+            want to avoid any duplicate callback bugs.
+            """
+            _forward.set_channel('')
+            _reverse.set_channel('')
+
+        _prefix = getattr(self.device, axis).prefix
+        _forward = getattr(self.ui, f'{axis}_forward')
+        _reverse = getattr(self.ui, f'{axis}_reverse')
+
+        if invert:
+            clear_channels()
+            _forward.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+            _reverse.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+        else:
+            clear_channels()
+            _forward.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+            _reverse.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+
     def _invert_tip_axis(self):
         """
         Shenanigans to invert the directional buttons to reflect physical space, as determined by the user.
         """
-        _prefix = self.device.tip.prefix
-        _axis = 'tip'
-        _forward = getattr(self.ui, f'{_axis}_forward')
-        _reverse = getattr(self.ui, f'{_axis}_reverse')
-        if getattr(self.ui, f'invert_{_axis}').isChecked():
-            _forward.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
-            _reverse.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+        if self.ui.invert_tip.isChecked():
+            self.invert_axis(axis='tip', invert=True)
         else:
-            _forward.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
-            _reverse.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
-
-        print('new forward channel:', _forward.channels())
-        print('new forward value:', _forward._pressValue)
-        print('new reverse channel:', _reverse.channels())
-        print('new reverse value:', _reverse._pressValue)
+            self.invert_axis(axis='tip', invert=False)
 
     def _invert_tilt_axis(self):
         """
         Shenanigans to invert the directional buttons to reflect physical space, as determined by the user.
         """
-        _prefix = self.device.tilt.prefix
         if self.ui.invert_tilt.isChecked():
-            self.ui.tilt_forward.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
-            self.ui.tilt_reverse.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
+            self.invert_axis(axis='tilt', invert=True)
         else:
-            self.ui.tilt_forward.set_channel(f'ca://{_prefix}:STEP_FORWARD.PROC')
-            self.ui.tilt_reverse.set_channel(f'ca://{_prefix}:STEP_REVERSE.PROC')
+            self.invert_axis(axis='tilt', invert=False)
 
     def get_names_to_omit(self) -> list[str]:
         """

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.ui
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
-    <height>353</height>
+    <width>306</width>
+    <height>377</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -38,6 +38,213 @@
    </item>
    <item>
     <layout class="QGridLayout" name="step_count_row">
+     <item row="1" column="0">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="tip_step_count">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string>Total Step Count</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+       <property name="enableRichText" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLabel" name="tilt_step_count">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string>Total Step Count</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+       <property name="enableRichText" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLineEdit" name="tilt_step_size">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string>Step Size</string>
+       </property>
+       <property name="monitorDisp" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="PyDMLineEdit" name="tip_step_size">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string>Step Size</string>
+       </property>
+       <property name="monitorDisp" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="tip_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Tip</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="2">
       <widget class="QLabel" name="tilt_label">
        <property name="sizePolicy">
@@ -62,133 +269,22 @@
        <property name="sizeHint" stdset="0">
         <size>
          <width>5</width>
-         <height>20</height>
+         <height>10</height>
         </size>
        </property>
       </spacer>
      </item>
-     <item row="3" column="1">
-      <widget class="PyDMLineEdit" name="tip_step_size">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="PyDMLineEdit" name="tilt_step_size">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="4">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>5</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="2">
-      <widget class="PyDMLabel" name="tilt_step_count">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="tip_step_count">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="tip_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+     <item row="4" column="1" alignment="Qt::AlignHCenter">
+      <widget class="QCheckBox" name="invert_tip">
        <property name="text">
-        <string>Tip</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <string>Invert</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="step_count_label">
+     <item row="4" column="2" alignment="Qt::AlignHCenter">
+      <widget class="QCheckBox" name="invert_tilt">
        <property name="text">
-        <string>Step Count</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="step_size_label">
-       <property name="text">
-        <string>Step Size</string>
+        <string>Invert</string>
        </property>
       </widget>
      </item>

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.ui
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>315</width>
+    <width>348</width>
     <height>380</height>
    </rect>
   </property>
@@ -38,19 +38,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="step_count_row">
-     <item row="0" column="3">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>5</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="3" column="1" alignment="Qt::AlignHCenter">
       <widget class="QCheckBox" name="invert_tilt">
        <property name="text">
@@ -114,7 +101,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>5</width>
+         <width>3</width>
          <height>10</height>
         </size>
        </property>
@@ -166,10 +153,42 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="3">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <widget class="QWidget" name="embedded" native="true">
        <property name="sizePolicy">
@@ -524,8 +543,24 @@
       </widget>
      </item>
      <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <layout class="QGridLayout" name="tip_indicator_layout">
-       <item row="0" column="0">
+       <item row="1" column="0">
         <widget class="PyDMLabel" name="tip_step_count">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -571,10 +606,10 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="PyDMLineEdit" name="tip_step_size">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -611,14 +646,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" alignment="Qt::AlignHCenter">
-        <widget class="QCheckBox" name="invert_tip">
-         <property name="text">
-          <string>Invert</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -634,7 +662,46 @@
          </property>
         </spacer>
        </item>
+       <item row="3" column="0" alignment="Qt::AlignHCenter">
+        <widget class="QCheckBox" name="invert_tip">
+         <property name="text">
+          <string>Invert</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>2</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.ui
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.ui
@@ -6,15 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>348</width>
+    <width>354</width>
     <height>380</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>350</width>
+    <height>380</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -37,158 +43,147 @@
     </widget>
    </item>
    <item>
-    <layout class="QGridLayout" name="step_count_row">
-     <item row="3" column="1" alignment="Qt::AlignHCenter">
-      <widget class="QCheckBox" name="invert_tilt">
-       <property name="text">
-        <string>Invert</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="PyDMLabel" name="tilt_step_count">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string>Total Step Count</string>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
-       <property name="enableRichText" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>3</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="2" column="1">
-      <widget class="PyDMLineEdit" name="tilt_step_size">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string>Step Size</string>
-       </property>
-       <property name="monitorDisp" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::MinimumExpanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QWidget" name="tilt_indicators_widget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>158</width>
+       <height>101</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>25</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="step_count_row">
+        <item row="3" column="1" alignment="Qt::AlignHCenter">
+         <widget class="QCheckBox" name="invert_tilt">
+          <property name="text">
+           <string>Invert</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="PyDMLabel" name="tilt_step_count">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="precision" stdset="0">
+           <number>0</number>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveContent" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="PyDMToolTip" stdset="0">
+           <string>Total Step Count</string>
+          </property>
+          <property name="channel" stdset="0">
+           <string/>
+          </property>
+          <property name="enableRichText" stdset="0">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="PyDMLineEdit" name="tilt_step_size">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="precision" stdset="0">
+           <number>0</number>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="precisionFromPV" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveContent" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="PyDMToolTip" stdset="0">
+           <string>Step Size</string>
+          </property>
+          <property name="monitorDisp" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="channel" stdset="0">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>5</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
      <item>
       <widget class="QWidget" name="embedded" native="true">
        <property name="sizePolicy">
@@ -543,149 +538,119 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="QWidget" name="tip_indicator_widget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
+       <property name="minimumSize">
         <size>
-         <width>5</width>
-         <height>20</height>
+         <width>144</width>
+         <height>118</height>
         </size>
        </property>
-      </spacer>
-     </item>
-     <item>
-      <layout class="QGridLayout" name="tip_indicator_layout">
-       <item row="1" column="0">
-        <widget class="PyDMLabel" name="tip_step_count">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="precision" stdset="0">
-          <number>0</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="alarmSensitiveContent" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="PyDMToolTip" stdset="0">
-          <string>Total Step Count</string>
-         </property>
-         <property name="channel" stdset="0">
-          <string/>
-         </property>
-         <property name="enableRichText" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="PyDMLineEdit" name="tip_step_size">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="precision" stdset="0">
-          <number>0</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="alarmSensitiveContent" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="PyDMToolTip" stdset="0">
-          <string>Step Size</string>
-         </property>
-         <property name="monitorDisp" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>3</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="0" alignment="Qt::AlignHCenter">
-        <widget class="QCheckBox" name="invert_tip">
-         <property name="text">
-          <string>Invert</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>2</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <layout class="QGridLayout" name="tip_indicator_layout">
+          <item row="2" column="0" alignment="Qt::AlignHCenter">
+           <widget class="QCheckBox" name="invert_tip">
+            <property name="text">
+             <string>Invert</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="PyDMLineEdit" name="tip_step_size">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string>Step Size</string>
+            </property>
+            <property name="monitorDisp" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="PyDMLabel" name="tip_step_count">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string>Total Step Count</string>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+            <property name="enableRichText" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </item>
      <item>
       <spacer name="horizontalSpacer_4">

--- a/pcdsdevices/ui/SmarActTipTilt.embedded.ui
+++ b/pcdsdevices/ui/SmarActTipTilt.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>306</width>
-    <height>377</height>
+    <width>315</width>
+    <height>380</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,8 +38,8 @@
    </item>
    <item>
     <layout class="QGridLayout" name="step_count_row">
-     <item row="1" column="0">
-      <spacer name="horizontalSpacer_2">
+     <item row="0" column="3">
+      <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -51,53 +51,14 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="tip_step_count">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string>Total Step Count</string>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
-       <property name="enableRichText" stdset="0">
-        <bool>false</bool>
+     <item row="3" column="1" alignment="Qt::AlignHCenter">
+      <widget class="QCheckBox" name="invert_tilt">
+       <property name="text">
+        <string>Invert</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="0" column="1">
       <widget class="PyDMLabel" name="tilt_step_count">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -143,7 +104,23 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="0" column="0">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="2" column="1">
       <widget class="PyDMLineEdit" name="tilt_step_size">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -189,459 +166,477 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="PyDMLineEdit" name="tip_step_size">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string>Step Size</string>
-       </property>
-       <property name="monitorDisp" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="tip_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Tip</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="tilt_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Tilt</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="4">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>5</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="1" alignment="Qt::AlignHCenter">
-      <widget class="QCheckBox" name="invert_tip">
-       <property name="text">
-        <string>Invert</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2" alignment="Qt::AlignHCenter">
-      <widget class="QCheckBox" name="invert_tilt">
-       <property name="text">
-        <string>Invert</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
-   <item alignment="Qt::AlignHCenter">
-    <widget class="QWidget" name="embedded" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="4" column="1">
-       <layout class="QGridLayout" name="dpad_step_grid">
-        <item row="2" column="2">
-         <widget class="PyDMPushButton" name="tip_forward">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>35</width>
-            <height>35</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="alarmSensitiveContent" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="PyDMToolTip" stdset="0">
-           <string/>
-          </property>
-          <property name="monitorDisp" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="channel" stdset="0">
-           <string/>
-          </property>
-          <property name="PyDMIcon" stdset="0">
-           <string>caret-right</string>
-          </property>
-          <property name="PyDMIconColor" stdset="0">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="passwordProtected" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="password" stdset="0">
-           <string/>
-          </property>
-          <property name="protectedPassword" stdset="0">
-           <string/>
-          </property>
-          <property name="showConfirmDialog" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="confirmMessage" stdset="0">
-           <string>Are you sure you want to proceed?</string>
-          </property>
-          <property name="pressValue" stdset="0">
-           <string>1</string>
-          </property>
-          <property name="releaseValue" stdset="0">
-           <string>None</string>
-          </property>
-          <property name="relativeChange" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="writeWhenRelease" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="dpad_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Step</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="PyDMPushButton" name="tip_reverse">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>35</width>
-            <height>35</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="alarmSensitiveContent" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="PyDMToolTip" stdset="0">
-           <string/>
-          </property>
-          <property name="monitorDisp" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="channel" stdset="0">
-           <string/>
-          </property>
-          <property name="PyDMIcon" stdset="0">
-           <string>caret-left</string>
-          </property>
-          <property name="PyDMIconColor" stdset="0">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="passwordProtected" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="password" stdset="0">
-           <string/>
-          </property>
-          <property name="protectedPassword" stdset="0">
-           <string/>
-          </property>
-          <property name="showConfirmDialog" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="confirmMessage" stdset="0">
-           <string>Are you sure you want to proceed?</string>
-          </property>
-          <property name="pressValue" stdset="0">
-           <string>1</string>
-          </property>
-          <property name="releaseValue" stdset="0">
-           <string>None</string>
-          </property>
-          <property name="relativeChange" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="writeWhenRelease" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1" alignment="Qt::AlignHCenter">
-         <widget class="PyDMPushButton" name="tilt_reverse">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>35</width>
-            <height>35</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="alarmSensitiveContent" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="PyDMToolTip" stdset="0">
-           <string/>
-          </property>
-          <property name="monitorDisp" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="channel" stdset="0">
-           <string/>
-          </property>
-          <property name="PyDMIcon" stdset="0">
-           <string>caret-down</string>
-          </property>
-          <property name="PyDMIconColor" stdset="0">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="passwordProtected" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="password" stdset="0">
-           <string/>
-          </property>
-          <property name="protectedPassword" stdset="0">
-           <string/>
-          </property>
-          <property name="showConfirmDialog" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="confirmMessage" stdset="0">
-           <string>Are you sure you want to proceed?</string>
-          </property>
-          <property name="pressValue" stdset="0">
-           <string>1</string>
-          </property>
-          <property name="releaseValue" stdset="0">
-           <string>None</string>
-          </property>
-          <property name="relativeChange" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="writeWhenRelease" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1" alignment="Qt::AlignHCenter">
-         <widget class="PyDMPushButton" name="tilt_forward">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>35</width>
-            <height>35</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="alarmSensitiveContent" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="PyDMToolTip" stdset="0">
-           <string/>
-          </property>
-          <property name="monitorDisp" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="channel" stdset="0">
-           <string/>
-          </property>
-          <property name="PyDMIcon" stdset="0">
-           <string>caret-up</string>
-          </property>
-          <property name="PyDMIconColor" stdset="0">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="passwordProtected" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="password" stdset="0">
-           <string/>
-          </property>
-          <property name="protectedPassword" stdset="0">
-           <string/>
-          </property>
-          <property name="showConfirmDialog" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="confirmMessage" stdset="0">
-           <string>Are you sure you want to proceed?</string>
-          </property>
-          <property name="pressValue" stdset="0">
-           <string>1</string>
-          </property>
-          <property name="releaseValue" stdset="0">
-           <string>None</string>
-          </property>
-          <property name="relativeChange" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="writeWhenRelease" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QWidget" name="embedded" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="4" column="1">
+         <layout class="QGridLayout" name="dpad_step_grid">
+          <item row="2" column="2">
+           <widget class="PyDMPushButton" name="tip_forward">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>35</width>
+              <height>35</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="monitorDisp" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+            <property name="PyDMIcon" stdset="0">
+             <string>caret-right</string>
+            </property>
+            <property name="PyDMIconColor" stdset="0">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="passwordProtected" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="password" stdset="0">
+             <string/>
+            </property>
+            <property name="protectedPassword" stdset="0">
+             <string/>
+            </property>
+            <property name="showConfirmDialog" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="confirmMessage" stdset="0">
+             <string>Are you sure you want to proceed?</string>
+            </property>
+            <property name="pressValue" stdset="0">
+             <string>1</string>
+            </property>
+            <property name="releaseValue" stdset="0">
+             <string>None</string>
+            </property>
+            <property name="relativeChange" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="writeWhenRelease" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="dpad_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Step</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="PyDMPushButton" name="tip_reverse">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>35</width>
+              <height>35</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="monitorDisp" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+            <property name="PyDMIcon" stdset="0">
+             <string>caret-left</string>
+            </property>
+            <property name="PyDMIconColor" stdset="0">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="passwordProtected" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="password" stdset="0">
+             <string/>
+            </property>
+            <property name="protectedPassword" stdset="0">
+             <string/>
+            </property>
+            <property name="showConfirmDialog" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="confirmMessage" stdset="0">
+             <string>Are you sure you want to proceed?</string>
+            </property>
+            <property name="pressValue" stdset="0">
+             <string>1</string>
+            </property>
+            <property name="releaseValue" stdset="0">
+             <string>None</string>
+            </property>
+            <property name="relativeChange" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="writeWhenRelease" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" alignment="Qt::AlignHCenter">
+           <widget class="PyDMPushButton" name="tilt_reverse">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>35</width>
+              <height>35</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="monitorDisp" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+            <property name="PyDMIcon" stdset="0">
+             <string>caret-down</string>
+            </property>
+            <property name="PyDMIconColor" stdset="0">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="passwordProtected" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="password" stdset="0">
+             <string/>
+            </property>
+            <property name="protectedPassword" stdset="0">
+             <string/>
+            </property>
+            <property name="showConfirmDialog" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="confirmMessage" stdset="0">
+             <string>Are you sure you want to proceed?</string>
+            </property>
+            <property name="pressValue" stdset="0">
+             <string>1</string>
+            </property>
+            <property name="releaseValue" stdset="0">
+             <string>None</string>
+            </property>
+            <property name="relativeChange" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="writeWhenRelease" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" alignment="Qt::AlignHCenter">
+           <widget class="PyDMPushButton" name="tilt_forward">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>35</width>
+              <height>35</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="monitorDisp" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+            <property name="PyDMIcon" stdset="0">
+             <string>caret-up</string>
+            </property>
+            <property name="PyDMIconColor" stdset="0">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="passwordProtected" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="password" stdset="0">
+             <string/>
+            </property>
+            <property name="protectedPassword" stdset="0">
+             <string/>
+            </property>
+            <property name="showConfirmDialog" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="confirmMessage" stdset="0">
+             <string>Are you sure you want to proceed?</string>
+            </property>
+            <property name="pressValue" stdset="0">
+             <string>1</string>
+            </property>
+            <property name="releaseValue" stdset="0">
+             <string>None</string>
+            </property>
+            <property name="relativeChange" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="writeWhenRelease" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
+      </widget>
+     </item>
+     <item>
+      <layout class="QGridLayout" name="tip_indicator_layout">
+       <item row="0" column="0">
+        <widget class="PyDMLabel" name="tip_step_count">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="precision" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string>Total Step Count</string>
+         </property>
+         <property name="channel" stdset="0">
+          <string/>
+         </property>
+         <property name="enableRichText" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="PyDMLineEdit" name="tip_step_size">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="precision" stdset="0">
+          <number>0</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="alarmSensitiveContent" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="PyDMToolTip" stdset="0">
+          <string>Step Size</string>
+         </property>
+         <property name="monitorDisp" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" alignment="Qt::AlignHCenter">
+        <widget class="QCheckBox" name="invert_tip">
+         <property name="text">
+          <string>Invert</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>3</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="PyDMPushButton" name="settings_button">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
1) Got rid of some text labels for the embedded screen to reduce footprint.
2) Added checkboxes for inverting the `tip` or `tilt` axes
3) Add logic to change which channel is assigned to which `pushbutton` for jogging the each stage. This lets the user functionally, and in real time, invert the directional pad to suit their needs/alignment/design.

Found a _neat_ ~~bug~~ feature in `pydm` when using `set_channel` sequentially on objects who may or may not have those channels set already. If you are re-assigning the channels on a pydm widget, explicitly set the channels to blank strings before proceeding or you _will_ have callback bugs.

## Motivation and Context
Unfortunately #1329 did not fix the issue the Laser team presented, due to how the protocol file works in the common IOC. Turns out `asyn` doesn't do math, who'd've thunk 🙃 

The real solution I was dragging my feet on was adding a user-widget to invert the axis by swapping what channels correspond to which button. 

## How Has This Been Tested?
Extensively tested using the STT50.8iv work horse in the laser lab. See below.

## Where Has This Been Documented?
In the code and in this PR!

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/8014e783-ba49-4d89-a118-a1c9b8450efd

UPDATE: 
New layout based on user request
![image](https://github.com/user-attachments/assets/f0bf6ec5-ac93-4c4f-869e-0ea8a0887904)


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
