### PR TITLE
Elliptec updates for Sliders

### DIFF
--- a/docs/source/upcoming_release_notes/1334-Elliptec_slider_update.rst
+++ b/docs/source/upcoming_release_notes/1334-Elliptec_slider_update.rst
@@ -1,0 +1,30 @@
+1334 Elliptec_slider_update
+#################
+
+API Breaks
+----------
+- EllBase: Calling this constructor now requires channel to be declared as a mandatory arg. It will no longer default to channel=1.
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- Ell6 and Ell9: overload done_comparator to not use numpy.isclose()
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/pcdsdevices/lasers/elliptec.py
+++ b/pcdsdevices/lasers/elliptec.py
@@ -77,6 +77,11 @@ class Ell6(EllBase):
     --------
     ell6 = Ell6('LM1K4:COM_DP1_TF1_SL1:ELL', port=0, channel=1, name='ell6')
     """
+    # Since the record for 2 and 4-position sliders are stored as an enum,
+    # we need a "str comparator" overload.
+    def done_comparator(self, readback, setpoint):
+        return readback == setpoint
+
     # Names for slider positions
     name_0 = FCpt(EpicsSignal, '{prefix}:M{self._channel}:NAME0',
                   kind='config')

--- a/pcdsdevices/lasers/elliptec.py
+++ b/pcdsdevices/lasers/elliptec.py
@@ -54,7 +54,7 @@ class EllBase(PVPositionerIsClose):
     user_readback = FCpt(EpicsSignal, '{prefix}:M{self._channel}:CURPOS',
                          kind='omitted')
 
-    def __init__(self, prefix, channel, port=0, **kwargs):
+    def __init__(self, prefix, *, channel, port=0, **kwargs):
         self._port = port
         self._channel = channel
         super().__init__(prefix, **kwargs)

--- a/pcdsdevices/lasers/elliptec.py
+++ b/pcdsdevices/lasers/elliptec.py
@@ -54,7 +54,7 @@ class EllBase(PVPositionerIsClose):
     user_readback = FCpt(EpicsSignal, '{prefix}:M{self._channel}:CURPOS',
                          kind='omitted')
 
-    def __init__(self, prefix, port=0, channel=1, **kwargs):
+    def __init__(self, prefix, channel, port=0, **kwargs):
         self._port = port
         self._channel = channel
         super().__init__(prefix, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Changed `channel` to be a mandatory arg in `EllBase` constructor for consistency in API usage. All our devices in the wild (as far as lasers are concerned) call the channel prop from their `happi` entry anyway. In `hutch_python` sessions this will now be more obvious to the user what information they need before device instantiation.

Also overloaded `done_comparator` to just use `readback` and `setpoint` methods if using `Ell6` or `Ell9`. No need to call a `numpy.isclose()` on `enums`.

## Motivation and Context
Couple of JIRA tickets on user frustration and terminal spam when opening LUCID with `Ell6` or `Ell9` implemented. Easy fix for root causes. See ECS-7383 and ECS-7390.

## How Has This Been Tested?
Tested with the same sliders specified in the above tickets using the CRIX_MODS toolbar and LUCID. 2 birds, 1 stone: no terminal spam now and clearer API for the class.

## Where Has This Been Documented?
This PR and the aforementioned tickets.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
