### PR TITLE
CI/TST/BLD: fix various incompatibilities

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,7 +1,6 @@
 docs-versions-menu
 sphinx >=3.3.1
 sphinx_rtd_theme
-whatrecord
 ipython
 # Required for compatibility with Sphinx 6.0+:
 sphinxcontrib-jquery

--- a/pcdsdevices/make_ophyd_device.py
+++ b/pcdsdevices/make_ophyd_device.py
@@ -142,8 +142,9 @@ def write_file(lines, name):
 
 
 if __name__ == '__main__':
-    from whatrecord import db
     import argparse
+
+    from whatrecord import db
     parser = argparse.ArgumentParser()
 
     parser.add_argument(

--- a/pcdsdevices/make_ophyd_device.py
+++ b/pcdsdevices/make_ophyd_device.py
@@ -1,8 +1,6 @@
 import re
 import sys
 
-from whatrecord import db
-
 
 def recurse_record(d, record):
     """
@@ -144,6 +142,7 @@ def write_file(lines, name):
 
 
 if __name__ == '__main__':
+    from whatrecord import db
     import argparse
     parser = argparse.ArgumentParser()
 

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -231,7 +231,7 @@ def test_presets_tab_init(fast_motor: FastMotor, deferred_fast_motor_presets):
 
 
 @pytest.mark.parametrize("attr", [
-    ("wm_dne",), ("wm_in",), ("mv_dne",), ("mv_in",), ("umv_dne",), ("umv_in",)
+    "wm_dne", "wm_in", "mv_dne", "mv_in", "umv_dne", "umv_in",
 ])
 def test_presets_getattribute_init(
     fast_motor: FastMotor, attr: str, deferred_fast_motor_presets

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -230,7 +230,7 @@ def test_presets_tab_init(fast_motor: FastMotor, deferred_fast_motor_presets):
     assert not fast_motor.presets.sync_needed()
 
 
-@pytest.mark.parametrize("attr,", [
+@pytest.mark.parametrize("attr", [
     "wm_dne", "wm_in", "mv_dne", "mv_in", "umv_dne, umv_in"
 ])
 def test_presets_getattribute_init(

--- a/pcdsdevices/tests/test_interface.py
+++ b/pcdsdevices/tests/test_interface.py
@@ -231,7 +231,7 @@ def test_presets_tab_init(fast_motor: FastMotor, deferred_fast_motor_presets):
 
 
 @pytest.mark.parametrize("attr", [
-    "wm_dne", "wm_in", "mv_dne", "mv_in", "umv_dne, umv_in"
+    ("wm_dne",), ("wm_in",), ("mv_dne",), ("mv_in",), ("umv_dne",), ("umv_in",)
 ])
 def test_presets_getattribute_init(
     fast_motor: FastMotor, attr: str, deferred_fast_motor_presets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=45", "setuptools_scm[toml]==10.0.5",]
+requires = [ "setuptools>=45", "setuptools_scm[toml]==9.2.2",]
 
 [project]
 classifiers = [ "Programming Language :: Python :: 3",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=45", "setuptools_scm[toml]>=6.2",]
+requires = [ "setuptools>=45", "setuptools_scm[toml]==10.0.5",]
 
 [project]
 classifiers = [ "Programming Language :: Python :: 3",]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The CI was broken in pcdsdevices. I made the following changes:
- Edit the broken test for the updated rules in the changelog for pytest 9.1.0, which now unpacks single-element tuples as one would expect in normal python syntax, which ends up breaking the parameterize here. Also update a clearly malformed test element.
  - Note: this test doesn't really do anything and should be a candidate for removal or revision. Even with extremely bad inputs the test passes.
- Drop setuptools_scm back to before version 10 because it seems to fix a strange build issue
- Rearrange the ophyd device generator to not require whatrecord on import so we can remove whatrecord (and therefore, epicsmacrolib) from the CI requirements, which is currently broken even on the versions that build for other packages

Possible Follow-up tasks:

- [ ] Learn precisely which version of setuptools_scm breaks us and why
- [ ] Figure out if we can get a new environment built that has whatrecord included at all anywhere
- [ ] Consider scrutinizing the test suite for bad/useless tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CI has been failing on this repo for at least a week

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The CI passes now.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
