### PR TITLE
update sp1k4-att targets from 5 to 9

### DIFF
--- a/docs/source/upcoming_release_notes/1376-add_new_targets.rst
+++ b/docs/source/upcoming_release_notes/1376-add_new_targets.rst
@@ -11,7 +11,7 @@ Library Features
 
 Device Features
 ---------------
-- change targets from 5 to 9
+- change 'TMOSpectrometerSOLIDATTStates'target count from 5 to 9
 
 New Devices
 -----------
@@ -27,4 +27,4 @@ Maintenance
 
 Contributors
 ------------
--@tongju12
+-tongju12

--- a/docs/source/upcoming_release_notes/1376-add_new_targets.rst
+++ b/docs/source/upcoming_release_notes/1376-add_new_targets.rst
@@ -1,0 +1,30 @@
+1376 add new targets
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- change targets from 5 to 9
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+-@tongju12

--- a/pcdsdevices/spectrometer.py
+++ b/pcdsdevices/spectrometer.py
@@ -457,11 +457,11 @@ class TMOSpectrometerSOLIDATTStates(TwinCATStatePMPS):
     """
     Spectrometer Solid Attenuator(FOIL X and Y) 2D States Setup
 
-    Here, we specify 6 states,(after adding an Unknown state), and 2 motors, for the X and Y
+    Here, we specify 10 states,(after adding an Unknown state), and 2 motors, for the X and Y
     axes.
     """
 
-    config = UpCpt(state_count=6, motor_count=2)
+    config = UpCpt(state_count=10, motor_count=2)
 
 
 class TMOSpectrometer(BaseInterface, GroupDevice, LightpathMixin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Sp1k4 attenuator swaps a new paddle that can hold more targets.
Scientists add four more targets
<!--- Describe your changes in detail -->
Change target number from 5 to 9
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists request it
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Yes, I test it. I move from OUT to target 1 without any issue. Will ask scientists to move all of them later. 
<img width="1098" height="949" alt="Screenshot 2025-09-09 at 2 15 36 PM" src="https://github.com/user-attachments/assets/6cb76680-5e7f-47bd-8fbf-39d699a282da" />

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://jira.slac.stanford.edu/browse/ECS-8796
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
