### PR TITLE
ENH: add pos_correction, backlash, and pos_cor_status components

### DIFF
--- a/pcdsdevices/twincat_motor.py
+++ b/pcdsdevices/twincat_motor.py
@@ -31,33 +31,54 @@ class InvertedBoolEpicsSignal(DerivedSignal):
 
 class EnabledDisabledSignal(EpicsSignal):
     """
-    EpicsSignal for longin enable/disable records that lack ONAM/ZNAM.
+    EpicsSignal for longin/longout enable records that lack ONAM/ZNAM.
 
-    Converts 0 -> 'Disabled', 1 -> 'Enabled' for display.
-    Accepts 'Enable'/'Disable' or 0/1 for writes.
+    Presents the underlying 0/1 channel as an enum-like signal with strings
+    'DISABLE' / 'ENABLE'. ``enum_strs`` is advertised through the signal's
+    metadata and ``describe()`` so Typhos selects an enum widget rather than
+    a raw integer line edit.
 
-    Used by the motor-record (MRE) TwinCAT axis variants whose soft-limit
-    enable PVs are plain longin records without string field definitions.
+    Used where the soft-limit enable PVs (e.g. NC:SoftPosMinOn) are plain
+    longin records without ONAM/ZNAM string fields.
     """
-    _enable_map = {0: 'Disabled', 1: 'Enabled'}
-    _disable_map = {'Enable': 1, 'Disable': 0,
-                    'Enabled': 1, 'Disabled': 0,
-                    1: 1, 0: 0}
+    _enum_strs = ('DISABLE', 'ENABLE')
 
-    def get(self, **kwargs):
-        val = super().get(**kwargs)
-        return self._enable_map.get(int(val), str(val))
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Advertise the synthetic enum strings via metadata so consumers
+        # (Typhos widget selector, ophyd describe()) treat this as an enum.
+        self._metadata['enum_strs'] = tuple(self._enum_strs)
+
+    def _int_to_str(self, value):
+        try:
+            return self._enum_strs[int(value)]
+        except (ValueError, IndexError, TypeError):
+            return value
+
+    def _str_to_int(self, value):
+        if isinstance(value, str):
+            try:
+                return self._enum_strs.index(value)
+            except ValueError:
+                pass
+        return value
+
+    def get(self, as_string=False, **kwargs):
+        raw = super().get(**kwargs)
+        if as_string:
+            return self._int_to_str(raw)
+        return raw
 
     def put(self, value, **kwargs):
-        if isinstance(value, str):
-            value = self._disable_map.get(value, value)
-        super().put(value, **kwargs)
+        super().put(self._str_to_int(value), **kwargs)
+
+    def describe(self):
+        desc = super().describe()
+        for key in desc:
+            desc[key]['enum_strs'] = list(self._enum_strs)
+        return desc
 
 
-"""
-EnabledDisabledSignal & InvertedBoolEpicsSignal  registered as FakeEpicsSignalRO;
-it's writable, so consider FakeEpicsSignal when adding tests.
-"""
 fake_device_cache[InvertedBoolEpicsSignal] = FakeEpicsSignalRO
 fake_device_cache[EnabledDisabledSignal] = FakeEpicsSignalRO
 
@@ -128,6 +149,11 @@ class TwinCATMotorInterface(FltMvInterface, PVPositioner):
     high_limit_travel = Cpt(EpicsSignal, ':NC:MaxPos:Val_RBV', write_pv=':NC:MaxPos:Goal', kind='config', auto_monitor=True)
     low_limit_enable = Cpt(EnabledDisabledSignal, ':NC:SoftPosMinOn:Val_RBV', write_pv=':NC:SoftPosMinOn:Goal', kind='config', auto_monitor=True)
     high_limit_enable = Cpt(EnabledDisabledSignal, ':NC:SoftPosMaxOn:Val_RBV', write_pv=':NC:SoftPosMaxOn:Goal', kind='config', auto_monitor=True)
+
+    # Position correction / backlash
+    pos_correction = Cpt(EnabledDisabledSignal, ':NC:PosCorr:Val_RBV', write_pv=':NC:PosCorr:Goal', kind='config', auto_monitor=True)
+    backlash = Cpt(EpicsSignal, ':NC:Backlash:Val_RBV', write_pv=':NC:Backlash:Goal', kind='config', auto_monitor=True)
+    pos_cor_status = Cpt(PytmcSignal, ":bBacklashStatus", io="i", kind="normal", auto_monitor=True)
 
     # Homing status/config
     homed = Cpt(PytmcSignal, ":bHomed", io="i", kind='normal', auto_monitor=True)
@@ -791,6 +817,7 @@ class TwinCATMREAxis(TwinCATAxis):
                       doc="Stop command (tcmotor.STOP)")
     # actuate overrides , MRE owns the actuation now
     actuate = None
+
     # Motion configuration: tcmotor record fields
     velocity = Cpt(EpicsSignal, ".VELO", kind="config",
                    auto_monitor=True, doc="Velocity (tcmotor.VELO)")
@@ -842,6 +869,13 @@ class TwinCATMREAxis(TwinCATAxis):
                             doc="High soft limit (tcmotor.HLM -> NC:MaxPos:Goal)")
     # low/high_limit_enable inherited from TwinCATMotorInterface
     # (EnabledDisabledSignal on the shared NC:SoftPos*On records).
+
+    # Backlash via tcmotor .BDST (writes to NC:Backlash:Goal via OUT_BDST).
+    # pos_correction and pos_cor_status have no tcmotor record equivalent and
+    # are inherited from TwinCATMotorInterface.
+    backlash = Cpt(EpicsSignal, '.BDST', kind='config',
+                   auto_monitor=True,
+                   doc='Backlash correction (tcmotor.BDST)')
 
     # Homing: tcmotor HOMF/HOMR command fields
     # homed and home_mode are inherited from TwinCATAxis (PLC :bHomed / :eHomeMode).


### PR DESCRIPTION
Fix EnabledDisabledSignal not display strings enums in typhos
Add pos_correction, backlash, and pos_cor_status components to TwinCAT axes

## Description
<!--- Describe your changes in detail -->
Adds three new components to `TwinCATMotorInterface` for position-correction and backlash configuration: `pos_correction` (EnabledDisabledSignal on `NC:PosCorr`, with `variety='enum'` so Typhos renders an Enable/Disable widget matching the existing limit enables), `backlash` (EpicsSignal on `NC:Backlash`), and `pos_cor_status` . In `TwinCATMREAxis`, `backlash` is overridden to bind to the tcmotor record's `.BDST` field;

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The position-correction and backlash PVs are configured on the PLC side but were not exposed through the device layer, so operators couldn't view or adjust them from Typhos. This adds access to those fields for both the legacy and motor-record axis classes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Instantiated `TwinCATMREAxis` via Typhos against a motor-record emulation IOC (`TST:MOTION:M1`). Verified `pos_correction` renders as an Enabled/Disabled enum widget, `backlash` reads/writes through `.BDST`, and `pos_cor_status` displays the PLC backlash status.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Inline comments next to the new components in `TwinCATMotorInterface` (Position correction/backlash group) and next to the `.BDST` override in `TwinCATMREAxis` noting that `pos_correction`/`pos_cor_status` are inherited.

<!--
## Screenshots (if appropriate):
-->
<img width="1082" height="326" alt="twincatmrefix" src="https://github.com/user-attachments/assets/3e9727b8-2b67-4585-958c-c8207e0cf4da" />

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions