### PR TITLE
BLD: unpin numpy in pip test suite as well

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -20,7 +20,6 @@ jobs:
       # Extras to be installed only for conda-based testing:
       conda-testing-extras: ""
       # Extras to be installed only for pip-based testing:
-      # Set numpy<2 for now, remove when xraylib updates
-      pip-testing-extras: "PyQt5 numpy<2"
+      pip-testing-extras: "PyQt5"
       # Set if using setuptools-scm for the conda-build workflow
       use-setuptools-scm: true

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -7,5 +7,3 @@ ipython
 sphinxcontrib-jquery
 # Required for update_api_list
 PyQt5
-# Required until xraylib works with numpy 2 on py3.9 or until we up the docs build base python version
-numpy <2


### PR DESCRIPTION
## Description
Though we unpinned numpy in the written requirements, we had a few straggling pins in the pip-testing extras and docs-extras

## Motivation and Context
New Env time

## How Has This Been Tested?
CI

## Where Has This Been Documented?
This PR, release notes maybe

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
