### PR TITLE
add SL3K4 to dream_motion

### DIFF
--- a/pcdsdevices/dream_motion.py
+++ b/pcdsdevices/dream_motion.py
@@ -7,7 +7,7 @@ This module contains classes related to the TMO-DREAM Motion System
 from ophyd import Component as Cpt
 
 from .device import GroupDevice
-from .epics_motor import BeckhoffAxis
+from .epics_motor import BeckhoffAxis, SmarAct
 from .interface import BaseInterface
 
 
@@ -97,3 +97,26 @@ class DREAM_GasNozzle(BaseInterface, GroupDevice):
     gas_nozzle_x = Cpt(BeckhoffAxis, ':MMS:X', kind='normal')
     gas_nozzle_y = Cpt(BeckhoffAxis, ':MMS:Y', kind='normal')
     gas_nozzle_z = Cpt(BeckhoffAxis, ':MMS:Z', kind='normal')
+
+
+class DREAM_SL3K4(BaseInterface, GroupDevice):
+    """
+    DREAM Motion Class
+    This class controls DREAM SL3K4 SmarAct based scatter slit
+
+    Parameters
+    ----------
+    prefix : str
+        DREAM:GSJN
+    name : str, keyword-only
+        Alias for the device
+    """
+    # UI representation
+    _icon = 'fa.minus-square'
+    tab_component_names = True
+
+    # Motor components
+    top = Cpt(SmarAct, ':m7', kind='normal')
+    bottom = Cpt(SmarAct, ':m12', kind='normal')
+    north = Cpt(SmarAct, ':m9', kind='normal')
+    south = Cpt(SmarAct, ':m8', kind='normal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
add SL3K4 SmarAct motors to dream_motion class

## Motivation and Context
James Cryan asked for add SL3K4 motors to Lucid

## How Has This Been Tested?
TMO hutch python

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
