### PR TITLE
FIX: Update for PseudoPositioner to handle PseudoSingle's delegated moves correctly

### DIFF
--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -206,6 +206,35 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         self._update_notepad_ioc(position, 'notepad_setpoint')
         return status
 
+    def _concurrent_move(self, real_pos, **kwargs):
+        """
+        Move all real positioners in parallel.
+
+        This fixes a bug where a PseudoPositioner has a PseudoSingle as one of
+        its axes and waits indefinitely for the move status. A PseudoSingle
+        does not perform the move itself. Instead, it delegates the move to its
+        parent PseudoPositioner. The parent reports that the move is done using
+        a callback, but the current PseudoPositioner is waiting for the
+        PseudoSingle child to report that it is done. Since the PseudoSingle
+        did not perform the move directly, that callback never arrives. The
+        current PseudoPositioner's status hangs and blocks other operations.
+
+        The solution is to have the PseudoPositioner object track the axis it 
+        asked to move, instead of instead of trusting which object the callback 
+        reports as done.
+        """
+        self._real_waiting.extend(self._real)
+
+        for real, value in zip(self._real, real_pos):
+            self.log.debug("[concurrent] Moving %s to %s", real.name, value)
+
+            def mark_requested_axis_done(status=None, *, obj=None,
+                                         real_axis=real, **cb_kwargs):
+                self._real_finished(status=status, obj=real_axis)
+
+            real.move(value, wait=False, moved_cb=mark_requested_axis_done,
+                      **kwargs)
+
     def _update_position(self):
         """Update the pseudo position based on that of the real positioners."""
         position = super()._update_position()
@@ -487,11 +516,12 @@ class SyncAxis(FltMvInterface, PseudoPositioner):
             try:
                 self.offset_mode = SyncAxisOffsetMode[self.offset_mode]
             except KeyError:
-                raise ValueError(f'Invalid offset_mode: {self.offset_mode}') from None
+                raise ValueError(
+                    f'Invalid offset_mode: {self.offset_mode}') from None
         self._check_info_dict(self.offsets, 'offsets')
         self._check_info_dict(self.scales, 'scales')
-        if (self.fix_sync_keep_still is not None
-                and self.fix_sync_keep_still not in self.component_names):
+        if (self.fix_sync_keep_still is not None and
+                self.fix_sync_keep_still not in self.component_names):
             raise ValueError(
                 f'Invalid fix_sync_keep_still == {self.fix_sync_keep_still}. Must match a motor.'
             )
@@ -1011,7 +1041,8 @@ class LookupTablePositioner(PseudoPositioner):
         '''
         values = pseudo_pos._asdict()
         pseudo_field, real_field = self._get_field_names()
-        xp, fp = self._load_table_arrays(x_name=pseudo_field, f_name=real_field)
+        xp, fp = self._load_table_arrays(
+            x_name=pseudo_field, f_name=real_field)
 
         real_value = np.interp(
             values[pseudo_field],
@@ -1037,7 +1068,8 @@ class LookupTablePositioner(PseudoPositioner):
         '''
         values = real_pos._asdict()
         pseudo_field, real_field = self._get_field_names()
-        xp, fp = self._load_table_arrays(x_name=real_field, f_name=pseudo_field)
+        xp, fp = self._load_table_arrays(
+            x_name=real_field, f_name=pseudo_field)
 
         pseudo_value = np.interp(
             values[real_field],

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -211,19 +211,19 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         Move all real positioners in parallel.
 
         This fixes a bug where a PseudoPositioner has a PseudoSingle as one of
-        its axes and waits indefinitely for the move status. 
+        its axes and waits indefinitely for the move status.
 
-        When a nested PseudoSingle receives a move request from the 
-        PseudoPositioner, it does not perform the move itself. Instead, it 
-        delegates the move to its parent PseudoPositioner. The parent reports 
-        that the move is done using a callback, but the current 
-        PseudoPositioner is waiting for the PseudoSingle child to report that 
-        it is done. Since the PseudoSingle did not perform the move directly, 
-        that callback never arrives. The current PseudoPositioner's status 
+        When a nested PseudoSingle receives a move request from the
+        PseudoPositioner, it does not perform the move itself. Instead, it
+        delegates the move to its parent PseudoPositioner. The parent reports
+        that the move is done using a callback, but the current
+        PseudoPositioner is waiting for the PseudoSingle child to report that
+        it is done. Since the PseudoSingle did not perform the move directly,
+        that callback never arrives. The current PseudoPositioner's status
         hangs and blocks other operations.
 
-        The solution is to have the PseudoPositioner object track the axis it 
-        asked to move, instead of instead of trusting which object the callback 
+        The solution is to have the PseudoPositioner object track the axis it
+        asked to move, instead of instead of trusting which object the callback
         reports as done.
         """
         self._real_waiting.extend(self._real)

--- a/pcdsdevices/pseudopos.py
+++ b/pcdsdevices/pseudopos.py
@@ -211,13 +211,16 @@ class PseudoPositioner(ophyd.pseudopos.PseudoPositioner):
         Move all real positioners in parallel.
 
         This fixes a bug where a PseudoPositioner has a PseudoSingle as one of
-        its axes and waits indefinitely for the move status. A PseudoSingle
-        does not perform the move itself. Instead, it delegates the move to its
-        parent PseudoPositioner. The parent reports that the move is done using
-        a callback, but the current PseudoPositioner is waiting for the
-        PseudoSingle child to report that it is done. Since the PseudoSingle
-        did not perform the move directly, that callback never arrives. The
-        current PseudoPositioner's status hangs and blocks other operations.
+        its axes and waits indefinitely for the move status. 
+
+        When a nested PseudoSingle receives a move request from the 
+        PseudoPositioner, it does not perform the move itself. Instead, it 
+        delegates the move to its parent PseudoPositioner. The parent reports 
+        that the move is done using a callback, but the current 
+        PseudoPositioner is waiting for the PseudoSingle child to report that 
+        it is done. Since the PseudoSingle did not perform the move directly, 
+        that callback never arrives. The current PseudoPositioner's status 
+        hangs and blocks other operations.
 
         The solution is to have the PseudoPositioner object track the axis it 
         asked to move, instead of instead of trusting which object the callback 

--- a/pcdsdevices/tests/test_pseudopos.py
+++ b/pcdsdevices/tests/test_pseudopos.py
@@ -284,12 +284,11 @@ def test_concurrent_move_with_pseudosingle():
 
     class OuterPseudoPositioner(PseudoPositioner):
         # Create a small outer PseudoPositioner that will send a request to the
-        # PseudoSingle. The inner PseudoPositioner will delegate the move to its
-        # real SoftPositioner.
+        # PseudoSingle, which delegates it to its parent.
 
         # Tells ophyd that this outer pseudo-positioner has one pseudo axis
         # named 'pseudo' and one real axis named 'nested'. In this test,
-        # nested will not be a normal motor. It will be a PseudoSingle.
+        # nested will be a PseudoSingle.
         _pseudo = ('pseudo',)
         _real = ('nested',)
 

--- a/pcdsdevices/tests/test_pseudopos.py
+++ b/pcdsdevices/tests/test_pseudopos.py
@@ -6,11 +6,15 @@ import numpy as np
 import pytest
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
+from ophyd.pseudopos import (pseudo_position_argument,
+                             real_position_argument)
 from ophyd.sim import make_fake_device
 
+from ..device import ObjectComponent as OCpt
 from ..pseudopos import (DelayBase, LookupTablePositioner, OffsetMotorBase,
-                         PseudoSingleInterface, SimDelayStage, SyncAxesBase,
-                         SyncAxis, SyncAxisOffsetMode, is_strictly_increasing)
+                         PseudoPositioner, PseudoSingleInterface,
+                         SimDelayStage, SyncAxesBase, SyncAxis,
+                         SyncAxisOffsetMode, is_strictly_increasing)
 from ..sim import FastMotor
 
 logger = logging.getLogger(__name__)
@@ -53,6 +57,22 @@ class SyncAxisCrazy(SyncAxis):
     scales = {'two': -2, 'three': 3}
     fix_sync_keep_still = 'two'
     sync_limits = (-10, 10)
+
+
+class InnerPseudoPositioner(PseudoPositioner):
+    # Create a real PseudoSingleInterface object whose move delegates to a
+    # parent PseudoPositioner. This is to test the bug fix in the
+    # _concurrent_move method.
+    pseudo = Cpt(PseudoSingleInterface)
+    real = Cpt(SoftPositioner, init_pos=0)
+
+    @pseudo_position_argument
+    def forward(self, pseudo_pos):
+        return self.RealPosition(real=pseudo_pos.pseudo)
+
+    @real_position_argument
+    def inverse(self, real_pos):
+        return self.PseudoPosition(pseudo=real_pos.real)
 
 
 @pytest.fixture(scope='function')
@@ -173,7 +193,7 @@ def test_delay_basic():
     stage_inv.move(-1e-9)
     for pos in (stage_s.motor.position, stage_ns.motor.position,
                 stage_inv.motor.position):
-        assert abs(pos*1e-3 - 1e-9 * approx_c / 2) < 0.01
+        assert abs(pos * 1e-3 - 1e-9 * approx_c / 2) < 0.01
 
     stage_s.set_current_position(1.0e-6)
     np.testing.assert_allclose(stage_s.position[0], 1.e-6)
@@ -257,6 +277,43 @@ def test_lut_positioner(real_sign: bool, pseudo_sign: bool):
 def test_increasing_helper(input: np.ndarray, expected: bool):
     logger.debug("test_increasing_helper")
     assert is_strictly_increasing(input) == expected
+
+
+def test_concurrent_move_with_pseudosingle():
+    # Create an inner PseudoPositioner
+    inner = InnerPseudoPositioner('', name='inner')
+
+    class OuterPseudoPositioner(PseudoPositioner):
+        # Create a small outer PseudoPositioner that will send a request to the
+        # PseudoSingle. The inner PseudoPositioner will delegate the move to its
+        # real SoftPositioner.
+
+        # Tells ophyd that this outer pseudo-positioner has one pseudo axis
+        # named 'pseudo' and one real axis named 'nested'. In this test,
+        # nested will not be a normal motor. It will be a PseudoSingle.
+        _pseudo = ('pseudo',)
+        _real = ('nested',)
+
+        pseudo = Cpt(PseudoSingleInterface)
+        nested = OCpt(inner.pseudo)
+
+        @pseudo_position_argument
+        def forward(self, pseudo_pos):
+            return self.RealPosition(nested=pseudo_pos.pseudo)
+
+        @real_position_argument
+        def inverse(self, real_pos):
+            return self.PseudoPosition(pseudo=real_pos.nested)
+
+    outer = OuterPseudoPositioner('', name='outer')
+    status = outer.move(5, wait=False, timeout=1)
+    status.wait(timeout=1)
+
+    assert status.done
+    assert status.success
+    assert inner.real.position == 5
+    assert inner.pseudo.position == 5
+    assert outer.pseudo.position == 5
 
 
 FakeDelayBase = make_fake_device(DelayBase)

--- a/pcdsdevices/tests/test_pseudopos.py
+++ b/pcdsdevices/tests/test_pseudopos.py
@@ -6,8 +6,7 @@ import numpy as np
 import pytest
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
-from ophyd.pseudopos import (pseudo_position_argument,
-                             real_position_argument)
+from ophyd.pseudopos import pseudo_position_argument, real_position_argument
 from ophyd.sim import make_fake_device
 
 from ..device import ObjectComponent as OCpt


### PR DESCRIPTION
## Description
This update fixes a bug where a PseudoPositioner has a PseudoSingle as one of its axes and waits indefinitely for the move status.  

**Issue:** When a nested PseudoSingle receives a move request from the PseudoPositioner, it does not perform the move itself. Instead, it delegates the move to its parent PseudoPositioner. The parent reports that the move is done using a callback, but the current PseudoPositioner is waiting for the PseudoSingle child to report that it is done. Since the PseudoSingle didn't perform the move directly, that callback never arrives. The current PseudoPositioner's status hangs and blocks other operations.

**Solution:** Have the PseudoPositioner track the axis it asked to move, instead of trusting which object the callback reports as done.

## Motivation and Context
https://jira.slac.stanford.edu/browse/ECS-4381

## How Has This Been Tested?
(Need to test this in a hutch)

## Where Has This Been Documented?
Documentation is in the method `_concurrent_move()`.

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
