### PR TITLE
pa1k4 hide 6 and 7

### DIFF
--- a/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
+++ b/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
@@ -11,7 +11,7 @@ Library Features
 
 Device Features
 ---------------
-- change target from 7 to 5 and hide 6 and 7
+-  for "PA1K4"('CalibrationAxis'),change target count from 7 to 5 to  hide 6 and 7
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
+++ b/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
@@ -11,7 +11,7 @@ Library Features
 
 Device Features
 ---------------
--  for "PA1K4"('CalibrationAxis'),change target count from 7 to 5 to  hide 6 and 7
+- For ``PA1K4`` (`CalibrationAxis`), change target count from 7 to 5 to hide targets 6 and 7
 
 New Devices
 -----------

--- a/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
+++ b/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
-- tongju
+- tongju12

--- a/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
+++ b/docs/source/upcoming_release_notes/1352-hide-pa1k4-targets.rst
@@ -1,0 +1,30 @@
+1352 hide-pa1k4-targets
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- change target from 7 to 5 and hide 6 and 7
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tongju

--- a/pcdsdevices/tmo_ip1.py
+++ b/pcdsdevices/tmo_ip1.py
@@ -15,7 +15,7 @@ class CalibrationAxis(TwinCATStatePMPS):
     Here, we specify 7 states, and 1 motor, for Y
     axe.Add OUT states IN, total is 8
     """
-    config = UpCpt(state_count=8, motor_count=1)
+    config = UpCpt(state_count=6, motor_count=1)
 
 
 class SCaFoil(BaseInterface, GroupDevice, LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## PA1k4 has some strange mechanical issue that get it stuck between target 6 and 7 during beam time. Before we figure it out why, we remove 6 and 7 targets from GUI
<!--- Describe your changes in detail -->
change state count from 8 to 6
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists make decision to make sure that it will not repeat again during beam time
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<img width="765" alt="Screenshot 2025-05-16 at 9 53 10 AM" src="https://github.com/user-attachments/assets/b77be25e-8c92-4f2b-af9f-df83e44644d0" />

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

(https://github.com/pcdshub/lcls-plc-tmo-motion/pull/149)

(https://jira.slac.stanford.edu/browse/ECS-7882?inline=true&decorator=dialog&_=1747152209196)
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
