### PR TITLE
MNT: update codeowners filters to explicitly list extensions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,12 @@
 * @pcdshub/software-admin
 
 # language-specific group(s)
-*.py* @pcdshub/python-reviewers @pcdshub/software-admin
+*.py @pcdshub/python-reviewers @pcdshub/software-admin
+*.pyi @pcdshub/python-reviewers @pcdshub/software-admin
+*.pyc @pcdshub/python-reviewers @pcdshub/software-admin
+*.pyw @pcdshub/python-reviewers @pcdshub/software-admin
+*.pyx @pcdshub/python-reviewers @pcdshub/software-admin
+*.pyd @pcdshub/python-reviewers @pcdshub/software-admin
 
 # github folder holds administrative files
 .github/** @pcdshub/software-admin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,11 +23,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 7.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -2036,38 +2036,38 @@ class LODCM(BaseInterface, GroupDevice, LightpathMixin):
             return f'{left_str:<16}{center_str:>26}{right_str:>26}'
 
         return f"""\
-{hutch}LODCM Motor Status Positions
-{state}
-Current Configuration: {configuration} ({ref})
-Photon Energy: {energy} [keV]
------------------------------------------------------------------
-{form(' ', 'Crystal Tower 1', 'Crystal Tower 2')}
-{form(f'z [{z_units}]', f'{z_user} ({z_dial})',
-      f'{z2_user} ({z2_dial})')}
-{form(f'x [{x_units}]', f'{x_user} ({x_dial})',
-      f'{x2_user} ({x2_dial})')}
-{form(f'th [{th_units}]', f'{th_user} ({th_dial})',
-      f'{th2_user} ({th2_dial})')}
-{form(f'chi [{chi_units}]', f'{chi_user} ({chi_dial})',
-      f'{chi2_user} ({chi2_dial})')}
-{form(f'y [{y_units}]', f'{y_user} ({y_dial})',
-      f'{y2_user} ({y2_dial})')}
-{form(f'hn [{hn_units}]', f'{hn_user} ({hn_dial})',
-      f'{hn2_user} ({hn2_dial})')}
-{form(f'hp [{hp_units}]', f'{hp_user} ({hp_dial})',
-      f'{hp2_user} ({hp2_dial})')}
-{form(f'diode [{diode_units}]', f'{diode_user} ({diode_dial})',
-      f'{diode2_user} ({diode2_dial})')}
------------------------------------------------------------------
-{form(' ', 'Diagnostic Tower', ' ')}
-{form(f'diag r [{dr_units}]', f'{dr_user} ({dr_dial})', '')}
-{form(f'diag h [{dh_units}]', f'{dh_user} ({dh_dial})', '')}
-{form(f'diag v [{dv_units}]', f'{dv_user} ({dv_dial})', '')}
-{form(f'filter [{df_units}]', f'{df_user} ({df_dial})', '')}
-{form(f'diode [{dd_units}]', f'{dd_user} ({dd_dial})', '')}
-{form(f'navitar zoom [{yag_zoom_units}]',
-      f'{yag_zoom_user} ({yag_zoom_dial})', '')}
-"""
+                {hutch}LODCM Motor Status Positions
+                {state}
+                Current Configuration: {configuration} ({ref})
+                Photon Energy: {energy} [keV]
+                -----------------------------------------------------------------
+                {form(' ', 'Crystal Tower 1', 'Crystal Tower 2')}
+                {form(f'z [{z_units}]', f'{z_user} ({z_dial})',
+                    f'{z2_user} ({z2_dial})')}
+                {form(f'x [{x_units}]', f'{x_user} ({x_dial})',
+                    f'{x2_user} ({x2_dial})')}
+                {form(f'th [{th_units}]', f'{th_user} ({th_dial})',
+                    f'{th2_user} ({th2_dial})')}
+                {form(f'chi [{chi_units}]', f'{chi_user} ({chi_dial})',
+                    f'{chi2_user} ({chi2_dial})')}
+                {form(f'y [{y_units}]', f'{y_user} ({y_dial})',
+                    f'{y2_user} ({y2_dial})')}
+                {form(f'hn [{hn_units}]', f'{hn_user} ({hn_dial})',
+                    f'{hn2_user} ({hn2_dial})')}
+                {form(f'hp [{hp_units}]', f'{hp_user} ({hp_dial})',
+                    f'{hp2_user} ({hp2_dial})')}
+                {form(f'diode [{diode_units}]', f'{diode_user} ({diode_dial})',
+                    f'{diode2_user} ({diode2_dial})')}
+                -----------------------------------------------------------------
+                {form(' ', 'Diagnostic Tower', ' ')}
+                {form(f'diag r [{dr_units}]', f'{dr_user} ({dr_dial})', '')}
+                {form(f'diag h [{dh_units}]', f'{dh_user} ({dh_dial})', '')}
+                {form(f'diag v [{dv_units}]', f'{dv_user} ({dv_dial})', '')}
+                {form(f'filter [{df_units}]', f'{df_user} ({df_dial})', '')}
+                {form(f'diode [{dd_units}]', f'{dd_user} ({dd_dial})', '')}
+                {form(f'navitar zoom [{yag_zoom_units}]',
+                    f'{yag_zoom_user} ({yag_zoom_dial})', '')}
+                """
 
 
 class XCSLODCM(LODCM):

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -2035,39 +2035,29 @@ class LODCM(BaseInterface, GroupDevice, LightpathMixin):
         def form(left_str, center_str, right_str):
             return f'{left_str:<16}{center_str:>26}{right_str:>26}'
 
-        return f"""
-                {hutch}LODCM Motor Status Positions
-                {state}
-                Current Configuration: {configuration} ({ref})
-                Photon Energy: {energy} [keV]
-                -----------------------------------------------------------------
-                {form(' ', 'Crystal Tower 1', 'Crystal Tower 2')}
-                {form(f'z [{z_units}]', f'{z_user} ({z_dial})',
-                      f'{z2_user} ({z2_dial})')}
-                {form(f'x [{x_units}]', f'{x_user} ({x_dial})',
-                      f'{x2_user} ({x2_dial})')}
-                {form(f'th [{th_units}]', f'{th_user} ({th_dial})',
-                      f'{th2_user} ({th2_dial})')}
-                {form(f'chi [{chi_units}]', f'{chi_user} ({chi_dial})',
-                      f'{chi2_user} ({chi2_dial})')}
-                {form(f'y [{y_units}]', f'{y_user} ({y_dial})',
-                      f'{y2_user} ({y2_dial})')}
-                {form(f'hn [{hn_units}]', f'{hn_user} ({hn_dial})',
-                      f'{hn2_user} ({hn2_dial})')}
-                {form(f'hp [{hp_units}]', f'{hp_user} ({hp_dial})',
-                      f'{hp2_user} ({hp2_dial})')}
-                {form(f'diode [{diode_units}]', f'{diode_user} ({diode_dial})',
-                      f'{diode2_user} ({diode2_dial})')}
-                -----------------------------------------------------------------
-                {form(' ', 'Diagnostic Tower', ' ')}
-                {form(f'diag r [{dr_units}]', f'{dr_user} ({dr_dial})', '')}
-                {form(f'diag h [{dh_units}]', f'{dh_user} ({dh_dial})', '')}
-                {form(f'diag v [{dv_units}]', f'{dv_user} ({dv_dial})', '')}
-                {form(f'filter [{df_units}]', f'{df_user} ({df_dial})', '')}
-                {form(f'diode [{dd_units}]', f'{dd_user} ({dd_dial})', '')}
-                {form(f'navitar zoom [{yag_zoom_units}]',
-                      f'{yag_zoom_user} ({yag_zoom_dial})', '')}
-                """
+        return f"""{hutch}LODCM Motor Status Positions
+        {state}
+        Current Configuration: {configuration} ({ref})
+        Photon Energy: {energy} [keV]
+        -----------------------------------------------------------------
+        {form(' ', 'Crystal Tower 1', 'Crystal Tower 2')}
+        {form(f'z [{z_units}]', f'{z_user} ({z_dial})', f'{z2_user} ({z2_dial})')}
+        {form(f'x [{x_units}]', f'{x_user} ({x_dial})', f'{x2_user} ({x2_dial})')}
+        {form(f'th [{th_units}]', f'{th_user} ({th_dial})', f'{th2_user} ({th2_dial})')}
+        {form(f'chi [{chi_units}]', f'{chi_user} ({chi_dial})', f'{chi2_user} ({chi2_dial})')}
+        {form(f'y [{y_units}]', f'{y_user} ({y_dial})', f'{y2_user} ({y2_dial})')}
+        {form(f'hn [{hn_units}]', f'{hn_user} ({hn_dial})', f'{hn2_user} ({hn2_dial})')}
+        {form(f'hp [{hp_units}]', f'{hp_user} ({hp_dial})', f'{hp2_user} ({hp2_dial})')}
+        {form(f'diode [{diode_units}]', f'{diode_user} ({diode_dial})', f'{diode2_user} ({diode2_dial})')}
+        -----------------------------------------------------------------
+        {form(' ', 'Diagnostic Tower', ' ')}
+        {form(f'diag r [{dr_units}]', f'{dr_user} ({dr_dial})', '')}
+        {form(f'diag h [{dh_units}]', f'{dh_user} ({dh_dial})', '')}
+        {form(f'diag v [{dv_units}]', f'{dv_user} ({dv_dial})', '')}
+        {form(f'filter [{df_units}]', f'{df_user} ({df_dial})', '')}
+        {form(f'diode [{dd_units}]', f'{dd_user} ({dd_dial})', '')}
+        {form(f'navitar zoom [{yag_zoom_units}]',
+              f'{yag_zoom_user} ({yag_zoom_dial})', '')}"""
 
 
 class XCSLODCM(LODCM):

--- a/pcdsdevices/lodcm.py
+++ b/pcdsdevices/lodcm.py
@@ -2035,7 +2035,7 @@ class LODCM(BaseInterface, GroupDevice, LightpathMixin):
         def form(left_str, center_str, right_str):
             return f'{left_str:<16}{center_str:>26}{right_str:>26}'
 
-        return f"""\
+        return f"""
                 {hutch}LODCM Motor Status Positions
                 {state}
                 Current Configuration: {configuration} ({ref})
@@ -2043,21 +2043,21 @@ class LODCM(BaseInterface, GroupDevice, LightpathMixin):
                 -----------------------------------------------------------------
                 {form(' ', 'Crystal Tower 1', 'Crystal Tower 2')}
                 {form(f'z [{z_units}]', f'{z_user} ({z_dial})',
-                    f'{z2_user} ({z2_dial})')}
+                      f'{z2_user} ({z2_dial})')}
                 {form(f'x [{x_units}]', f'{x_user} ({x_dial})',
-                    f'{x2_user} ({x2_dial})')}
+                      f'{x2_user} ({x2_dial})')}
                 {form(f'th [{th_units}]', f'{th_user} ({th_dial})',
-                    f'{th2_user} ({th2_dial})')}
+                      f'{th2_user} ({th2_dial})')}
                 {form(f'chi [{chi_units}]', f'{chi_user} ({chi_dial})',
-                    f'{chi2_user} ({chi2_dial})')}
+                      f'{chi2_user} ({chi2_dial})')}
                 {form(f'y [{y_units}]', f'{y_user} ({y_dial})',
-                    f'{y2_user} ({y2_dial})')}
+                      f'{y2_user} ({y2_dial})')}
                 {form(f'hn [{hn_units}]', f'{hn_user} ({hn_dial})',
-                    f'{hn2_user} ({hn2_dial})')}
+                      f'{hn2_user} ({hn2_dial})')}
                 {form(f'hp [{hp_units}]', f'{hp_user} ({hp_dial})',
-                    f'{hp2_user} ({hp2_dial})')}
+                      f'{hp2_user} ({hp2_dial})')}
                 {form(f'diode [{diode_units}]', f'{diode_user} ({diode_dial})',
-                    f'{diode2_user} ({diode2_dial})')}
+                      f'{diode2_user} ({diode2_dial})')}
                 -----------------------------------------------------------------
                 {form(' ', 'Diagnostic Tower', ' ')}
                 {form(f'diag r [{dr_units}]', f'{dr_user} ({dr_dial})', '')}
@@ -2066,7 +2066,7 @@ class LODCM(BaseInterface, GroupDevice, LightpathMixin):
                 {form(f'filter [{df_units}]', f'{df_user} ({df_dial})', '')}
                 {form(f'diode [{dd_units}]', f'{dd_user} ({dd_dial})', '')}
                 {form(f'navitar zoom [{yag_zoom_units}]',
-                    f'{yag_zoom_user} ({yag_zoom_dial})', '')}
+                      f'{yag_zoom_user} ({yag_zoom_dial})', '')}
                 """
 
 


### PR DESCRIPTION
## Description
Update codeowners to use more verbose syntax

## Motivation and Context
Codeowners files actually use fnmatch, not glob like we initially thought.  They also don't support some of the convenient syntax that .gitignore files use

## How Has This Been Tested?
I spammed pcds-ci-test-repo-python

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
