### PR TITLE
Enh smaract ethercat

### DIFF
--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1922,7 +1922,7 @@ class SmarActEtherCAT(SmarAct, BeckhoffAxis):
                      doc='Motor load')
     channel_type = Cpt(PytmcSignal, ':CHAN_TYPE', io='io', kind='config',
                        doc='Channel type')
-    op_mode_req = Cpt(EpicsSignal, ':OPMODE_REQ', kind='config',
+    op_mode_req = Cpt(PytmcSignal, ':OPMODE_REQ', io='io', kind='config',
                       doc='DS402 operation mode request')
     home_mode = Cpt(PytmcSignal, ':HOME_MODE', io='i', kind='config',
                     doc='Vendor homing mode')

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1908,13 +1908,16 @@ class SmarActEtherCAT(SmarAct, BeckhoffAxis):
                           doc='Referencing options')
     reference_type = Cpt(PytmcSignal, ':REF_TYPE', io='i', kind='config',
                          doc='Reference type')
-    safe_direction = Cpt(PytmcSignal, ':SAFE_DIR', io='io', kind='config',
+    safe_direction = Cpt(PytmcSignal, ':SAFE_DIR', io='i', kind='config',
                          doc='Safe direction (0x200C). For positioners '
                              'referenced by a mechanical end stop, homing and '
                              'calibration ignore the requested start direction '
                              'and use this plus the logical scale inversion. '
-                             'FORWARD=0, BACKWARD=1. Stored in NVRAM; '
-                             're-calibrate after changing.')
+                             'FORWARD=0, BACKWARD=1. Read-only here: this is an '
+                             'R(W)* object, writable only in the Pre-Op ESM '
+                             'state, so configure it via the CoE startup list '
+                             'or vendor software. Stored in NVRAM; re-calibrate '
+                             'after changing.')
     motor_load = Cpt(PytmcSignal, ':MOTOR_LOAD', io='i', kind='normal',
                      doc='Motor load')
     channel_type = Cpt(PytmcSignal, ':CHAN_TYPE', io='io', kind='config',

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1908,16 +1908,16 @@ class SmarActEtherCAT(SmarAct, BeckhoffAxis):
                           doc='Referencing options')
     reference_type = Cpt(PytmcSignal, ':REF_TYPE', io='i', kind='config',
                          doc='Reference type')
-    safe_direction = Cpt(PytmcSignal, ':SAFE_DIR', io='i', kind='config',
+    safe_direction = Cpt(PytmcSignal, ':SAFE_DIR', io='io', kind='config',
                          doc='Safe direction (0x200C). For positioners '
                              'referenced by a mechanical end stop, homing and '
                              'calibration ignore the requested start direction '
                              'and use this plus the logical scale inversion. '
-                             'FORWARD=0, BACKWARD=1. Read-only here: this is an '
-                             'R(W)* object, writable only in the Pre-Op ESM '
-                             'state, so configure it via the CoE startup list '
-                             'or vendor software. Stored in NVRAM; re-calibrate '
-                             'after changing.')
+                             'FORWARD=0, BACKWARD=1. This is an R(W)* object, '
+                             'writable only in the Pre-Op ESM state, so the PLC '
+                             'applies a new setpoint only while the drive is in '
+                             'Pre-Op. Stored in NVRAM; re-calibrate after '
+                             'changing.')
     motor_load = Cpt(PytmcSignal, ':MOTOR_LOAD', io='i', kind='normal',
                      doc='Motor load')
     channel_type = Cpt(PytmcSignal, ':CHAN_TYPE', io='io', kind='config',

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1523,6 +1523,18 @@ class MotorDisabledError(Exception):
     pass
 
 
+def _set_long_name(signal, long_name):
+    """
+    Assign ``long_name`` to a component signal if it exists.
+
+    Subclasses may remove unsupported components by setting the corresponding
+    Component to None. This helper skips those so that ``__init__`` long-name
+    assignments do not raise AttributeError.
+    """
+    if signal is not None:
+        signal.long_name = long_name
+
+
 class SmarActOpenLoop(Device):
     """
     Class containing the open loop PVs used to control an un-encoded SmarAct
@@ -1569,16 +1581,16 @@ class SmarActOpenLoop(Device):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Long name shenanigans
-        self.step_voltage.long_name = 'Step Voltage'
-        self.step_freq.long_name = 'Step Frequency'
-        self.jog_step_size.long_name = 'Jog Step Size'
-        self.jog_fwd.long_name = 'Jog Forward'
-        self.jog_rev.long_name = 'Jog Backward'
-        self.total_step_count.long_name = 'Total Step Count'
-        self.step_clear_cmd.long_name = 'Clear Step Count'
-        self.scan_move.long_name = 'Scan Voltage'
-        self.channel_temp.long_name = 'Channel Temp. (°C)'
-        self.module_temp.long_name = 'Module Temp. (°C)'
+        _set_long_name(self.step_voltage, 'Step Voltage')
+        _set_long_name(self.step_freq, 'Step Frequency')
+        _set_long_name(self.jog_step_size, 'Jog Step Size')
+        _set_long_name(self.jog_fwd, 'Jog Forward')
+        _set_long_name(self.jog_rev, 'Jog Backward')
+        _set_long_name(self.total_step_count, 'Total Step Count')
+        _set_long_name(self.step_clear_cmd, 'Clear Step Count')
+        _set_long_name(self.scan_move, 'Scan Voltage')
+        _set_long_name(self.channel_temp, 'Channel Temp. (°C)')
+        _set_long_name(self.module_temp, 'Module Temp. (°C)')
 
 
 class SmarActTipTilt(Device):
@@ -1676,37 +1688,37 @@ class SmarAct(EpicsMotorInterface):
         super().__init__(*args, **kwargs)
         # Long name shenanigans
         # Motor Record long name overrides
-        self.velocity.long_name = 'Velocity'
-        self.velocity_base.long_name = 'Velocity Min'
-        self.velocity_max.long_name = 'Velocity Max'
-        self.acceleration.long_name = 'Acceleration'
-        self.motor_stop.long_name = 'Stop Motor'
-        self.motor_is_moving.long_name = 'Actively Moving'
-        self.dial_position.long_name = 'Dial Position'
-        self.direction_of_travel.long_name = 'Direction of Travel'
-        self.home_forward.long_name = 'Home Forward'
-        self.home_reverse.long_name = 'Home Backward'
-        self.low_limit_switch.long_name = 'Low Limit Switch'
-        self.high_limit_switch.long_name = 'High Limit Switch'
-        self.high_limit_travel.long_name = 'High Limit Travel'
-        self.low_limit_travel.long_name = 'Low Limit Travel'
-        self.user_setpoint.long_name = 'Setpoint'
-        self.user_offset.long_name = 'User Offset'
-        self.user_offset_dir.long_name = 'User Offset Direction'
-        self.motor_egu.long_name = 'EGU'
-        self.description.long_name = 'Description'
+        _set_long_name(self.velocity, 'Velocity')
+        _set_long_name(self.velocity_base, 'Velocity Min')
+        _set_long_name(self.velocity_max, 'Velocity Max')
+        _set_long_name(self.acceleration, 'Acceleration')
+        _set_long_name(self.motor_stop, 'Stop Motor')
+        _set_long_name(self.motor_is_moving, 'Actively Moving')
+        _set_long_name(self.dial_position, 'Dial Position')
+        _set_long_name(self.direction_of_travel, 'Direction of Travel')
+        _set_long_name(self.home_forward, 'Home Forward')
+        _set_long_name(self.home_reverse, 'Home Backward')
+        _set_long_name(self.low_limit_switch, 'Low Limit Switch')
+        _set_long_name(self.high_limit_switch, 'High Limit Switch')
+        _set_long_name(self.high_limit_travel, 'High Limit Travel')
+        _set_long_name(self.low_limit_travel, 'Low Limit Travel')
+        _set_long_name(self.user_setpoint, 'Setpoint')
+        _set_long_name(self.user_offset, 'User Offset')
+        _set_long_name(self.user_offset_dir, 'User Offset Direction')
+        _set_long_name(self.motor_egu, 'EGU')
+        _set_long_name(self.description, 'Description')
         # SmarAct specific long names
-        self.pos_type.long_name = 'Positioner Type'
-        self.needs_calib.long_name = 'Needs Calibration?'
-        self.do_calib.long_name = 'Calibrate'
-        self.log_scale_offset.long_name = 'Logical Scale Offset'
-        self.def_range_min.long_name = 'Default Range Min.'
-        self.def_range_max.long_name = 'Default Range Max'
-        self.log_scale_inv.long_name = 'Logical Scale Inversion'
-        self.dist_code_inv.long_name = 'Distance Code Inversion'
-        self.channel_temp.long_name = 'Channel Temp. (°C)'
-        self.module_temp.long_name = 'Module Temp. (°C)'
-        self.channel_state_raw.long_name = 'Channel State'
+        _set_long_name(self.pos_type, 'Positioner Type')
+        _set_long_name(self.needs_calib, 'Needs Calibration?')
+        _set_long_name(self.do_calib, 'Calibrate')
+        _set_long_name(self.log_scale_offset, 'Logical Scale Offset')
+        _set_long_name(self.def_range_min, 'Default Range Min.')
+        _set_long_name(self.def_range_max, 'Default Range Max')
+        _set_long_name(self.log_scale_inv, 'Logical Scale Inversion')
+        _set_long_name(self.dist_code_inv, 'Distance Code Inversion')
+        _set_long_name(self.channel_temp, 'Channel Temp. (°C)')
+        _set_long_name(self.module_temp, 'Module Temp. (°C)')
+        _set_long_name(self.channel_state_raw, 'Channel State')
 
 
 class SmarActEncodedTipTilt(Device):
@@ -1722,6 +1734,182 @@ class SmarActEncodedTipTilt(Device):
         self._tip_pv = tip_pv
         self._tilt_pv = tilt_pv
         super().__init__(prefix, **kwargs)
+
+
+class SmarActChannelState(Device):
+    """
+    Decoded SmarAct MCS2 channel-state flags exposed over EtherCAT.
+
+    Each flag mirrors one bit of the raw channel-state bitmask as a separate
+    read-only pytmc record, suitable for Typhos status indicators. The raw
+    bitmask remains available on the parent as ``channel_state_raw``.
+    """
+    moving = Cpt(PytmcSignal, ':MOVING', io='i', kind='normal',
+                 doc='Actively moving')
+    closed_loop = Cpt(PytmcSignal, ':CLOSED_LOOP', io='i', kind='normal',
+                      doc='Closed loop active')
+    calibrating = Cpt(PytmcSignal, ':CALIBRATING', io='i', kind='normal',
+                      doc='Calibrating')
+    referencing = Cpt(PytmcSignal, ':REFERENCING', io='i', kind='normal',
+                      doc='Referencing')
+    move_delayed = Cpt(PytmcSignal, ':MOVE_DELAYED', io='i', kind='normal',
+                       doc='Move delayed')
+    sensor_present = Cpt(PytmcSignal, ':SENSOR_PRESENT', io='i', kind='normal',
+                         doc='Sensor present')
+    calibrated = Cpt(PytmcSignal, ':CALIBRATED', io='i', kind='normal',
+                     doc='Is calibrated')
+    referenced = Cpt(PytmcSignal, ':REFERENCED', io='i', kind='normal',
+                     doc='Is referenced')
+    end_stop = Cpt(PytmcSignal, ':END_STOP', io='i', kind='normal',
+                   doc='End stop reached')
+    range_limit = Cpt(PytmcSignal, ':RANGE_LIMIT', io='i', kind='normal',
+                      doc='Range limit reached')
+    following_limit = Cpt(PytmcSignal, ':FOLLOWING_LIMIT', io='i',
+                          kind='normal', doc='Following limit reached')
+    move_failed = Cpt(PytmcSignal, ':MOVE_FAILED', io='i', kind='normal',
+                      doc='Movement failed')
+    streaming = Cpt(PytmcSignal, ':STREAMING', io='i', kind='normal',
+                    doc='Is streaming')
+    overload = Cpt(PytmcSignal, ':OVERLOAD', io='i', kind='normal',
+                   doc='Positioner overload')
+    over_temp = Cpt(PytmcSignal, ':OVER_TEMP', io='i', kind='normal',
+                    doc='Over temperature')
+    ref_mark = Cpt(PytmcSignal, ':REF_MARK', io='i', kind='normal',
+                   doc='Reference mark')
+    phased = Cpt(PytmcSignal, ':PHASED', io='i', kind='normal',
+                 doc='Is phased')
+    fault = Cpt(PytmcSignal, ':FAULT', io='i', kind='normal',
+                doc='Positioner fault')
+    amp_enabled = Cpt(PytmcSignal, ':AMP_ENABLED', io='i', kind='normal',
+                      doc='Amplifier enabled')
+    in_position = Cpt(PytmcSignal, ':IN_POSITION', io='i', kind='normal',
+                      doc='In position')
+    brake_enabled = Cpt(PytmcSignal, ':BRAKE_ENABLED', io='i', kind='normal',
+                        doc='Brake enabled')
+
+
+class SmarActEtherCATOpenLoop(SmarActOpenLoop):
+    """
+    Open-loop (step mode) PVs for a SmarAct MCS2 stage driven over EtherCAT.
+
+    The DS402 interface exposes step mode through pytmc records that differ
+    from the serial IOC: readbacks carry the ``_RBV`` suffix. Forward and
+    reverse jog commands set the step-count sign in the PLC, and a signed
+    step-move command is also available. The step-count reset and scan mode
+    have no DS402 backing and are removed, as does the module temperature.
+    Channel temperature is backed by an SDO and kept.
+    """
+    step_voltage = Cpt(PytmcSignal, ':STEP_VOLTAGE', io='io', kind='omitted',
+                       doc='Voltage for sawtooth (0-100V)')
+    step_freq = Cpt(PytmcSignal, ':STEP_FREQ', io='io', kind='config',
+                    doc='Sawtooth drive frequency')
+    jog_step_size = Cpt(PytmcSignal, ':STEP_COUNT', io='io', kind='normal',
+                        doc='Signed number of steps per move command')
+    # A single signed-count move command replaces the FWD/REV jog commands
+    step_move = Cpt(PytmcSignal, ':STEP_MOVE', io='io', kind='normal',
+                    doc='Execute a signed open-loop step move')
+    set_metadata(step_move, dict(variety='command-proc', value=1))
+    # Forward/reverse jog the step count magnitude; the PLC applies the sign
+    jog_fwd = Cpt(PytmcSignal, ':STEP_FORWARD', io='io', kind='normal',
+                  doc='Jog one step count forward')
+    set_metadata(jog_fwd, dict(variety='command-proc', value=1))
+    jog_rev = Cpt(PytmcSignal, ':STEP_REVERSE', io='io', kind='normal',
+                  doc='Jog one step count backward')
+    set_metadata(jog_rev, dict(variety='command-proc', value=1))
+    # Channel temperature is backed by DS402 SDO 0x2026
+    channel_temp = Cpt(PytmcSignal, ':CHANTEMP', io='i', kind='normal',
+                       doc='Channel temperature (0x2026)')
+    # No DS402 backing for these
+    total_step_count = None
+    step_clear_cmd = None
+    scan_move = None
+    module_temp = None
+
+
+class SmarActEtherCAT(SmarAct, BeckhoffAxis):
+    """
+    SmarAct MCS2 stage driven through a Beckhoff EtherCAT DS402 PLC.
+
+    This combines the SmarAct-specific configuration and diagnostics with the
+    BeckhoffAxis motor record, PLC error handling, and homing. The DS402
+    interface exposes fewer objects than the serial MCS2 IOC, so unsupported
+    components (module temperature, default range, and the need-calibration
+    readback) are removed, and the remaining components are re-pointed to
+    their pytmc record names.
+    """
+    # DS402 has no separate module temperature, default range, or
+    # need-calibration readback
+    needs_calib = None
+    def_range_min = None
+    def_range_max = None
+    module_temp = None
+
+    # Per-channel diagnostics/config backed by DS402 SDOs
+    channel_temp = Cpt(PytmcSignal, ':CHANTEMP', io='i', kind='normal',
+                       doc='Channel temperature (0x2026)')
+    dist_code_inv = Cpt(PytmcSignal, ':DCIN', io='io', kind='config',
+                        doc='Distance code inverted (0x2029)')
+    movement_type = Cpt(PytmcSignal, ':MOVE_TYPE', io='i', kind='config',
+                        doc='Movement type (0x2003)')
+    base_unit = Cpt(PytmcSignal, ':BASE_UNIT', io='i', kind='config',
+                    doc='Base unit (0x2005)')
+    base_resolution = Cpt(PytmcSignal, ':BASE_RES', io='i', kind='config',
+                          doc='Base resolution (0x2006)')
+    pos_control_opt = Cpt(PytmcSignal, ':POS_CTRL_OPT', io='io', kind='config',
+                          doc='Positioner control options (0x2027)')
+    actuator_mode = Cpt(PytmcSignal, ':ACT_MODE', io='io', kind='config',
+                        doc='Actuator mode (0x2028)')
+    motor_load_protection = Cpt(PytmcSignal, ':MOTOR_LOAD_PROT', io='io',
+                                kind='config',
+                                doc='Motor load protection threshold (0x202B)')
+
+    # Calibrate command is a plain bo record, not a .PROC field
+    do_calib = Cpt(PytmcSignal, ':DO_CALIB', io='io', kind='config',
+                   doc='Calibrate command')
+    set_metadata(do_calib, dict(variety='command-proc', value=1))
+
+    # NVRAM config: pytmc exposes X / X_RBV rather than X / SET_X
+    log_scale_offset = Cpt(PytmcSignal, ':LSCO', io='io', kind='omitted',
+                           doc='Logical Scale Offset')
+    log_scale_inv = Cpt(PytmcSignal, ':LSCI', io='io', kind='omitted',
+                        doc='Logical Scale Inversion')
+
+    # Raw channel-state bitmask is nested under the chanState struct
+    channel_state_raw = Cpt(PytmcSignal, ':chanState:STATE', io='i',
+                            kind='omitted',
+                            doc='Channel state bitmask represented as raw int')
+    # Decoded channel-state bits for named indicators
+    channel_state = Cpt(SmarActChannelState, ':chanState', kind='normal',
+                        doc='Decoded channel state flags')
+
+    # Open-loop step mode over EtherCAT
+    open_loop = Cpt(SmarActEtherCATOpenLoop, '', kind='omitted')
+
+    # Additional DS402 configuration objects (SDOs/PDOs)
+    step_egu = Cpt(PytmcSignal, ':STEP_EGU', io='io', kind='config',
+                   doc='Step scale factor')
+    hold_time = Cpt(PytmcSignal, ':HOLD_TIME', io='io', kind='config',
+                    doc='Closed-loop hold time')
+    max_close_loop_freq = Cpt(PytmcSignal, ':MAX_CLF', io='io', kind='config',
+                              doc='Maximum closed-loop frequency')
+    calibration_opt = Cpt(PytmcSignal, ':CAL_OPT', io='io', kind='config',
+                          doc='Calibration options')
+    sensor_mode = Cpt(PytmcSignal, ':SENSOR_MODE', io='io', kind='config',
+                      doc='Sensor power mode')
+    referencing_opt = Cpt(PytmcSignal, ':REF_OPT', io='io', kind='config',
+                          doc='Referencing options')
+    reference_type = Cpt(PytmcSignal, ':REF_TYPE', io='i', kind='config',
+                         doc='Reference type')
+    safe_direction = Cpt(PytmcSignal, ':SAFE_DIR', io='io', kind='config',
+                         doc='Safe direction')
+    motor_load = Cpt(PytmcSignal, ':MOTOR_LOAD', io='i', kind='normal',
+                     doc='Motor load')
+    channel_type = Cpt(PytmcSignal, ':CHAN_TYPE', io='io', kind='config',
+                       doc='Channel type')
+    op_mode_req = Cpt(EpicsSignal, ':OPMODE_REQ', kind='config',
+                      doc='DS402 operation mode request')
+    home_mode = Cpt(PytmcSignal, ':HOME_MODE', io='i', kind='config',
+                    doc='Vendor homing mode')
 
 
 class SmarActPicoscale(SmarAct):

--- a/pcdsdevices/epics_motor.py
+++ b/pcdsdevices/epics_motor.py
@@ -1862,6 +1862,14 @@ class SmarActEtherCAT(SmarAct, BeckhoffAxis):
     motor_load_protection = Cpt(PytmcSignal, ':MOTOR_LOAD_PROT', io='io',
                                 kind='config',
                                 doc='Motor load protection threshold (0x202B)')
+    diag_closed_loop_freq_max = Cpt(PytmcSignal, ':DIAG_CLF_MAX', io='i',
+                                    kind='normal',
+                                    doc='Diagnostic closed-loop frequency, '
+                                        'max (0x202A:1)')
+    diag_closed_loop_freq_avg = Cpt(PytmcSignal, ':DIAG_CLF_AVG', io='i',
+                                    kind='normal',
+                                    doc='Diagnostic closed-loop frequency, '
+                                        'avg (0x202A:2)')
 
     # Calibrate command is a plain bo record, not a .PROC field
     do_calib = Cpt(PytmcSignal, ':DO_CALIB', io='io', kind='config',
@@ -1901,7 +1909,12 @@ class SmarActEtherCAT(SmarAct, BeckhoffAxis):
     reference_type = Cpt(PytmcSignal, ':REF_TYPE', io='i', kind='config',
                          doc='Reference type')
     safe_direction = Cpt(PytmcSignal, ':SAFE_DIR', io='io', kind='config',
-                         doc='Safe direction')
+                         doc='Safe direction (0x200C). For positioners '
+                             'referenced by a mechanical end stop, homing and '
+                             'calibration ignore the requested start direction '
+                             'and use this plus the logical scale inversion. '
+                             'FORWARD=0, BACKWARD=1. Stored in NVRAM; '
+                             're-calibrate after changing.')
     motor_load = Cpt(PytmcSignal, ':MOTOR_LOAD', io='i', kind='normal',
                      doc='Motor load')
     channel_type = Cpt(PytmcSignal, ':CHAN_TYPE', io='io', kind='config',

--- a/pcdsdevices/tests/test_epics_motor.py
+++ b/pcdsdevices/tests/test_epics_motor.py
@@ -14,7 +14,7 @@ from ophyd.utils.errors import LimitError
 from ..epics_motor import (IMS, MMC100, PMC100, BeckhoffAxis, EpicsMotor,
                            EpicsMotorInterface, Motor, MotorDisabledError,
                            Newport, OffsetIMSWithPreset, OffsetMotor,
-                           PCDSMotorBase)
+                           PCDSMotorBase, SmarActEtherCAT)
 from ..twincat_motor import TwinCATAxis, TwinCATAxisEPS, TwinCATMotorInterface
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ def fake_motor(cls, name='test_motor'):
 @pytest.fixture(scope='function',
                 params=[
                     EpicsMotorInterface, PCDSMotorBase, IMS, Newport,
-                    MMC100, PMC100, BeckhoffAxis,
+                    MMC100, PMC100, BeckhoffAxis, SmarActEtherCAT,
                     TwinCATMotorInterface, TwinCATAxis, TwinCATAxisEPS
                 ])
 def fake_epics_motor(request):
@@ -119,6 +119,14 @@ def fake_beckhoff(request):
     Test Beckhoff-specific overrides
     """
     return fake_motor(BeckhoffAxis, name=f'mot_{request.node.name}')
+
+
+@pytest.fixture(scope='function')
+def fake_smaract_ethercat(request):
+    """
+    Test SmarActEtherCAT
+    """
+    return fake_motor(SmarActEtherCAT, name=f'mot_{request.node.name}')
 
 
 @pytest.fixture(scope='function')
@@ -649,7 +657,8 @@ def test_motion_error_filter(fake_epics_motor, caplog):
 
 
 @pytest.mark.parametrize("cls", [PCDSMotorBase, IMS, Newport, MMC100,
-                                 PMC100, BeckhoffAxis, EpicsMotor, TwinCATAxis])
+                                 PMC100, BeckhoffAxis, SmarActEtherCAT,
+                                 EpicsMotor, TwinCATAxis])
 @pytest.mark.timeout(5)
 def test_disconnected_motors(cls):
     cls('MOTOR', name='motor')

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -9,7 +9,7 @@ from pydm.widgets import (PyDMByteIndicator, PyDMEnumComboBox, PyDMLabel,
 from qtpy import QtCore, QtGui, QtWidgets
 from typhos import utils
 
-from ..epics_motor import SmarActEtherCAT
+from pcdsdevices.epics_motor import SmarActEtherCAT
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -229,21 +229,22 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
             led.labels = ['Calibrated']
 
         # Safe direction (0x200C) is EtherCAT-only, so the serial .ui has no
-        # widget for it. Add a row to the Configuration tab so operators can
-        # set the end-stop homing/calibration reference direction.
+        # widget for it. Add a read-only row to the Configuration tab so
+        # operators can see the end-stop homing/calibration reference direction.
         self._add_safe_direction_row(prefix)
 
     def _add_safe_direction_row(self, prefix: str):
         """
-        Append a Safe Direction row to the Configuration tab grid.
+        Append a read-only Safe Direction row to the Configuration tab grid.
 
         ``safe_direction`` (SDO 0x200C) exists only on the EtherCAT DS402
-        stage, so the shared serial ``.ui`` carries no widget for it. Build the
-        label / readback / setpoint trio at runtime and drop it into
-        ``config_grid_layout`` below the existing rows.
+        stage, so the shared serial ``.ui`` carries no widget for it. It is an
+        R(W)* object (writable only in the Pre-Op ESM state), so it is set via
+        the CoE startup list or vendor software, not from EPICS. Show the
+        readback only.
         """
         grid = self.findChild(QtWidgets.QGridLayout, 'config_grid_layout')
-        if grid is None or hasattr(self, 'safe_direction_set'):
+        if grid is None or hasattr(self, 'safe_direction_rbv'):
             return
         row = grid.rowCount()
 
@@ -254,17 +255,13 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         rbv.setAlignment(QtCore.Qt.AlignCenter)
         rbv.showUnits = False
         rbv.precisionFromPV = True
-        set_box = PyDMEnumComboBox(self, init_channel=f'ca://{prefix}:SAFE_DIR')
-        set_box.setObjectName('safe_direction_set')
 
         grid.addWidget(label, row, 0, QtCore.Qt.AlignLeft)
         grid.addWidget(rbv, row, 1)
-        grid.addWidget(set_box, row, 2)
 
         # Register as attributes so add_tool_tips() can find the label.
         self.safe_direction_label = label
         self.safe_direction_rbv = rbv
-        self.safe_direction_set = set_box
 
     def add_tool_tips(self):
         """

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -9,6 +9,8 @@ from pydm.widgets import (PyDMByteIndicator, PyDMEnumComboBox, PyDMLabel,
 from qtpy import QtCore, QtGui, QtWidgets
 from typhos import utils
 
+from ..epics_motor import SmarActEtherCAT
+
 logger = logging.getLogger(__name__)
 
 
@@ -152,12 +154,12 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         Adapt the serial detailed screen for EtherCAT SmarAct stages.
 
         The screen targets the serial MCS2 IOC. The EtherCAT DS402 stage,
-        detected here by its decoded ``channel_state`` device, exposes a
-        reduced object set with pytmc naming. Re-point the widgets whose PV
-        only changed name, and hide the widgets whose object has no DS402
-        backing so they do not sit disconnected.
+        identified here by an ``isinstance`` check against `SmarActEtherCAT`,
+        exposes a reduced object set with pytmc naming. Re-point the widgets
+        whose PV only changed name, and hide the widgets whose object has no
+        DS402 backing so they do not sit disconnected.
         """
-        if not hasattr(self.device, 'channel_state'):
+        if not isinstance(self.device, SmarActEtherCAT):
             return
         prefix = self.device.prefix
 

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -96,6 +96,7 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
     ui: _SmarActDetailedUI
 
     def __init__(self, parent=None, ui_filename='SmarAct.detailed.ui', **kwargs):
+        logger.warning("SMARACT-DIAG: SmarActDetailedWidget.__init__ (ui_filename=%s)", ui_filename)
         super().__init__(parent=parent, ui_filename=ui_filename)
 
     @property
@@ -122,6 +123,11 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         Up some of the signals and maybe add new widgets to the display.
         Add any other init-esque shenanigans you need here.
         """
+        logger.warning(
+            "SMARACT-DIAG: post_typhos_init for device=%s (type=%s)",
+            getattr(self.device, 'name', None),
+            type(self.device).__name__,
+        )
         self.fix_pvs()
         self.maybe_fix_ethercat_pvs()
         self.maybe_add_pico()
@@ -158,7 +164,12 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         backing so they do not sit disconnected.
         """
         if not hasattr(self.device, 'channel_state'):
+            logger.warning(
+                "SMARACT-DIAG: maybe_fix_ethercat_pvs early-return, "
+                "device has no channel_state (serial device?)"
+            )
             return
+        logger.warning("SMARACT-DIAG: maybe_fix_ethercat_pvs applying EtherCAT tweaks")
         prefix = self.device.prefix
 
         # Widgets whose PV exists but under a different pytmc name.

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -6,7 +6,7 @@ import re
 from pydm import Display
 from pydm.widgets import (PyDMByteIndicator, PyDMEnumComboBox, PyDMLabel,
                           PyDMLineEdit, PyDMPushButton, PyDMSlider)
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from typhos import utils
 
 logger = logging.getLogger(__name__)
@@ -123,6 +123,7 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         Add any other init-esque shenanigans you need here.
         """
         self.fix_pvs()
+        self.maybe_fix_ethercat_pvs()
         self.maybe_add_pico()
         self.add_tool_tips()
 
@@ -145,6 +146,125 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         self.egu_set.set_channel(f'sig://{self.device.name}_motor_egu')
         self.scan_move_set._minimum = 0
         self.scan_move_set._maximum = 65535
+
+    def maybe_fix_ethercat_pvs(self):
+        """
+        Adapt the serial detailed screen for EtherCAT SmarAct stages.
+
+        The screen targets the serial MCS2 IOC. The EtherCAT DS402 stage,
+        detected here by its decoded ``channel_state`` device, exposes a
+        reduced object set with pytmc naming. Re-point the widgets whose PV
+        only changed name, and hide the widgets whose object has no DS402
+        backing so they do not sit disconnected.
+        """
+        if not hasattr(self.device, 'channel_state'):
+            return
+        prefix = self.device.prefix
+
+        # Widgets whose PV exists but under a different pytmc name.
+        repoint = {
+            # Status-bar bits: serial mbbiDirect .Bn -> decoded booleans
+            'has_encoder_bool': ':chanState:SENSOR_PRESENT',
+            'calibrated_bool': ':chanState:CALIBRATED',
+            'referenced_bool': ':chanState:REFERENCED',
+            # Raw state bitmask lives under the chanState struct
+            'channel_states': ':chanState:STATE_RBV',
+            # Commands write the pytmc bo record directly, no .PROC field
+            'jog_rev_button': ':STEP_REVERSE',
+            'do_calib_button': ':DO_CALIB',
+            # Read-only diagnostics: pytmc appends _RBV
+            'channel_temp_rbv': ':CHANTEMP_RBV',
+            'motor_load_rbv': ':MOTOR_LOAD_RBV',
+            # Diagnostic closed-loop frequency (0x202A:1 max, 0x202A:2 avg)
+            'diag_closed_loop_freq_max_rbv': ':DIAG_CLF_MAX_RBV',
+            'diag_closed_loop_freq_avg_rbv': ':DIAG_CLF_AVG_RBV',
+            # NVRAM config: pytmc uses X / X_RBV instead of X / SET_X
+            'log_scale_offset_rbv': ':LSCO_RBV',
+            'log_scale_offset_set': ':LSCO',
+            'log_scale_inversion_set': ':LSCI',
+            'dist_code_inversion_set': ':DCIN',
+        }
+        for name, suffix in repoint.items():
+            widget = getattr(self, name, None)
+            if widget is not None:
+                widget.set_channel(f'ca://{prefix}{suffix}')
+
+        # Widgets whose object has no DS402 backing at all.
+        hide = [
+            # Open loop: no step counter, reset, or scan over DS402
+            'total_step_count_rbv', 'total_step_count_label',
+            'step_clear_cmd_button', 'step_clear_cmd_label',
+            'scan_move_rbv', 'scan_move_set', 'scan_move_label',
+            # MCS2 homes via home_mode (AUTOZERO / CURRENT_POSITION_METHOD)
+            # and cmd_home. The .HOMF/.HOMR directional buttons are hidden:
+            # for an end-stop stage the reference direction is the configured
+            # safe direction, not whichever button is pressed.
+            'home_forward_button', 'home_forward_label',
+            'home_reverse_button', 'home_reverse_label',
+            # Diagnostics: no module temp, channel error, or CLF diagnostics
+            'module_temp_rbv', 'module_temp_label', 'module_temp_units',
+            'chan_error_rbv', 'chan_error_label',
+            # Only the timebase has no DS402 backing; max/avg are re-pointed
+            'diag_closed_loop_freq_timebase_rbv',
+            'diag_closed_loop_freq_timebase_set',
+            'diag_closed_loop_freq_timebase_label',
+            # Config: no TTZV or default range
+            'ttzv_rbv', 'ttzv_set', 'ttzv_label',
+            'ttzv_threshold_rbv', 'ttzv_threshold_set', 'ttzv_threshold_label',
+            'def_range_min_rbv', 'def_range_min_set', 'def_range_min_label',
+            'def_range_max_rbv', 'def_range_max_set', 'def_range_max_label',
+        ]
+        for name in hide:
+            widget = getattr(self, name, None)
+            if widget is not None:
+                widget.hide()
+
+        # DS402 has no NEED_CALIB record; the channel-state struct carries a
+        # CALIBRATED flag instead. Point the indicator at it and flip the
+        # sense so a lit green LED reads as calibrated.
+        led = getattr(self, 'needs_calib_led', None)
+        if led is not None:
+            led.set_channel(f'ca://{prefix}:chanState:CALIBRATED')
+            led.onColor = QtGui.QColor(0, 255, 0)
+            led.labels = ['Calibrated']
+
+        # Safe direction (0x200C) is EtherCAT-only, so the serial .ui has no
+        # widget for it. Add a row to the Configuration tab so operators can
+        # set the end-stop homing/calibration reference direction.
+        self._add_safe_direction_row(prefix)
+
+    def _add_safe_direction_row(self, prefix: str):
+        """
+        Append a Safe Direction row to the Configuration tab grid.
+
+        ``safe_direction`` (SDO 0x200C) exists only on the EtherCAT DS402
+        stage, so the shared serial ``.ui`` carries no widget for it. Build the
+        label / readback / setpoint trio at runtime and drop it into
+        ``config_grid_layout`` below the existing rows.
+        """
+        grid = self.findChild(QtWidgets.QGridLayout, 'config_grid_layout')
+        if grid is None or hasattr(self, 'safe_direction_set'):
+            return
+        row = grid.rowCount()
+
+        label = QtWidgets.QLabel('Safe Direction', self)
+        label.setObjectName('safe_direction_label')
+        rbv = PyDMLabel(self, init_channel=f'ca://{prefix}:SAFE_DIR_RBV')
+        rbv.setObjectName('safe_direction_rbv')
+        rbv.setAlignment(QtCore.Qt.AlignCenter)
+        rbv.showUnits = False
+        rbv.precisionFromPV = True
+        set_box = PyDMEnumComboBox(self, init_channel=f'ca://{prefix}:SAFE_DIR')
+        set_box.setObjectName('safe_direction_set')
+
+        grid.addWidget(label, row, 0, QtCore.Qt.AlignLeft)
+        grid.addWidget(rbv, row, 1)
+        grid.addWidget(set_box, row, 2)
+
+        # Register as attributes so add_tool_tips() can find the label.
+        self.safe_direction_label = label
+        self.safe_direction_rbv = rbv
+        self.safe_direction_set = set_box
 
     def add_tool_tips(self):
         """

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -221,9 +221,11 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
             'diag_closed_loop_freq_timebase_rbv',
             'diag_closed_loop_timebase_set',
             'diag_closed_loop_freq_timebase_label',
-            # Config: no TTZV or default range
+            # Config: no TTZV or default range. The "TTZV Threshold" caption
+            # carries the generic object name 'label' in the .ui, not
+            # 'ttzv_threshold_label', so hide 'label' to drop the orphan.
             'ttzv_rbv', 'ttzv_set', 'ttzv_label',
-            'ttzv_threshold_rbv', 'ttzv_threshold_set', 'ttzv_threshold_label',
+            'ttzv_threshold_rbv', 'ttzv_threshold_set', 'label',
             'def_range_min_rbv', 'def_range_min_set', 'def_range_min_label',
             'def_range_max_rbv', 'def_range_max_set', 'def_range_max_label',
         ]

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -96,7 +96,6 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
     ui: _SmarActDetailedUI
 
     def __init__(self, parent=None, ui_filename='SmarAct.detailed.ui', **kwargs):
-        logger.warning("SMARACT-DIAG: SmarActDetailedWidget.__init__ (ui_filename=%s)", ui_filename)
         super().__init__(parent=parent, ui_filename=ui_filename)
 
     @property
@@ -123,11 +122,6 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         Up some of the signals and maybe add new widgets to the display.
         Add any other init-esque shenanigans you need here.
         """
-        logger.warning(
-            "SMARACT-DIAG: post_typhos_init for device=%s (type=%s)",
-            getattr(self.device, 'name', None),
-            type(self.device).__name__,
-        )
         self.fix_pvs()
         self.maybe_fix_ethercat_pvs()
         self.maybe_add_pico()
@@ -164,12 +158,7 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         backing so they do not sit disconnected.
         """
         if not hasattr(self.device, 'channel_state'):
-            logger.warning(
-                "SMARACT-DIAG: maybe_fix_ethercat_pvs early-return, "
-                "device has no channel_state (serial device?)"
-            )
             return
-        logger.warning("SMARACT-DIAG: maybe_fix_ethercat_pvs applying EtherCAT tweaks")
         prefix = self.device.prefix
 
         # Widgets whose PV exists but under a different pytmc name.

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -175,9 +175,9 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         # Widgets whose PV exists but under a different pytmc name.
         repoint = {
             # Status-bar bits: serial mbbiDirect .Bn -> decoded booleans
-            'has_encoder_bool': ':chanState:SENSOR_PRESENT',
-            'calibrated_bool': ':chanState:CALIBRATED',
-            'referenced_bool': ':chanState:REFERENCED',
+            'has_encoder_bool': ':chanState:SENSOR_PRESENT_RBV',
+            'calibrated_bool': ':chanState:CALIBRATED_RBV',
+            'referenced_bool': ':chanState:REFERENCED_RBV',
             # Raw state bitmask lives under the chanState struct
             'channel_states': ':chanState:STATE_RBV',
             # Commands write the pytmc bo record directly, no .PROC field
@@ -209,7 +209,9 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
             # MCS2 homes via home_mode (AUTOZERO / CURRENT_POSITION_METHOD)
             # and cmd_home. The .HOMF/.HOMR directional buttons are hidden:
             # for an end-stop stage the reference direction is the configured
-            # safe direction, not whichever button is pressed.
+            # safe direction, not whichever button is pressed. The "Home"
+            # section header is dropped too since only its buttons lived under it.
+            'home_label',
             'home_forward_button', 'home_forward_label',
             'home_reverse_button', 'home_reverse_label',
             # Diagnostics: no module temp, channel error, or CLF diagnostics
@@ -217,7 +219,7 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
             'chan_error_rbv', 'chan_error_label',
             # Only the timebase has no DS402 backing; max/avg are re-pointed
             'diag_closed_loop_freq_timebase_rbv',
-            'diag_closed_loop_freq_timebase_set',
+            'diag_closed_loop_timebase_set',
             'diag_closed_loop_freq_timebase_label',
             # Config: no TTZV or default range
             'ttzv_rbv', 'ttzv_set', 'ttzv_label',
@@ -235,7 +237,7 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         # sense so a lit green LED reads as calibrated.
         led = getattr(self, 'needs_calib_led', None)
         if led is not None:
-            led.set_channel(f'ca://{prefix}:chanState:CALIBRATED')
+            led.set_channel(f'ca://{prefix}:chanState:CALIBRATED_RBV')
             led.onColor = QtGui.QColor(0, 255, 0)
             led.labels = ['Calibrated']
 

--- a/pcdsdevices/ui/SmarAct.detailed.py
+++ b/pcdsdevices/ui/SmarAct.detailed.py
@@ -226,28 +226,30 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
                 widget.hide()
 
         # DS402 has no NEED_CALIB record; the channel-state struct carries a
-        # CALIBRATED flag instead. Point the indicator at it and flip the
-        # sense so a lit green LED reads as calibrated.
+        # CALIBRATED flag instead. This row reads "needs calibration", so show
+        # the inverse of CALIBRATED: red when the bit is 0 (calibration needed,
+        # hit Calibrate) and green once the channel reports calibrated.
         led = getattr(self, 'needs_calib_led', None)
         if led is not None:
             led.set_channel(f'ca://{prefix}:chanState:CALIBRATED_RBV')
-            led.onColor = QtGui.QColor(0, 255, 0)
-            led.labels = ['Calibrated']
+            led.onColor = QtGui.QColor(0, 255, 0)    # calibrated
+            led.offColor = QtGui.QColor(255, 0, 0)   # needs calibration
+            led.labels = ['Needs Calibration']
 
         # Safe direction (0x200C) is EtherCAT-only, so the serial .ui has no
-        # widget for it. Add a read-only row to the Configuration tab so
-        # operators can see the end-stop homing/calibration reference direction.
+        # widget for it. Add a row to the Configuration tab so operators can
+        # see and set the end-stop homing/calibration reference direction.
         self._add_safe_direction_row(prefix)
 
     def _add_safe_direction_row(self, prefix: str):
         """
-        Append a read-only Safe Direction row to the Configuration tab grid.
+        Append a Safe Direction row to the Configuration tab grid.
 
         ``safe_direction`` (SDO 0x200C) exists only on the EtherCAT DS402
         stage, so the shared serial ``.ui`` carries no widget for it. It is an
-        R(W)* object (writable only in the Pre-Op ESM state), so it is set via
-        the CoE startup list or vendor software, not from EPICS. Show the
-        readback only.
+        R(W)* object, writable only in the Pre-Op ESM state; the PLC applies a
+        new setpoint while the drive is in Pre-Op. Show the readback plus a
+        write combo so operators can request a direction.
         """
         grid = self.findChild(QtWidgets.QGridLayout, 'config_grid_layout')
         if grid is None or hasattr(self, 'safe_direction_rbv'):
@@ -261,13 +263,18 @@ class SmarActDetailedWidget(Display, utils.TyphosBase):
         rbv.setAlignment(QtCore.Qt.AlignCenter)
         rbv.showUnits = False
         rbv.precisionFromPV = True
+        set_widget = PyDMEnumComboBox(
+            self, init_channel=f'ca://{prefix}:SAFE_DIR')
+        set_widget.setObjectName('safe_direction_set')
 
         grid.addWidget(label, row, 0, QtCore.Qt.AlignLeft)
         grid.addWidget(rbv, row, 1)
+        grid.addWidget(set_widget, row, 2)
 
         # Register as attributes so add_tool_tips() can find the label.
         self.safe_direction_label = label
         self.safe_direction_rbv = rbv
+        self.safe_direction_set = set_widget
 
     def add_tool_tips(self):
         """


### PR DESCRIPTION
<!-- Suggested title: ENH: Add SmarActEtherCAT DS402 device and adapt the detailed screen -->

## Description
Adds device support and a typhos screen for SmarAct MCS2 stages driven through a Beckhoff EtherCAT DS402 PLC (as opposed to the serial MCS2 IOC).

- New `SmarActEtherCAT` (combines `SmarAct` config/diagnostics with `BeckhoffAxis` motor record, PLC error handling, and homing) and `SmarActEtherCATOpenLoop`.
- Adds DS402 config/diagnostic components : diagnostic closed-loop frequency (max/avg), safe direction, referencing/calibration options, sensor mode, hold time, step scaling, operation-mode request, motor load, decoded channel-state flags (`SmarActChannelState`), etc.
- Removes components with no DS402 backing (module temperature, default range, need-calibration readback) and re-points the rest to their pytmc record names.
- Adapts `SmarAct.detailed.ui`/`SmarAct.detailed.py`: re-points renamed pytmc PVs and hides widgets whose objects have no DS402 backing (orphaned TTZV threshold label and chanState RBV widgets) so they do not sit disconnected.

## Motivation and Context
The DREAM EtherCAT SmarAct stages run through a TwinCAT DS402 PLC, which exposes a reduced, pytmc-named object set that the existing serial `SmarAct` device and its detailed screen do not match. Without this, components connect to the wrong PV names (or write-only PVs with no readback) and the screen shows disconnected widgets.
https://jira.slac.stanford.edu/browse/ECS-10975

## How Has This Been Tested?
Loaded `SmarActEtherCAT` and its typhos detailed screen interactively against alive MCS2 EtherCAT IOC (`DREAM:DGPD:MMT:RET`). Confirmed the DS402 config/diagnostic PVs read back and that unsupported widgets are hidden rather than disconnected. Also perfomed full motion control on hardware: homing, closed-loop moves, and open-loop step operations.
<img width="1100" height="288" alt="image" src="https://github.com/user-attachments/assets/7cb7b94d-e92d-41d6-b745-e9f6cb032edd" />
<img width="1033" height="934" alt="image" src="https://github.com/user-attachments/assets/c0152d3c-8c39-4673-927d-2b3c9528ca2b" />

### Default serial interface screens test
Also verified the shared serial path using the default serial interfa **SmarAct device class**. Built and launched a test IOC from the common SmarAct IOC and drove a real SmarAct stage over the serial interface. Focused on the calibrate command and confirmed with @aberges-SLAC  it fires exactly once per request without re-triggering. Every operation ran through the default SmarAct screens, including our changes. All motion tests passed.
<img width="1099" height="916" alt="image" src="https://github.com/user-attachments/assets/52727089-969e-499c-8fc2-d24186f7ccd8" />

## Where Has This Been Documented?
Component-level `doc=` strings and class docstrings on `SmarActEtherCAT` / `SmarActEtherCATOpenLoop`, plus explanatory comments in `maybe_fix_ethercat_pvs`.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions