### PR TITLE
MNT: tweak LD labels to reduce overlap in btms_ui

### DIFF
--- a/pcdsdevices/lasers/btms_config.py
+++ b/pcdsdevices/lasers/btms_config.py
@@ -299,16 +299,16 @@ class DestinationPosition(str, enum.Enum):
         """
         # NOTE: Add new descriptions here.
         return {
-            DestinationPosition.ld1: "Diagnostics",
-            DestinationPosition.ld2: "RIX 3RIX",
-            DestinationPosition.ld4: "RIX ChemRIXS",
-            DestinationPosition.ld6: "RIX QRIXS",
-            DestinationPosition.ld8: "TMO IP1",
-            DestinationPosition.ld9: "Laser Lab 1",
-            DestinationPosition.ld10: "TMO IP2 (DREAM)",
-            DestinationPosition.ld11: "Laser Lab 2",
-            DestinationPosition.ld12: "TXI",
-            DestinationPosition.ld14: "XPP",
+            DestinationPosition.ld1: "Diag.\nBox",
+            DestinationPosition.ld2: "RIX 3RIX\n",
+            DestinationPosition.ld4: "RIX ChemRIXS\n",
+            DestinationPosition.ld6: "RIX QRIXS\n",
+            DestinationPosition.ld8: "TMO IP1\n",
+            DestinationPosition.ld9: "Laser Lab\nTable 1",
+            DestinationPosition.ld10: "TMO IP2\n(DREAM)",
+            DestinationPosition.ld11: "Laser Lab\nTable 2",
+            DestinationPosition.ld12: "TXI\n",
+            DestinationPosition.ld14: "XPP\n",
         }.get(self, "Unknown")
 
     @classmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Needed to add line breaks in the labels for Laser Destinations to prevent overlapping text/graphics in `btms_ui`.

I'm starting to really dislike that these configs live in `pcdsdevices` and I'm willing to cut these two scripts out and plop them in `btms_ui`.

## Motivation and Context
SDT maintenance of BTS and addition of new valves/destinations.

## How Has This Been Tested?
Actually tested this on `las-console`, 

## Where Has This Been Documented?
This PR

## Screenshots (if appropriate):
For reference, this is what it'll look like now in the `scene` for the BTS in the `btms_ui` app:
<img width="1092" height="811" alt="image" src="https://github.com/user-attachments/assets/de9791c7-1c02-4725-81bb-5bd128cddf58" />


## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
