### PR TITLE
ENH: set mpod voltage limits based on parent module

### DIFF
--- a/docs/source/upcoming_release_notes/1332-enh_mpod_polarity.rst
+++ b/docs/source/upcoming_release_notes/1332-enh_mpod_polarity.rst
@@ -1,0 +1,30 @@
+1332 enh_mpod_polarity
+######################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adjusts MPODApalisChannel inform its limits based on the parent MPODApalisModule settings
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/mpod_apalis.py
+++ b/pcdsdevices/mpod_apalis.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from enum import Enum, auto
 
 import numpy as np
 from ophyd.device import Component as Cpt
@@ -139,19 +138,8 @@ class MPODApalisChannel(BaseInterface, Device):
 
         If not, defaults to setting limits to positive definite
         """
-        polarity = getattr(self, "biological_parent.polarity", Polarity.POSITIVE)
         limit_scales = getattr(self, "biological_parent.limit_scales", (0, 100))
         limits = [lim * self._max_voltage / 100 for lim in limit_scales]
-
-        if polarity is Polarity.BIPOLAR:
-            if 0 in limits:
-                logger.debug(f"Bipolar limits expected, got: ({limits})")
-        elif polarity is Polarity.NEGATIVE:
-            if all(lim >= 0 for lim in limits):
-                logger.debug(f"Negative limits expected, got: ({limits})")
-        elif polarity is Polarity.POSITIVE:
-            if all(lim <= 0 for lim in limits):
-                logger.debug(f"Positive limits expected, got: ({limits})")
 
         self.voltage._override_metadata(
             lower_ctrl_limit=min(limits),
@@ -191,12 +179,6 @@ def _put_clamped(signal: EpicsSignal, value: float) -> None:
         value = high_val
 
     signal.put(value)
-
-
-class Polarity(Enum):
-    POSITIVE = auto()
-    NEGATIVE = auto()
-    BIPOLAR = auto()
 
 
 class MPODApalisModule(BaseInterface, GroupDevice):
@@ -248,9 +230,6 @@ class MPODApalisModule(BaseInterface, GroupDevice):
                  write_pv=':Control:doClear',
                  kind='normal', string=True,
                  doc='Clears all MPOD module faults')
-
-    model = Cpt(EpicsSignalRO, ':Model', kind='omitted', string=True,
-                doc="Model number")
 
     limit_pos = Cpt(EpicsSignalRO, ':VoltageLimit', kind='omitted',
                     doc='Positive voltage limit as a % of the max voltage')

--- a/pcdsdevices/mpod_apalis.py
+++ b/pcdsdevices/mpod_apalis.py
@@ -132,14 +132,12 @@ class MPODApalisChannel(BaseInterface, Device):
 
     def _update_max_voltage_limits(self) -> None:
         """
-        Set explicit symmetric limits on voltage for better error reporting.
+        Update limits on voltage, referring to the parent module if it exists
 
-        Refers to the parent module if it exists, to determine the limit scaling
-
-        If not, defaults to setting limits to positive definite
+        If parent module does not exist, defaults limits to (0, 100)
         """
-        limit_scales = getattr(self, "biological_parent.limit_scales", (0, 100))
-        limits = [lim * self._max_voltage / 100 for lim in limit_scales]
+        limit_pct = getattr(self, "biological_parent.limit_percents", (0, 100))
+        limits = [lim * self._max_voltage / 100 for lim in limit_pct]
 
         self.voltage._override_metadata(
             lower_ctrl_limit=min(limits),
@@ -281,13 +279,13 @@ class MPODApalisModule(BaseInterface, GroupDevice):
         self.current_ramp_speed.put(ramp_speed)
 
     @property
-    def limit_scales(self) -> tuple[float, float]:
+    def limit_percents(self) -> tuple[float, float]:
         """
-        Returns limit scaling tuple.  When multiplied by the channel's max_voltage
-        signal (:VoltageNominal) will produce the actual limits for the channel
+        Returns limit percentage tuple.  Represents the % of the channel's max_voltage
+        signal (:VoltageNominal) to be used as the actual limits for the channel
 
         Returns
-        -------
+        -------p
         tuple[float, float]
             The voltage limits as a proportion of the max_voltage
         """

--- a/pcdsdevices/tests/test_mpod_apalis.py
+++ b/pcdsdevices/tests/test_mpod_apalis.py
@@ -5,15 +5,19 @@ from ophyd.sim import make_fake_device
 from ophyd.utils import LimitError
 
 from ..device_types import MPODApalisModule4Channel
-from ..mpod_apalis import MPODApalisChannel, MPODApalisCrate
+from ..mpod_apalis import MPODApalisCrate
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
 def fake_mpod_channel1():
-    FakeMPODChannel = make_fake_device(MPODApalisChannel)
-    c1 = FakeMPODChannel('TEST:MPOD:CHANNEL1', name='TestC1')
+    FakeMPODmodule = make_fake_device(MPODApalisModule4Channel)
+    module = FakeMPODmodule("TEST:MPOD", name="TestPos1Module")
+    c1 = module.c1
+    module.model.sim_put("modelp")
+    module.limit_pos.sim_put(110)
+    module.limit_neg.sim_put(0)
     # switch off
     c1.state.sim_put(0)
     c1.voltage.sim_put(50)
@@ -25,8 +29,13 @@ def fake_mpod_channel1():
 
 @pytest.fixture(scope='function')
 def fake_mpod_channel2():
-    FakeMPODChannel = make_fake_device(MPODApalisChannel)
-    c2 = FakeMPODChannel('TEST:MPOD:CHANNEL2', name='TestC2')
+    FakeMPODmodule = make_fake_device(MPODApalisModule4Channel)
+    module = FakeMPODmodule("TEST:MPOD", name="TestPos2Module")
+    c2 = module.c2
+    # switch off
+    module.model.sim_put("modelp")
+    module.limit_pos.sim_put(120)
+    module.limit_neg.sim_put(0)
     # switch off
     c2.state.sim_put(0)
     c2.voltage.sim_put(90)
@@ -38,9 +47,13 @@ def fake_mpod_channel2():
 
 @pytest.fixture(scope='function')
 def fake_mpod_channel_neg():
-    FakeMPODChannel = make_fake_device(MPODApalisChannel)
-    cn = FakeMPODChannel('TEST:MPOD:CHANNEL2', name='TestC2')
+    FakeMPODmodule = make_fake_device(MPODApalisModule4Channel)
+    module = FakeMPODmodule("TEST:MPOD", name="TestNegativeModule")
+    cn = module.c0
     # switch off
+    module.model.sim_put("modeln")
+    module.limit_pos.sim_put(130)
+    module.limit_neg.sim_put(0)
     cn.state.sim_put(0)
     cn.voltage.sim_put(-90)
     cn.current.sim_put(0.01)
@@ -77,7 +90,7 @@ def test_switch_on_off(fake_mpod_channel1):
 
 def test_channel_limits(fake_mpod_channel1, fake_mpod_channel2, fake_mpod_channel_neg):
     logger.debug('Testing MPOD Channel control limits')
-    assert fake_mpod_channel1.voltage.limits == (0, 100)
+    assert fake_mpod_channel1.voltage.limits == (0, 110)
     assert fake_mpod_channel1.current.limits == (0, 0.1)
     with pytest.raises(LimitError):
         fake_mpod_channel1.voltage.put(-1)
@@ -88,7 +101,7 @@ def test_channel_limits(fake_mpod_channel1, fake_mpod_channel2, fake_mpod_channe
     with pytest.raises(LimitError):
         fake_mpod_channel1.current.put(2)
 
-    assert fake_mpod_channel_neg.voltage.limits == (-100, 0)
+    assert fake_mpod_channel_neg.voltage.limits == (-130, 0)
     with pytest.raises(LimitError):
         fake_mpod_channel_neg.voltage.put(1)
     with pytest.raises(LimitError):
@@ -102,7 +115,7 @@ def test_set_voltage(fake_mpod_channel1, fake_mpod_channel2, fake_mpod_channel_n
     assert fake_mpod_channel1.voltage.get() == 0
     assert fake_mpod_channel2.voltage.get() == 90
     fake_mpod_channel2.set_voltage(140)
-    assert fake_mpod_channel2.voltage.get() == 100
+    assert fake_mpod_channel2.voltage.get() == 120
     fake_mpod_channel2.set_voltage(-140)
     assert fake_mpod_channel1.voltage.get() == 0
     fake_mpod_channel_neg.set_voltage(-20)
@@ -110,7 +123,29 @@ def test_set_voltage(fake_mpod_channel1, fake_mpod_channel2, fake_mpod_channel_n
     fake_mpod_channel_neg.set_voltage(20)
     assert fake_mpod_channel_neg.voltage.get() == 0
     fake_mpod_channel_neg.set_voltage(-2000000)
-    assert fake_mpod_channel_neg.voltage.get() == -100
+    assert fake_mpod_channel_neg.voltage.get() == -130
+
+
+def test_limit_scales(fake_mpod_channel1):
+    logger.debug("Test limits scaling")
+    print("start test limit scales")
+    module = fake_mpod_channel1.biological_parent
+    fake_mpod_channel1.max_voltage.sim_put(100)
+
+    # starting with (0, 110)
+    assert fake_mpod_channel1.voltage.limits == (0, 110)
+    assert module.limit_scales == (0, 110)
+
+    module.limit_pos.sim_put(0)
+    module.limit_neg.sim_put(5)
+    assert fake_mpod_channel1.voltage.limits == (-5, 0)
+    assert module.limit_scales == (-5, 0)
+
+    # Ignoring the model warning numbers
+    module.limit_pos.sim_put(50)
+    module.limit_neg.sim_put(50)
+    assert fake_mpod_channel1.voltage.limits == (-50, 50)
+    assert module.limit_scales == (-50, 50)
 
 
 def test_set_current(fake_mpod_channel1, fake_mpod_channel2):

--- a/pcdsdevices/tests/test_mpod_apalis.py
+++ b/pcdsdevices/tests/test_mpod_apalis.py
@@ -128,7 +128,6 @@ def test_set_voltage(fake_mpod_channel1, fake_mpod_channel2, fake_mpod_channel_n
 
 def test_limit_scales(fake_mpod_channel1):
     logger.debug("Test limits scaling")
-    print("start test limit scales")
     module = fake_mpod_channel1.biological_parent
     fake_mpod_channel1.max_voltage.sim_put(100)
 

--- a/pcdsdevices/tests/test_mpod_apalis.py
+++ b/pcdsdevices/tests/test_mpod_apalis.py
@@ -15,7 +15,6 @@ def fake_mpod_channel1():
     FakeMPODmodule = make_fake_device(MPODApalisModule4Channel)
     module = FakeMPODmodule("TEST:MPOD", name="TestPos1Module")
     c1 = module.c1
-    module.model.sim_put("modelp")
     module.limit_pos.sim_put(110)
     module.limit_neg.sim_put(0)
     # switch off
@@ -33,7 +32,6 @@ def fake_mpod_channel2():
     module = FakeMPODmodule("TEST:MPOD", name="TestPos2Module")
     c2 = module.c2
     # switch off
-    module.model.sim_put("modelp")
     module.limit_pos.sim_put(120)
     module.limit_neg.sim_put(0)
     # switch off
@@ -51,7 +49,6 @@ def fake_mpod_channel_neg():
     module = FakeMPODmodule("TEST:MPOD", name="TestNegativeModule")
     cn = module.c0
     # switch off
-    module.model.sim_put("modeln")
     module.limit_pos.sim_put(130)
     module.limit_neg.sim_put(0)
     cn.state.sim_put(0)
@@ -126,25 +123,30 @@ def test_set_voltage(fake_mpod_channel1, fake_mpod_channel2, fake_mpod_channel_n
     assert fake_mpod_channel_neg.voltage.get() == -130
 
 
-def test_limit_scales(fake_mpod_channel1):
+def test_limit_percents(fake_mpod_channel1):
     logger.debug("Test limits scaling")
     module = fake_mpod_channel1.biological_parent
     fake_mpod_channel1.max_voltage.sim_put(100)
 
     # starting with (0, 110)
     assert fake_mpod_channel1.voltage.limits == (0, 110)
-    assert module.limit_scales == (0, 110)
+    assert module.limit_percents == (0, 110)
 
     module.limit_pos.sim_put(0)
     module.limit_neg.sim_put(5)
     assert fake_mpod_channel1.voltage.limits == (-5, 0)
-    assert module.limit_scales == (-5, 0)
+    assert module.limit_percents == (-5, 0)
+
+    # small changes have no effect
+    module.limit_neg.sim_put(5.1)
+    assert fake_mpod_channel1.voltage.limits == (-5, 0)
+    assert module.limit_percents == (-5, 0)
 
     # Ignoring the model warning numbers
     module.limit_pos.sim_put(50)
     module.limit_neg.sim_put(50)
     assert fake_mpod_channel1.voltage.limits == (-50, 50)
-    assert module.limit_scales == (-50, 50)
+    assert module.limit_percents == (-50, 50)
 
 
 def test_set_current(fake_mpod_channel1, fake_mpod_channel2):


### PR DESCRIPTION
## Description
Sets channel limits based on the value obtained from `.max_voltage` and the model number from the parent module.

## Motivation and Context
In response to TMO's recent troubles setting the voltage limits on the mpod channels.  Our previous application of the hotfix (#1293) only assumed positive definite voltage limits, and failed to cover the negative or bipolar channels.

According to James, the simplest way to grab this information is from the model number of the parent module.  All channels in a given module have the same polarity.

Also, it seems our approach to imposing limits on the MPOD channels is to monitor the max voltage PV and set the limits in python-land.  This was a bit misleading, and I'd like to document this more thoroughly (TODO)

## How Has This Been Tested?
Interactively, though tests will be added I swear.

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
