### PR TITLE
Updating hla disabled error message

### DIFF
--- a/pcdsdevices/lxe.py
+++ b/pcdsdevices/lxe.py
@@ -503,7 +503,7 @@ class Lcls2LaserTiming(FltMvInterface, PVPositioner):
             if self.hla_enabled.get() == 1:
                 func(self, *args, **kwargs)
             else:
-                raise Exception("HLA is not enabled.")
+                raise Exception("Laser Locker Timing: Calibration Required.")
         return wrapper
 
     @check_hla


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changing the exception message from `HLA is not enabled` to 'Laser Locker Timing: Calibration Required' when you attempt to move an lxt while hla is not enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://slac.slack.com/archives/C03D4JT7U15/p1778806386537109
This exception happened correctly yesterday but the exception (and what to do about it) was unclear. The new message comes from the timing team

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested because I only changed a string


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
