### PR TITLE
adding tm2k4 targets to 8 from 6

### DIFF
--- a/docs/source/upcoming_release_notes/1347-adding_targets_into_tm2k4.rst
+++ b/docs/source/upcoming_release_notes/1347-adding_targets_into_tm2k4.rst
@@ -1,0 +1,30 @@
+1347 adding targets into tm2k4
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- adding new targets number into tm2k4
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tongju

--- a/pcdsdevices/atm.py
+++ b/pcdsdevices/atm.py
@@ -69,10 +69,10 @@ class TM2K4Target(ATMTarget):
     """
     Controls TM2K4's states, an ATM in TMO.
 
-    Defines the state count as 5 (OUT and 4 targets), one less than the
+    Defines the state count as 9 (OUT and 8 targets), three more than the
     standard ATM.
     """
-    config = UpCpt(state_count=5)
+    config = UpCpt(state_count=9)
 
 
 class TM2K4(ArrivalTimeMonitor):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## TM2K4 targets are totally swapped and increase up to 8 targets.
<!--- Describe your changes in detail -->
Changing statemover count to 9 (including OUT)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists require this.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Not yet because laser scientists want to test it later. This is for dream. 
Currently the state mover only shows 6 targets and we need 9 targets, so I need to complete this.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
(https://jira.slac.stanford.edu/browse/ECS-7475)

(https://github.com/pcdshub/lcls-plc-tmo-motion/pull/148)
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
