### PR TITLE
MNT: also sync presets when accessing presets.position (ECS-8086)

### DIFF
--- a/docs/source/upcoming_release_notes/1357-mnt_presets_sync_2.rst
+++ b/docs/source/upcoming_release_notes/1357-mnt_presets_sync_2.rst
@@ -1,0 +1,30 @@
+1357 mnt_presets_sync_2
+#######################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Sync presets when Presets.positions is accessed.
+
+Contributors
+------------
+- tangkong

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1125,6 +1125,14 @@ class Presets:
                       'File may be being edited by another user.'), self.name)
         logger.debug('', exc_info=True)
 
+    @property
+    def positions(self) -> 'PresetPosition':
+        if self.sync_needed():
+            print('syncing from positions call')
+            self.sync()
+
+        return self._positions
+
     def _create_methods(self):
         """
         Create the dynamic methods based on the configured paths.
@@ -1148,7 +1156,7 @@ class Presets:
                     self._register_method(self._device, 'mv_' + name, mv)
                     self._register_method(self._device, 'umv_' + name, umv)
                     self._register_method(self._device, 'wm_' + name, wm)
-                    setattr(self.positions, name,
+                    setattr(self._positions, name,
                             PresetPosition(self, preset_type, name))
 
     def _register_method(self, obj, method_name, method):
@@ -1308,7 +1316,7 @@ class Presets:
             if hasattr(obj, '_tab'):
                 obj._tab.remove(method_name)
         self._methods = []
-        self.positions = SimpleNamespace()
+        self._positions = SimpleNamespace()
 
     @property
     def has_presets(self):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -1128,7 +1128,6 @@ class Presets:
     @property
     def positions(self) -> 'PresetPosition':
         if self.sync_needed():
-            print('syncing from positions call')
             self.sync()
 
         return self._positions

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -214,16 +214,12 @@ def test_presets_desync(presets, fast_motor: FastMotor):
     fast_motor2.mv(5, wait=True)
     fast_motor2.presets.positions.four.update_pos()
 
-    # in-memory python objects have different preset positions
-    assert fast_motor.presets.positions.four.pos == 4
-    assert fast_motor2.presets.positions.four.pos == 5
-
-    # but point to the same file
+    # both point to the same file
     assert fast_motor.presets._path("hutch") == fast_motor2.presets._path("hutch")
 
-    # original object needs a sync, but second does not
-    assert fast_motor.presets.sync_needed()
-    assert not fast_motor2.presets.sync_needed()
+    # assessing positions will check if sync is needed
+    assert fast_motor.presets.positions.four.pos == 5
+    assert fast_motor2.presets.positions.four.pos == 5
 
 
 def test_presets_tab_init(fast_motor: FastMotor, deferred_fast_motor_presets):


### PR DESCRIPTION
## Description
Also sync presets when accessing the `presets.position` attribute

## Motivation and Context
https://jira.slac.stanford.edu/browse/ECS-8086

James had a few scripts that were trying to check if presets existed before moving them.  Our deferred sync update broke this for him.

## How Has This Been Tested?
The desync test I have now syncs more aggressively, so one test has been adjusted.


## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
