### PR TITLE
Adding PDU typhos screen support

### DIFF
--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -679,3 +679,17 @@ class Leviton(LCLSItem):
     kwargs.default['elevations'] = "{{elevations}}"
     elevations = EntryInfo(doc='List of elevation numbers for rack',
                            optional=False, enforce=list)
+
+class PDU(LCLSItem):
+    """
+    Container for non-Tripplite PDUs
+    """
+    device_class = copy(LCLSItem.device_class)
+    device_class.default = 'pcdsdevices.pdu.PDU'
+
+class TripplitePDU(LCLSItem):
+    """
+    Container for Tripplite PDUs
+    """
+    device_class = copy(LCLSItem.device_class)
+    device_class.default = 'pcdsdevices.pdu.TripplitePDU'

--- a/pcdsdevices/happi/containers.py
+++ b/pcdsdevices/happi/containers.py
@@ -702,12 +702,14 @@ class Leviton(LCLSItem):
     elevations = EntryInfo(doc='List of elevation numbers for rack',
                            optional=False, enforce=list)
 
+
 class PDU(LCLSItem):
     """
     Container for non-Tripplite PDUs
     """
     device_class = copy(LCLSItem.device_class)
     device_class.default = 'pcdsdevices.pdu.PDU'
+
 
 class TripplitePDU(LCLSItem):
     """

--- a/pcdsdevices/pdu.py
+++ b/pcdsdevices/pdu.py
@@ -1,0 +1,212 @@
+"""
+Standard classes for L2SI DC power devices.
+"""
+import logging
+
+from ophyd import Device, EpicsSignal, EpicsSignalRO
+from ophyd import FormattedComponent as FCpt
+from ophyd import Component as Cpt
+
+from .device import GroupDevice
+from .interface import BaseInterface
+
+logger = logging.getLogger(__name__)
+
+
+class PDUChannel(Device):
+    """
+    Class to define a particular channel of the PDU.
+
+    Parameters
+    ---------
+    prefix : str
+        The base PV of the relevant PDU.
+
+    channel : str
+        The output channel on the pPDU, e.g. '1', '2', etc.
+
+    pdu_type : str
+        The pdu type, e.g TrippLite, Leviton, or Sentry
+    """
+
+    ch_index = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_index}',
+                    kind='hinted', string=True)
+    ch_name = FCpt(EpicsSignal, '{self.prefix}:Outlet:{self._ch}:{self._ch_name}',
+                    kind='hinted', string=True)
+    ch_status = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_status}',
+                    kind='hinted', string=True)
+    ch_ctrl_state = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_ctrl_state}',
+                    kind='hinted', string=True)
+    ch_ctrl_command_on = FCpt(EpicsSignal, '{self.prefix}:Outlet:{self._ch}:{self._ch_command_on}',
+                    kind='hinted', string=True)
+    ch_ctrl_command_off = FCpt(EpicsSignal, '{self.prefix}:Outlet:{self._ch}:{self._ch_command_off}',
+                    kind='hinted', string=True)
+    ch_ctrl_command_reboot = FCpt(EpicsSignal, '{self.prefix}:Outlet:{self._ch}:{self._ch_command_reboot}',
+                    kind='hinted', string=True)
+
+    def __init__(self, prefix, *, name=None, parent=None, channel=None, **kwargs):
+        self._ch = f'{channel}'
+        self._ch_index = 'GetID'
+        self._ch_status = 'GetStatus'
+        self._ch_name = 'SetName'
+        self._ch_ctrl_state = 'GetControlState'
+        self._ch_command_on = 'TurnOn'
+        self._ch_command_off = 'TurnOff'
+        self._ch_command_reboot = 'CycleOffOn'
+
+        super().__init__(prefix, name=name, **kwargs)
+
+class TripplitePDUChannel(Device):
+    """
+    Class to define a particular channel of a Tripplite PDU.
+
+    Parameters
+    ---------
+    prefix : str
+        The base PV of the relevant PDU.
+
+    channel : str
+        The output channel on the pPDU, e.g. '1', '2', etc.
+
+    pdu_type : str
+        The pdu type, e.g TrippLite, Leviton, or Sentry
+    """
+    ch_index = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_index}',
+                    kind='hinted', string=True)
+    ch_name = FCpt(EpicsSignal, '{self.prefix}:Outlet:{self._ch}:{self._ch_name}',
+                    kind='hinted', string=True)
+    ch_status = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_status}',
+                    kind='hinted', string=True)
+    ch_ctrl_state = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_ctrl_state}',
+                    kind='hinted', string=True)
+    ch_ctrl_command = FCpt(EpicsSignal, '{self.prefix}:Outlet:{self._ch}:{self._ch_command}',
+                    kind='hinted', string=True)
+
+    def __init__(self, prefix, *, name=None, parent=None, channel=None, **kwargs):
+        self._ch = f'{channel}'
+        self._ch_index = 'getPduOutletIndex'
+        self._ch_status = 'getPduOutletState'
+        self._ch_name = 'setPduOutletName'
+        self._ch_ctrl_state = 'getPduOutletControllable'
+        self._ch_command = 'setPduOutletCommand'
+
+        super().__init__(prefix, name=name, **kwargs)
+
+
+class PDU(Device):
+    """
+    Class to define a non-Tripplite PDU.
+
+    Parameters
+    ---------
+    prefix : str
+        The base PV of the relevant PDU.
+
+    num_channels : int
+        The output channels for the PDU.
+
+    """
+
+    pdu_name = FCpt(EpicsSignal, '{prefix}{self._tower}:SetTowerName', kind='hinted')
+    pdu_location = Cpt(EpicsSignal, ':SetSystemLocation', kind='hinted')
+    pdu_status = FCpt(EpicsSignalRO, '{prefix}{self._tower}:GetTowerStatus', kind='hinted')
+    pdu_output_c_max = FCpt(EpicsSignalRO, '{prefix}{self._tower}:SetInfeedLoadHighThresh', kind='hinted')
+    pdu_output_c = FCpt(EpicsSignalRO, '{prefix}{self._tower}:GetInfeedLoadValue', kind='hinted')
+    pdu_output_c_status = FCpt(EpicsSignalRO, '{prefix}{self._tower}:GetInfeedLoadStatus', kind='hinted')
+    pdu_output_p = FCpt(EpicsSignalRO, '{prefix}{self._tower}:GetTowerActivePower', kind='hinted')
+
+
+    pdu_temperature_lo = FCpt(EpicsSignal, '{prefix}{self._tower}:Sensor:All:SetTempLowThresh', kind='hinted')
+    pdu_humidity_lo = FCpt(EpicsSignal, '{prefix}{self._tower}:Sensor:All:SetHumidLowThresh', kind='hinted')
+    pdu_temperature_hi = FCpt(EpicsSignal, '{prefix}{self._tower}:Sensor:All:SetTempHighThresh', kind='hinted')
+    pdu_humidity_hi = FCpt(EpicsSignal, '{prefix}{self._tower}:Sensor:All:SetHumidHighThresh', kind='hinted')
+
+    pdu_sensor1_id = Cpt(EpicsSignal, ':Sensor:1:GetID', kind='hinted')
+    pdu_sensor1_status = Cpt(EpicsSignal, ':Sensor:1:GetStatus', kind='hinted')
+    pdu_sensor1_temperature = Cpt(EpicsSignal, ':Sensor:1:GetTempStatus', kind='hinted')
+    pdu_sensor1_humidity = Cpt(EpicsSignal, ':Sensor:1:GetHumidStatus', kind='hinted')
+
+    pdu_sensor2_id = Cpt(EpicsSignal, ':Sensor:2:GetID', kind='hinted')
+    pdu_sensor2_status = Cpt(EpicsSignal, ':Sensor:2:GetStatus', kind='hinted')
+    pdu_sensor2_temperature = Cpt(EpicsSignal, ':Sensor:2:GetTempStatus', kind='hinted')
+    pdu_sensor2_humidity = Cpt(EpicsSignal, ':Sensor:2:GetHumidStatus', kind='hinted')
+
+    channel_ctrl = FCpt(EpicsSignal, '{prefix}{self._ctrl}:SetControlAction', kind='hinted')
+
+
+    tab_component_names = True
+
+    def __init__(self, prefix, num_channels, pdu_type=None, name='PDU', **kwargs):
+
+        if pdu_type.lower() == 'sentry4':
+            self._tower = ":1"
+            self._ctrl = ":Outlet:G1"
+        else:
+            self._tower = ":"
+            self._ctrl = ":Outlet:All"
+
+        # Dynamically create channels here
+        for i in range(1, num_channels + 1):
+            ch = PDUChannel(f"{prefix}", name=f"channel{i}", channel=i)
+            setattr(self, f'channel{i}', ch)
+
+        self.num_channels = num_channels
+
+        super().__init__(prefix, name=name, **kwargs)
+
+
+class TripplitePDU(Device):
+    """
+        Class to define a Tripplite PDU.
+
+        Parameters
+        ---------
+        prefix : str
+            The base PV of the relevant PDU.
+
+        num_channels : int
+            The output channels for the PDU.
+    """
+
+    pdu_name = Cpt(EpicsSignal, ':setDeviceName', kind='hinted')
+    pdu_location = Cpt(EpicsSignal, ':setDeviceLocation', kind='hinted')
+    pdu_status = Cpt(EpicsSignalRO, ':getDeviceStatus', kind='hinted')
+
+    pdu_num_inputs = Cpt(EpicsSignalRO, ':getPduIdentNumInputs', kind='hinted')
+    pdu_num_outputs = Cpt(EpicsSignalRO, ':getPduIdentNumOutputs', kind='hinted')
+    pdu_num_outlets = Cpt(EpicsSignalRO, ':getPduIdentNumOutlets', kind='hinted')
+    pdu_num_groups = Cpt(EpicsSignalRO, ':getPduIdentNumOutletGroups', kind='hinted')
+    pdu_num_phases = Cpt(EpicsSignalRO, ':getPduIdentNumPhases', kind='hinted')
+    pdu_num_circuits = Cpt(EpicsSignalRO, ':getPduIdentNumCircuits', kind='hinted')
+    pdu_num_breakers = Cpt(EpicsSignalRO, ':getPduIdentNumBreakers', kind='hinted')
+    pdu_num_heatsinks = Cpt(EpicsSignalRO, ':getPduIdentNumHeatsinks', kind='hinted')
+
+    pdu_input_f = Cpt(EpicsSignalRO, ':getPduInputPhaseFrequency', kind='hinted')
+
+    pdu_input_v = Cpt(EpicsSignalRO, ':getPduInputPhaseVoltage', kind='hinted')
+    pdu_input_v_min = Cpt(EpicsSignalRO, ':getPduInputPhaseVoltageMin', kind='hinted')
+    pdu_input_v_max = Cpt(EpicsSignalRO, ':getPduInputPhaseVoltageMax', kind='hinted')
+
+    pdu_output_f = Cpt(EpicsSignalRO, ':getPduOutputFrequency', kind='hinted')
+    pdu_output_v = Cpt(EpicsSignalRO, ':getPduOutputVoltage', kind='hinted')
+    pdu_output_p = Cpt(EpicsSignalRO, ':getPduOutputActivePower', kind='hinted')
+    pdu_output_c = Cpt(EpicsSignalRO, ':getPduOutputCurrent', kind='hinted')
+    pdu_output_c_min = Cpt(EpicsSignalRO, ':getPduOutputCurrentMin', kind='hinted')
+    pdu_output_c_max = Cpt(EpicsSignalRO, ':getPduOutputCurrentMax', kind='hinted')
+
+    channels_on = Cpt(EpicsSignal, ':setPduControlPduOn', kind='hinted')
+    channels_off = Cpt(EpicsSignal, ':setPduControlPduOff', kind='hinted')
+    channels_reboot = Cpt(EpicsSignal, ':setPduControlPduReboot', kind='hinted')
+
+    tab_component_names = True
+
+    def __init__(self, prefix, num_channels, name='PDU', **kwargs):
+
+        # Dynamically create channels here
+        for i in range(1, num_channels + 1):
+            ch = TripplitePDUChannel(f"{prefix}", name=f"channel{i}", channel=i)
+            setattr(self, f'channel{i}', ch)
+
+        self.num_channels = num_channels
+
+        super().__init__(prefix, name=name, **kwargs)

--- a/pcdsdevices/pdu.py
+++ b/pcdsdevices/pdu.py
@@ -23,10 +23,7 @@ class PDUChannel(Device):
         The base PV of the relevant PDU.
 
     channel : str
-        The output channel on the pPDU, e.g. '1', '2', etc.
-
-    pdu_type : str
-        The pdu type, e.g TrippLite, Leviton, or Sentry
+        The output channel on the PDU, e.g. '1', '2', etc.
     """
 
     ch_index = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_index}',
@@ -66,10 +63,8 @@ class TripplitePDUChannel(Device):
         The base PV of the relevant PDU.
 
     channel : str
-        The output channel on the pPDU, e.g. '1', '2', etc.
+        The output channel on the PDU, e.g. '1', '2', etc.
 
-    pdu_type : str
-        The pdu type, e.g TrippLite, Leviton, or Sentry
     """
     ch_index = FCpt(EpicsSignalRO, '{self.prefix}:Outlet:{self._ch}:{self._ch_index}',
                     kind='hinted', string=True)
@@ -105,6 +100,8 @@ class PDU(Device):
     num_channels : int
         The output channels for the PDU.
 
+    pdu_type : str
+        The pdu type, e.g Leviton, or Sentry4
     """
 
     pdu_name = FCpt(EpicsSignal, '{prefix}{self._tower}:SetTowerName', kind='hinted')

--- a/pcdsdevices/pdu.py
+++ b/pcdsdevices/pdu.py
@@ -95,7 +95,7 @@ class TripplitePDUChannel(Device):
 
 class PDU(Device):
     """
-    Class to define a non-Tripplite PDU.
+    Class to define a non-Tripplite PDU with one tower defined in its IOC
 
     Parameters
     ---------
@@ -140,7 +140,10 @@ class PDU(Device):
 
         if pdu_type.lower() == 'sentry4':
             self._tower = ":1"
-            self._ctrl = ":Outlet:G1"
+            if num_channels == 8:
+                self._ctrl = ":Outlet:G1"
+            else:
+                self._ctrl = ":Outlet:All"
         else:
             self._tower = ":"
             self._ctrl = ":Outlet:All"

--- a/pcdsdevices/pdu.py
+++ b/pcdsdevices/pdu.py
@@ -3,9 +3,9 @@ Standard classes for L2SI DC power devices.
 """
 import logging
 
+from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent as FCpt
-from ophyd import Component as Cpt
 
 from .device import GroupDevice
 from .interface import BaseInterface

--- a/pcdsdevices/ui/PDU.detailed.py
+++ b/pcdsdevices/ui/PDU.detailed.py
@@ -1,0 +1,233 @@
+import pydm
+import re
+
+from pydm import Display
+from os import path
+
+from pydm.widgets import PyDMEmbeddedDisplay
+from qtpy import QtCore, QtWidgets
+from typhos import utils
+
+class PDUDetailedWidget(Display, utils.TyphosBase):
+    """
+    Custom widget for managing the pdu detailed screen
+    """
+
+    def __init__(self, parent=None, ui_filename='PDU.detailed.ui', **kwargs):
+        super().__init__(parent=parent, ui_filename=ui_filename)
+
+    @property
+    def device(self):
+        """The associated device."""
+        try:
+            return self.devices[0]
+        except Exception:
+            ...
+
+    def add_device(self, device):
+        """Typhos hook for adding a new device."""
+        super().add_device(device)
+        self.post_typhos_init()
+
+    def post_typhos_init(self):
+        """
+        Once typhos has relinked the device and parent widget, we need to clean
+        Up some of the signals and maybe add new widgets to the display.
+        Add any other init-esque shenanigans you need here.
+        """
+        self.fix_pvs()
+        self.add_channels()
+
+
+    def fix_pvs(self):
+        """
+        Reconnect PyDM widgets to the actual PVs from the device object.
+        This is necessary because the macros aren't expanded during UI parsing.
+        I'm doing this manually for now, as this screen expands with more signals,
+        I will make use of find_pydm_names()
+        """
+
+        # High-level overview data
+        name_widget = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Channel_Name")
+        name_widget.setReadOnly(False)
+        status_widget = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Status_Label")
+        location_widget = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Location_Label")
+        name_widget.setReadOnly(False)
+
+        # Sensor data and threshholds
+        sensor1_id = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S1_ID")
+        sensor1_name = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S1_Status")
+        sensor1_temp = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S1_Temp")
+        sensor1_humid = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S1_Hum")
+        sensor2_id = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S2_ID")
+        sensor2_name = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S2_Status")
+        sensor2_temp = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S2_Temp")
+        sensor2_humid = self.ui.findChild(pydm.widgets.label.PyDMLabel, "S2_Hum")
+
+        temp_lo = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Temp_Lo")
+        temp_hi = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Temp_Hi")
+        humid_lo = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Hum_Lo")
+        humid_hi = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Hum_Hi")
+
+        # Input/output details:
+        output_c = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Infeed_Load")
+        output_c_max = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Infeed_Load_Threshhold")
+        output_c_status = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Infeed_Status")
+        output_p = self.ui.findChild(pydm.widgets.label.PyDMLabel, "PDU_Power")
+
+        if name_widget:
+            name_widget.channel = f"ca://{self.device.pdu_name.pvname}"
+        if status_widget:
+            status_widget.channel = f"ca://{self.device.pdu_status.pvname}"
+        if location_widget:
+            location_widget.channel = f"ca://{self.device.pdu_location.pvname}"
+        if sensor1_id:
+            sensor1_id.channel = f"ca://{self.device.pdu_sensor1_id.pvname}"
+        if sensor1_name:
+            sensor1_name.channel = f"ca://{self.device.pdu_sensor1_status.pvname}"
+        if sensor1_temp:
+            sensor1_temp.channel = f"ca://{self.device.pdu_sensor1_temperature.pvname}"
+        if sensor1_humid:
+            sensor1_humid.channel = f"ca://{self.device.pdu_sensor1_humidity.pvname}"
+        if sensor2_id:
+            sensor2_id.channel = f"ca://{self.device.pdu_sensor2_id.pvname}"
+        if sensor2_name:
+            sensor2_name.channel = f"ca://{self.device.pdu_sensor2_status.pvname}"
+        if sensor2_temp:
+            sensor2_temp.channel = f"ca://{self.device.pdu_sensor2_temperature.pvname}"
+        if sensor2_humid:
+            sensor2_humid.channel = f"ca://{self.device.pdu_sensor2_humidity.pvname}"
+        if temp_lo:
+            temp_lo.channel = f"ca://{self.device.pdu_temperature_lo.pvname}"
+        if temp_hi:
+            temp_hi.channel = f"ca://{self.device.pdu_temperature_hi.pvname}"
+        if humid_lo:
+            humid_lo.channel = f"ca://{self.device.pdu_humidity_lo.pvname}"
+        if humid_hi:
+            humid_hi.channel = f"ca://{self.device.pdu_humidity_hi.pvname}"
+        if output_c:
+            output_c.channel = f"ca://{self.device.pdu_output_c.pvname}"
+        if output_c_max:
+            output_c_max.channel = f"ca://{self.device.pdu_output_c_max.pvname}"
+        if output_c_status:
+            output_c_status.channel = f"ca://{self.device.pdu_output_c_status.pvname}"
+        if output_p:
+            output_p.channel = f"ca://{self.device.pdu_output_p.pvname}"
+
+
+    def add_channels(self):
+        """
+        Find all attributes of the PDU that start with the name 'channel'
+        Append them and their signals to a dictionary, then call the
+        function responsible for adding them to the layout
+        """
+        self.channel_signal_dict = {}
+
+        for attr in dir(self.device):
+            if attr.startswith("channel"):
+                ch_obj = getattr(self.device, attr, None)
+                if ch_obj is None or not all(hasattr(ch_obj, k) for k in ('ch_index', 'ch_name', 'ch_status', 'ch_ctrl_state')):
+                    continue
+                self.channel_signal_dict[attr] = {
+                    'ch_index': ch_obj.ch_index.pvname,
+                    'ch_name': ch_obj.ch_name.pvname,
+                    'ch_status': ch_obj.ch_status.pvname,
+                    'ch_ctrl_state': ch_obj.ch_ctrl_state.pvname
+                }
+        """
+        If we have a PDU with more than 8 channels, the rows will sort lexigraphically
+        by channel (ex: 10 comes before 1). Force it to conform with some shenanigans
+        """
+        self.channel_signal_dict_sorted = dict(sorted(self.channel_signal_dict.items(), key=lambda item: self.order_channels(item[1]['ch_index'])))
+        self.generate_rows()
+
+
+    def generate_rows(self):
+        """
+        Format each ophyd pdu channel component into a row and append to the layout.
+        Split channels into two collumns to keep the screen from growing length-wise
+        """
+        def add_channel_row(layout, ch_info, ch_obj):
+            row_layout = QtWidgets.QHBoxLayout()
+
+            # Index label
+            idx_label = pydm.widgets.label.PyDMLabel()
+            idx_label.channel = f"ca://{ch_info['ch_index']}"
+            idx_label.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(idx_label, 1)
+
+            # Name
+            name_edit = pydm.widgets.line_edit.PyDMLineEdit()
+            name_edit.channel = f"ca://{ch_info['ch_name']}"
+            name_edit.setReadOnly(False)
+            name_edit.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(name_edit, 8)
+
+            # Status
+            status = pydm.widgets.label.PyDMLabel()
+            status.channel = f"ca://{ch_info['ch_status']}"
+            status.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(status, 2)
+
+            # Ctrl atate
+            ctrl_state = pydm.widgets.label.PyDMLabel()
+            ctrl_state.channel = f"ca://{ch_info['ch_ctrl_state']}"
+            ctrl_state.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(ctrl_state, 2)
+
+            """
+            Command combo box
+            This would be a pydm enum combo box but the Epics record is not a mbbo. I need to
+            do more schenanigans to wrap this in one widget. I connect it to a helper function for
+            setting the appropriate command component on the pdu channel
+            """
+            cmd = QtWidgets.QComboBox()
+            cmd.wheelEvent = lambda event: None  # This disables scrolling on the widget to stop people from accidentally turning channels off
+            cmd.addItems(["Idle", "Turn On", "Turn Off", "Cycle"])
+
+            def on_action_selected(index):
+                if index == 1:
+                    ch_obj.ch_ctrl_command_on.put(1)
+                elif index == 2:
+                    ch_obj.ch_ctrl_command_off.put(2)
+                elif index == 3:
+                    ch_obj.ch_ctrl_command_reboot.put(3)
+
+            cmd.currentIndexChanged.connect(on_action_selected)
+            row_layout.addWidget(cmd)
+
+            row_widget = QtWidgets.QWidget()
+            row_widget.setLayout(row_layout)
+            layout.addWidget(row_widget)
+
+        left_layout = self.ui.Left_Channels
+        right_layout = self.ui.Right_Channels
+
+        # Clear layouts
+        for layout in (left_layout, right_layout):
+            while layout.count():
+                item = layout.takeAt(0)
+                widget = item.widget()
+                if widget:
+                    widget.deleteLater()
+
+        # Split channels
+        ch_list = list(self.channel_signal_dict_sorted.items())
+        midpoint = len(ch_list) // 2
+        left_half = ch_list[:midpoint]
+        right_half = ch_list[midpoint:]
+
+        # Reminder that left and right half are dicitonaries with entries: (<string name of channel attribute>, <dict of channel attributes>)
+        for ch, ch_info in left_half:
+            ch_obj = getattr(self.device, ch)
+            add_channel_row(left_layout, ch_info, ch_obj)
+        for ch, ch_info in right_half:
+            ch_obj = getattr(self.device, ch)
+            add_channel_row(right_layout, ch_info, ch_obj)
+
+    def order_channels(self, pvname):
+        """
+        Helper function for sorting the channel dictionaries
+        """
+        match = re.search(r':Outlet:(\d+):', pvname)
+        return int(match.group(1)) if match else float('inf')

--- a/pcdsdevices/ui/PDU.detailed.py
+++ b/pcdsdevices/ui/PDU.detailed.py
@@ -39,7 +39,6 @@ class PDUDetailedWidget(Display, utils.TyphosBase):
         self.fix_pvs()
         self.add_channels()
 
-
     def fix_pvs(self):
         """
         Reconnect PyDM widgets to the actual PVs from the device object.
@@ -246,6 +245,15 @@ class PDUDetailedWidget(Display, utils.TyphosBase):
         for ch, ch_info in right_half:
             ch_obj = getattr(self.device, ch)
             add_channel_row(right_layout, ch_info, ch_obj)
+
+        # I need to resize the window after the scroll widget is populated, or else the screen will cuttoff all the channels
+        # I Encapsulate in a function so I can add a delay, Qt needs time to draw everything to screen before I resize
+        def delayed_resize():
+            current_width = self.width()
+            top_window = self.window()
+            top_window.resize(current_width, 1000)
+
+        QtCore.QTimer.singleShot(100, delayed_resize)
 
     def order_channels(self, pvname):
         """

--- a/pcdsdevices/ui/PDU.detailed.py
+++ b/pcdsdevices/ui/PDU.detailed.py
@@ -1,13 +1,13 @@
-import pydm
 import re
-
-from pydm import Display
 from os import path
 
+import pydm
+from epics import PV, caget, camonitor
+from pydm import Display
 from pydm.widgets import PyDMEmbeddedDisplay
 from qtpy import QtCore, QtWidgets
 from typhos import utils
-from epics import PV, camonitor, caget
+
 
 class PDUDetailedWidget(Display, utils.TyphosBase):
     """

--- a/pcdsdevices/ui/PDU.detailed.py
+++ b/pcdsdevices/ui/PDU.detailed.py
@@ -76,6 +76,19 @@ class PDUDetailedWidget(Display, utils.TyphosBase):
         output_c_status = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Infeed_Status")
         output_p = self.ui.findChild(pydm.widgets.label.PyDMLabel, "PDU_Power")
 
+        # Get control buttons
+        on_btn = self.ui.findChild(pydm.widgets.pushbutton.PyDMPushButton, 'All_On_Button')
+        off_btn = self.ui.findChild(pydm.widgets.pushbutton.PyDMPushButton, 'All_Off_Button')
+        reboot_btn = self.ui.findChild(pydm.widgets.pushbutton.PyDMPushButton, 'Reboot_All_Button')
+
+        # Set control button
+        if on_btn:
+            on_btn.clicked.connect(lambda: self.device.channel_ctrl.put(1))
+        if off_btn:
+            off_btn.clicked.connect(lambda: self.device.channel_ctrl.put(2))
+        if reboot_btn:
+            reboot_btn.clicked.connect(lambda: self.device.channel_ctrl.put(3))
+
         if name_widget:
             name_widget.channel = f"ca://{self.device.pdu_name.pvname}"
         if status_widget:

--- a/pcdsdevices/ui/PDU.detailed.ui
+++ b/pcdsdevices/ui/PDU.detailed.ui
@@ -1,0 +1,858 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>928</width>
+    <height>509</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>920</width>
+    <height>480</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="show_switcher" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="layout_margin" stdset="0">
+      <number>3</number>
+     </property>
+     <property name="layout_spacing" stdset="0">
+      <number>3</number>
+     </property>
+     <property name="underline_lineWidth" stdset="0">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_30">
+     <property name="text">
+      <string>&lt;b&gt;Overview:&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="PDU_overview_layout" stretch="0,0,0,0,0,3,15">
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>PDU: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="Channel_Name">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Location:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="Location_Label">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="Status_Label">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0" columnstretch="4,0,6,0,2,2">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+     <item row="0" column="2" rowspan="2">
+      <layout class="QVBoxLayout" name="Sensor_Layout">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_20">
+         <item>
+          <widget class="QLabel" name="label_33">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Device Sensors:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="1,5,5">
+         <item>
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>ID:                  </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S1_ID">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S2_ID">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="1,5,5">
+         <item>
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Status:           </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S1_Status">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S2_Status">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,4,4">
+         <item>
+          <widget class="QLabel" name="label_17">
+           <property name="text">
+            <string>Temp (C):       </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S2_Temp">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S1_Temp">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,4,4">
+         <item>
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Humidity (%);</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S1_Hum">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="S2_Hum">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_18" stretch="6,2,6,3,6,5">
+         <item>
+          <widget class="QLabel" name="label_32">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Sensor Threshholds:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Low</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_13">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>High</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_14">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="Threshhold_Layout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="1,9,1,11,1,12">
+           <item>
+            <widget class="QLabel" name="label_9">
+             <property name="text">
+              <string>Temperature (C):</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="PyDMLineEdit" name="Temp_Lo">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://{prefix}:{template_t_lo}</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="PyDMLineEdit" name="Temp_Hi">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://{prefix}:{template_t_hi}</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="1,9,1,11,1,12">
+           <item>
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Humidity (%):     </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="PyDMLineEdit" name="Hum_Lo">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://{prefix}:{template_h_lo}</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_8">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="PyDMLineEdit" name="Hum_Hi">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+             <property name="channel" stdset="0">
+              <string>ca://{prefix}:{template_h_hi}</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_9">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="3">
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_31">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Outlet Control:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_On_Button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All On</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_Off_Button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All Off</string>
+         </property>
+         <property name="pressValue" stdset="0">
+          <string>1</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="Reboot_All_Button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>Reboot All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="1">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <spacer name="horizontalSpacer_15">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0">
+      <layout class="QVBoxLayout" name="Infeed_Layout" stretch="0,0,1,1,1,4">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_19">
+         <item>
+          <widget class="QLabel" name="label_34">
+           <property name="text">
+            <string>&lt;b&gt;Input Details:&lt;/b&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0">
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Infeed Status:          </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Infeed_Status">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>######</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <item>
+          <widget class="QLabel" name="label_35">
+           <property name="text">
+            <string>Active Power (W):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="PDU_Power">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0">
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Infeed Load Threshhold (A):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLineEdit" name="Infeed_Load_Threshhold">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Infeed Load (A):      </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Infeed_Load">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>######</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="2,10,1,1,1">
+       <item>
+        <widget class="QLabel" name="label_24">
+         <property name="text">
+          <string>   ID:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_23">
+         <property name="text">
+          <string>Name:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_22">
+         <property name="text">
+          <string>Status:    </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>State:      </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_20">
+         <property name="text">
+          <string>Ctl. Action:      </string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="2,10,1,1,1">
+       <item>
+        <widget class="QLabel" name="label_27">
+         <property name="text">
+          <string>   ID:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_29">
+         <property name="text">
+          <string>Name:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_28">
+         <property name="text">
+          <string>Status:     </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_26">
+         <property name="text">
+          <string>State:      </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_25">
+         <property name="text">
+          <string>Ctl. Action:        </string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scroll_layout">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>908</width>
+        <height>135</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_15">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="Left_Channels"/>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="Right_Channels"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/PDU.detailed.ui
+++ b/pcdsdevices/ui/PDU.detailed.ui
@@ -6,20 +6,32 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>928</width>
-    <height>509</height>
+    <width>920</width>
+    <height>552</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
     <width>920</width>
-    <height>480</height>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>920</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,1">
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
      <property name="sizePolicy">
@@ -47,6 +59,12 @@
    </item>
    <item>
     <widget class="QLabel" name="label_30">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>&lt;b&gt;Overview:&lt;/b&gt;</string>
      </property>
@@ -97,6 +115,18 @@
      </item>
      <item>
       <widget class="PyDMLabel" name="Status_Label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>70</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -121,27 +151,595 @@
     </layout>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0" columnstretch="4,0,6,0,2,2">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0" columnstretch="0,0,0,0,0,0">
      <property name="sizeConstraint">
       <enum>QLayout::SetFixedSize</enum>
      </property>
-     <item row="0" column="2" rowspan="2">
+     <item row="1" column="4">
+      <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_31">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>110</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Outlet Control:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_On_Button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>120</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All On</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_Off_Button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>120</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All Off</string>
+         </property>
+         <property name="pressValue" stdset="0">
+          <string>1</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="Reboot_All_Button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>120</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>Reboot All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>100</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="1">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <layout class="QVBoxLayout" name="Infeed_Layout" stretch="0,0,1,1,1,0">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_19">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_34">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>&lt;b&gt;Input Details:&lt;/b&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_21">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>170</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Infeed Status:          </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Infeed_Status">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>######</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_22">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>70</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_35">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Active Power (W):    </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="PDU_Power">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_23">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>70</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Infeed Load Threshhold (A):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLineEdit" name="Infeed_Load_Threshhold">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_24">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>10</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Infeed Load (A):      </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Infeed_Load">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>######</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_25">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>70</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>80</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="5">
+      <spacer name="horizontalSpacer_15">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>200</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="2">
       <layout class="QVBoxLayout" name="Sensor_Layout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_20">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
           <widget class="QLabel" name="label_33">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>120</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Device Sensors:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>210</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="1,5,5">
+        <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="1,5,0,5,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
           <widget class="QLabel" name="label_15">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>120</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>ID:                  </string>
            </property>
@@ -149,6 +747,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="S1_ID">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -158,7 +768,35 @@
           </widget>
          </item>
          <item>
+          <spacer name="horizontalSpacer_17">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="PyDMLabel" name="S2_ID">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -166,13 +804,50 @@
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="1,5,5">
+        <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="1,5,0,5,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
           <widget class="QLabel" name="label_16">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>120</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>Status:           </string>
            </property>
@@ -180,6 +855,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="S1_Status">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -189,7 +876,35 @@
           </widget>
          </item>
          <item>
+          <spacer name="horizontalSpacer_18">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="PyDMLabel" name="S2_Status">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -197,13 +912,50 @@
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_10">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,4,4">
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,4,0,4,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
           <widget class="QLabel" name="label_17">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>120</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>Temp (C):       </string>
            </property>
@@ -211,6 +963,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="S2_Temp">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -220,7 +984,35 @@
           </widget>
          </item>
          <item>
+          <spacer name="horizontalSpacer_19">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="PyDMLabel" name="S1_Temp">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -228,13 +1020,50 @@
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,4,4">
+        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,4,0,4,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
           <widget class="QLabel" name="label_18">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>120</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>Humidity (%);</string>
            </property>
@@ -242,6 +1071,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="S1_Hum">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -251,7 +1092,35 @@
           </widget>
          </item>
          <item>
+          <spacer name="horizontalSpacer_20">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="PyDMLabel" name="S2_Hum">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -259,13 +1128,44 @@
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_16">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_18" stretch="6,2,6,3,6,5">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
           <widget class="QLabel" name="label_32">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Sensor Threshholds:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -276,9 +1176,12 @@
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>20</width>
              <height>20</height>
             </size>
            </property>
@@ -286,6 +1189,24 @@
          </item>
          <item>
           <widget class="QLabel" name="label_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>Low</string>
            </property>
@@ -295,6 +1216,9 @@
           <spacer name="horizontalSpacer_13">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -306,6 +1230,24 @@
          </item>
          <item>
           <widget class="QLabel" name="label_7">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="text">
             <string>High</string>
            </property>
@@ -316,9 +1258,12 @@
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>10</width>
              <height>20</height>
             </size>
            </property>
@@ -331,10 +1276,34 @@
          <property name="spacing">
           <number>0</number>
          </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="1,9,1,11,1,12">
+          <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="1,0,1,11,1,12">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetFixedSize</enum>
+           </property>
            <item>
             <widget class="QLabel" name="label_9">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>15</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>110</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="text">
               <string>Temperature (C):</string>
              </property>
@@ -345,9 +1314,12 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>50</width>
                <height>20</height>
               </size>
              </property>
@@ -355,6 +1327,24 @@
            </item>
            <item>
             <widget class="PyDMLineEdit" name="Temp_Lo">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>15</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="toolTip">
               <string/>
              </property>
@@ -371,6 +1361,9 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
                <width>40</width>
@@ -381,6 +1374,24 @@
            </item>
            <item>
             <widget class="PyDMLineEdit" name="Temp_Hi">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>15</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="toolTip">
               <string/>
              </property>
@@ -397,9 +1408,12 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>10</width>
                <height>20</height>
               </size>
              </property>
@@ -408,9 +1422,30 @@
           </layout>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="1,9,1,11,1,12">
+          <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="1,0,1,11,1,12">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetFixedSize</enum>
+           </property>
            <item>
             <widget class="QLabel" name="label_10">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>15</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>110</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="text">
               <string>Humidity (%):     </string>
              </property>
@@ -421,9 +1456,12 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>50</width>
                <height>20</height>
               </size>
              </property>
@@ -431,6 +1469,24 @@
            </item>
            <item>
             <widget class="PyDMLineEdit" name="Hum_Lo">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>15</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="toolTip">
               <string/>
              </property>
@@ -447,6 +1503,9 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
                <width>40</width>
@@ -457,6 +1516,24 @@
            </item>
            <item>
             <widget class="PyDMLineEdit" name="Hum_Hi">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>15</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="toolTip">
               <string/>
              </property>
@@ -473,9 +1550,12 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>10</width>
                <height>20</height>
               </size>
              </property>
@@ -487,226 +1567,15 @@
        </item>
       </layout>
      </item>
-     <item row="0" column="3">
-      <widget class="Line" name="line_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="4">
-      <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
-       <property name="topMargin">
-        <number>3</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_31">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Outlet Control:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMPushButton" name="All_On_Button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>All On</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMPushButton" name="All_Off_Button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>All Off</string>
-         </property>
-         <property name="pressValue" stdset="0">
-          <string>1</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMPushButton" name="Reboot_All_Button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>Reboot All</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="0" column="1">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="5">
-      <spacer name="horizontalSpacer_15">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="0">
-      <layout class="QVBoxLayout" name="Infeed_Layout" stretch="0,0,1,1,1,4">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_19">
-         <item>
-          <widget class="QLabel" name="label_34">
-           <property name="text">
-            <string>&lt;b&gt;Input Details:&lt;/b&gt;</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0">
-         <item>
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>Infeed Status:          </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="Infeed_Status">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="text">
-            <string>######</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_16">
-         <item>
-          <widget class="QLabel" name="label_35">
-           <property name="text">
-            <string>Active Power (W):</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="PDU_Power">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0">
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Infeed Load Threshhold (A):</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLineEdit" name="Infeed_Load_Threshhold">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Infeed Load (A):      </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="Infeed_Load">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="text">
-            <string>######</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="2,10,1,1,1">
+      <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="2,10,1,0,1">
        <item>
         <widget class="QLabel" name="label_24">
          <property name="text">
@@ -724,14 +1593,14 @@
        <item>
         <widget class="QLabel" name="label_22">
          <property name="text">
-          <string>Status:    </string>
+          <string>Status:   </string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="label_21">
          <property name="text">
-          <string>State:      </string>
+          <string>State:     </string>
          </property>
         </widget>
        </item>
@@ -763,14 +1632,14 @@
        <item>
         <widget class="QLabel" name="label_28">
          <property name="text">
-          <string>Status:     </string>
+          <string>Status:   </string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="label_26">
          <property name="text">
-          <string>State:      </string>
+          <string>State:     </string>
          </property>
         </widget>
        </item>
@@ -795,8 +1664,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>908</width>
-        <height>135</height>
+        <width>900</width>
+        <height>166</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -819,10 +1688,18 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" name="Left_Channels"/>
+        <layout class="QVBoxLayout" name="Left_Channels" stretch="">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+        </layout>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="Right_Channels"/>
+        <layout class="QVBoxLayout" name="Right_Channels" stretch="">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/pcdsdevices/ui/TripplitePDU.detailed.py
+++ b/pcdsdevices/ui/TripplitePDU.detailed.py
@@ -1,0 +1,258 @@
+import pydm
+import re
+
+from pydm import Display
+
+from qtpy import QtCore, QtWidgets
+from typhos import utils
+from epics import camonitor
+
+class PDUDetailedWidget(Display, utils.TyphosBase):
+    """
+    Custom widget for managing the pdu detailed screen
+    """
+
+    def __init__(self, parent=None, ui_filename='TripplitePDU.detailed.ui', **kwargs):
+        super().__init__(parent=parent, ui_filename=ui_filename)
+
+    @property
+    def device(self):
+        """The associated device."""
+        try:
+            return self.devices[0]
+        except Exception:
+            ...
+
+    def add_device(self, device):
+        """Typhos hook for adding a new device."""
+        super().add_device(device)
+        self.post_typhos_init()
+
+    def post_typhos_init(self):
+        """
+        Once typhos has relinked the device and parent widget, we need to clean
+        up some of the signals and maybe add new widgets to the display.
+        Add any other init-esque shenanigans you need here.
+        """
+        self.fix_pvs()
+        self.add_channels()
+
+
+    def fix_pvs(self):
+        """
+        Reconnect PyDM widgets to the actual PVs from the device object.
+        This is necessary because the macros aren't expanded during UI parsing.
+        """
+
+        # Get high-level overview widgets
+        name_widget = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Channel_Name")
+        name_widget.setReadOnly(False)
+        status_widget = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Status_Label")
+        location_widget = self.ui.findChild(pydm.widgets.line_edit.PyDMLineEdit, "Location_Label")
+        location_widget.setReadOnly(False)
+
+        # Get PDU details
+        num_inputs = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Input")
+        num_outputs = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Output")
+        num_outlets = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Outlet")
+        num_groups = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Group")
+        num_phases = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Phase")
+        num_circuits = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Circuit")
+        num_breakers = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Breaker")
+        num_heatsinks = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Num_Heatsink")
+
+        # Get input details
+        input_f = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Input_F")
+        input_v = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Input_V")
+        input_v_min = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Input_V_Min")
+        input_v_max = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Input_V_Max")
+
+        # Get output details
+        output_f = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Output_F")
+        output_v = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Output_V")
+        output_p = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Output_P")
+        output_c = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Output_C")
+        output_c_min = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Output_C_Min")
+        output_c_max = self.ui.findChild(pydm.widgets.label.PyDMLabel, "Output_C_Max")
+
+        # Get control buttons
+        on_btn = self.ui.findChild(pydm.widgets.pushbutton.PyDMPushButton, 'All_On_Button')
+        off_btn = self.ui.findChild(pydm.widgets.pushbutton.PyDMPushButton, 'All_Off_Button')
+        reboot_btn = self.ui.findChild(pydm.widgets.pushbutton.PyDMPushButton, 'Reboot_All_Button')
+
+        # Set control button
+        if on_btn:
+            on_btn.channel = f"ca://{self.device.channels_on.pvname}"
+            on_btn.pressValue = 1
+        if off_btn:
+            off_btn.channel = f"ca://{self.device.channels_off.pvname}"
+            off_btn.pressValue = 1
+        if reboot_btn:
+            reboot_btn.channel = f"ca://{self.device.channels_reboot.pvname}"
+            reboot_btn.pressValue = 1
+
+
+        # Set PDU data
+        if name_widget:
+            name_widget.channel = f"ca://{self.device.pdu_name.pvname}"
+        if status_widget:
+            status_widget.channel = f"ca://{self.device.pdu_status.pvname}"
+        if location_widget:
+            location_widget.channel = f"ca://{self.device.pdu_location.pvname}"
+        if num_inputs:
+            num_inputs.channel = f"ca://{self.device.pdu_num_inputs.pvname}"
+        if num_outputs:
+            num_outputs.channel = f"ca://{self.device.pdu_num_outputs.pvname}"
+        if num_outlets:
+            num_outlets.channel = f"ca://{self.device.pdu_num_outlets.pvname}"
+        if num_groups:
+            num_groups.channel = f"ca://{self.device.pdu_num_groups.pvname}"
+        if num_phases:
+            num_phases.channel = f"ca://{self.device.pdu_num_phases.pvname}"
+        if num_circuits:
+            num_circuits.channel = f"ca://{self.device.pdu_num_circuits.pvname}"
+        if num_breakers:
+            num_breakers.channel = f"ca://{self.device.pdu_num_breakers.pvname}"
+        if num_heatsinks:
+            num_heatsinks.channel = f"ca://{self.device.pdu_num_heatsinks.pvname}"
+
+        # PVs that need scalling
+        if input_f:
+            self.monitor_pv_to_label(input_f, self.device.pdu_input_f.pvname, scale=0.1)
+        if input_v:
+            self.monitor_pv_to_label(input_v, self.device.pdu_input_v.pvname, scale=0.1)
+        if input_v_min:
+            self.monitor_pv_to_label(input_v_min, self.device.pdu_input_v_min.pvname, scale=0.1)
+        if input_v_max:
+            self.monitor_pv_to_label(input_v_max, self.device.pdu_input_v_max.pvname, scale=0.1)
+        if output_f:
+            self.monitor_pv_to_label(output_f, self.device.pdu_output_f.pvname, scale=0.1)
+        if output_v:
+            self.monitor_pv_to_label(output_v, self.device.pdu_output_v.pvname, scale=0.1)
+        if output_p:
+            self.monitor_pv_to_label(output_p, self.device.pdu_output_p.pvname, scale=1.0)
+        if output_c:
+            self.monitor_pv_to_label(output_c, self.device.pdu_output_c.pvname, scale=0.1)
+        if output_c_min:
+            self.monitor_pv_to_label(output_c_min, self.device.pdu_output_c_min.pvname, scale=0.1)
+        if output_c_max:
+            self.monitor_pv_to_label(output_c_max, self.device.pdu_output_c_max.pvname, scale=0.1)
+
+
+    def add_channels(self):
+        """
+        Find all attributes of the PDU that start with the name 'channel'
+        Append them and their signals to a dictionary, then call the
+        function responsible for adding them to the layout
+        """
+        self.channel_signal_dict = {}
+
+        for attr in dir(self.device):
+            if attr.startswith("channel"):
+                ch_obj = getattr(self.device, attr, None)
+                if ch_obj is None or not all(hasattr(ch_obj, k) for k in ('ch_index', 'ch_name', 'ch_status', 'ch_ctrl_state', 'ch_ctrl_command')):
+                    continue
+
+                self.channel_signal_dict[attr] = {
+                    'ch_index': ch_obj.ch_index.pvname,
+                    'ch_name': ch_obj.ch_name.pvname,
+                    'ch_status': ch_obj.ch_status.pvname,
+                    'ch_ctrl_state': ch_obj.ch_ctrl_state.pvname,
+                    'ch_ctrl_command': ch_obj.ch_ctrl_command.pvname,
+                }
+        """
+        If we have a PDU with more than 8 channels, the rows will sort lexigraphically
+        by channel (i.e 10 comes before 1). Force it to conform with some shenanigans
+        """
+        self.channel_signal_dict_sorted = dict(sorted(self.channel_signal_dict.items(), key=lambda item: self.extract_outlet_number(item[1]['ch_index'])))
+        self.generate_rows()
+
+
+    def generate_rows(self):
+        """
+        Format each ophyd pdu channel component into a row and append to the layout.
+        Split channels into two collumns to keep the screen from growing length-wise
+        """
+        def add_channel_row(layout, ch_info):
+            row_layout = QtWidgets.QHBoxLayout()
+
+            # Index label
+            idx_label = pydm.widgets.label.PyDMLabel()
+            idx_label.channel = f"ca://{ch_info['ch_index']}"
+            idx_label.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(idx_label, 1)
+
+            # Name
+            name_edit = pydm.widgets.line_edit.PyDMLineEdit()
+            name_edit.channel = f"ca://{ch_info['ch_name']}"
+            name_edit.setReadOnly(False)
+            name_edit.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(name_edit, 8)
+
+            # Status
+            status = pydm.widgets.label.PyDMLabel()
+            status.channel = f"ca://{ch_info['ch_status']}"
+            status.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(status, 2)
+
+            # Ctrl atate
+            ctrl_state = pydm.widgets.label.PyDMLabel()
+            ctrl_state.channel = f"ca://{ch_info['ch_ctrl_state']}"
+            ctrl_state.setAlignment(QtCore.Qt.AlignCenter)
+            row_layout.addWidget(ctrl_state, 2)
+
+            # Command enum
+            cmd = pydm.widgets.enum_combo_box.PyDMEnumComboBox()
+            cmd.channel = f"ca://{ch_info['ch_ctrl_command']}"
+            row_layout.addWidget(cmd, 2)
+
+            row_widget = QtWidgets.QWidget()
+            row_widget.setLayout(row_layout)
+            layout.addWidget(row_widget)
+
+        left_layout = self.ui.Left_Channels
+        right_layout = self.ui.Right_Channels
+
+        # Clear layouts
+        for layout in (left_layout, right_layout):
+            while layout.count():
+                item = layout.takeAt(0)
+                widget = item.widget()
+                if widget:
+                    widget.deleteLater()
+
+        # Split channels
+        ch_list = list(self.channel_signal_dict.values())
+        midpoint = len(ch_list) // 2
+        left_half = ch_list[:midpoint]
+        right_half = ch_list[midpoint:]
+
+        for ch in left_half:
+            add_channel_row(left_layout, ch)
+        for ch in right_half:
+            add_channel_row(right_layout, ch)
+
+
+    def monitor_pv_to_label(self, label, pvname, scale=1.0, precision=1):
+        """
+        Subscribe the PV, as saved in the ophyd component, to an EPICS
+        monitor that executes a function to scale its value and assign
+        it to the cooresponding widget's text. This works around using
+        the channel property in these widgets, which to the best of
+        my knowledge does not support scalling.
+        """
+        def on_change(pvname=None, value=None, **kwargs):
+            if value is not None:
+                label.setText(f"{value * scale:.{precision}f}")
+            else:
+                label.setText("--")
+
+        # Register the monitor
+        camonitor(pvname, callback=on_change)
+
+    def extract_outlet_number(self, pvname):
+        """
+        Helper function for sorting the channel dictionaries
+        """
+        match = re.search(r':Outlet:(\d+):', pvname)
+        return int(match.group(1)) if match else float('inf')

--- a/pcdsdevices/ui/TripplitePDU.detailed.py
+++ b/pcdsdevices/ui/TripplitePDU.detailed.py
@@ -1,11 +1,11 @@
-import pydm
 import re
 
+import pydm
+from epics import PV, caget, camonitor
 from pydm import Display
-
 from qtpy import QtCore, QtWidgets
 from typhos import utils
-from epics import PV, camonitor, caget
+
 
 class PDUDetailedWidget(Display, utils.TyphosBase):
     """

--- a/pcdsdevices/ui/TripplitePDU.detailed.ui
+++ b/pcdsdevices/ui/TripplitePDU.detailed.ui
@@ -1,0 +1,852 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1002</width>
+    <height>691</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,5,1,10">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="show_switcher" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_36">
+     <property name="text">
+      <string>&lt;b&gt;Overview:&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="PDU_overview_layout" stretch="0,0,0,0,0,2,15">
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>PDU: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="Channel_Name">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="readOnly">
+        <bool>false</bool>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Location:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="Location_Label">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="Status_Label">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="rules" stdset="0">
+        <string>[{&quot;name&quot;: &quot;text&quot;, &quot;property&quot;: &quot;Text&quot;, &quot;initial_value&quot;: &quot;&quot;, &quot;expression&quot;: &quot;\&quot;'Normal' if int(channel) == 1 else 'NO COM'\&quot;\n&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${prefix}:${template_status}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}], &quot;notes&quot;: &quot;&quot;}]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:${template_status}</string>
+       </property>
+       <property name="enableRichText" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0" columnstretch="4,0,2,0,4,0,2,1">
+     <item row="1" column="6">
+      <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
+       <item>
+        <widget class="QLabel" name="label_19">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Outlet Control:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_On_Button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All On</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_Off_Button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All Off</string>
+         </property>
+         <property name="pressValue" stdset="0">
+          <string>None</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="Reboot_All_Button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>Reboot All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="2" rowspan="2">
+      <layout class="QVBoxLayout" name="Input_Layout">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>&lt;b&gt;Input Details&lt;/b&gt;:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>Frequency (Hz):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_F">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Voltage (V):      </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_V">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_17">
+           <property name="text">
+            <string>Voltage (Min):  </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_V_Min">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Voltage (Max): </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_V_Max">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0" rowspan="2">
+      <layout class="QVBoxLayout" name="Detail_Layout">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>&lt;b&gt;PDU Details:&lt;/b&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,0,0,0">
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Inputs:      </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Input">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Phases:    </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Phase">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,0,0,0">
+         <item>
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Outputs:   </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Output">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>Circuits:    </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Circuit">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="0,0,0,0">
+         <item>
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Outlets:    </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Outlet">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_14">
+           <property name="text">
+            <string>Breakers: </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Breaker">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
+         <item>
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Groups:    </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Group">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_12">
+           <property name="text">
+            <string>Heatsinks:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Num_Heatsink">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="4">
+      <layout class="QVBoxLayout" name="Output_Layout">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_19">
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>&lt;b&gt;Output Details:&lt;/b&gt;      </string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <item>
+          <widget class="QLabel" name="label_30">
+           <property name="text">
+            <string>Frequency (Hz):   </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Output_F">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_31">
+           <property name="text">
+            <string>Current (A):   </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Output_C">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
+         <item>
+          <widget class="QLabel" name="label_33">
+           <property name="text">
+            <string>Voltage (V):         </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Output_V">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_32">
+           <property name="text">
+            <string>Current (Min):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Output_C_Min">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_34">
+           <property name="text">
+            <string>Active Power (W):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Output_P">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_35">
+           <property name="text">
+            <string>Currrent (Max):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Output_C_Max">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="5">
+      <widget class="Line" name="line_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="Line" name="line_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Line" name="line">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Sunken</enum>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="7">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="2,10,1,1,1">
+       <item>
+        <widget class="QLabel" name="label_24">
+         <property name="text">
+          <string>    ID:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_23">
+         <property name="text">
+          <string>Name:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_22">
+         <property name="text">
+          <string>Status:    </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>State:      </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_20">
+         <property name="text">
+          <string>Ctl. Action:   </string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="2,10,1,1,1">
+       <item>
+        <widget class="QLabel" name="label_27">
+         <property name="text">
+          <string>   ID:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_29">
+         <property name="text">
+          <string>Name:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_28">
+         <property name="text">
+          <string>Status:     </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_26">
+         <property name="text">
+          <string>State:     </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_25">
+         <property name="text">
+          <string>Ctl. Action:     </string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scroll_layout">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>982</width>
+        <height>327</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_18">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="Left_Channels"/>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="Right_Channels"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdsdevices/ui/TripplitePDU.detailed.ui
+++ b/pcdsdevices/ui/TripplitePDU.detailed.ui
@@ -14,6 +14,9 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,5,1,10">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
      <property name="sizePolicy">
@@ -113,7 +116,7 @@
         <bool>true</bool>
        </property>
        <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="alarmSensitiveBorder" stdset="0">
         <bool>true</bool>
@@ -146,6 +149,9 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0" columnstretch="4,0,2,0,4,0,2,1">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
      <item row="1" column="6">
       <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
        <item>

--- a/pcdsdevices/ui/TripplitePDU.detailed.ui
+++ b/pcdsdevices/ui/TripplitePDU.detailed.ui
@@ -6,9 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1002</width>
-    <height>691</height>
+    <width>978</width>
+    <height>547</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>970</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>978</width>
+    <height>16777215</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -42,8 +54,17 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="PDU_overview_layout" stretch="0,0,0,0,0,2,15">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
      <item>
       <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>PDU: </string>
        </property>
@@ -53,6 +74,12 @@
       <widget class="PyDMLineEdit" name="Channel_Name">
        <property name="enabled">
         <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="toolTip">
         <string/>
@@ -70,6 +97,12 @@
      </item>
      <item>
       <widget class="QLabel" name="label_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Location:</string>
        </property>
@@ -77,6 +110,12 @@
      </item>
      <item>
       <widget class="PyDMLineEdit" name="Location_Label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -87,6 +126,12 @@
      </item>
      <item>
       <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Status:</string>
        </property>
@@ -94,6 +139,18 @@
      </item>
      <item>
       <widget class="PyDMLabel" name="Status_Label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>60</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string/>
        </property>
@@ -150,190 +207,46 @@
    <item>
     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0" columnstretch="4,0,2,0,4,0,2,1">
      <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
+      <enum>QLayout::SetFixedSize</enum>
      </property>
-     <item row="1" column="6">
-      <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
-       <item>
-        <widget class="QLabel" name="label_19">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Outlet Control:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMPushButton" name="All_On_Button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>All On</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMPushButton" name="All_Off_Button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>All Off</string>
-         </property>
-         <property name="pressValue" stdset="0">
-          <string>None</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMPushButton" name="Reboot_All_Button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>Reboot All</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="2" rowspan="2">
-      <layout class="QVBoxLayout" name="Input_Layout">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_17">
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>&lt;b&gt;Input Details&lt;/b&gt;:</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="label_15">
-           <property name="text">
-            <string>Frequency (Hz):</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="Input_F">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="label_16">
-           <property name="text">
-            <string>Voltage (V):      </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="Input_V">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="label_17">
-           <property name="text">
-            <string>Voltage (Min):  </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="Input_V_Min">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="label_18">
-           <property name="text">
-            <string>Voltage (Max): </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="PyDMLabel" name="Input_V_Max">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
      <item row="1" column="0" rowspan="2">
       <layout class="QVBoxLayout" name="Detail_Layout">
        <property name="spacing">
         <number>6</number>
        </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_6">
          <item>
           <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>&lt;b&gt;PDU Details:&lt;/b&gt;</string>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>185</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -341,6 +254,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,0,0,0">
          <item>
           <widget class="QLabel" name="label_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Inputs:      </string>
            </property>
@@ -348,6 +267,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Input">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -358,6 +289,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_7">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Phases:    </string>
            </property>
@@ -365,6 +302,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Phase">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -379,6 +328,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,0,0,0">
          <item>
           <widget class="QLabel" name="label_9">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Outputs:   </string>
            </property>
@@ -386,6 +341,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Output">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -396,6 +363,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Circuits:    </string>
            </property>
@@ -403,6 +376,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Circuit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -417,6 +402,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="0,0,0,0">
          <item>
           <widget class="QLabel" name="label_10">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Outlets:    </string>
            </property>
@@ -424,6 +415,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Outlet">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -434,6 +437,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_14">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Breakers: </string>
            </property>
@@ -441,6 +450,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Breaker">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -455,6 +476,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_12">
          <item>
           <widget class="QLabel" name="label_13">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Groups:    </string>
            </property>
@@ -462,6 +489,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Group">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -472,6 +511,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Heatsinks:</string>
            </property>
@@ -479,6 +524,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Num_Heatsink">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -494,10 +551,13 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>30</height>
           </size>
          </property>
         </spacer>
@@ -506,14 +566,39 @@
      </item>
      <item row="1" column="4">
       <layout class="QVBoxLayout" name="Output_Layout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_19">
          <item>
           <widget class="QLabel" name="label_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>&lt;b&gt;Output Details:&lt;/b&gt;      </string>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>235</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -521,6 +606,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_16">
          <item>
           <widget class="QLabel" name="label_30">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Frequency (Hz):   </string>
            </property>
@@ -528,6 +619,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Output_F">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -538,6 +641,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_31">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Current (A):   </string>
            </property>
@@ -545,6 +654,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Output_C">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -559,6 +680,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_15">
          <item>
           <widget class="QLabel" name="label_33">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Voltage (V):         </string>
            </property>
@@ -566,6 +693,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Output_V">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -576,6 +715,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_32">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Current (Min):</string>
            </property>
@@ -583,6 +728,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Output_C_Min">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -597,6 +754,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QLabel" name="label_34">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Active Power (W):</string>
            </property>
@@ -604,6 +767,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Output_P">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -614,6 +789,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_35">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Currrent (Max):</string>
            </property>
@@ -621,6 +802,18 @@
          </item>
          <item>
           <widget class="PyDMLabel" name="Output_C_Max">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -636,41 +829,18 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>60</height>
           </size>
          </property>
         </spacer>
        </item>
       </layout>
-     </item>
-     <item row="1" column="5">
-      <widget class="Line" name="line_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="Line" name="line_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
      </item>
      <item row="1" column="1">
       <widget class="Line" name="line">
@@ -688,6 +858,19 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="5">
+      <widget class="Line" name="line_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="7">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
@@ -695,20 +878,368 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>10</width>
          <height>20</height>
         </size>
        </property>
       </spacer>
      </item>
+     <item row="1" column="3">
+      <widget class="Line" name="line_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <layout class="QVBoxLayout" name="Control_Layout" stretch="0,1,1,1,0">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_19">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Outlet Control:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_On_Button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All On</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="All_Off_Button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>All Off</string>
+         </property>
+         <property name="pressValue" stdset="0">
+          <string>None</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMPushButton" name="Reboot_All_Button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>Reboot All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>60</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="2" rowspan="2">
+      <layout class="QVBoxLayout" name="Input_Layout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&lt;b&gt;Input Details&lt;/b&gt;:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>70</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_15">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Frequency (Hz):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_F">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_16">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Voltage (V):      </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_V">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_17">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Voltage (Min):  </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_V_Min">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="label_18">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Voltage (Max): </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="Input_V_Max">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>30</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="2,10,1,1,1">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
        <item>
         <widget class="QLabel" name="label_24">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>    ID:</string>
          </property>
@@ -716,6 +1247,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_23">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Name:</string>
          </property>
@@ -723,6 +1260,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_22">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Status:    </string>
          </property>
@@ -730,6 +1273,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_21">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>State:      </string>
          </property>
@@ -737,6 +1286,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_20">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Ctl. Action:   </string>
          </property>
@@ -746,8 +1301,17 @@
      </item>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="2,10,1,1,1">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
        <item>
         <widget class="QLabel" name="label_27">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>   ID:</string>
          </property>
@@ -755,6 +1319,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_29">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Name:</string>
          </property>
@@ -762,6 +1332,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_28">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Status:     </string>
          </property>
@@ -769,6 +1345,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_26">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>State:     </string>
          </property>
@@ -776,6 +1358,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_25">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Ctl. Action:     </string>
          </property>
@@ -795,8 +1383,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>982</width>
-        <height>327</height>
+        <width>958</width>
+        <height>250</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -806,6 +1394,9 @@
        </sizepolicy>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_18">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -819,10 +1410,18 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" name="Left_Channels"/>
+        <layout class="QVBoxLayout" name="Left_Channels">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+        </layout>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="Right_Channels"/>
+        <layout class="QVBoxLayout" name="Right_Channels">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+        </layout>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I've added typhos screens for PDUs, essentially coping over the current EDM screens into pydm. I've broken this out into two pcdsdevices, one for Tripplite PDUs, and another for Leviton / Sentry4. The reason being that Tripplite IOCs are too different than Leviton/Sentry4 to justify (in my mind) keeping them together.

Each class has its own happi container and .py file for typhos to execute when the detailed screen is opened. 

Some features include:
- Channel status widgets will change color when a minor (yellow) or major (red) alarm state is active.
- Channels cannot be accidentally cycled by hovering the mouse key over the enum button while scrolling. You have to click to change state,

Some personal reservations include:
- I had to source pcds-6.0.0 during testing in order for typhos to execute my custom .py files when launching the detailed screens.
- Old Sentry IOCs will not work for my screen, only newer Sentry4 IOCs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This effort is motivated mainly by the fact that PDUs are not supported in pydm. Furthermore, this coincides with cleaning up the Lucid buttons on some of the more cluttered hutches by utilizing happi/typhos instead. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with test PDUs in the makerspace. Testing included ensuring channels cannot be easily powered down by accident and that all channels are controllable in the same fashion to the EDM screens.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Once this PR is merged, I will add to the confluence pages on how to set up Tripplite & Sentry4/Leviton PDUs

<!--
## Screenshots (if appropriate):
-->
<img width="710" height="720" alt="Screenshot 2025-07-28 165921" src="https://github.com/user-attachments/assets/06ae383b-75ef-471f-9b48-e2a1a23a2cbe" />


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
