### PR TITLE
FIX: ignore useless attribute errors for empty string at startup

### DIFF
--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -790,10 +790,13 @@ class DelayBase(FltMvInterface, PseudoPositioner):
 
         For delay motors, these internal variables are not used and are safe to
         skip at startup.
+
+        Sometimes this shows itself as an attribute error instead of a timeout
+        when the egu resolves to the default value, empty string.
         """
         try:
             super()._real_pos_update(*args, **kwargs)
-        except TimeoutError:
+        except (TimeoutError, AttributeError):
             pass
 
     @pseudo_position_argument


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
xpp is having a minor issue where due to load order, the position can be updated before the egu is ready on the unit conversion motors.

This can be avoided by skipping the position updates when the units are invalid- e.g. are not a valid unit for the conversion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Causes spam at open of xpp lucid screen

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively: the xpp motors still work, and the spam went away

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
