### PR TITLE
SmarAct detailed screen maintenance

### DIFF
--- a/docs/source/upcoming_release_notes/1333-SmarAct_detailed_maintenance.rst
+++ b/docs/source/upcoming_release_notes/1333-SmarAct_detailed_maintenance.rst
@@ -1,0 +1,30 @@
+1333 SmarAct_detailed_maintenance
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- SmarAct: fix TTZ_THRESHOLD setter in detailed screen
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/1333-SmarAct_detailed_maintenance.rst
+++ b/docs/source/upcoming_release_notes/1333-SmarAct_detailed_maintenance.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- N/A
+- aberges-SLAC

--- a/pcdsdevices/ui/SmarAct.detailed.ui
+++ b/pcdsdevices/ui/SmarAct.detailed.ui
@@ -2390,7 +2390,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>475</width>
+            <width>655</width>
             <height>250</height>
            </rect>
           </property>
@@ -3113,7 +3113,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-113</y>
+            <y>0</y>
             <width>509</width>
             <height>478</height>
            </rect>
@@ -3953,6 +3953,12 @@
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>25</height>
+                </size>
                </property>
                <property name="toolTip">
                 <string/>

--- a/pcdsdevices/ui/SmarAct.detailed.ui
+++ b/pcdsdevices/ui/SmarAct.detailed.ui
@@ -2390,7 +2390,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>655</width>
+            <width>475</width>
             <height>250</height>
            </rect>
           </property>
@@ -3113,7 +3113,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>0</y>
+            <y>-113</y>
             <width>509</width>
             <height>478</height>
            </rect>
@@ -4443,7 +4443,7 @@
                 <bool>false</bool>
                </property>
                <property name="channel" stdset="0">
-                <string>ca://${prefix}:TTZ_THRESHOLD_RBV</string>
+                <string>ca://${prefix}:TTZ_THRESHOLD</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixed a bad PV macro for `TTZ_THRESHOLD` setter. Originally both the `PyDMLabel` and `PyDMLineEdit` were set to `TTZ_THRESHOLD_RBV`. Fixed some aesthetics on size hints.

## Motivation and Context
Noticed a setter didn't work out in the wild in TMO IP1, dug to find root cause and fixed it.

## How Has This Been Tested?
Tested in my dev branch on the offending IP1 motors.

## Where Has This Been Documented?
In this PR

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
