### PR TITLE
Restore xyzstage

### DIFF
--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -12,8 +12,7 @@ from .epics_motor import (IMS, PMC100, BeckhoffAxis, DelayNewport, EpicsMotor,
 from .evr import Trigger
 from .gauge import GaugeSet
 from .gbs import GratingBeamSplitterTarget
-from .gon import (BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi,
-                  XYZStage)
+from .gon import BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi, XYZStage
 from .inout import Reflaser, TTReflaser
 from .ipm import IPM, IPM_IPIMB, BeckhoffIntensityProfileTarget, IPM_Wave8
 from .jet import BeckhoffJet

--- a/pcdsdevices/device_types.py
+++ b/pcdsdevices/device_types.py
@@ -12,7 +12,8 @@ from .epics_motor import (IMS, PMC100, BeckhoffAxis, DelayNewport, EpicsMotor,
 from .evr import Trigger
 from .gauge import GaugeSet
 from .gbs import GratingBeamSplitterTarget
-from .gon import BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi
+from .gon import (BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi,
+                  XYZStage)
 from .inout import Reflaser, TTReflaser
 from .ipm import IPM, IPM_IPIMB, BeckhoffIntensityProfileTarget, IPM_Wave8
 from .jet import BeckhoffJet

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -202,6 +202,38 @@ def Goniometer(**kwargs):
         return BaseGon(**kwargs)
 
 
+class XYZStage(BaseInterface, Device):
+    """
+    Sample XYZ stage.
+
+    Parameters
+    ----------
+    name : str
+        A name to refer to the device
+
+    prefix_x : str
+        The EPICS base PV of the sample-stage's x motor.
+
+    prefix_y : str
+        The EPICS base PV of the sample-stage's y motor.
+
+    prefix_z : str
+        The EPICS base PV of the sample-stage's z motor.
+    """
+
+    x = FCpt(IMS, '{self._prefix_x}', kind='normal')
+    y = FCpt(IMS, '{self._prefix_y}', kind='normal')
+    z = FCpt(IMS, '{self._prefix_z}', kind='normal')
+
+    tab_component_names = True
+
+    def __init__(self, *, name, prefix_x, prefix_y, prefix_z, **kwargs):
+        self._prefix_x = prefix_x
+        self._prefix_y = prefix_y
+        self._prefix_z = prefix_z
+        super().__init__('', name=name, **kwargs)
+
+
 class SamPhi(BaseInterface, GroupDevice):
     """
     Sample Phi stage.

--- a/pcdsdevices/gon.py
+++ b/pcdsdevices/gon.py
@@ -202,7 +202,7 @@ def Goniometer(**kwargs):
         return BaseGon(**kwargs)
 
 
-class XYZStage(BaseInterface, Device):
+class XYZStage(BaseInterface, GroupDevice):
     """
     Sample XYZ stage.
 
@@ -232,6 +232,18 @@ class XYZStage(BaseInterface, Device):
         self._prefix_y = prefix_y
         self._prefix_z = prefix_z
         super().__init__('', name=name, **kwargs)
+
+    def format_status_info(self, status_info):
+        """Override status info handler to render the `XYZStage`."""
+        x = get_status_float(status_info, 'x', 'position')
+        y = get_status_float(status_info, 'y', 'position')
+        z = get_status_float(status_info, 'z', 'position')
+        units = get_status_value(status_info, 'x', 'user_setpoint', 'units')
+
+        return f"""\
+XYZStage
+X, Y, Z: {x}, {y}, {z} [{units}]
+"""
 
 
 class SamPhi(BaseInterface, GroupDevice):

--- a/pcdsdevices/tests/test_gon.py
+++ b/pcdsdevices/tests/test_gon.py
@@ -5,7 +5,8 @@ import numpy as np
 import pytest
 from ophyd.sim import make_fake_device
 
-from ..gon import BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi, SimKappa
+from ..gon import (BaseGon, Goniometer, GonWithDetArm, Kappa, SamPhi, SimKappa,
+                   XYZStage)
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,8 @@ def test_gon_init():
             prefix_rot='rot', prefix_tip='tip', prefix_tilt='tilt',
             prefix_detver='detver', prefix_dettilt='dettilt',
             prefix_2theta='2theta')
+    FakeGon = make_fake_device(XYZStage)
+    FakeGon(name='test', prefix_x='x', prefix_y='y', prefix_z='z')
     FakeGon = make_fake_device(SamPhi)
     FakeGon(name='test', prefix_samz='samz', prefix_samphi='samphi')
     FakeGon = make_fake_device(Kappa)
@@ -60,6 +63,7 @@ def test_gon_disconnected():
                   prefix_rot='rot', prefix_tip='tip', prefix_tilt='tilt',
                   prefix_detver='detver', prefix_dettilt='dettilt',
                   prefix_2theta='2theta')
+    XYZStage(name='test3', prefix_x='x', prefix_y='y', prefix_z='z')
     SamPhi(name='test4', prefix_samz='samz', prefix_samphi='samphi')
     Kappa(name='test5', prefix='TST:KAPPA5')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

XYZStage was removed in b466a6cd ("Added Kappa stages #1425"), but is still used by XCS so restoring it in gon.py.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
XCS still uses this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in XCS hutch-python.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
