### PR TITLE
Add DCCM to device_types

### DIFF
--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -5,6 +5,7 @@ from .atm import ArrivalTimeMonitor
 from .attenuator import Attenuator
 from .beam_stats import BeamStats
 from .ccm import CCM
+from .dccm import DCCM
 from .dc_devices import ICT
 from .epics_motor import (IMS, PMC100, BeckhoffAxis, DelayNewport, EpicsMotor,
                           Motor, Newport)


### PR DESCRIPTION
Add DCCM in device_types.py

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adding DCCM to device_types.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DCCM was missing from device_types.py and was causing an import error in hutch python.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in XCS hutch python

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
