### PR TITLE
Kashiyama G Series

### DIFF
--- a/docs/source/upcoming_release_notes/1415-Adding_Kashiyama_NeoDry_G.rst
+++ b/docs/source/upcoming_release_notes/1415-Adding_Kashiyama_NeoDry_G.rst
@@ -1,0 +1,31 @@
+1415 Adding Kashiyama NeoDry G
+#################
+
+API Breaks
+----------
+- N/A
+
+Library Features
+----------------
+- N/A
+
+Device Features
+---------------
+- Adds commands to run the pump, set remote/local setting, and low speed setting. Serial Device provides further monitoring.
+
+New Devices
+-----------
+- Kashiyama_G adds support for new Vacuum Library function block FB_Kashiyama_G
+- Kashiyama_G_Serial adds support for new serial IOC
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- TrumanPar

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -250,6 +250,7 @@ class Kashiyama_G(Device):
     remote = Cpt(EpicsSignalWithRBV, ':REMOTE_SW', kind='omitted')
     remote_do = Cpt(EpicsSignalRO, ':REM_DO_RBV', kind='normal')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')  # NORMALLY CLOSED 0 = OK | 1 = ALARM
+    state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal')
 
 class Kashiyama_G_Serial(Device):
     """Class for the Kashiyama Neo Dry G-Series IOC"""

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -234,6 +234,51 @@ class Ebara_EV_A03_1(PROPLC):
     reset_di = Cpt(EpicsSignalWithRBV, ':RST_SW', kind='omitted')
 
 
+class Kashiyama_G(Device):
+    """
+    Class for the Kashiyama Neo Dry G-Series
+    Does not inherit from PROPLC as some PVs are unused in the implementation
+    """
+    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted')
+    interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
+                       doc='interlock is ok when true')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal')
+    reset = Cpt(EpicsSignalWithRBV, ':RESET_SW', kind='omitted')
+    reset_do = Cpt(EpicsSignalRO, ':RESET_DO_RBV', kind='normal')
+    low_speed = Cpt(EpicsSignalWithRBV, ':LSPD_SW', kind='omitted')
+    low_speed_do = Cpt(EpicsSignalRO, ':LSPD_DO', kind='normal')
+    remote = Cpt(EpicsSignalWithRBV, ':REMOTE_SW', kind='omitted')
+    remote_do = Cpt(EpicsSignalRO, ':REM_DO_RBV', kind='normal')
+    alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')  # NORMALLY CLOSED 0 = OK | 1 = ALARM
+
+class Kashiyama_G_Serial(Device):
+    """Class for the Kashiyama Neo Dry G-Series IOC"""
+    run_cmd = Cpt(EpicsSignal, ':CMD', kind='normal')
+    run = Cpt(EpicsSignalRO, ':RUN_RBV', kind='normal')
+    mode_cmd = Cpt(EpicsSignal, ':OPMODE', kind='normal')
+    mode_cmd_rbv = Cpt(EpicsSignalRO, ':OPMODE_RBV', kind='normal')
+    freq = Cpt(EpicsSignalRO, ':FREQ_HZ', kind='normal')
+    freq_cpm = Cpt(EpicsSignal, ':FREQSET', kind='normal') # cpm
+    freq_cpm_rbv = Cpt(EpicsSignalRO, ':FREQSET_RBV', kind='normal') # cpm
+    lspd_freq_cpm_rbv = Cpt(EpicsSignalRO, ':LOWFREQSET_RBV', kind='normal') # cpm
+    current = Cpt(EpicsSignalRO, ':CURR_RBV', kind='normal')
+    voltage = Cpt(EpicsSignalRO, ':VOLT_RBV', kind='normal')
+    power = Cpt(EpicsSignalRO, ':PWR_RBV', kind='normal')
+    motor_temp = Cpt(EpicsSignalRO, ':MTRTEMP_RBV', kind='normal')
+    driver_temp = Cpt(EpicsSignalRO, ':DRVTEMP_RBV', kind='omitted')
+    ipm_temp = Cpt(EpicsSignalRO, ':IPMTEMP_RBV', kind='omitted')
+    warn = Cpt(EpicsSignalRO, ':WARN_RBV', kind='normal')
+    alarm = Cpt(EpicsSignalRO, ':ALM_RBV', kind='normal')
+    error_count = Cpt(EpicsSignalRO, ':ERRCNT_RBV', kind='omitted')
+    error_reset = Cpt(EpicsSignal, ':ERRRST', kind='normal')
+    valve_status = Cpt(EpicsSignalRO, ':VALVE_RBV', kind='normal')
+    fan_status = Cpt(EpicsSignalRO, ':FAN_RBV', kind='normal')
+    overhaul_one = Cpt(EpicsSignalRO, ':OVHL1_RBV', kind='ommitted')
+    overaul_two = Cpt(EpicsSignalRO, ':OVHL2_RBV', kind='ommitted')
+    run_time = Cpt(EpicsSignalRO, ':RTIME_RBV', kind ='ommited')  # hours
+    run_time_post_overhaul = Cpt(EpicsSignalRO, ':RTIME_OH_RBV', kind ='ommited')  # hours
+
+
 class AgilentSerial(Device):
     """Class for Agilent Turbo Pump controlled via serial."""
     run = Cpt(EpicsSignal, ':RUN', kind='omitted')

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -252,6 +252,7 @@ class Kashiyama_G(Device):
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')  # NORMALLY CLOSED 0 = OK | 1 = ALARM
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal')
 
+
 class Kashiyama_G_Serial(Device):
     """Class for the Kashiyama Neo Dry G-Series IOC"""
     run_cmd = Cpt(EpicsSignal, ':CMD', kind='normal')
@@ -259,9 +260,9 @@ class Kashiyama_G_Serial(Device):
     mode_cmd = Cpt(EpicsSignal, ':OPMODE', kind='normal')
     mode_cmd_rbv = Cpt(EpicsSignalRO, ':OPMODE_RBV', kind='normal')
     freq = Cpt(EpicsSignalRO, ':FREQ_HZ', kind='normal')
-    freq_cpm = Cpt(EpicsSignal, ':FREQSET', kind='normal') # cpm
-    freq_cpm_rbv = Cpt(EpicsSignalRO, ':FREQSET_RBV', kind='normal') # cpm
-    lspd_freq_cpm_rbv = Cpt(EpicsSignalRO, ':LOWFREQSET_RBV', kind='normal') # cpm
+    freq_cpm = Cpt(EpicsSignal, ':FREQSET', kind='normal')  # cpm
+    freq_cpm_rbv = Cpt(EpicsSignalRO, ':FREQSET_RBV', kind='normal')  # cpm
+    lspd_freq_cpm_rbv = Cpt(EpicsSignalRO, ':LOWFREQSET_RBV', kind='normal')  # cpm
     current = Cpt(EpicsSignalRO, ':CURR_RBV', kind='normal')
     voltage = Cpt(EpicsSignalRO, ':VOLT_RBV', kind='normal')
     power = Cpt(EpicsSignalRO, ':PWR_RBV', kind='normal')
@@ -276,8 +277,8 @@ class Kashiyama_G_Serial(Device):
     fan_status = Cpt(EpicsSignalRO, ':FAN_RBV', kind='normal')
     overhaul_one = Cpt(EpicsSignalRO, ':OVHL1_RBV', kind='omitted')
     overaul_two = Cpt(EpicsSignalRO, ':OVHL2_RBV', kind='omitted')
-    run_time = Cpt(EpicsSignalRO, ':RTIME_RBV', kind ='omitted')  # hours
-    run_time_post_overhaul = Cpt(EpicsSignalRO, ':RTIME_OH_RBV', kind ='omitted')  # hours
+    run_time = Cpt(EpicsSignalRO, ':RTIME_RBV', kind='omitted')  # hours
+    run_time_post_overhaul = Cpt(EpicsSignalRO, ':RTIME_OH_RBV', kind='omitted')  # hours
 
 
 class AgilentSerial(Device):

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -247,7 +247,7 @@ class Kashiyama_G(Device):
     reset_do = Cpt(EpicsSignalRO, ':RESET_DO_RBV', kind='normal')
     low_speed = Cpt(EpicsSignal, ':LSPD_SW', kind='normal')
     low_speed_do = Cpt(EpicsSignalRO, ':LSPD_DO_RBV', kind='normal')
-    remote = Cpt(EpicsSignal, ':REMOTE_SW', kind='omitted')
+    remote = Cpt(EpicsSignal, ':REMOTE_SW', kind='normal')
     remote_do = Cpt(EpicsSignalRO, ':REM_DO_RBV', kind='normal')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')  # NORMALLY CLOSED 0 = OK | 1 = ALARM
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal')

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -242,13 +242,13 @@ class Kashiyama_G(Device):
     switch_pump_on = Cpt(EpicsSignal, ':RUN_SW', kind='omitted')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock is ok when true')
-    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal')
+    run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='omitted')
     reset = Cpt(EpicsSignal, ':RESET_SW', kind='normal')
     reset_do = Cpt(EpicsSignalRO, ':RESET_DO_RBV', kind='normal')
     low_speed = Cpt(EpicsSignal, ':LSPD_SW', kind='normal')
-    low_speed_do = Cpt(EpicsSignalRO, ':LSPD_DO_RBV', kind='normal')
+    low_speed_do = Cpt(EpicsSignalRO, ':LSPD_DO_RBV', kind='omitted')
     remote = Cpt(EpicsSignal, ':REMOTE_SW', kind='normal')
-    remote_do = Cpt(EpicsSignalRO, ':REM_DO_RBV', kind='normal')
+    remote_do = Cpt(EpicsSignalRO, ':REM_DO_RBV', kind='omitted')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')  # NORMALLY CLOSED 0 = OK | 1 = ALARM
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal')
 

--- a/pcdsdevices/pump.py
+++ b/pcdsdevices/pump.py
@@ -239,15 +239,15 @@ class Kashiyama_G(Device):
     Class for the Kashiyama Neo Dry G-Series
     Does not inherit from PROPLC as some PVs are unused in the implementation
     """
-    switch_pump_on = Cpt(EpicsSignalWithRBV, ':RUN_SW', kind='omitted')
+    switch_pump_on = Cpt(EpicsSignal, ':RUN_SW', kind='omitted')
     interlock_ok = Cpt(EpicsSignalRO, ':ILK_OK_RBV', kind='normal',
                        doc='interlock is ok when true')
     run_do = Cpt(EpicsSignalRO, ':RUN_DO_RBV', kind='normal')
-    reset = Cpt(EpicsSignalWithRBV, ':RESET_SW', kind='omitted')
+    reset = Cpt(EpicsSignal, ':RESET_SW', kind='normal')
     reset_do = Cpt(EpicsSignalRO, ':RESET_DO_RBV', kind='normal')
-    low_speed = Cpt(EpicsSignalWithRBV, ':LSPD_SW', kind='omitted')
-    low_speed_do = Cpt(EpicsSignalRO, ':LSPD_DO', kind='normal')
-    remote = Cpt(EpicsSignalWithRBV, ':REMOTE_SW', kind='omitted')
+    low_speed = Cpt(EpicsSignal, ':LSPD_SW', kind='normal')
+    low_speed_do = Cpt(EpicsSignalRO, ':LSPD_DO_RBV', kind='normal')
+    remote = Cpt(EpicsSignal, ':REMOTE_SW', kind='omitted')
     remote_do = Cpt(EpicsSignalRO, ':REM_DO_RBV', kind='normal')
     alarm = Cpt(EpicsSignalRO, ':ALARM_OK_RBV', kind='normal')  # NORMALLY CLOSED 0 = OK | 1 = ALARM
     state = Cpt(EpicsSignalRO, ':STATE_RBV', kind='normal')
@@ -274,10 +274,10 @@ class Kashiyama_G_Serial(Device):
     error_reset = Cpt(EpicsSignal, ':ERRRST', kind='normal')
     valve_status = Cpt(EpicsSignalRO, ':VALVE_RBV', kind='normal')
     fan_status = Cpt(EpicsSignalRO, ':FAN_RBV', kind='normal')
-    overhaul_one = Cpt(EpicsSignalRO, ':OVHL1_RBV', kind='ommitted')
-    overaul_two = Cpt(EpicsSignalRO, ':OVHL2_RBV', kind='ommitted')
-    run_time = Cpt(EpicsSignalRO, ':RTIME_RBV', kind ='ommited')  # hours
-    run_time_post_overhaul = Cpt(EpicsSignalRO, ':RTIME_OH_RBV', kind ='ommited')  # hours
+    overhaul_one = Cpt(EpicsSignalRO, ':OVHL1_RBV', kind='omitted')
+    overaul_two = Cpt(EpicsSignalRO, ':OVHL2_RBV', kind='omitted')
+    run_time = Cpt(EpicsSignalRO, ':RTIME_RBV', kind ='omitted')  # hours
+    run_time_post_overhaul = Cpt(EpicsSignalRO, ':RTIME_OH_RBV', kind ='omitted')  # hours
 
 
 class AgilentSerial(Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adding two pump classes to cover new PVs for the Kashiyama Neo Dry G series. One adds support for PLC PVs (also a new FB to go along with it --> FB_KashiyamaPump_G) and the other adds PVs from the serial IOC, which is also new.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding the Kashiyama NeoDry G series to the SDL.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in PyDM

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
Interlocked due to being in local:
<img width="550" height="727" alt="image" src="https://github.com/user-attachments/assets/a1ac94ad-d018-48d6-ae2e-67d404c0da90" />

Not interlocked after setting to remote:
<img width="527" height="715" alt="image" src="https://github.com/user-attachments/assets/35a167e1-cf2a-48c2-a7aa-8140694e4947" />

Running:
<img width="530" height="716" alt="image" src="https://github.com/user-attachments/assets/a5eaea9d-fb64-4218-9ad0-04428301b478" />

Faulted (forced from PLC):
<img width="522" height="707" alt="image" src="https://github.com/user-attachments/assets/5883e628-a448-487a-b0d5-9c4bbd7a8234" />

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
