### PR TITLE
MNT: make 'port' a mandatory arg, add a warning for deprecated defaults

### DIFF
--- a/pcdsdevices/lasers/elliptec.py
+++ b/pcdsdevices/lasers/elliptec.py
@@ -13,6 +13,9 @@ from pcdsdevices.variety import set_metadata
 class EllBase(PVPositionerIsClose):
     """
     Base class for Elliptec stages.
+
+    NOTE: For ioc_release >= R1.0.0, 'port' should default to 15,
+    else it should default to 'port' = 0.
     """
     set_position = FCpt(EpicsSignal, '{prefix}:M{self._channel}:CURPOS',
                         write_pv='{prefix}:M{self._channel}:MOVE',
@@ -56,7 +59,7 @@ class EllBase(PVPositionerIsClose):
     error_message = FCpt(EpicsSignal, '{prefix}:M{self._channel}:STATUS',
                          kind='omitted')
 
-    def __init__(self, prefix, *, channel, port=0, **kwargs):
+    def __init__(self, prefix, *, channel, port, **kwargs):
         self._port = port
         self._channel = channel
         super().__init__(prefix, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Makes `port` a mandatory arg from `kwargs` when instantiating any device derived from `EllBase`.

This is to alert downstream users of the `PORT` default changes in `R1.0.0`.

Closes #1366. 

## Motivation and Context
If you silently trust the `port=0` default, but your child is using the common release >= R1.0.0, your device will fail to connect when you `device.wait_for_connections()` — and it is presently unclear why.

## How Has This Been Tested?
```
aberges@ctl-las-crix-srv07 ~$  source pcds_conda
(pcds-5.9.1) aberges@ctl-las-crix-srv07 ~$  export PYTHONPATH=/cds/group/pcds/epics-dev/aberges/pcdshub/pcdsdevices:${PYTHONPATH}
(pcds-5.9.1) aberges@ctl-las-crix-srv07 ~$  ipython
Python 3.9.19 | packaged by conda-forge | (main, Mar 20 2024, 12:50:21)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from pcdsdevices.lasers.elliptec import Ell6
...
In [3]: ejx_shutter = Ell6("LM2K2:EJX:ELL:1", channel=1, name='ejx_shutter', port=15)

In [4]: ejx_shutter.wait_for_connection()

In [5]: ejx_shutter = Ell6("LM2K2:EJX:ELL:1", channel=1, name='ejx_shutter')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 ejx_shutter = Ell6("LM2K2:EJX:ELL:1", channel=1, name='ejx_shutter')

TypeError: __init__() missing 1 required keyword-only argument: 'port'
```

If you're going to test this, use the laser lab PV `LAS:LLN:ELL:1` which is also channel 1, port 15.

## Where Has This Been Documented?
This ticket!

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
